### PR TITLE
集約式の注記の翻訳を修正

### DIFF
--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -2607,7 +2607,7 @@ SELECT string_agg(a ORDER BY a, ',') FROM table;  -- incorrect
      The ability to specify both <literal>DISTINCT</> and <literal>ORDER BY</>
      in an aggregate function is a <productname>PostgreSQL</> extension.
 -->
-集計関数における<literal>DISTINCT</>と<literal>ORDER BY</>の指定機能はPostgreSQL独自の拡張です。
+集計関数において<literal>DISTINCT</>と<literal>ORDER BY</>の両方を指定できる機能はPostgreSQL独自の拡張です。
     </para>
    </note>
 


### PR DESCRIPTION
"both" の訳が抜けていたので修正しました。
SQL:2008 (preliminary) ドラフト版を見ましたが、aggregate function の set quantifier として DISTINCT は指定可能でした。