### PR TITLE
fix typo (remove extra '(')

### DIFF
--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -6792,7 +6792,7 @@ OID別名型のさらなる属性は依存性の作成です。
     representation of <type>XLogRecPtr</type> and an internal system type of
     <productname>PostgreSQL</productname>.
 -->
-<type>pg_lsn</type>型はXLOGの位置を示すLSN((Log Sequence Number)データを格納するために使用します。
+<type>pg_lsn</type>型はXLOGの位置を示すLSN(Log Sequence Number)データを格納するために使用します。
 この型は<type>XLogRecPtr</type>を示す<productname>PostgreSQL</productname>の内部的なシステムの型です。
    </para>
 


### PR DESCRIPTION
余分な「（」を削除