### PR TITLE
translate release-9-4 about 9.4.1

### DIFF
--- a/doc/src/sgml/release-9.4.sgml
+++ b/doc/src/sgml/release-9.4.sgml
@@ -1,6 +1,1084 @@
 <!-- doc/src/sgml/release-9.4.sgml -->
 <!-- See header comment in release.sgml about typical markup -->
 
+ <sect1 id="release-9-4-1">
+<!--
+  <title>Release 9.4.1</title>
+-->
+  <title>リリース 9.4.1</title>
+
+  <note>
+<!--
+  <title>Release Date</title>
+-->
+  <title>リリース日</title>
+  <simpara>2015-02-05</simpara>
+  </note>
+
+  <para>
+<!--
+   This release contains a variety of fixes from 9.4.0.
+   For information about new features in the 9.4 major release, see
+   <xref linkend="release-9-4">.
+-->
+このリリースは9.4.0に対し、各種不具合を修正したものです。
+9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">
+を参照してください。
+  </para>
+
+  <sect2>
+<!--
+   <title>Migration to Version 9.4.1</title>
+-->
+   <title>バージョン 9.4.1への移行</title>
+
+   <para>
+<!--
+    A dump/restore is not required for those running 9.4.X.
+-->
+9.4.Xからの移行ではダンプ/リストアは不要です。
+   </para>
+
+   <para>
+<!--
+    However, if you are a Windows user and are using the <quote>Norwegian
+    (Bokm&aring;l)</> locale, manual action is needed after the upgrade to
+    replace any <quote>Norwegian (Bokm&aring;l)_Norway</>
+    or <quote>norwegian-bokmal</> locale names stored
+    in <productname>PostgreSQL</> system catalogs with the plain-ASCII
+    alias <quote>Norwegian_Norway</>.  For details see
+    <ulink url="http://wiki.postgresql.org/wiki/Changes_To_Norwegian_Locale"></>
+-->
+しかしながら、あなたがWindowsユーザで<quote>Norwegian (Bokm&aring;l)</>ロケールを使っているのなら、アップグレード後に<productname>PostgreSQL</>システムカタログ内に格納された全ての<quote>Norwegian (Bokm&aring;l)_Norway</>または<quote>norwegian-bokmal</>ロケール名をASCIIによる別名<quote>Norwegian_Norway</>に置き換える手動操作が必要です。
+詳細は<ulink url="http://wiki.postgresql.org/wiki/Changes_To_Norwegian_Locale"></>を参照してください。
+   </para>
+  </sect2>
+
+  <sect2>
+<!--
+   <title>Changes</title>
+-->
+   <title>変更点</title>
+
+   <itemizedlist>
+
+<!--
+Author: Bruce Momjian <bruce@momjian.us>
+Branch: master [0150ab567] 2015-02-02 10:00:44 -0500
+Branch: REL9_4_STABLE [1628a0bbf] 2015-02-02 10:00:49 -0500
+Branch: REL9_3_STABLE [b8b580147] 2015-02-02 10:00:50 -0500
+Branch: REL9_2_STABLE [5ae3bf1af] 2015-02-02 10:00:50 -0500
+Branch: REL9_1_STABLE [037529a11] 2015-02-02 10:00:51 -0500
+Branch: REL9_0_STABLE [611e110aa] 2015-02-02 10:00:52 -0500
+Author: Bruce Momjian <bruce@momjian.us>
+Branch: master [9241c84cb] 2015-02-02 10:00:45 -0500
+Branch: REL9_4_STABLE [56d2bee9d] 2015-02-02 10:00:49 -0500
+Branch: REL9_3_STABLE [fe2526990] 2015-02-02 10:00:50 -0500
+Branch: REL9_2_STABLE [e09651e9d] 2015-02-02 10:00:50 -0500
+Branch: REL9_1_STABLE [2ceb63deb] 2015-02-02 10:00:51 -0500
+Branch: REL9_0_STABLE [56b970f2e] 2015-02-02 10:00:52 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Fix buffer overruns in <function>to_char()</>
+      (Bruce Momjian)
+-->
+<function>to_char()</>のバッファオーバーランを修正しました。
+(Bruce Momjian)
+     </para>
+
+     <para>
+<!--
+      When <function>to_char()</> processes a numeric formatting template
+      calling for a large number of digits, <productname>PostgreSQL</>
+      would read past the end of a buffer.  When processing a crafted
+      timestamp formatting template, <productname>PostgreSQL</> would write
+      past the end of a buffer.  Either case could crash the server.
+      We have not ruled out the possibility of attacks that lead to
+      privilege escalation, though they seem unlikely.
+      (CVE-2015-0241)
+-->
+<function>to_char()</>が大きな桁数をとる数値整形テンプレートを処理するとき、<productname>PostgreSQL</>がバッファ終端を超えて読み取ることがありえました。
+また、巧妙に作りこまれたタイムスタンプ整形テンプレートに対して、<productname>PostgreSQL</>がバッファ終端を超えて書き込むことがありえました。
+どちらの場合もサーバをクラッシュさせることができます。
+可能性は低いと見られますが、権限昇格に至る攻撃ができる可能性も排除できません。
+     </para>
+    </listitem>
+
+<!--
+Author: Bruce Momjian <bruce@momjian.us>
+Branch: master [29725b3db] 2015-02-02 10:00:45 -0500
+Branch: REL9_4_STABLE [2ac95c83c] 2015-02-02 10:00:49 -0500
+Branch: REL9_3_STABLE [bc4d5f2e5] 2015-02-02 10:00:50 -0500
+Branch: REL9_2_STABLE [c6c6aa288] 2015-02-02 10:00:51 -0500
+Branch: REL9_1_STABLE [98f2479d8] 2015-02-02 10:00:51 -0500
+Branch: REL9_0_STABLE [9e05c5063] 2015-02-02 10:00:52 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Fix buffer overrun in replacement <function>*printf()</> functions
+      (Tom Lane)
+-->
+<function>*printf()</>置換関数におけるバッファオーバランを修正しました。
+(Tom Lane)
+     </para>
+
+     <para>
+<!--
+      <productname>PostgreSQL</> includes a replacement implementation
+      of <function>printf</> and related functions.  This code will overrun
+      a stack buffer when formatting a floating point number (conversion
+      specifiers <literal>e</>, <literal>E</>, <literal>f</>, <literal>F</>,
+      <literal>g</> or <literal>G</>) with requested precision greater than
+      about 500.  This will crash the server, and we have not ruled out the
+      possibility of attacks that lead to privilege escalation.
+      A database user can trigger such a buffer overrun through
+      the <function>to_char()</> SQL function.  While that is the only
+      affected core <productname>PostgreSQL</> functionality, extension
+      modules that use printf-family functions may be at risk as well.
+-->
+<productname>PostgreSQL</>には<function>printf</>や関連する関数の置き換え実装が含まれています。
+およそ500桁以上の精度で浮動小数点数を（変換指定子<literal>e</>、<literal>E</>、<literal>f</>、<literal>F</>、<literal>g</>、<literal>G</>で）整形するとき、これらのコードでスタックバッファオーバランが起きます。
+これはサーバをクラッシュさせ、また、権限昇格に至る攻撃ができる可能性も排除できません。データベース利用者はSQL関数<function>to_char()</>を通してこのバッファオーバランを起こすことができます。
+<productname>PostgreSQL</>コア機能に影響があるほか、printf族の関数を使用している拡張モジュールにも危険があると考えられます。
+     </para>
+
+     <para>
+<!--
+      This issue primarily affects <productname>PostgreSQL</> on Windows.
+      <productname>PostgreSQL</> uses the system implementation of these
+      functions where adequate, which it is on other modern platforms.
+      (CVE-2015-0242)
+-->
+この問題は主にWindows上の<productname>PostgreSQL</>に影響があります。
+<productname>PostgreSQL</>は、その他の現代的なプラットフォーム上では、これら関数のシステム実装を使います。
+(CVE-2015-0242)
+     </para>
+    </listitem>
+
+<!--
+Author: Noah Misch <noah@leadboat.com>
+Branch: master [1dc755158] 2015-02-02 10:00:45 -0500
+Branch: REL9_4_STABLE [82806cf4e] 2015-02-02 10:00:49 -0500
+Branch: REL9_3_STABLE [6994f0790] 2015-02-02 10:00:50 -0500
+Branch: REL9_2_STABLE [d95ebe0ac] 2015-02-02 10:00:51 -0500
+Branch: REL9_1_STABLE [11f738a8a] 2015-02-02 10:00:51 -0500
+Branch: REL9_0_STABLE [ce6f261cd] 2015-02-02 10:00:52 -0500
+Author: Noah Misch <noah@leadboat.com>
+Branch: master [8b59672d8] 2015-02-02 10:00:45 -0500
+Branch: REL9_4_STABLE [258e294db] 2015-02-02 10:00:49 -0500
+Branch: REL9_3_STABLE [a558ad3a7] 2015-02-02 10:00:50 -0500
+Branch: REL9_2_STABLE [d1972da8c] 2015-02-02 10:00:51 -0500
+Branch: REL9_1_STABLE [8d412e02e] 2015-02-02 10:00:52 -0500
+Branch: REL9_0_STABLE [0a3ee8a5f] 2015-02-02 10:00:52 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Fix buffer overruns in <filename>contrib/pgcrypto</>
+      (Marko Tiikkaja, Noah Misch)
+-->
+<filename>contrib/pgcrypto</>でのバッファオーバランを修正しました。
+(Marko Tiikkaja, Noah Misch)
+     </para>
+
+     <para>
+<!--
+      Errors in memory size tracking within the <filename>pgcrypto</>
+      module permitted stack buffer overruns and improper dependence on the
+      contents of uninitialized memory.  The buffer overrun cases can
+      crash the server, and we have not ruled out the possibility of
+      attacks that lead to privilege escalation.
+      (CVE-2015-0243)
+-->
+<filename>pgcrypto</>モジュールでのメモリサイズ追跡の誤りにより、
+スタックバッファオーバランと未初期化メモリ内容への不適切な依存が起こりえました。
+このバッファオーバランはサーバをクラッシュさせ、また、
+権限昇格に至る攻撃ができる可能性も排除できません。
+(CVE-2015-0243)
+     </para>
+    </listitem>
+
+<!--
+Author: Heikki Linnakangas <heikki.linnakangas@iki.fi>
+Branch: master [2b3a8b20c] 2015-02-02 17:09:53 +0200
+Branch: REL9_4_STABLE [57ec87c6b] 2015-02-02 17:09:46 +0200
+Branch: REL9_3_STABLE [cd19848bd] 2015-02-02 17:09:40 +0200
+Branch: REL9_2_STABLE [289592b23] 2015-02-02 17:09:35 +0200
+Branch: REL9_1_STABLE [af9c5c074] 2015-02-02 17:09:31 +0200
+Branch: REL9_0_STABLE [47ba0fbd7] 2015-02-02 17:09:25 +0200
+-->
+
+    <listitem>
+     <para>
+<!--
+      Fix possible loss of frontend/backend protocol synchronization after
+      an error
+      (Heikki Linnakangas)
+-->
+エラー後にフロントエンド/バックエンドプロトコルの同期が失われる可能性があり、
+修正しました。
+(Heikki Linnakangas)
+     </para>
+
+     <para>
+<!--
+      If any error occurred while the server was in the middle of reading a
+      protocol message from the client, it could lose synchronization and
+      incorrectly try to interpret part of the message's data as a new
+      protocol message.  An attacker able to submit crafted binary data
+      within a command parameter might succeed in injecting his own SQL
+      commands this way.  Statement timeout and query cancellation are the
+      most likely sources of errors triggering this scenario.  Particularly
+      vulnerable are applications that use a timeout and also submit
+      arbitrary user-crafted data as binary query parameters.  Disabling
+      statement timeout will reduce, but not eliminate, the risk of
+      exploit.  Our thanks to Emil Lenngren for reporting this issue.
+      (CVE-2015-0244)
+-->
+サーバがクライアントからのメッセージを読んでいる途中に何らかエラーが起きた場合、同期が失われ、メッセージデータの一部分を新たなプロトコルメッセージと解釈しようと誤って試みられる可能性がありました。
+攻撃者がコマンドパラメータ中に巧妙に作りこんだバイナリデータを送り出すことで、SQLコマンドを注入することができるかもしれません。
+この筋書を引き起こす最もありそうなエラーは、ステートメントタイムアウトと問い合わせキャンセルです。
+とりわけ脆弱なのは、タイムアウトを使っていて、任意のユーザ作成データをバイナリの問い合わせパラメータとして送れるアプリケーションです。
+ステートメントタイムアウトを無効にすることで、脆弱性を悪用される危険性を無くせはしませんが軽減できます。
+本問題を報告してくれた Emil Lenngren 氏に感謝します。(CVE-2015-0244)
+     </para>
+    </listitem>
+
+<!--
+Author: Stephen Frost <sfrost@snowman.net>
+Branch: master [804b6b6db] 2015-01-28 12:31:30 -0500
+Branch: REL9_4_STABLE [3cc74a3d6] 2015-01-28 12:32:06 -0500
+Branch: REL9_3_STABLE [4b9874216] 2015-01-28 12:32:39 -0500
+Branch: REL9_2_STABLE [d49f84b08] 2015-01-28 12:32:56 -0500
+Branch: REL9_1_STABLE [9406884af] 2015-01-28 12:33:15 -0500
+Branch: REL9_0_STABLE [3a2063369] 2015-01-28 12:33:29 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Fix information leak via constraint-violation error messages
+      (Stephen Frost)
+-->
+制約違反エラーメッセージを通した情報漏洩を修正しました。
+(Stephen Frost)
+     </para>
+
+     <para>
+<!--
+      Some server error messages show the values of columns that violate
+      a constraint, such as a unique constraint.  If the user does not have
+      <literal>SELECT</> privilege on all columns of the table, this could
+      mean exposing values that the user should not be able to see.  Adjust
+      the code so that values are displayed only when they came from the SQL
+      command or could be selected by the user.
+      (CVE-2014-8161)
+-->
+いくつかのサーバエラーメッセージはユニーク制約などの制約に違反した列の値を表示します。ユーザがテーブルの全カラムに<literal>SELECT</>権限を持たないとすれば、このことは、見れてはいけない値が露出していることになります。
+該当コードを修正し、値が表示されるのは SQLコマンドに由来する値であるか、ユーザで<literal>SELECT</>可能であるときだけにしました。
+(CVE-2014-8161)
+     </para>
+    </listitem>
+
+<!--
+Author: Noah Misch <noah@leadboat.com>
+Branch: master [f6dc6dd5b] 2014-12-17 22:48:40 -0500
+Branch: REL9_4_STABLE [6b87d423d] 2014-12-17 22:48:45 -0500
+Branch: REL9_3_STABLE [442dc2c35] 2014-12-17 22:48:46 -0500
+Branch: REL9_2_STABLE [0046f651d] 2014-12-17 22:48:47 -0500
+Branch: REL9_1_STABLE [6aa98e957] 2014-12-17 22:48:47 -0500
+Branch: REL9_0_STABLE [6d45ee572] 2014-12-17 22:48:48 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Lock down regression testing's temporary installations on Windows
+      (Noah Misch)
+-->
+Windows上で回帰テストの一時インストールへの接続制限を厳重にしました。
+(Noah Misch)
+     </para>
+
+     <para>
+<!--
+      Use SSPI authentication to allow connections only from the OS user
+      who launched the test suite.  This closes on Windows the same
+      vulnerability previously closed on other platforms, namely that other
+      users might be able to connect to the test postmaster.
+      (CVE-2014-0067)
+-->
+テスト一式を起動したOSユーザからのみ接続を許すようにSSPI認証を使うようにします。
+これは、他のユーザがテスト用postmasterに接続できるという、他のプラットフォームむけで以前封鎖したのと同様の脆弱性を、Windows上でも封鎖するものです。
+(CVE-2014-0067)
+     </para>
+    </listitem>
+
+<!--
+Author: Heikki Linnakangas <heikki.linnakangas@iki.fi>
+Branch: REL9_3_STABLE [8f80dcf3c] 2014-10-24 19:59:49 +0300
+Branch: REL9_2_STABLE [d440c4b55] 2014-10-24 19:59:52 +0300
+Author: Heikki Linnakangas <heikki.linnakangas@iki.fi>
+Branch: REL9_3_STABLE [2a1b34959] 2014-10-24 19:36:28 +0300
+Branch: REL9_2_STABLE [737ae3fc7] 2014-10-24 19:53:27 +0300
+Author: Heikki Linnakangas <heikki.linnakangas@iki.fi>
+Branch: master [aa1d2fc5e] 2015-01-16 13:28:19 +0200
+Branch: REL9_4_STABLE [2049a7d82] 2015-01-16 13:10:06 +0200
+Branch: REL9_3_STABLE [1619442a1] 2015-01-16 13:10:15 +0200
+Branch: REL9_2_STABLE [6bf343c6e] 2015-01-16 13:10:23 +0200
+-->
+
+    <listitem>
+     <para>
+<!--
+      Cope with the Windows locale named <quote>Norwegian (Bokm&aring;l)</>
+      (Heikki Linnakangas)
+-->
+Windowsの<quote>Norwegian (Bokm&aring;l)</>ロケールに対応しました。
+(Heikki Linnakangas)
+     </para>
+
+     <para>
+<!--
+      Non-ASCII locale names are problematic since it's not clear what
+      encoding they should be represented in.  Map the troublesome locale
+      name to a plain-ASCII alias, <quote>Norwegian_Norway</>.
+-->
+非ASCIIのロケール名は、どのエンコーディングで解釈すべきか明らかでないので問題があります。やっかいなロケール名にASCIIの別名<quote>Norwegian_Norway</>を割り当てました。
+     </para>
+
+     <para>
+<!--
+      9.4.0 mapped the troublesome name to <quote>norwegian-bokmal</>,
+      but that turns out not to work on all Windows configurations.
+      <quote>Norwegian_Norway</> is now recommended instead.
+-->
+9.4.0では、これを<quote>norwegian-bokmal</>に割り当てていましたが、全てのWindows構成で動作するわけではないことがわかりました。
+現在は代替に<quote>Norwegian_Norway</>が推奨されます。
+     </para>
+    </listitem>
+
+<!--
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: master [c480cb9d2] 2015-01-15 18:52:58 -0500
+Branch: REL9_4_STABLE [b75d18bd4] 2015-01-15 18:53:05 -0500
+Branch: REL9_3_STABLE [34668c8ec] 2015-01-15 18:52:28 -0500
+Branch: REL9_2_STABLE [0acb32efb] 2015-01-15 18:52:31 -0500
+Branch: REL9_1_STABLE [450530fce] 2015-01-15 18:52:34 -0500
+Branch: REL9_0_STABLE [5308e085b] 2015-01-15 18:52:38 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Fix use-of-already-freed-memory problem in EvalPlanQual processing
+      (Tom Lane)
+-->
+EvalPlanQual処理で解放済みメモリを使用してしまう問題を修正しました。
+(Tom Lane)
+     </para>
+
+     <para>
+<!--
+      In <literal>READ COMMITTED</> mode, queries that lock or update
+      recently-updated rows could crash as a result of this bug.
+-->
+<literal>READ COMMITTED</>モードで最近に更新した行をロックまたは更新すると、
+本障害によりクラッシュする可能性がありました。
+     </para>
+    </listitem>
+
+<!--
+Author: Alvaro Herrera <alvherre@alvh.no-ip.org>
+Branch: master [0e5680f47] 2014-12-26 13:52:27 -0300
+Branch: REL9_4_STABLE [0e3a1f71d] 2014-12-26 13:52:27 -0300
+Branch: REL9_3_STABLE [048912386] 2014-12-26 13:52:27 -0300
+-->
+
+    <listitem>
+     <para>
+<!--
+      Avoid possible deadlock while trying to acquire tuple locks
+      in EvalPlanQual processing (&Aacute;lvaro Herrera, Mark Kirkwood)
+-->
+EvalPlanQual処理でタプルロック取得を試みる際にデッドロックに陥る可能性を回避しました。
+(&Aacute;lvaro Herrera, Mark Kirkwood)
+     </para>
+    </listitem>
+
+<!--
+Author: Alvaro Herrera <alvherre@alvh.no-ip.org>
+Branch: master [d5e3d1e96] 2015-01-04 15:48:29 -0300
+Branch: REL9_4_STABLE [51742063b] 2015-01-04 15:48:29 -0300
+Branch: REL9_3_STABLE [54a8abc2b] 2015-01-04 15:48:29 -0300
+-->
+
+    <listitem>
+     <para>
+<!--
+      Fix failure to wait when a transaction tries to acquire a <literal>FOR
+      NO KEY EXCLUSIVE</> tuple lock, while multiple other transactions
+      currently hold <literal>FOR SHARE</> locks (&Aacute;lvaro Herrera)
+-->
+複数の他トランザクションが同時に<literal>FOR SHARE</>タプルロックを保持している中で、トランザクションが<literal>FOR NO KEY EXCLUSIVE</>タプルロックの取得を試みて待つのに失敗してしまうのを、修正しました。
+(&Aacute;lvaro Herrera)
+     </para>
+    </listitem>
+
+<!--
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: master [a5cd70dcb] 2015-01-15 13:18:12 -0500
+Branch: REL9_4_STABLE [d25192892] 2015-01-15 13:18:16 -0500
+Branch: REL9_3_STABLE [939f0fb67] 2015-01-15 13:18:19 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Improve performance of <command>EXPLAIN</> with large range tables
+      (Tom Lane)
+-->
+幅の大きいテーブルに対する<command>EXPLAIN</>の性能を改善しました。 
+(Tom Lane)
+     </para>
+    </listitem>
+
+<!--
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: master [451d28081] 2015-01-30 14:44:56 -0500
+Branch: REL9_4_STABLE [4cbf390d5] 2015-01-30 14:44:49 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Fix <type>jsonb</> Unicode escape processing, and in consequence
+      disallow <literal>\u0000</> (Tom Lane)
+-->
+<type>jsonb</>ユニコードエスケープ処理について修正し、結果として<literal>\u0000</>は使用不能になりました。
+(Tom Lane)
+     </para>
+
+     <para>
+<!--
+      Previously, the JSON Unicode escape <literal>\u0000</> was accepted
+      and was stored as those six characters; but that is indistinguishable
+      from what is stored for the input <literal>\\u0000</>, resulting in
+      ambiguity.  Moreover, in cases where de-escaped textual output is
+      expected, such as the <literal>-&gt;&gt;</> operator, the sequence was
+      printed as <literal>\u0000</>, which does not meet the expectation
+      that JSON escaping would be removed.  (Consistent behavior would
+      require emitting a zero byte, but <productname>PostgreSQL</> does not
+      support zero bytes embedded in text strings.)  9.4.0 included an
+      ill-advised attempt to improve this situation by adjusting JSON output
+      conversion rules; but of course that could not fix the fundamental
+      ambiguity, and it turned out to break other usages of Unicode escape
+      sequences.  Revert that, and to avoid the core problem,
+      reject <literal>\u0000</> in <type>jsonb</> input.
+-->
+これまでは、JSONユニコードエスケープ<literal>\u0000</>は受け入れられ、6文字データとして格納されました。
+しかし、これは<literal>\\u0000</>の入力で格納されたものと区別がつかず、曖昧になっています。
+さらに、<literal>-&gt;&gt;</>演算子など、エスケープ解除したテキスト出力が期待されるところで、エスケープシーケンスが<literal>\u0000</>と出力され、JSONエスケープが除去されるという予想に合いません
+（バイト00を出力するのが一貫した振る舞いですが<productname>PostgreSQL</>はテキスト文字列中にバイト00を含めることをサポートしていません）。
+9.4.0 ではJSON出力変換規則を修正してこの状況を改善しようという思慮に欠けた試みを入れました。
+しかし、当然ながらこれは根本的な曖昧さを修正するものではなく、ユニコードエスケープシーケンスの他の使用方法の破壊を生じました。
+これをもとに戻し、中心的問題を回避するため<literal>\u0000</>は<type>jsonb</>入力では受け付けないようにしました。
+     </para>
+
+     <para>
+<!--
+      If a <type>jsonb</> column contains a <literal>\u0000</> value stored
+      with 9.4.0, it will henceforth read out as though it
+      were <literal>\\u0000</>, which is the other valid interpretation of
+      the data stored by 9.4.0 for this case.
+-->
+<type>jsonb</>カラムに9.4.0で格納された<literal>\u0000</>値が含まれている場合、これからは、それは、本ケースで9.4.0により格納されたデータの他の有効な解釈である<literal>\\u0000</>であったものとして読み出されます。
+     </para>
+
+     <para>
+<!--
+      The <type>json</> type did not have the storage-ambiguity problem, but
+      it did have the problem of inconsistent de-escaped textual output.
+      Therefore <literal>\u0000</> will now also be rejected
+      in <type>json</> values when conversion to de-escaped form is
+      required.  This change does not break the ability to
+      store <literal>\u0000</> in <type>json</> columns so long as no
+      processing is done on the values.  This is exactly parallel to the
+      cases in which non-ASCII Unicode escapes are allowed when the database
+      encoding is not UTF8.
+-->
+<type>json</>型は曖昧な格納の問題を持ちませんが、一貫性に欠けたエスケープ解除したテキスト出力の問題があります。
+そのため今後は、エスケープ解除した形式への変換が必要なときには、<literal>\u0000</>は<type>json</>値の中でも受け付けられません。
+この変更は、値に何ら処理を加えない限り、<type>json</>カラムに<literal>\u0000</>を格納できなくするものではありません。
+これは、非ASCIIのユニコードエスケープをUTF8以外のデータベースに格納することが許されていることと、ちょうど類似しています。
+     </para>
+    </listitem>
+
+<!--
+Author: Peter Eisentraut <peter_e@gmx.net>
+Branch: master [79af9a1d2] 2015-01-06 23:06:13 -0500
+Branch: REL9_4_STABLE [6bbf75192] 2015-01-17 22:11:20 -0500
+Branch: REL9_3_STABLE [e32cb8d0e] 2015-01-17 22:13:27 -0500
+Branch: REL9_2_STABLE [c8ef5b1ac] 2015-01-17 22:14:21 -0500
+Branch: REL9_1_STABLE [c975fa471] 2015-01-17 22:37:07 -0500
+Branch: REL9_0_STABLE [cebb3f032] 2015-01-17 22:37:32 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Fix namespace handling in <function>xpath()</> (Ali Akbar)
+-->
+<function>xpath()</>の名前空間の扱いを修正しました。
+(Ali Akbar)
+     </para>
+
+     <para>
+<!--
+      Previously, the <type>xml</> value resulting from
+      an <function>xpath()</> call would not have namespace declarations if
+      the namespace declarations were attached to an ancestor element in the
+      input <type>xml</> value, rather than to the specific element being
+      returned.  Propagate the ancestral declaration so that the result is
+      correct when considered in isolation.
+-->
+これまで、入力<type>xml</>値で返される指定要素でなく先祖要素に名前空間宣言が付加されているとき、<function>xpath()</>呼び出しから返される<type>xml</>値は、名前空間宣言を持ちませんでした。
+孤立と見なされるとき結果が正しいなら先祖の宣言を伝搬するようにしました。
+     </para>
+    </listitem>
+
+<!--
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: master [3d660d33a] 2015-01-30 12:30:59 -0500
+Branch: REL9_4_STABLE [b6a164e5c] 2015-01-30 12:31:08 -0500
+Branch: REL9_3_STABLE [527ff8baf] 2015-01-30 12:30:43 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Fix assorted oversights in range-operator selectivity estimation
+      (Emre Hasegeli)
+-->
+範囲演算子の選択率見積についていくつか誤りを修正しました。
+(Emre Hasegeli)
+     </para>
+
+     <para>
+<!--
+      This patch fixes corner-case <quote>unexpected operator NNNN</> planner
+      errors, and improves the selectivity estimates for some other cases.
+-->
+このパッチは稀なプランナエラー <quote>unexpected operator NNNN</>（予想外の演算子NNNN）を修正して、そのほかいくつかの選択率見積を改善します。
+     </para>
+    </listitem>
+
+<!--
+Author: Heikki Linnakangas <heikki.linnakangas@iki.fi>
+Branch: master [930fd6845] 2014-12-30 14:53:11 +0200
+Branch: REL9_4_STABLE [4e241f7cd] 2014-12-30 14:53:03 +0200
+-->
+
+    <listitem>
+     <para>
+<!--
+      Revert unintended reduction in maximum size of a GIN index item
+      (Heikki Linnakangas)
+-->
+意図しないGINインデックス要素の最大サイズの縮小を元に戻しました。
+(Heikki Linnakangas)
+     </para>
+
+     <para>
+<!--
+      9.4.0 could fail with <quote>index row size exceeds maximum</> errors
+      for data that previous versions would accept.
+-->
+9.4.0は以前のバージョンでは受付されていたデータに対して、<quote>index row size exceeds maximum</>（インデックス行のサイズが最大値を超えています）というエラーで失敗することがありました。
+     </para>
+    </listitem>
+
+<!--
+Author: Heikki Linnakangas <heikki.linnakangas@iki.fi>
+Branch: master [68fa75f31] 2015-01-30 17:58:23 +0100
+Branch: REL9_4_STABLE [dc40ca696] 2015-01-30 17:59:17 +0100
+-->
+
+    <listitem>
+     <para>
+<!--
+      Fix query-duration memory leak during repeated GIN index rescans
+      (Heikki Linnakangas)
+-->
+GINインデックス再スキャンを繰り返すときの、問い合わせ中のメモリリークを修正しました。
+(Heikki Linnakangas)
+     </para>
+    </listitem>
+
+<!--
+Author: Heikki Linnakangas <heikki.linnakangas@iki.fi>
+Branch: master [31ed42b9a] 2015-01-29 19:35:55 +0200
+Branch: REL9_4_STABLE [28a37deab] 2015-01-29 19:37:29 +0200
+Branch: REL9_3_STABLE [1c2774f37] 2015-01-29 19:37:27 +0200
+Branch: REL9_2_STABLE [61729e99d] 2015-01-29 19:37:25 +0200
+Branch: REL9_1_STABLE [37e0f13f2] 2015-01-29 19:37:22 +0200
+-->
+
+    <listitem>
+     <para>
+<!--
+      Fix possible crash when using
+      nonzero <varname>gin_fuzzy_search_limit</> (Heikki Linnakangas)
+-->
+ゼロ以外の<varname>gin_fuzzy_search_limit</>を使うときクラッシュする可能性があり、修正しました。
+(Heikki Linnakangas)
+     </para>
+    </listitem>
+
+<!--
+Author: Andres Freund <andres@anarazel.de>
+Branch: master [3fabed070] 2015-01-07 00:19:37 +0100
+Branch: REL9_4_STABLE [7da102154] 2015-01-07 00:24:58 +0100
+Author: Andres Freund <andres@anarazel.de>
+Branch: master [31912d01d] 2015-01-07 00:18:00 +0100
+Branch: REL9_4_STABLE [84911ff51] 2015-01-07 00:24:47 +0100
+-->
+
+    <listitem>
+     <para>
+<!--
+      Assorted fixes for logical decoding (Andres Freund)
+-->
+ロジカルデコーディングについて様々な修正をしました。
+(Andres Freund)
+     </para>
+    </listitem>
+
+<!--
+Author: Heikki Linnakangas <heikki.linnakangas@iki.fi>
+Branch: master [49b04188f] 2015-01-15 20:52:41 +0200
+Branch: REL9_4_STABLE [b337d9657] 2015-01-15 20:52:18 +0200
+-->
+
+    <listitem>
+     <para>
+<!--
+      Fix incorrect replay of WAL parameter change records that report
+      changes in the <varname>wal_log_hints</> setting (Petr Jelinek)
+-->
+<varname>wal_log_hints</>の変更を伝えるパラメータ変更レコードの誤ったWAL再生を修正しました。
+(Petr Jelinek)
+     </para>
+    </listitem>
+
+<!--
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: master [75b48e1ff] 2015-01-19 23:01:33 -0500
+Branch: REL9_4_STABLE [3387cbbcb] 2015-01-19 23:01:36 -0500
+Branch: REL9_3_STABLE [19794e997] 2015-01-19 23:01:39 -0500
+Branch: REL9_2_STABLE [33b723538] 2015-01-19 23:01:41 -0500
+Branch: REL9_1_STABLE [b87c1dcef] 2015-01-19 23:01:44 -0500
+Branch: REL9_0_STABLE [a1a8d0249] 2015-01-19 23:01:46 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Change <quote>pgstat wait timeout</> warning message to be LOG level,
+      and rephrase it to be more understandable (Tom Lane)
+-->
+<quote>pgstat wait timeout</>というメッセージをWARNINGレベルからLOGレベルに変更して、文言もより分かりやすくしました。
+(Tom Lane)
+     </para>
+
+     <para>
+<!--
+      This message was originally thought to be essentially a can't-happen
+      case, but it occurs often enough on our slower buildfarm members to be
+      a nuisance.  Reduce it to LOG level, and expend a bit more effort on
+      the wording: it now reads <quote>using stale statistics instead of
+      current ones because stats collector is not responding</>.
+-->
+本メッセージは元々は基本的には起こらないケースと考えられていました。
+しかし、遅いビルドファームのマシンでたびたび発生して、邪魔になっていました。
+LOGレベルに下げ、また、言い回しに幾分の努力を払い、<quote>using stale statistics instead of current ones because stats collector is not responding</> （統計情報コレクタが応答しないため最新でない鮮度に欠けた統計情報を使います）としました。
+     </para>
+    </listitem>
+
+<!--
+Author: Noah Misch <noah@leadboat.com>
+Branch: master [894459e59] 2015-01-07 22:35:44 -0500
+Branch: REL9_4_STABLE [83fb1ca5c] 2015-01-07 22:36:35 -0500
+Branch: REL9_3_STABLE [1a366d51e] 2015-01-07 22:40:40 -0500
+Branch: REL9_2_STABLE [5ca4e444c] 2015-01-07 22:41:49 -0500
+Branch: REL9_1_STABLE [8dc83104e] 2015-01-07 22:42:42 -0500
+Branch: REL9_0_STABLE [2e4946169] 2015-01-07 22:46:20 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Warn if OS X's <function>setlocale()</> starts an unwanted extra
+      thread inside the postmaster (Noah Misch)
+-->
+OS X の<function>setlocale()</>がpostmaster内で不必要な追加スレッドを開始するときに警告するようにしました。
+(Noah Misch)
+     </para>
+    </listitem>
+
+<!--
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: master [080eabe2e] 2015-01-11 12:35:44 -0500
+Branch: REL9_4_STABLE [733728ff3] 2015-01-11 12:35:47 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Fix <application>libpq</>'s behavior when <filename>/etc/passwd</>
+      isn't readable (Tom Lane)
+-->
+<filename>/etc/passwd</>が読めないときの<application>libpq</>の振る舞いを修正しました。
+(Tom Lane)
+     </para>
+
+     <para>
+<!--
+      While doing <function>PQsetdbLogin()</>, <application>libpq</>
+      attempts to ascertain the user's operating system name, which on most
+      Unix platforms involves reading <filename>/etc/passwd</>.  As of 9.4,
+      failure to do that was treated as a hard error.  Restore the previous
+      behavior, which was to fail only if the application does not provide a
+      database role name to connect as.  This supports operation in chroot
+      environments that lack an <filename>/etc/passwd</> file.
+-->
+<function>PQsetdbLogin()</>を実行するとき、<application>libpq</>はOSユーザ名を確認しようとします。それは、ほとんどのUnixプラットフォームで<filename>/etc/passwd</>の読み取りを伴います。
+9.4時点では読み取り失敗をハードエラーとして扱っていましたが、アプリケーションが接続するデータベースロール名を提示しない場合のみ失敗にするという従来の振る舞いに戻しました。
+このことは<filename>/etc/passwd</>ファイルの無いchroot環境での運用を支援します。
+
+     </para>
+    </listitem>
+
+<!--
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: master [28551797a] 2014-12-31 12:18:50 -0500
+Branch: REL9_4_STABLE [c35249939] 2014-12-31 12:16:57 -0500
+Branch: REL9_3_STABLE [7582cce56] 2014-12-31 12:17:00 -0500
+Branch: REL9_2_STABLE [64c506535] 2014-12-31 12:17:04 -0500
+Branch: REL9_1_STABLE [1773e0702] 2014-12-31 12:17:08 -0500
+Branch: REL9_0_STABLE [2600e4436] 2014-12-31 12:17:12 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Improve consistency of parsing of <application>psql</>'s special
+      variables (Tom Lane)
+-->
+<application>psql</>特別変数の解析について一貫性を改善しました。
+(Tom Lane)
+     </para>
+
+     <para>
+<!--
+      Allow variant spellings of <literal>on</> and <literal>off</> (such
+      as <literal>1</>/<literal>0</>) for <literal>ECHO_HIDDEN</>
+      and <literal>ON_ERROR_ROLLBACK</>.  Report a warning for unrecognized
+      values for <literal>COMP_KEYWORD_CASE</>, <literal>ECHO</>,
+      <literal>ECHO_HIDDEN</>, <literal>HISTCONTROL</>,
+      <literal>ON_ERROR_ROLLBACK</>, and <literal>VERBOSITY</>.  Recognize
+      all values for all these variables case-insensitively; previously
+      there was a mishmash of case-sensitive and case-insensitive behaviors.
+-->
+<literal>ECHO_HIDDEN</>と<literal>ON_ERROR_ROLLBACK</>に対して<literal>on</>と<literal>off</>を異なる書き方（<literal>1</>/<literal>0</>など）で書けるようになります。 
+<literal>COMP_KEYWORD_CASE</>、<literal>ECHO</>、<literal>ECHO_HIDDEN</>、<literal>HISTCONTROL</>、<literal>ON_ERROR_ROLLBACK</>、および、<literal>VERBOSITY</>に対して解釈できない値には警告するようになります。
+全ての特別変数の値について大文字小文字の区別なく受け付けるようになります。
+これまでは大文字小文字の区別があるものと無いものが混在していました。 
+     </para>
+    </listitem>
+
+<!--
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: master [adfc157dd] 2015-01-05 19:27:04 -0500
+Branch: REL9_4_STABLE [c99e41f68] 2015-01-05 19:27:06 -0500
+Branch: REL9_3_STABLE [bb1e2426b] 2015-01-05 19:27:09 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Fix <application>pg_dump</> to handle comments on event triggers
+      without failing (Tom Lane)
+-->
+<application>pg_dump</>をイベントトリガーのコメントを失敗せずに扱うように修正しました。
+(Tom Lane)
+     </para>
+    </listitem>
+
+<!--
+Author: Kevin Grittner <kgrittn@postgresql.org>
+Branch: master [cff1bd2a3] 2015-01-30 08:57:24 -0600
+Branch: REL9_4_STABLE [cb0168528] 2015-01-30 08:57:53 -0600
+Branch: REL9_3_STABLE [cc609c46f] 2015-01-30 09:01:36 -0600
+-->
+
+    <listitem>
+     <para>
+<!--
+      Allow parallel <application>pg_dump</> to
+      use <option>&#045;&#045;serializable-deferrable</> (Kevin Grittner)
+-->
+並列の<application>pg_dump</>で<option>--serializable-deferrable</>を使えるようにしました。
+(Kevin Grittner)
+     </para>
+    </listitem>
+
+<!--
+Author: Andres Freund <andres@anarazel.de>
+Branch: master [2c0a48589] 2015-01-03 20:54:12 +0100
+Branch: REL9_4_STABLE [90e4a2bf9] 2015-01-03 20:54:13 +0100
+Branch: REL9_3_STABLE [f6cea4502] 2015-01-03 20:54:13 +0100
+Branch: REL9_2_STABLE [f961ad479] 2015-01-03 20:54:13 +0100
+Branch: REL9_1_STABLE [2a0bfa4d6] 2015-01-03 20:54:13 +0100
+-->
+
+    <listitem>
+     <para>
+<!--
+      Prevent WAL files created by <literal>pg_basebackup -x/-X</> from
+      being archived again when the standby is promoted (Andres Freund)
+-->
+<literal>pg_basebackup -x/-X</>で作られたWALファイルが、スタンバイが昇格したときに再度アーカイブされることを防止しました。
+(Andres Freund)
+     </para>
+    </listitem>
+
+<!--
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: master [37507962c] 2015-01-29 20:18:33 -0500
+Branch: REL9_4_STABLE [202621d04] 2015-01-29 20:18:37 -0500
+Branch: REL9_3_STABLE [53ae24692] 2015-01-29 20:18:40 -0500
+Branch: REL9_2_STABLE [66cc74680] 2015-01-29 20:18:42 -0500
+Branch: REL9_1_STABLE [290c2daad] 2015-01-29 20:18:44 -0500
+Branch: REL9_0_STABLE [dc9a506e6] 2015-01-29 20:18:46 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Handle unexpected query results, especially NULLs, safely in
+      <filename>contrib/tablefunc</>'s <function>connectby()</>
+      (Michael Paquier)
+-->
+<filename>contrib/tablefunc</>の<function>connectby()</>で、予想外の問い合わせ結果（特にNULL）を安全に扱えるようにしました。
+(Michael Paquier)
+     </para>
+
+     <para>
+<!--
+      <function>connectby()</> previously crashed if it encountered a NULL
+      key value.  It now prints that row but doesn't recurse further.
+-->
+これまで<function>connectby()</>はNULLのキー値に遭遇するとクラッシュしていました。現在はその行を出力しますが更なる再帰はしません。
+     </para>
+    </listitem>
+
+<!--
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: master [a59ee8819] 2015-01-30 13:05:30 -0500
+Branch: REL9_4_STABLE [70da7aeba] 2015-01-30 13:04:59 -0500
+Branch: REL9_3_STABLE [f08cf8ad9] 2015-01-30 13:05:01 -0500
+Branch: REL9_2_STABLE [a97dfdfd9] 2015-01-30 13:05:04 -0500
+Branch: REL9_1_STABLE [8f51c432c] 2015-01-30 13:05:07 -0500
+Branch: REL9_0_STABLE [7c41a32b3] 2015-01-30 13:05:09 -0500
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: REL9_3_STABLE [8824bae87] 2014-11-18 13:28:13 -0500
+Author: Robert Haas <rhaas@postgresql.org>
+Branch: master [0b49642b9] 2015-01-15 09:26:03 -0500
+Branch: REL9_4_STABLE [7b65f194e] 2015-01-15 09:29:41 -0500
+Branch: REL9_3_STABLE [ebbef4f39] 2015-01-15 09:29:55 -0500
+Branch: REL9_2_STABLE [d452bfd1b] 2015-01-15 09:42:21 -0500
+Branch: REL9_1_STABLE [151fb75b0] 2015-01-15 09:42:33 -0500
+Branch: REL9_0_STABLE [0a67c0018] 2015-01-15 09:42:47 -0500
+Author: Heikki Linnakangas <heikki.linnakangas@iki.fi>
+Branch: master [e37d474f9] 2015-01-13 14:33:05 +0200
+Branch: REL9_4_STABLE [4ebb3494e] 2015-01-13 16:01:04 +0200
+Author: Andres Freund <andres@anarazel.de>
+Branch: master [8cadeb792] 2015-01-04 15:44:49 +0100
+Branch: REL9_4_STABLE [7ced1b6c5] 2015-01-04 15:52:52 +0100
+Branch: REL9_3_STABLE [a68b8aec7] 2015-01-04 15:53:08 +0100
+Branch: REL9_2_STABLE [6f9b84a40] 2015-01-04 15:55:00 +0100
+Author: Andres Freund <andres@anarazel.de>
+Branch: master [58bc4747b] 2015-01-04 15:35:46 +0100
+Branch: REL9_4_STABLE [2d8411a0a] 2015-01-04 15:35:46 +0100
+Branch: REL9_3_STABLE [d33f36f16] 2015-01-04 15:35:47 +0100
+Branch: REL9_2_STABLE [029e41afd] 2015-01-04 15:35:47 +0100
+Branch: REL9_1_STABLE [39cdf365a] 2015-01-04 15:35:47 +0100
+Branch: REL9_0_STABLE [17797e18d] 2015-01-04 15:35:48 +0100
+Author: Andres Freund <andres@anarazel.de>
+Branch: master [0398ece4c] 2015-01-04 14:36:21 +0100
+Branch: REL9_4_STABLE [ff7d46b85] 2015-01-04 14:36:21 +0100
+Branch: REL9_3_STABLE [ec14f1601] 2015-01-04 14:36:22 +0100
+Branch: REL9_2_STABLE [f4060db11] 2015-01-04 14:36:22 +0100
+Author: Tatsuo Ishii <ishii@postgresql.org>
+Branch: master [3b5a89c48] 2014-12-30 20:33:01 +0900
+Branch: REL9_4_STABLE [458e8bc65] 2014-12-30 20:27:26 +0900
+Branch: REL9_3_STABLE [ed0e03283] 2014-12-30 20:20:56 +0900
+Branch: REL9_2_STABLE [4db7eaae0] 2014-12-30 19:59:26 +0900
+Branch: REL9_1_STABLE [4c136b0b6] 2014-12-30 19:48:53 +0900
+Branch: REL9_0_STABLE [9b74f3574] 2014-12-30 19:37:55 +0900
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: master [66709133c] 2014-12-16 15:35:33 -0500
+Branch: REL9_4_STABLE [383d224a0] 2014-12-16 15:35:36 -0500
+Branch: REL9_3_STABLE [53960e7eb] 2014-12-16 15:35:40 -0500
+Branch: REL9_2_STABLE [e92c67ddc] 2014-12-16 15:35:43 -0500
+Branch: REL9_1_STABLE [5c784d96a] 2014-12-16 15:35:46 -0500
+Branch: REL9_0_STABLE [a2969bd72] 2014-12-16 15:35:49 -0500
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: master [d38e8d30c] 2014-12-16 13:31:42 -0500
+Branch: REL9_4_STABLE [6c75384ee] 2014-12-16 13:31:57 -0500
+Branch: REL9_3_STABLE [3b750ec15] 2014-12-16 13:32:02 -0500
+Branch: REL9_2_STABLE [5b2c8f04a] 2014-12-16 13:32:15 -0500
+Branch: REL9_1_STABLE [926da211a] 2014-12-16 13:32:25 -0500
+Branch: REL9_0_STABLE [961df1853] 2014-12-16 13:32:38 -0500
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: master [586dd5d6a] 2015-01-24 13:05:42 -0500
+Branch: REL9_4_STABLE [d51d4ff31] 2015-01-24 13:05:45 -0500
+Branch: REL9_3_STABLE [7240f9200] 2015-01-24 13:05:49 -0500
+Branch: REL9_2_STABLE [502e5f9c3] 2015-01-24 13:05:53 -0500
+Branch: REL9_1_STABLE [b00a08859] 2015-01-24 13:05:56 -0500
+Branch: REL9_0_STABLE [3a3ee655c] 2015-01-24 13:05:58 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Numerous cleanups of warnings from Coverity static code analyzer
+      (Andres Freund, Tatsuo Ishii, Marko Kreen, Tom Lane, Michael Paquier)
+-->
+Coverity静的コード解析からの多数の警告を一掃しました。
+(Andres Freund, Tatsuo Ishii, Marko Kreen, Tom Lane, Michael Paquier)
+     </para>
+
+     <para>
+<!--
+      These changes are mostly cosmetic but in some cases fix corner-case
+      bugs, for example a crash rather than a proper error report after an
+      out-of-memory failure.  None are believed to represent security
+      issues.
+-->
+ほとんどは表面的な変更ですが、一部は稀に起こりうるバグの修正で、メモリ不足で失敗した後に適切なエラーを出さずクラッシュする例があります。
+セキュリティ問題は無いと考えられます。
+     </para>
+    </listitem>
+
+<!--
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: master [85a2a8903] 2015-01-14 11:08:13 -0500
+Branch: REL9_4_STABLE [adb355106] 2015-01-14 11:08:17 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Allow <varname>CFLAGS</> from <application>configure</>'s environment
+      to override automatically-supplied <varname>CFLAGS</> (Tom Lane)
+-->
+<application>configure</>の<varname>CFLAGS</>環境変数で自動設定される<varname>CFLAGS</>を上書きできるようにしました。
+(Tom Lane)
+     </para>
+
+     <para>
+<!--
+      Previously, <application>configure</> would add any switches that it
+      chose of its own accord to the end of the
+      user-specified <varname>CFLAGS</> string.  Since most compilers
+      process switches left-to-right, this meant that configure's choices
+      would override the user-specified flags in case of conflicts.  That
+      should work the other way around, so adjust the logic to put the
+      user's string at the end not the beginning.
+-->
+これまでは、<application>configure</>は自発的に選択したスイッチをユーザ指定された<varname>CFLAGS</>文字列の末尾に追加していました。
+ほとんどのコンパイラはスイッチを左から右に処理するため、このことはconfigureによる選択がユーザ指定を（競合する内容の場合には）上書きしていたことを意味します。
+これは反対にしなければいけません。それで、ユーザの文字列を最初でなく最後に置くように修正しました。
+     </para>
+    </listitem>
+
+<!--
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: master [aa719391d] 2015-01-19 23:44:19 -0500
+Branch: REL9_4_STABLE [3de9f22ac] 2015-01-19 23:44:22 -0500
+Branch: REL9_3_STABLE [1681e2f74] 2015-01-19 23:44:24 -0500
+Branch: REL9_2_STABLE [89b6a19e1] 2015-01-19 23:44:28 -0500
+Branch: REL9_1_STABLE [f4f522deb] 2015-01-19 23:44:30 -0500
+Branch: REL9_0_STABLE [338ff75fc] 2015-01-19 23:44:33 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Make <application>pg_regress</> remove any temporary installation it
+      created upon successful exit (Tom Lane)
+-->
+<application>pg_regress</>が成功して終了したら、一時インストールで作成したものを全て削除するようにしました。
+(Tom Lane)
+     </para>
+
+     <para>
+<!--
+      This results in a very substantial reduction in disk space usage
+      during <literal>make check-world</>, since that sequence involves
+      creation of numerous temporary installations.
+-->
+<literal>make check-world</>では多数の一時インストール作成を必要とするため、これは、<literal>make check-world</>実行におけるかなりのディスク使用量削減になります。
+     </para>
+    </listitem>
+
+<!--
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: master [5b89473d8] 2014-12-24 16:35:23 -0500
+Branch: REL9_4_STABLE [068024719] 2014-12-24 16:35:34 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Add CST (China Standard Time) to our lists of timezone abbreviations
+      (Tom Lane)
+-->
+タイムゾーン省略形のリストにCST(China Standard Time)を追加しました。
+(Tom Lane)
+     </para>
+    </listitem>
+
+<!--
+Author: Tom Lane <tgl@sss.pgh.pa.us>
+Branch: master [08bd0c581] 2015-01-30 22:45:44 -0500
+Branch: REL9_4_STABLE [c2b06ab17] 2015-01-30 22:45:58 -0500
+-->
+
+    <listitem>
+     <para>
+<!--
+      Update time zone data files to <application>tzdata</> release 2015a
+      for DST law changes in Chile and Mexico, plus historical changes in
+      Iceland.
+-->
+タイムゾーンデータファイルを、中国とメキシコの夏時間規則の変更がされ、アイスランドの歴史的変更が加わった <application>tzdata</> release 2015a に更新しました。
+     </para>
+    </listitem>
+
+   </itemizedlist>
+
+  </sect2>
+ </sect1>
+
  <sect1 id="release-9-4">
 <!--
   <title>Release 9.4</title>
