### PR TITLE
fix typo in plpgsql

### DIFF
--- a/doc/src/sgml/plpgsql.sgml
+++ b/doc/src/sgml/plpgsql.sgml
@@ -7703,7 +7703,7 @@ END;
      reference page for details.
 -->
 <productname>PostgreSQL</>には実行を最適化するために2つの関数生成修飾子があります。
-変動性（同じ引数が与えられた場合常に同じ結果が返します）と<quote>厳密性</quote>（引数のいずれかにNULLが含まれる場合NULLを返します）です。
+変動性（同じ引数が与えられた場合常に同じ結果を返します）と<quote>厳密性</quote>（引数のいずれかにNULLが含まれる場合NULLを返します）です。
 詳細は<xref linkend="sql-createfunction">を参照してください。
     </para>
 


### PR DESCRIPTION
てにをは の修正

結果が返ります としても良かったですが、後に合わせて 結果を返します としました。