### PR TITLE
Fix typos (part 1)

### DIFF
--- a/doc/src/sgml/acronyms.sgml
+++ b/doc/src/sgml/acronyms.sgml
@@ -143,6 +143,9 @@
     <term><acronym>CTE</acronym></term>
     <listitem>
      <para>
+<!--
+      <link linkend="queries-with">Common Table Expression</link>
+-->
       <link linkend="queries-with">Common Table Expression（共通テーブル式）</link>
      </para>
     </listitem>

--- a/doc/src/sgml/arch-dev.sgml
+++ b/doc/src/sgml/arch-dev.sgml
@@ -237,7 +237,7 @@
 <!--
     The <firstterm>parser stage</firstterm> consists of two parts:
 -->
-<firstterm>構文解析過程</firstterm>は2つの部から構成されています。
+<firstterm>構文解析過程</firstterm>は2つの部分から構成されています。
 
     <itemizedlist>
      <listitem>
@@ -325,7 +325,7 @@
 そして<filename>gram.y</filename>は<application>bison</application>を使って<filename>gram.c</filename>に書き換えられます。
 これらの書き換えが終わると、パーサを作るために通常のCコンパイラが使えるようになります。
 生成されたCのファイルには絶対に変更を加えないでください。
-と言うのは次に<application>flex</application>もしくは<application>bison</application> が呼ばれた時に上書きされる可能性があるからです。
+と言うのは次に<application>flex</application>もしくは<application>bison</application> が呼ばれた時に上書きされるからです。
 
      <note>
       <para>
@@ -481,9 +481,8 @@
     representation or level of semantic detail in the trees.  Rewriting
     can be thought of as a form of macro expansion.
 -->
-問い合わせの書き換えについては<xref linkend="rules">にて詳しく論議されますのでここでは取り扱いません。
-書き換えの入出力ともに問い合わせツリーであることを指摘するのに留めます。
-と言うのは、ツリー内の表現の仕方や語義をどの程度詳しく判断するかには影響がないからです。
+問い合わせの書き換えについては<xref linkend="rules">にて詳しく論議されますので、ここでは取り扱いません。
+書き換えの入出力はともに問い合わせツリーである、つまり、ツリー内の表現の仕方や語義をどの程度詳しく判断するかには変更はない、ということを指摘するのに留めます。
 書き換えはマクロの拡張と捉えることもできます。
    </para>
 
@@ -577,7 +576,7 @@
 各リレーション上で利用できるインデックスにより実行可能な計画が決まります。
 リレーションをシーケンシャルスキャンする可能性は常にありますので、シーケンシャルスキャンを使用する計画は常に作成されます。
 リレーション上にインデックス（例えばB-treeインデックス）が定義され、問い合わせには<literal>relation.attribute OPR constant</literal>という条件があるとしましょう。
-もし<literal>relation.attribute</literal>がB-treeインデックスのキーと一致し、<literal>OPR</literal>がインデックスの <firstterm>演算子クラス</>に列挙されている演算子の1つであれば、リレーションをスキャンするためにB-treeインデックスを使用する別の計画が作られます。
+もし<literal>relation.attribute</literal>がB-treeインデックスのキーと一致し、<literal>OPR</literal>がインデックスの<firstterm>演算子クラス</>に列挙されている演算子の1つであれば、リレーションをスキャンするためにB-treeインデックスを使用する別の計画が作られます。
 さらに他のインデックスが存在し、問い合わせの中で条件がインデックスのキーに一致した場合、なおその上に計画が検討されます。インデックススキャン計画は、問い合わせの （もし存在すれば）<literal>ORDER BY</>句に一致するソート順、もしくはマージ結合に便利なソート順を所有するインデックスに対して生成されます（以下を参照してください）。
     </para>
 
@@ -788,9 +787,9 @@
     any selection or projection expressions that were assigned to it by
     the planner.
 -->
-複雑な問い合わせは多くの階層となった計画ノードに関われますが、概略的な取り扱い方は同じです。
+複雑な問い合わせは多くの階層となった計画ノードに関わるかもしれませんが、概略的な取り扱い方は同じです。
 それぞれのノードは呼び出される度に次の出力行を計算して返します。