@@ -183,7 +1261,10 @@ WALデータの<link linkend="logicaldecoding">ロジカルデコーディング
 <literal>u</>と16進数4桁に続くバックスラッシュはエスケープされません。
      </para>
      <para>
-（訳注：9.4.1 で再度振る舞いが変更されています）
+訳注：9.4.1で本修正は取り消されています。
+オリジナルの9.4.1マニュアルでは、
+9.4.0リリースノートから本項目自体が削除されていますが、
+9.4.0 バージョンの情報を残すため、日本語訳では項目を残しました。
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.4.sgml
+++ b/doc/src/sgml/release-9.4.sgml
@@ -280,7 +280,7 @@ Branch: REL9_0_STABLE [3a2063369] 2015-01-28 12:33:29 -0500
       command or could be selected by the user.
       (CVE-2014-8161)
 -->
-いくつかのサーバエラーメッセージはユニーク制約などの制約に違反した列の値を表示します。ユーザがテーブルの全カラムに<literal>SELECT</>権限を持たないとすれば、このことは、見れてはいけない値が露出していることになります。
+いくつかのサーバエラーメッセージは一意制約などの制約に違反した列の値を表示します。ユーザがテーブルの全列に<literal>SELECT</>権限を持たないとすれば、このことは、見ることができてはいけない値が露出していることになります。
 該当コードを修正し、値が表示されるのは SQLコマンドに由来する値であるか、ユーザで<literal>SELECT</>可能であるときだけにしました。
 (CVE-2014-8161)
      </para>
