### PR TITLE
Fix the confusing description about CONCURRENTLY option in REFRESH comma...

### DIFF
--- a/doc/src/sgml/ref/refresh_materialized_view.sgml
+++ b/doc/src/sgml/ref/refresh_materialized_view.sgml
@@ -100,7 +100,7 @@ REFRESH MATERIALIZED VIEW [ CONCURRENTLY ] <replaceable class="PARAMETER">name</
       This option may not be used when the materialized view is not already
       populated.
 -->
-このオプションは、マテリアライズドビューにまだデータが入っていないときは使うことができません。
+このオプションは、マテリアライズドビューがスキャン不可状態のときは使うことができません。
      </para>
      <para>
 <!--


### PR DESCRIPTION
> このオプションは、マテリアライズドビューにまだデータが入っていないときは使うことができません。 

REFRESH MATERIALIZED VIEWのCONCURRENTLYオプションについて上記の説明がドキュメントにあります。
しかし、マテビューにデータが入っていない(マテビューが空)のときも問題なくCONCURRENTLYオプションは
指定できるため、上記の説明だと誤解を生んでしまうかもしれません。
CONCURRENTLYオプションを指定できないのは、WITH NO DATAオプション付でマテビューが作成されたときなど、
マテビューがスキャン不可状態にあるときなので、そのように記述を変更するのはいかがでしょうか？