-それぞれのノードは同時にプランナによって割り当てられたいかなる選択式や射影式でも適用しなければならない責任があります。
+それぞれのノードは同時にプランナによって割り当てられたいかなる選択式や射影式でも適用する責任があります。
    </para>
 
    <para>
@@ -818,14 +817,14 @@
 -->
 エクゼキュータ機構は全ての4つの基本的なSQL型を検証するために用いられます。
 4つのSQL型とは<command>SELECT</>、<command>INSERT</>、<command>UPDATE</>、そして<command>DELETE</>です。
-<command>SELECT</>では、最上位階層のエクゼキュータコードはクライアントから離れて問い合わせ計画によって返されるそれぞれのだけを行を送り返せばよいことになっています。
+<command>SELECT</>では、最上位階層のエクゼキュータコードは問い合わせ計画によって返されるそれぞれの行をクライアントへ送り返すだけでよいことになっています。
 <command>INSERT</>では、<command>INSERT</>で指定された対象となるテーブルに返された行が挿入されます。
 これは<literal>ModifyTable</>と呼ばれる特別な最上位階層の計画ノードの中で行われます。
 （ある単純な<command>INSERT ... VALUES</>コマンドは1つの<literal>Result</>ノード（これは、結果としての行を1つだけ計算するに留まります）とその上の挿入を実行するための<literal>ModifyTable</>からなる単純な計画ツリーを生成します。
 しかし、<command>INSERT ... SELECT</>はエクゼキュータ機構ができ得る限りの能力を発揮することを要求する場合があります）。
-<command>UPDATE</>ではプランナは全ての更新された列の値を含んだ行の演算結果と<firstterm>TID</>（タプルID、または行ID）を準備します。
+<command>UPDATE</>ではプランナはすべての更新された列の値を含んだ行の演算結果と<firstterm>TID</>（タプルID、または行ID）を準備します。
 このデータは<literal>ModifyTable</>ノードに入力され、ノードでは新しく更新された行の作成と削除された古い行に印を付けるためこの情報を利用します。
-<command>DELETE</>では計画から実際に返されたただ1つの列はTIDで、<literal>ModifyTable</>ノードは各対象行を尋ね当てることと削除の印を付けるために単にこのTIDを使用します。
+<command>DELETE</>では計画から実際に返されるただ1つの列はTIDで、<literal>ModifyTable</>ノードは単に各対象行を尋ね当てて削除の印を付けるためにこのTIDを使用します。
    </para>
 
   </sect1>

--- a/doc/src/sgml/bki.sgml
+++ b/doc/src/sgml/bki.sgml
@@ -220,7 +220,8 @@
       Close the open table.  The name of the table can be given as a
       cross-check, but this is not required.
 -->
-開いているテーブルを閉じます。テーブル名は様々な方法で検査可能ですが、必要性はありません
+開いているテーブルを閉じます。
+テーブル名は照合用に指定可能ですが、必須ではありません。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/btree-gin.sgml
+++ b/doc/src/sgml/btree-gin.sgml
@@ -46,9 +46,15 @@
 
 <programlisting>
 CREATE TABLE test (a int4);
--- create index
+<!--
+&#045;- create index
+-->
+-- インデックスの作成
 CREATE INDEX testidx ON test USING gin (a);
--- query
+<!--
+&#045;- query
+-->
+-- 問い合わせ
 SELECT * FROM test WHERE a &lt; 10;
 </programlisting>
 

--- a/doc/src/sgml/charset.sgml
+++ b/doc/src/sgml/charset.sgml
@@ -39,7 +39,6 @@
       between client and server.
       This is covered in <xref linkend="multibyte">.
 -->
-
 Á´¤Æ¤Î¼ïÎà¤Î¸À¸ì¤Ë¤è¤ë¥Æ¥­¥¹¥È¤Î³ÊÇ¼¤Î¥µ¥Ý¡¼¥È¡¢¤ª¤è¤Ó¥¯¥é¥¤¥¢¥ó¥È¥µ¡¼¥Ð´Ö¤ÎÊ¸»ú¥»¥Ã¥ÈËÝÌõ¤ÎÄó¶¡¤ò¹Ô¤¦¤¿¤á¡¢Â¿¤¯¤ÎÊ¸»ú¥»¥Ã¥È¤òÄó¶¡¤·¤Þ¤¹¡£
 ¤³¤ì¤Ï<xref linkend="multibyte">Æâ¤Ç²òÀâ¤µ¤ì¤Æ¤¤¤Þ¤¹¡£
      </para>