@@ -498,7 +498,7 @@ Branch: REL9_4_STABLE [4cbf390d5] 2015-01-30 14:44:49 -0500
       were <literal>\\u0000</>, which is the other valid interpretation of
       the data stored by 9.4.0 for this case.
 -->
-<type>jsonb</>カラムに9.4.0で格納された<literal>\u0000</>値が含まれている場合、これからは、それは、本ケースで9.4.0により格納されたデータの他の有効な解釈である<literal>\\u0000</>であったものとして読み出されます。
+<type>jsonb</>列に9.4.0で格納された<literal>\u0000</>値が含まれている場合、これからは、それは、本ケースで9.4.0により格納されたデータの他の有効な解釈である<literal>\\u0000</>であったものとして読み出されます。
      </para>
 
      <para>
@@ -515,7 +515,7 @@ Branch: REL9_4_STABLE [4cbf390d5] 2015-01-30 14:44:49 -0500
 -->
 <type>json</>型は曖昧な格納の問題を持ちませんが、一貫性に欠けたエスケープ解除したテキスト出力の問題があります。
 そのため今後は、エスケープ解除した形式への変換が必要なときには、<literal>\u0000</>は<type>json</>値の中でも受け付けられません。
-この変更は、値に何ら処理を加えない限り、<type>json</>カラムに<literal>\u0000</>を格納できなくするものではありません。
+この変更は、値に何ら処理を加えない限り、<type>json</>列に<literal>\u0000</>を格納できなくするものではありません。
 これは、非ASCIIのユニコードエスケープをUTF8以外のデータベースに格納することが許されていることと、ちょうど類似しています。
      </para>
     </listitem>
