### PR TITLE
typoの修正

### DIFF
--- a/doc/src/sgml/release-9.0.sgml
+++ b/doc/src/sgml/release-9.0.sgml
@@ -1979,7 +1979,7 @@ GiST索引のタプルがページと一致しない場合、無限に再帰に�
       and/or <varname>cost_delay</> settings from autovacuum's global cost
       balancing rules (&Aacute;lvaro Herrera)
 -->
-自動バキュームのテーブルごとの<varname>cost_limit</>や/または<varname>cost_delay</>をグローバルコストのバランスルールからから除外します。
+自動バキュームのテーブルごとの<varname>cost_limit</>や/または<varname>cost_delay</>をグローバルコストのバランスルールから除外します。
 (&Aacute;lvaro Herrera)
      </para>
 

--- a/doc/src/sgml/release-9.1.sgml
+++ b/doc/src/sgml/release-9.1.sgml
@@ -2177,7 +2177,7 @@ GiST索引のタプルがページと一致しない場合、無限に再帰に�
       and/or <varname>cost_delay</> settings from autovacuum's global cost
       balancing rules (&Aacute;lvaro Herrera)
 -->
-自動バキュームのテーブルごとの<varname>cost_limit</>や/または<varname>cost_delay</>をグローバルコストのバランスルールからから除外します。
+自動バキュームのテーブルごとの<varname>cost_limit</>や/または<varname>cost_delay</>をグローバルコストのバランスルールから除外します。
 (&Aacute;lvaro Herrera)
      </para>
 

--- a/doc/src/sgml/release-9.2.sgml
+++ b/doc/src/sgml/release-9.2.sgml
@@ -2438,7 +2438,7 @@ GiST索引のタプルがページと一致しない場合、無限に再帰に�
       and/or <varname>cost_delay</> settings from autovacuum's global cost
       balancing rules (&Aacute;lvaro Herrera)
 -->
-自動バキュームのテーブルごとの<varname>cost_limit</>や/または<varname>cost_delay</>をグローバルコストのバランスルールからから除外します。
+自動バキュームのテーブルごとの<varname>cost_limit</>や/または<varname>cost_delay</>をグローバルコストのバランスルールから除外します。
 (&Aacute;lvaro Herrera)
      </para>
 

--- a/doc/src/sgml/release-9.3.sgml
+++ b/doc/src/sgml/release-9.3.sgml
@@ -3050,7 +3050,7 @@ Branch: REL9_0_STABLE [50a757698] 2014-10-03 13:01:27 -0300
       and/or <varname>cost_delay</> settings from autovacuum's global cost
       balancing rules (&Aacute;lvaro Herrera)
 -->
-自動バキュームのテーブルごとの<varname>cost_limit</>や/または<varname>cost_delay</>をグローバルコストのバランスルールからから除外します。
+自動バキュームのテーブルごとの<varname>cost_limit</>や/または<varname>cost_delay</>をグローバルコストのバランスルールから除外します。
 (&Aacute;lvaro Herrera)
      </para>
 
@@ -7580,7 +7580,7 @@ Branch: REL9_3_STABLE [a4aa854ca] 2014-01-30 14:51:19 -0500
       Fix mishandling of <literal>WHERE</> conditions pulled up from
       a <literal>LATERAL</> subquery (Tom Lane)
 -->
-<literal>LATERAL</>を使ったサブクエリ—から引き上げられた<literal>WHERE</>条件の処理ミスを修正しました。
+<literal>LATERAL</>を使ったサブクエリから引き上げられた<literal>WHERE</>条件の処理ミスを修正しました。
      </para>
 
      <para>


### PR DESCRIPTION
からから -> から
U+2014 の除去（長音だったとしても不要だった）