@@ -53,7 +52,7 @@
   <title>Locale Support</title>
 -->
 <title>¥í¥±¡¼¥ë¤Î¥µ¥Ý¡¼¥È</title>
-  
+
 <!--
   <indexterm zone="locale"><primary>locale</></>
 -->
@@ -68,7 +67,7 @@
    system.  For additional information refer to the documentation of your
    system.
 -->
-<firstterm>¥í¥±¡¼¥ë</>¤Î¥µ¥Ý¡¼¥È¤Ï¥¢¥ë¥Õ¥¡¥Ù¥Ã¥È¡¢ÊÂ¤Ó´¹¤¨¡¢¿ô»ú¤Î½ñ¼°¤Ê¤ÉÊ¸²½ÅªÓÏ¹¥¤òÇÛÎ¸¤·¤¿¤¢¤ë¥¢¥×¥ê¥±¡¼¥·¥ç¥ó¤òÂÐ¾Ý¤Ë¤·¤Þ¤¹¡£  
+<firstterm>¥í¥±¡¼¥ë</>¤Î¥µ¥Ý¡¼¥È¤Ï¥¢¥ë¥Õ¥¡¥Ù¥Ã¥È¡¢ÊÂ¤Ó´¹¤¨¡¢¿ô»ú¤Î½ñ¼°¤Ê¤ÉÊ¸²½ÅªÓÏ¹¥¤òÇÛÎ¸¤·¤¿¥¢¥×¥ê¥±¡¼¥·¥ç¥ó¤òÂÐ¾Ý¤Ë¤·¤Þ¤¹¡£
 <productname>PostgreSQL</>¤Ï¡¢¥µ¡¼¥Ð¤Î¥ª¥Ú¥ì¡¼¥Æ¥£¥ó¥°¥·¥¹¥Æ¥à¤¬Äó¶¡¤¹¤ë¡¢É¸½àISO C¤È<acronym>POSIX</acronym>¤Î¥í¥±¡¼¥ëµ¡Ç½¤ò»ÈÍÑ¤·¤Þ¤¹¡£
 ¤³¤ì°Ê¾å¤Î¾ðÊó¤Ë¤Ä¤¤¤Æ¤Ï¤ª»È¤¤¤Î¥·¥¹¥Æ¥à¤Î¥É¥­¥å¥á¥ó¥È¤ò»²¾È¤¯¤À¤µ¤¤¡£
   </para>
@@ -254,8 +253,7 @@ Windows¤Ï¡¢<literal>German_Germany</>¤ä<literal>Swedish_Sweden.1252</>¤Î¤è¤¦¤Ê¤â
 ¤½¤ÎÂ¾¤Î¥í¥±¡¼¥ë¥«¥Æ¥´¥ê¤Ï¡¢¤¤¤Ä¤Ç¤â¡¢¥í¥±¡¼¥ë¥«¥Æ¥´¥ê¤ÈÆ±¤¸Ì¾Á°¤Î¼Â¹Ô»þ¥Ñ¥é¥á¡¼¥¿¤òÀßÄê¤¹¤ë¤³¤È¤Ç¡¢´õË¾ÃÍ¤ËÊÑ¹¹¤¹¤ë¤³¤È¤¬¤Ç¤­¤Þ¤¹
 ¡Ê¾ÜºÙ¤Ï<xref linkend="runtime-config">¤ò»²¾È¤·¤Æ¤¯¤À¤µ¤¤¡Ë¡£
 <command>initdb</command>¤ÇÁªÂò¤µ¤ì¤¿ÃÍ¤Ï¡¢¼ÂºÝ¤Î¤È¤³¤í¡¢¥µ¡¼¥Ð¤Îµ¯Æ°»þ¤Ë¥Ç¥Õ¥©¥ë¥È¤È¤·¤ÆÆ°ºî¤¹¤ë¤è¤¦¤Ë<filename>postgresql.conf</filename>ÀßÄê¥Õ¥¡¥¤¥ë¤Ë½ñ¤­¹þ¤Þ¤ì¤ë¤À¤±¤Ç¤¹¡£
