### PR TITLE
fix typos in libpq.sgml and wal.sgml

### DIFF
--- a/doc/src/sgml/libpq.sgml
+++ b/doc/src/sgml/libpq.sgml
@@ -750,7 +750,7 @@ PQconninfoOption *PQconninfo(PGconn *conn);
        apply to the result of <function>PQconninfo</function>.
 -->
 接続オプション配列を返します。これは全ての可能性のある<function>PQconnectdb</function>オプションとサーバに接続するのに使用される値を確定するために使用することができます。
-返り値は<structname>PQconninfoOption</structname>構造体の配列を指し示めます。それはnull <structfield>keyword</> ポインタを持つ項目で終結します。<function>PQconndefaults</function>に対する上記の全ての注釈はまた<function>PQconninfo</function>の結果に適用されます。
+返り値は<structname>PQconninfoOption</structname>構造体の配列を指し示します。それはnull <structfield>keyword</> ポインタを持つ項目で終結します。<function>PQconndefaults</function>に対する上記の全ての注釈はまた<function>PQconninfo</function>の結果に適用されます。
       </para>
 
      </listitem>

--- a/doc/src/sgml/wal.sgml
+++ b/doc/src/sgml/wal.sgml
@@ -1102,7 +1102,7 @@ WALログが高遅延の回転ディスクに格納されているとき、<varn
    <acronym>WAL</acronym> log files do not make such false reports.
    (See <xref linkend="wal-reliability">.)
 -->
-<acronym>WAL</acronym>の目的である、確実にデータベースレコードが変更される前にログが書き出されることは、実際にはキャッシュにしかデータがなく、ディスクには格納されていない時に<indexterm><primary>ディスクドライブ</></>が格納に成功したとカーネルに虚偽の報告を行うことによって失われる可能性があります。
+<acronym>WAL</acronym>の目的である、確実にデータベースレコードが変更される前にログが書き出されることは、実際にはキャッシュにしかデータがなく、ディスクには格納されていない時にディスクドライブ<indexterm><primary>ディスクドライブ</></>が格納に成功したとカーネルに虚偽の報告を行うことによって失われる可能性があります。
 そのような状況では、電源が落ちた際に、復旧不可能なデータの破壊が起こることがあります。
 管理者は、<productname>PostgreSQL</productname>の<acronym>WAL</acronym>ログを保持しているディスク装置がそのような嘘の報告をしないように保証するべきです。(<xref linkend="wal-reliability">を参照して下さい。)
   </para>


### PR DESCRIPTION
日本語として明らかにおかしいところを直しました。
（と思ったのですが、片方はタグを誤解したものみたいです）