@@ -1440,7 +1440,7 @@ ISO 8601に従った書式にします。
       to functions that pay attention to column names within composite
       arguments (Tom Lane)
 -->
-行全体の変数で期待されるカラム名が、複合型引数を取りカラム名に注意をはらう関数に
+行全体の変数で期待される列名が、複合型引数を取り列名に注意をはらう関数に
 伝わることを、保証するようになりました。
 (Tom Lane)
      </para>
@@ -1454,9 +1454,9 @@ ISO 8601に従った書式にします。
       of any aliases assigned in the query.
 -->
 <literal>row_to_json(tab.*)</>などのデータ構成で、これからは、常に呼び出し時点の
-テーブル<literal>tab</>のカラムエイリアスに一致するカラム名を出力します。
-以前のリリースでは、カラム名がクエリに割り当てられた別名に関係なく
-テーブルの実際のカラム名になっていました。
+テーブル<literal>tab</>の列別名に一致する列名を出力します。
+以前のリリースでは、列名がクエリに割り当てられた別名に関係なく
+テーブルの実際の列名になっていました。
      </para>
     </listitem>
 
@@ -1542,9 +1542,9 @@ ISO 8601に従った書式にします。
       in the <literal>RETURNING</> clause (if any).
 -->
 <literal>AFTER ROW</>トリガがある場合、トリガが読むかもしれないので、
