### PR TITLE
fix typo

### DIFF
--- a/doc/src/sgml/event-trigger.sgml
+++ b/doc/src/sgml/event-trigger.sgml
@@ -877,7 +877,7 @@ C言語で作成したイベントトリガ関数に関するとても簡単な�
 -->
 <function>noddl</>関数は、呼ばれるたびに例外を発生させます。
 このイベントトリガは、この関数と<literal>ddl_command_start</literal>イベントを関連づけます。
-そのため、(<xref linkend="event-trigger-definition">で言及した例外を含む)すべてのDDLコマンドは、実行できません。
+そのため、(<xref linkend="event-trigger-definition">で言及した例外はありますが)すべてのDDLコマンドは、実行できません。
    </para>
 
    <para>


### PR DESCRIPTION
with the exceptions の訳を修正。

[jpug-doc: 4692] with the exceptions の訳について
でやり取りした件です。