### PR TITLE
Apply changes from PostgreSQL 9.4.0 to 9.4.1.

### DIFF
--- a/doc/src/sgml/libpq.sgml
+++ b/doc/src/sgml/libpq.sgml
@@ -9684,14 +9684,14 @@ Microsoft Windowsにおいては、このファイルが安全なディレクト
    at <filename>~/.pg_service.conf</filename> or the location
    specified by the environment variable <envar>PGSERVICEFILE</envar>,
    or it can be a system-wide file
-   at <filename>`pg_config --sysconfdir`/pg_service.conf</filename> or in the directory
+   at <filename>`pg_config -sysconfdir`/pg_service.conf</filename> or in the directory
    specified by the environment variable
    <envar>PGSYSCONFDIR</envar>.  If service definitions with the same
    name exist in the user and the system file, the user file takes
    precedence.
 -->
 この接続サービスファイルは、ユーザごとに<filename>~/.pg_service.conf</filename>というサービスファイルとすること、または、<envar>PGSERVICEFILE</envar>環境変数で指定される場所にすることができます。
-また、システム全体についてのファイルとして<filename>etc/pg_service.conf</filename>とすること、<envar>PGSYSCONFDIR</envar>環境変数で指定されたディレクトリに置くことができます。
+また、システム全体についてのファイルとして<filename>`pg_config --sysconfdir`/pg_service.conf</filename>とすること、<envar>PGSYSCONFDIR</envar>環境変数で指定されたディレクトリに置くことができます。
 ユーザ用、システム用のファイルで同名のサービス定義が存在する場合、ユーザ用のものが優先されます。
   </para>
 

--- a/doc/src/sgml/libpq.sgml
+++ b/doc/src/sgml/libpq.sgml
@@ -9684,7 +9684,7 @@ Microsoft Windowsにおいては、このファイルが安全なディレクト
    at <filename>~/.pg_service.conf</filename> or the location
    specified by the environment variable <envar>PGSERVICEFILE</envar>,
    or it can be a system-wide file
-   at <filename>`pg_config -sysconfdir`/pg_service.conf</filename> or in the directory
+   at <filename>`pg_config &#045;&#045;sysconfdir`/pg_service.conf</filename> or in the directory
    specified by the environment variable
    <envar>PGSYSCONFDIR</envar>.  If service definitions with the same
    name exist in the user and the system file, the user file takes


### PR DESCRIPTION
To avoid the jade error,

   at <filename>`pg_config --sysconfdir`/pg_service.conf</filename> or in the directory

is changed to:

   at <filename>`pg_config -sysconfdir`/pg_service.conf</filename> or in the directory

(note "--sysconfdir" is changed to "-sysconfdir")