-更新動作でテーブルのすべてのカラムを返されなければいけません。
+更新動作でテーブルのすべての列を返されなければいけません。
 これまでは、外部テーブルはトリガを持つことがなかったので、外部データラッパが
-<literal>RETURNING</>句で言及されていないカラムの取得を省略して最適化しているかもしれません。
+<literal>RETURNING</>句で言及されていない列の取得を省略して最適化しているかもしれません。
      </para>
     </listitem>
 
@@ -1557,7 +1557,7 @@ ISO 8601に従った書式にします。
       <structfield>tableoid</> (Amit Kapila)
 -->
 <link linkend="ddl-constraints-check-constraints"><literal>CHECK</></link>制約が
-<structfield>tableoid</>以外のシステムカラムを参照できないようにしました。
+<structfield>tableoid</>以外のシステム列を参照できないようにしました。
 (Amit Kapila)
      </para>
 
@@ -1624,7 +1624,7 @@ Windowsで、機械的にユーザが書いたコマンド文字列内のクオ�
       linkend="catalog-pg-class"><structfield>pg_class.reltoastidxid</></link>
       (Michael Paquier)
 -->
-システムカタログのカラム
+システムカタログの列
 <link linkend="catalog-pg-class"><structfield>pg_class.reltoastidxid</></link>
 が取り除かれました。
 (Michael Paquier)
