### PR TITLE
Change to hide <script> contents.

### DIFF
--- a/doc/src/sgml/stylesheet.css
+++ b/doc/src/sgml/stylesheet.css
@@ -15,6 +15,10 @@ BODY > * {
 	text-align: left;
 }
 
+script {
+        display: none;
+}
+
 A:link		{ color:#0085B0; }
 A:visited	{ color:#004E66; }
 A:active	{ color:#0085B0; }


### PR DESCRIPTION
サイト上で body 直下に埋め込んだ Google Analytics の script が表示されていまうので、script タグはすべて非表示とします。