### PR TITLE
pg_start_backupの第2引数の説明を修正

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -22231,8 +22231,8 @@ postgres=# select pg_start_backup('label_goes_here');
     spike in I/O operations, slowing any concurrently executing queries.
 -->
 オプションの<type>boolean</type>型パラメータがあります。
-<literal>真</>であれば、すべからく早く<function>pg_start_backup</>の実行を指定します。
-いかなる現時点で実行中の問い合わせも速度を落とし、I/O操作で急増の原因の即時チェックポイントを強要します。
+<literal>真</>であれば、できる限り高速に<function>pg_start_backup</>を実行します。
+これは、即時のチェックポイントを強制するため、I/O 操作の急激な増加を引き起こし、実行中の問い合わせ全てを遅延させることがあります。
    </para>
 
    <para>


### PR DESCRIPTION
日本語が原文直訳っぽくなって分かりづらかったので、意訳しつつ語順を修正しました。