@@ -1638,7 +1638,7 @@ Windowsで、機械的にユーザが書いたコマンド文字列内のクオ�
       linkend="catalog-pg-rewrite"><structfield>pg_rewrite.ev_attr</></link>
       (Kevin Grittner)
 -->
-システムカタログのカラム
+システムカタログの列
 <link linkend="catalog-pg-rewrite"><structfield>pg_rewrite.ev_attr</></link>
 が取り除かれました。
 (Kevin Grittner)
@@ -1649,7 +1649,7 @@ Windowsで、機械的にユーザが書いたコマンド文字列内のクオ�
       Per-column rules have not been supported since
       <application>PostgreSQL</> 7.3.
 -->
-カラム単位のルールは<application>PostgreSQL</> 7.3以来サポートされていませんでした。
+列単位のルールは<application>PostgreSQL</> 7.3以来サポートされていませんでした。
      </para>
     </listitem>
 
@@ -1737,8 +1737,7 @@ libpq の
       operations.  <application>intarray</>'s behavior in this area now
       matches the built-in array operators.
 -->
-これまでは、空配列を長さゼロの１次元配列として返していました。それらのテキスト表現は
-ゼロ次元配列としたときと同じ（<literal>{}</>）ですが、配列操作での動作が異なります。
+これまでは、空配列を長さゼロの１次元配列として返していました。それらのテキスト表現はゼロ次元配列としたときと同じ（<literal>{}</>）ですが、配列操作での動作が異なります。
 この部分で<application>intarray</>の振る舞いが組み込みの配列演算子と同じになります。
      </para>
     </listitem>
