### PR TITLE
enable_indexonlyscanの説明修正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -4575,7 +4575,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
         Enables or disables the query planner's use of index-only-scan plan
         types. The default is <literal>on</>.
        -->
-       問い合わせプランナがインデックス走査計画型のみを選択することを有効もしくは無効にします。デフォルトは<literal>on</>です。
+       問い合わせプランナがインデックスオンリースキャン計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</>です。
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
"index-only-scan plan type"が「インデックス走査計画型のみ」となっていたので、「インデックスオンリースキャン計画型」に修正してみました。
ただ、この節では"scan"を「走査」と訳している箇所が多いので、「インデックスオンリー走査計画型」の方が統一感はあります。