-¤³¤ÎÂåÆþÊ¸¤ò<filename>postgresql.conf</filename>¤Çºï½ü¤¹¤ë¤È¡¢¥µ¡¼¥Ð¤Ï¼Â¹Ô´Ä¶­¤ÎÀßÄê¤ò¤½¤Î¤Þ¤Þ»ÈÍÑ¤·¤Þ¤¹¡£
-
+¤³¤ÎÂåÆþÊ¸¤ò<filename>postgresql.conf</filename>¤«¤éºï½ü¤¹¤ë¤È¡¢¥µ¡¼¥Ð¤Ï¼Â¹Ô´Ä¶­¤ÎÀßÄê¤ò¤½¤Î¤Þ¤Þ»ÈÍÑ¤·¤Þ¤¹¡£
    </para>
 
    <para>
@@ -284,7 +282,7 @@ Windows¤Ï¡¢<literal>German_Germany</>¤ä<literal>Swedish_Sweden.1252</>¤Î¤è¤¦¤Ê¤â
      <envar>LANG</envar>.  If none of these environment variables are
      set then the locale defaults to <literal>C</literal>.
 -->
-¼Â¹Ô´Ä¶­¤Î¥í¥±¡¼¥ë¤ò¤½¤Î¤Þ¤Þ»ÈÍÑ¤¹¤ë¤È¤¤¤¦¤³¤È¤Ï¡¢¤Û¤È¤ó¤É¤Î¥ª¥Ú¥ì¡¼¥·¥ç¥ó¥·¥¹¥Æ¥à¤Ç¤Ï¼¡¤Î¤è¤¦¤Ê°ÕÌ£¤ò»ý¤Á¤Þ¤¹¡£
+¼Â¹Ô´Ä¶­¤Î¥í¥±¡¼¥ë¤ò¤½¤Î¤Þ¤Þ»ÈÍÑ¤¹¤ë¤È¤¤¤¦¤³¤È¤Ï¡¢¤Û¤È¤ó¤É¤Î¥ª¥Ú¥ì¡¼¥Æ¥£¥ó¥°¥·¥¹¥Æ¥à¤Ç¤Ï¼¡¤Î¤è¤¦¤Ê°ÕÌ£¤ò»ý¤Á¤Þ¤¹¡£
 »ØÄê¤µ¤ì¤¿¥í¥±¡¼¥ë¥«¥Æ¥´¥ê¡ÊÎã¤¨¤Ð¾È¹ç¡Ë¤Ë¤Ä¤¤¤Æ¡¢ÀßÄê¤¹¤ë¤â¤Î¤¬¸«¤Ä¤«¤ë¤Þ¤Ç¡¢°Ê²¼¤Î´Ä¶­ÊÑ¿ô¤¬¤³¤Î½çÈÖ¤ÇÄ´¤Ù¤é¤ì¤Þ¤¹¡£<envar>LC_ALL</envar>¡¢<envar>LC_COLLATE</envar>¡Ê¤Þ¤¿¤Ï¤½¤ì¤¾¤ì¤Î¥«¥Æ¥´¥ê¤ËÂÐ±þ¤¹¤ëÊÑ¿ô¡Ë¡¢<envar>LANG</envar>¡£
 ¤³¤ì¤é¤Î¤¤¤º¤ì¤Î´Ä¶­ÊÑ¿ô¤âÀßÄê¤µ¤ì¤Ê¤¤¾ì¹ç¤Ë¡¢¥í¥±¡¼¥ë¤Ï¥Ç¥Õ¥©¥ë¥È¤Ç<literal>C</literal>¤ËÀßÄê¤µ¤ì¤Þ¤¹¡£
     </para>