@@ -2078,7 +2077,7 @@ B-treeインデックスのページ削除における稀な競合状態を修�
 -->
 デフォルトがシーケンスの
 <link linkend="functions-sequence-table"><function>nextval()</></link>
-であるカラムに対する<xref linkend="SQL-COPY">の速度を改善しました。
+である列に対する<xref linkend="SQL-COPY">の速度を改善しました。
 (Simon Riggs)
        </para>
       </listitem>
@@ -2207,7 +2206,7 @@ PL/pgSQL手続き言語の<xref linkend="SQL-DO">ブロックによるメモリ�
         <xref linkend="pg-stat-all-tables-view"> and related system views
         (Mark Kirkwood)
 -->
-<structfield>n_mod_since_analyze</>カラムを
+<structfield>n_mod_since_analyze</>列を
 <xref linkend="pg-stat-all-tables-view">と関連するシステムビューに追加しました。
 (Mark Kirkwood)
        </para>
@@ -2218,7 +2217,7 @@ PL/pgSQL手続き言語の<xref linkend="SQL-DO">ブロックによるメモリ�
         tuples since the table's last <xref linkend="sql-analyze">.  This
         estimate drives decisions about when to auto-analyze.
 -->
-本カラムは、最後に<xref linkend="sql-analyze">が行われて以降のタプル変更回数の推計値を表示します。この推計値が自動ANALYZEの駆動を決めるために使われます。
+この列は最後に<xref linkend="sql-analyze">が行われて以降のタプル変更回数の推計値を表示します。この推計値が自動ANALYZEの駆動を決めるために使われます。
        </para>
       </listitem>
 
