### PR TITLE
fix typos in backup.sgml

### DIFF
--- a/doc/src/sgml/backup.sgml
+++ b/doc/src/sgml/backup.sgml
@@ -1661,7 +1661,7 @@ restore_command = 'cp /mnt/server/archivedir/%f %p'
     up.
 -->
 このコマンドが失敗した時に非ゼロの終了ステータスを返すことが重要です。
-このコマンドは、アーカイブに存在しないファイル要求する<emphasis>かもしれません</>が、その場合でも非ゼロを返さなければなりません。
+このコマンドは、アーカイブに存在しないファイルを要求する<emphasis>かもしれません</>が、その場合でも非ゼロを返さなければなりません。
 これはエラー状態ではありません。例外は、コマンドがシグナルによって中断された場合(データベースの停止に使用される<systemitem>SIGTERM</systemitem>以外)か、シェルによるエラー(コマンドが見つかりませんなど)でリカバリが中断され、サーバが起動しない場合です。
    </para>
    <para>
@@ -1672,9 +1672,9 @@ restore_command = 'cp /mnt/server/archivedir/%f %p'
     the base name of the <literal>%p</> path will be different from
     <literal>%f</>; do not expect them to be interchangeable.
 -->
-必要なファイルはWALセグメントファイルだけではありません。
-<literal>.backup</>、または<literal>.history</>が付いているファイルが要求されることを想定しなければなりません。
-<literal>.backup</>、または<literal>.history</>が付いているファイルに対しての要求を期待することもあるでしょう。同時に、<literal>%p</>パスのファイル名部分は<literal>%f</>と異なることに注意してください。これらが相互に置き換え可能であるとは考えないでください。
+要求されるファイルはWALセグメントファイルだけではありません。
+<literal>.backup</>、または<literal>.history</>が付いているファイルが要求されることも想定しなければなりません。
+同時に、<literal>%p</>パスのファイル名部分は<literal>%f</>と異なることに注意してください。これらが相互に置き換え可能であるとは考えないでください。
    </para>
 
    <para>


### PR DESCRIPTION
<literal>.backup</>、または<literal>.history</>が付いているファイル云々は重複を削除しました。
あとその周辺でファイルが「要求される」という表現に揃えています。