### PR TITLE
fix typos

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -4331,7 +4331,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
        -->
        プライマリー、または上位サーバに対してレプリケーションの進捗情報を送信するため、スタンバイ上のWAL受信プロセスの最小頻度を指定します。ここで、<link linkend="monitoring-stats-views-table">
        <literal>pg_stat_replication</></link>ビューにより確認することが可能です。
-       スタンドバイサーバは既に書き込まれた最終のログ位置を報告し、その最終位置がディスクにフラッシュされ、その最終位置が適用されます。
+       スタンバイサーバは既に書き込まれた最終のログ位置を報告し、その最終位置がディスクにフラッシュされ、その最終位置が適用されます。
        このパラメータの値がそれぞれの報告間における秒単位の最大の時間間隔です。
        書き込み、またはフラッシュ位置が変更される毎に更新が行われます。
        あるいは、少なくともこのパラメータで設定された頻度で行われます。
@@ -5192,7 +5192,7 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
         value changes the set of join paths explored, and may result in a
         better or worse best path being found.
        -->
-       結合順序検索空間にわたって、GEQOが無作為のパスを選択するために使用される乱数発生器の初期値を制御済ます。
+       結合順序検索空間にわたって、GEQOが無作為のパスを選択するために使用される乱数発生器の初期値を制御します。
        値は0（デフォルト）から1までの範囲です。
        値を変動させると探査される結合パスの集合を変化させ、それが見つかっているより良いか、より悪い最善のパスとなる可能性があります。
        </para>
@@ -6905,7 +6905,7 @@ FROM pg_stat_activity;
 <literal>ddl</>は、<literal>CREATE</>、<literal>ALTER</>、および<literal>DROP</>文といった、データ定義文を全てログに記録します。
 <literal>mod</>は、全ての<literal>ddl</>文に加え、<literal>INSERT</>、<literal>UPDATE</>、<literal>DELETE</>、<literal>TRUNCATE</>、および<literal>COPY FROM</>といった、データ変更文をログに記録します。
 <literal>PREPARE</>と<literal>EXPLAIN ANALYZE</>コマンドも、そこに含まれるコマンドが適切な種類であればログが録られます。
-拡張問い合わせプロトコルを使用するクライアントでは、Executeメッセージを受け取った時にBindパラメータの値が（すべての単一引用符が二重にされた常態で）含まれていた場合、ログに記録されます。
+拡張問い合わせプロトコルを使用するクライアントでは、Executeメッセージを受け取った時にBindパラメータの値が（すべての単一引用符が二重にされた状態で）含まれていた場合、ログに記録されます。
        </para>
 
        <para>
@@ -7042,7 +7042,7 @@ FROM pg_stat_activity;
         and application name.
         Here is a sample table definition for storing CSV-format log output:
        -->
-       <varname>log_destination</>リストに<literal>csvlog</>を含めることは、ログファイルをデータベーステーブルにインポートする簡便な方法を提供します。このオプションはカンマ区切り値書式（(<acronym>CSV</>）で以下の列を含むログ行を生成します。
+       <varname>log_destination</>リストに<literal>csvlog</>を含めることは、ログファイルをデータベーステーブルにインポートする簡便な方法を提供します。このオプションはカンマ区切り値書式（<acronym>CSV</>）で以下の列を含むログ行を生成します。
 
         ミリ秒単位のtimestamp、
         ユーザ名、
@@ -10933,7 +10933,7 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
         as for <symbol>trace_locks</symbol>, only for advisory locks.
        -->
        有効な場合、ユーザロックの使用状況に関する情報を出力します。
-       出力は<symbol>trace_locks</symbol>と同じですが、助言ロックに関するもののみを出力します。
+       出力は<symbol>trace_locks</symbol>と同じですが、勧告的ロックに関するもののみを出力します。
        </para>
        <para>
        <!--


### PR DESCRIPTION
スタンドバイサーバ -> スタンバイサーバ
助言ロック -> 勧告的ロック
と多数派に合わせています。

それ以外は明らかに日本語としておかしいかと。