### PR TITLE
log_truncate_on_rotationの説明を修正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -5901,12 +5901,12 @@ linkend="guc-log-timezone">で指定された時間帯で計算が行われま�
         any size-driven rotations that might occur to select a file name
         different from the hour's initial file name.
        -->
-       例：24時間のログを保持、1時間おきに1つのログファイルを作成、ただし、ログファイルのサイズが1ギガバイトを超えそうな場合即座に切り替えさせるには、
+       例：24時間のログを保持、1時間おきに1つのログファイルを作成、ただし、ログファイルのサイズが1ギガバイトを超えた場合即座に切り替えさせるには、
         <varname>log_filename</varname> を <literal>server_log.%H%M</literal>にし、 
         <varname>log_truncate_on_rotation</varname> を <literal>on</literal>にし、 
         <varname>log_rotation_age</varname> を <literal>60</literal>にし、そして
         <varname>log_rotation_size</varname> を <literal>1000000</literal>に設定します。
-        <varname>log_filename</varname>に<literal>%M</>を含めると、元の時間毎のファイル名と異なる名前を選択する可能性がある、サイズを元にしたローテーションを行うことができます。
+        <varname>log_filename</varname>に<literal>%M</>を含めると、サイズを元にしたローテーションが時間毎の始めのファイル名とは異なる名前のファイルを選択するようにできます。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -5901,7 +5901,7 @@ linkend="guc-log-timezone">で指定された時間帯で計算が行われま�
         any size-driven rotations that might occur to select a file name
         different from the hour's initial file name.
        -->
-       例：24時間のログを保持、1時間おきに1つのログファイルを作成、ただし、ログファイルのサイズが1ギガバイトを超えた場合即座に切り替えさせるには、
+       例：24時間のログを保持、1時間おきに1つのログファイルを作成、ただし、ログファイルのサイズが1ギガバイトを超えた場合それより早く切り替えさせるには、
         <varname>log_filename</varname> を <literal>server_log.%H%M</literal>にし、 
         <varname>log_truncate_on_rotation</varname> を <literal>on</literal>にし、 
         <varname>log_rotation_age</varname> を <literal>60</literal>にし、そして


### PR DESCRIPTION
log_truncate_on_rotationの説明で、例を出して説明している箇所がやや分かりづらかったので修正してみました。