@@ -2230,9 +2229,9 @@ PL/pgSQL手続き言語の<xref linkend="SQL-DO">ブロックによるメモリ�
         and a <structfield>backend_xmin</> column to
         <xref linkend="pg-stat-replication-view"> (Christian Kruse)
 -->
-<structfield>backend_xid</>カラム、<structfield>backend_xmin</>カラムを、
+<structfield>backend_xid</>列、<structfield>backend_xmin</>列を、
 システムビュー<xref linkend="pg-stat-activity-view">に追加し、
-<structfield>backend_xmin</>カラムが<xref linkend="pg-stat-replication-view">
+<structfield>backend_xmin</>列が<xref linkend="pg-stat-replication-view">
 に追加しました。
 (Christian Kruse)
        </para>
@@ -2878,7 +2877,7 @@ Windowsにて<literal>SQL_ASCII</>エンコーディングのデータベース�
         This was added so that views that select from a table with zero
         columns can be dumped and restored correctly.
 -->
-これにより、ゼロ個のカラムを選択するビューを正しくダンプ、リストアできるようになります。
+これにより、ゼロ個の列を選択するビューを正しくダンプ、リストアできるようになります。
        </para>
       </listitem>
 
@@ -2994,7 +2993,7 @@ Windowsにて<literal>SQL_ASCII</>エンコーディングのデータベース�
          Make <command>EXPLAIN</> show the grouping columns in Agg and
          Group nodes (Tom Lane)
 -->
-<command>EXPLAIN</>がAgg、Groupプラン要素にて集約しているカラムを出力するようにしました。
+<command>EXPLAIN</>がAgg、Groupプラン要素にて集約している列を出力するようにしました。
 (Tom Lane)
         </para>
        </listitem>
@@ -3051,7 +3050,7 @@ Windowsにて<literal>SQL_ASCII</>エンコーディングのデータベース�
         updated</link> even if they contain some non-updatable columns
         (Dean Rasheed)
 -->
-たとえ更新できないカラムが含まれていても、ビューが<link linkend="SQL-CREATEVIEW-updatable-views">自動更新可能</link>になります。
+たとえ更新できない列が含まれていても、ビューが<link linkend="SQL-CREATEVIEW-updatable-views">自動更新可能</link>になります。
 (Dean Rasheed)
        </para>
 
@@ -3063,8 +3062,8 @@ Windowsにて<literal>SQL_ASCII</>エンコーディングのデータベース�
         <command>DELETE</>s are supported, provided that they do not
         attempt to assign new values to any of the non-updatable columns.
 -->
-これまでは、式や定数、関数呼び出しなどの更新不能な出力カラムがあると、
-ビューは自動更新可能にはなりませんでした。これからは、更新不能なカラムに新しい値を割り当てしようとしないなら<command>INSERT</>、<command>UPDATE</>、<command>DELETE</>がサポートされます。
+これまでは、式や定数、関数呼び出しなどの更新不能な出力列があると、
+ビューは自動更新可能にはなりませんでした。これからは、更新不能な列に新しい値を割り当てしようとしないなら<command>INSERT</>、<command>UPDATE</>、<command>DELETE</>がサポートされます。
 
        </para>
       </listitem>
@@ -3398,7 +3397,7 @@ UTCオフセットが変化するタイムゾーン略称をサポートしま�
          rather than being stored as text as in the original <type>json</>
          data type.
 -->
-この新しいデータ型は、JSON文書により高速にアクセスでき、また、JSONカラムにより高速で有用なインデックス適用ができます。
+この新しいデータ型は、JSON文書により高速にアクセスでき、また、JSON列により高速で有用なインデックス適用ができます。
 従来の<type>json</>型がJSON文書全体をテキストとして格納するのに対し、
 <type>jsonb</>文書のスカラ値は適当なSQLデータ型として格納され、JSON文書の構造は事前解析されます。
         </para>
@@ -3669,7 +3668,7 @@ UTCオフセットが変化するタイムゾーン略称をサポートしま�
         linkend="infoschema-parameters"><structname>information_schema.parameters</></link>
         view (Peter Eisentraut)
 -->
-<link linkend="infoschema-parameters"><structname>information_schema.parameters</></link>ビューに<structfield>parameter_default</>カラムを追加しました。
+<link linkend="infoschema-parameters"><structname>information_schema.parameters</></link>ビューに<structfield>parameter_default</>列を追加しました。
 (Peter Eisentraut)
        </para>
       </listitem>
@@ -4132,7 +4131,7 @@ Windowsで相対パスで指定された<option>-D</>オプションを<xref lin
          <literal>OID</> line only if an <literal>oid</literal> column
          exists in the table (Bruce Momjian)
 -->
-<command>\d+</>でテーブルに<literal>oid</literal>カラムがある場合だけ
+<command>\d+</>でテーブルに<literal>oid</literal>列がある場合だけ
 <literal>OID</>行を表示するようにしました。
 (Bruce Momjian)
         </para>
@@ -4142,7 +4141,7 @@ Windowsで相対パスで指定された<option>-D</>オプションを<xref lin
          Previously, the presence or absence of an <literal>oid</literal>
          column was always reported.
 -->
-これまでは<literal>oid</literal>カラムの有無にかかわらず常に報告されていました。
+これまでは<literal>oid</literal>列の有無にかかわらず常に報告されていました。
         </para>
        </listitem>
 


### PR DESCRIPTION
9.4.1 のリリースノートを訳しました。
以下の点については意見を貰いたいです。
・エラーメッセージの英文を残しました。これは先例から離れていますがどうでしょうか？
・9.4.0 から revert された修正点について 9.4.0 のリリースノートから項目が消えていますが、訳注を付けたうえで残しました。