@@ -575,9 +573,7 @@ C°Ê³°¤Î¥í¥±¡¼¥ë¤Ë¤ª¤¤¤Æ¡¢<productname>PostgreSQL</>¤¬<literal>LIKE</>¶ç¤ò»ý¤Ä¥¤¥
 ¤³¤ì¤Ï¡¢¤¿¤È¤¨¤Ð<literal>ORDER BY</literal>¶ç¤ä<literal>&lt;</literal>±é»»»Ò¤ä´Ø¿ô¤ò»ÈÍÑ¤¹¤ëºÝ¤ËÈ¯À¸¤·¤Þ¤¹¡£
 <literal>ORDER BY</literal>¶ç¤ËÅ¬ÍÑ¤¹¤ë¾È¹ç¤Ï¡¢Ã±½ã¤Ë¥½¡¼¥È¥­¡¼¤Î¾È¹ç¤Ç¤¹¡£
 ´Ø¿ô¤ä±é»»»Ò¤Î¸Æ¤Ó½Ð¤·¤ËÂÐ¤·¤ÆÅ¬ÍÑ¤µ¤ì¤ë¾È¹ç¤Ï¡¢°Ê²¼¤Ë½Ò¤Ù¤ë¤è¤¦¤Ë°ú¿ô¤Ë¤è¤ê·è¤Þ¤ê¤Þ¤¹¡£
-Èæ³Ó±é»»»Ò¤Ë²Ã¤¨¤Æ¡¢¾È¹ç¤Ï
-<function>lower</>¡¢<function>upper</>¡¢<function>initcap</>¤È¤¤¤Ã¤¿¾®Ê¸»ú¤ÈÂçÊ¸»ú¤òÊÑ´¹¤¹¤ë´Ø¿ô¤ä
-¥Ñ¥¿¡¼¥ó¥Þ¥Ã¥Á¥ó¥°¤Î±é»»»Ò¡¢<function>to_char</>´ØÏ¢¤Î´Ø¿ô¤Ç¹ÍÎ¸¤µ¤ì¤Æ¤¤¤Þ¤¹¡£
+Èæ³Ó±é»»»Ò¤Ë²Ã¤¨¤Æ¡¢¾È¹ç¤Ï<function>lower</>¡¢<function>upper</>¡¢<function>initcap</>¤È¤¤¤Ã¤¿¾®Ê¸»ú¤ÈÂçÊ¸»ú¤òÊÑ´¹¤¹¤ë´Ø¿ô¤ä¥Ñ¥¿¡¼¥ó¥Þ¥Ã¥Á¥ó¥°¤Î±é»»»Ò¡¢<function>to_char</>´ØÏ¢¤Î´Ø¿ô¤Ç¹ÍÎ¸¤µ¤ì¤Æ¤¤¤Þ¤¹¡£
    </para>
 
    <para>
@@ -704,8 +700,7 @@ SELECT a &lt; b FROM test1;
     error.  The error can be resolved by attaching an explicit collation
     specifier to either input expression, thus:
 -->
-¥Ñ¡¼¥µ¤Ï¤É¤Î¾È¹ç¤òÅ¬ÍÑ¤¹¤ë¤«·èÄê¤Ç¤­¤Þ¤»¤ó¡£¤È¤¤¤¦¤Î¤â<structfield>a</>¤È<structfield>b</>Îó¤Ï
-°ÅÌÛ¤Î¾×ÆÍ¤¹¤ë¾È¹ç¤ò»ý¤Ä¤¿¤á¤Ç¤¹¡£
+¥Ñ¡¼¥µ¤Ï¤É¤Î¾È¹ç¤òÅ¬ÍÑ¤¹¤ë¤«·èÄê¤Ç¤­¤Þ¤»¤ó¡£¤È¤¤¤¦¤Î¤â<structfield>a</>¤È<structfield>b</>Îó¤Ï°ÅÌÛ¤Î¾×ÆÍ¤¹¤ë¾È¹ç¤ò»ý¤Ä¤¿¤á¤Ç¤¹¡£
 <literal>&lt;</literal>±é»»»Ò¤¬¤É¤Á¤é¤Î¾È¹ç¤ò»ÈÍÑ¤¹¤ë¤«ÃÎ¤ëÉ¬Í×¤¬¤¢¤ë¤¿¤á¡¢¤³¤ì¤Ï¥¨¥é¡¼¤È¤Ê¤ê¤Þ¤¹¡£
 
 <programlisting>
