### PR TITLE
autovacuum_{vacuum,analyze}_thresholdのテーブル個別設定方法の記述修正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -7656,7 +7656,7 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
        いかなる1つのテーブル内に<command>VACUUM</>をトリガする必要のある、更新もしくは削除されたタプルの最小数を指定します。
 デフォルトは50タプルです。
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
-この設定は<structname>pg_autovacuum</>内の項目により、それぞれのテーブルに対して上書きすることができます。
+この設定は格納パラメータの変更により、それぞれのテーブルに対して上書きすることができます。
 
        </para>
       </listitem>
@@ -7685,7 +7685,7 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
        いかなる1つのテーブル内に<command>ANALYZE</>をトリガする必要のある、挿入、更新、もしくは削除されたタプルの最小数を指定します。
 デフォルトは50タプルです。
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
-この設定はにより、それぞれのテーブルに対して上書きすることができます。     
+この設定は格納パラメータの変更により、それぞれのテーブルに対して上書きすることができます。     
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
autovacuum_vacuum_thresholdの方は、pg_autovacuumについて言及していますが、8.3以前のバージョンについての説明のまま？のようです。