### PR TITLE
shared_buffersの説明を修正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -1993,9 +1993,9 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
         longer period of time.
        -->
        1GBまたはそれより多いRAMを載せた専用データベースサーバを使用している場合、<varname>shared_buffers</varname>に対する妥当な初期値はシステムメモリの25%です。
-       <varname>shared_buffers</varname>に対し大きな値が有効であってもなんらかの作業負荷は存在します。
-       しかし、<productname>PostgreSQL</productname>は同時にオペレーティングシステムキャッシュを信頼しますので、<varname>shared_buffers</varname>にRAMの40%以上を割り当てても、より少ない量より動きがより良くなると言う見込みはありません。
-        <varname>shared_buffers</varname>をより大きく設定するには、通常対応する<varname>checkpoint_segments</varname>を増やす必要があります。より長い期間にわたっての新規、または変更された多量のデータを書き出すプロセスを展開するためです。
+       <varname>shared_buffers</varname>をこれよりも大きな値に設定することが有効なワークロードもあります。
+       しかし、<productname>PostgreSQL</productname>はオペレーティングシステムキャッシュも頼りにするため、<varname>shared_buffers</varname>にRAMの40%以上を割り当てても、それより小さい値の時より動作が良くなる見込みはありません。
+        <varname>shared_buffers</varname>をより大きく設定する場合は、大抵<varname>checkpoint_segments</varname>も合わせて増やす必要があります。これは、新規または変更された多量のデータを書き出す処理をより長い時間に渡って散らすためです。
        </para>
 
        <para>
@@ -2008,7 +2008,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
         useful range for <varname>shared_buffers</varname> on Windows systems
         is generally from 64MB to 512MB.
        -->
-       1GB以下のRAMのシステムでは、オペレーティングシステムに十分な余裕を残せるため、より少ない比率のRAMが適切です。同時に、Windowsでは<varname>shared_buffers</varname>に対し大きな値は有効でありません。設定を比較的少なく保ち、その代わりオペレーティングシステムのキャッシュを使用するとより良い結果が見つかります。Windowsシステムでの<varname>shared_buffers</varname>の範囲は一般的に64MBから512MBです。
+       1GB以下のRAMのシステムでは、オペレーティングシステムに十分な余裕を残すために、RAMに対してより小さい割合を設定することが適切です。同様に、Windowsでは<varname>shared_buffers</varname>に対し大きな値を設定することは有効でありません。設定値を比較的小さく保ち、代わりにオペレーティングシステムのキャッシュを使用することが、より良い結果になるでしょう。Windowsシステムでの<varname>shared_buffers</varname>の範囲は一般的に64MBから512MBです。
        </para>
 
       </listitem>

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -1994,8 +1994,8 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
        -->
        1GBまたはそれより多いRAMを載せた専用データベースサーバを使用している場合、<varname>shared_buffers</varname>に対する妥当な初期値はシステムメモリの25%です。
        <varname>shared_buffers</varname>をこれよりも大きな値に設定することが有効なワークロードもあります。
-       しかし、<productname>PostgreSQL</productname>はオペレーティングシステムキャッシュも頼りにするため、<varname>shared_buffers</varname>にRAMの40%以上を割り当てても、それより小さい値の時より動作が良くなる見込みはありません。
-        <varname>shared_buffers</varname>をより大きく設定する場合は、大抵<varname>checkpoint_segments</varname>も合わせて増やす必要があります。これは、新規または変更された多量のデータを書き出す処理をより長い時間に渡って散らすためです。
+       しかし、<productname>PostgreSQL</productname>はオペレーティングシステムキャッシュにも依存するため、<varname>shared_buffers</varname>にRAMの40%以上を割り当てても、それより小さい値の時より動作が良くなる見込みはありません。
+        <varname>shared_buffers</varname>をより大きく設定する場合は、大抵<varname>checkpoint_segments</varname>も合わせて増やす必要があります。これは、新規または変更された多量のデータを書き出す処理をより長い時間に渡って分散させるためです。
        </para>
 
        <para>


### PR DESCRIPTION
shared_buffersの説明にわかりにくい部分があったので、訳文を修正してみました。
やや意訳気味かもしれません。