@@ -846,8 +841,7 @@ SELECT * FROM test1 ORDER BY a || b COLLATE "fr_FR";
 ¥Ç¡¼¥¿¥Ù¡¼¥¹¥¯¥é¥¹¥¿¤¬½é´ü²½¤µ¤ì¤ë¤È<command>initdb</command>¤Ï¡¢¥ª¥Ú¥ì¡¼¥Æ¥£¥ó¥°¥·¥¹¥Æ¥à¾å¤Ç¸«¤Ä¤±¤¿Á´¤Æ¤Î¥í¥±¡¼¥ë¤Ë´ð¤Å¤¯¾È¹ç¤ò
 ¥·¥¹¥Æ¥à¥«¥¿¥í¥°¤Î<literal>pg_collation</literal>¤Ë½ñ¤­¹þ¤ß¤Þ¤¹¡£
 Îã¤¨¤Ð¡¢¥ª¥Ú¥ì¡¼¥Æ¥£¥ó¥°¥·¥¹¥Æ¥à¤¬<literal>de_DE.utf8</literal>¤ÎÌ¾¾Î¤Î¥í¥±¡¼¥ë¤òÄó¶¡¤·¤¿¾ì¹ç¡¢
-<command>initdb</command>¤Ï¡¢<literal>de_DE.utf8</literal>¤ËÀßÄê¤µ¤ì¤¿<symbol>LC_COLLATE</symbol>¤È<symbol>LC_CTYPE</symbol>¤ÎÎ¾Êý¤ò
-»ý¤Ä<literal>UTF8</literal>¥¨¥ó¥³¡¼¥Ç¥£¥ó¥°¤Î<literal>de_DE.utf8</literal>¤È¤¤¤¦Ì¾¾Î¤Î¾È¹ç¤òºîÀ®¤·¤Þ¤¹¡£
+<command>initdb</command>¤Ï¡¢<literal>de_DE.utf8</literal>¤ËÀßÄê¤µ¤ì¤¿<symbol>LC_COLLATE</symbol>¤È<symbol>LC_CTYPE</symbol>¤ÎÎ¾Êý¤ò»ý¤Ä<literal>UTF8</literal>¥¨¥ó¥³¡¼¥Ç¥£¥ó¥°¤Î<literal>de_DE.utf8</literal>¤È¤¤¤¦Ì¾¾Î¤Î¾È¹ç¤òºîÀ®¤·¤Þ¤¹¡£
 Æ±»þ¤Ë¾È¹ç¤ÎÌ¾¾Î¤«¤é<literal>.utf8</literal>¤òºï½ü¤·¤¿¾È¹ç¤âºîÀ®¤·¤Þ¤¹¡£¤³¤ì¤Ï¼ê´Ö¤ò¾Ê¤­¡¢Ì¾¾Î¤¬¥¨¥ó¥³¡¼¥Ç¥£¥ó¥°¤Ë°ÍÂ¸¤·¤Ê¤¤¤è¤¦¤Ë¤Ê¤ê¤Þ¤¹¡£
 ¤¤¤¦¤Þ¤Ç¤â¤Ê¤¯¡¢¾È¹çÌ¾¾Î¤Î½é´üÃÍ¤Ï¥×¥é¥Ã¥È¥Õ¥©¡¼¥à°ÍÂ¸¤È¤Ê¤ë¤³¤È¤Ëµ¤¤ò¤Ä¤±¤Æ¤¯¤À¤µ¤¤¡£
    </para>
@@ -1786,8 +1780,8 @@ $ <userinput>psql -l</userinput>
 ¤³¤³¤Ç¤Î´Ö°ã¤¤¤Ï¡¢¥½¡¼¥È½èÍý¤Ê¤É¤Î¥í¥±¡¼¥ë¤Ë°ÍÂ¸¤¹¤ëÁàºî¤¬¡¢´ñÌ¯¤ÊÆ°ºî¤¹¤ë¤È¤¤¤Ã¤¿¤³¤È¤Ë¤Ä¤Ê¤¬¤ê¤Þ¤¹¡£
      </para>
 
-<!--
      <para>
+<!--
       <productname>PostgreSQL</productname> will allow superusers to create
       databases with <literal>SQL_ASCII</> encoding even when
       <envar>LC_CTYPE</> is not <literal>C</> or <literal>POSIX</>.  As noted
@@ -1795,9 +1789,7 @@ $ <userinput>psql -l</userinput>
       the database has any particular encoding, and so this choice poses risks
       of locale-dependent misbehavior.  Using this combination of settings is
       deprecated and may someday be forbidden altogether.
-     </para>
 -->
