### PR TITLE
remove extra '.'

### DIFF
--- a/doc/src/sgml/installation.sgml
+++ b/doc/src/sgml/installation.sgml
@@ -2261,7 +2261,7 @@ PostgreSQL, contrib and HTML documentation successfully made. Ready to install.
 <!--
     <title>Client-only installation:</title>
 -->
-<title>クライアント側のみのインストール：</title>
+<title>クライアント側のみのインストール:</title>
     <para>
 <!--
      If you want to install only the client applications and
@@ -2288,7 +2288,7 @@ PostgreSQL, contrib and HTML documentation successfully made. Ready to install.
 <!--
    <title>Uninstallation:</title>
 -->
-   <title>アンインストール：</title>
+   <title>アンインストール:</title>
    <para>
 <!--
     To undo the installation use the command <command>make
@@ -2302,7 +2302,7 @@ PostgreSQL, contrib and HTML documentation successfully made. Ready to install.
 <!--
    <title>Cleaning:</title>
 -->
-<title>クリーニング：</title>
+<title>クリーニング:</title>
 
    <para>
 <!--


### PR DESCRIPTION
余分な「.」が付かないように:を半角に変更。

詳しくは[jpug-doc: 4543] 謎の「.」から始まるやり取りを見てください。