-     <para>
       <productname>PostgreSQL</productname>¤Ï¡¢<envar>LC_CTYPE</>¤¬<literal>C</>¤â¤·¤¯¤Ï<literal>POSIX</>¤Ç¤â¤Ê¤¤¾ì¹ç¤Ë¤â¡¢¥¹¡¼¥Ñ¥æ¡¼¥¶¤¬<literal>SQL_ASCII</>¥¨¥ó¥³¡¼¥Ç¥£¥ó¥°¤Ç¥Ç¡¼¥¿¥Ù¡¼¥¹¤òºîÀ®¤¹¤ë¤³¤È¤òµö²Ä¤·¤Þ¤¹¡£¾åµ­¤Î¤è¤¦¤Ë¡¢<literal>SQL_ASCII</>¤Ï¡¢¥Ç¡¼¥¿¥Ù¡¼¥¹¤ËÊÝÂ¸¤µ¤ì¤Æ¤¤¤ë¥Ç¡¼¥¿¤¬ÆÃÄê¤Î¥¨¥ó¥³¡¼¥Ç¥£¥ó¥°¤ò»ý¤Ä¤³¤È¤ò¶¯À©¤·¤Þ¤»¤ó¡£¤µ¤é¤Ë¡¢¤³¤ÎÁªÂò¤Ï¥í¥±¡¼¥ë¤Ë°ÍÂ¸¤·¤¿¤ª¤«¤·¤ÊÆ°ºî¤ò°ú¤­µ¯¤³¤¹¥ê¥¹¥¯¤ò¹â¤á¤Þ¤¹¡£¤³¤ÎÀßÄê¤ÎÁÈ¤ß¹ç¤ï¤»¤ò»ÈÍÑ¤¹¤ë¤³¤È¤Ï¡¢¤ª´«¤á¤Ç¤­¤Þ¤»¤ó¤·¡¢¤¤¤Ä¤ÎÆü¤«´°Á´¤Ë¶Ø»ß¤µ¤ì¤ë¤«¤â¤·¤ì¤Þ¤»¤ó¡£
      </para>
     </important>
@@ -2141,7 +2133,7 @@ $ <userinput>psql -l</userinput>
           <literal>EUC_TW</literal>¡¢
           <literal>ISO_8859_5</literal>¡¢
           <literal>KOI8R</literal>¡¢
-          <literal>LATIN1</literal> to <literal>LATIN4</literal>¡¢
+          <literal>LATIN1</literal>¤«¤é<literal>LATIN4</literal>¤Þ¤Ç¡¢
           <literal>SJIS</literal>¡¢
           <literal>WIN866</literal>¡¢
           <literal>WIN1250</literal>¡¢
@@ -2252,19 +2244,31 @@ $ <userinput>psql -l</userinput>
         </row>
         <row>
          <entry><literal>WIN1253</literal></entry>
+<!--
          <entry><emphasis>WIN1253</emphasis>,
+          <literal>UTF8</literal>
+-->
+         <entry><emphasis>WIN1253</emphasis>¡¢
           <literal>UTF8</literal>
          </entry>
         </row>
         <row>
          <entry><literal>WIN1254</literal></entry>
+<!--
          <entry><emphasis>WIN1254</emphasis>,
+          <literal>UTF8</literal>
+-->
+         <entry><emphasis>WIN1254</emphasis>¡¢
           <literal>UTF8</literal>
          </entry>
         </row>
         <row>
          <entry><literal>WIN1255</literal></entry>
+<!--
          <entry><emphasis>WIN1255</emphasis>,
+          <literal>UTF8</literal>
+-->
+         <entry><emphasis>WIN1255</emphasis>¡¢
           <literal>UTF8</literal>
          </entry>
         </row>
@@ -2280,7 +2284,11 @@ $ <userinput>psql -l</userinput>
         </row>
         <row>
          <entry><literal>WIN1257</literal></entry>
+<!--
          <entry><emphasis>WIN1257</emphasis>,
+          <literal>UTF8</literal>
+-->
+         <entry><emphasis>WIN1257</emphasis>¡¢
           <literal>UTF8</literal>
          </entry>
         </row>


### PR DESCRIPTION
Fix typos in the files in which there are no changes from 9.3.2 to 9.4.0. (part 1)[retry]