### PR TITLE
Adjust back-branch release note description of commits a2a718b22 et al.

### DIFF
--- a/doc/src/sgml/release-9.0.sgml
+++ b/doc/src/sgml/release-9.0.sgml
@@ -2338,10 +2338,10 @@ GiST索引のタプルがページと一致しない場合、無限に再帰に�
      <para>
 <!--
       The most notable oversight was
-      that <varname>recovery_min_apply_delay</> failed to delay application
-      of a two-phase commit.
+      that <varname>recovery_target_xid</> could not be used to stop at
+      a two-phase commit.
 -->
-最も注目すべき見過ごしは<varname>recovery_min_apply_delay</>がアプリケーションの２フェーズコミットの遅延適用に失敗していることでした。
+最も注目すべき見過ごしは、<varname>recovery_target_xid</>が２フェーズコミット(訳注: のコミット時点)で停止させるためには使用することができないということでした。
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.1.sgml
+++ b/doc/src/sgml/release-9.1.sgml
@@ -2589,10 +2589,10 @@ GiST索引のタプルがページと一致しない場合、無限に再帰に�
      <para>
 <!--
       The most notable oversight was
-      that <varname>recovery_min_apply_delay</> failed to delay application
-      of a two-phase commit.
+      that <varname>recovery_target_xid</> could not be used to stop at
+      a two-phase commit.
 -->
-最も注目すべき見過ごしは<varname>recovery_min_apply_delay</>がアプリケーションの２フェーズコミットの遅延適用に失敗していることでした。
+最も注目すべき見過ごしは、<varname>recovery_target_xid</>が２フェーズコミット(訳注: のコミット時点)で停止させるためには使用することができないということでした。
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.2.sgml
+++ b/doc/src/sgml/release-9.2.sgml
@@ -2868,10 +2868,10 @@ GiST索引のタプルがページと一致しない場合、無限に再帰に�
      <para>
 <!--
       The most notable oversight was
-      that <varname>recovery_min_apply_delay</> failed to delay application
-      of a two-phase commit.
+      that <varname>recovery_target_xid</> could not be used to stop at
+      a two-phase commit.
 -->
-最も注目すべき見過ごしは<varname>recovery_min_apply_delay</>がアプリケーションの２フェーズコミットの遅延適用に失敗していることでした。
+最も注目すべき見過ごしは、<varname>recovery_target_xid</>が２フェーズコミット(訳注: のコミット時点)で停止させるためには使用することができないということでした。
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.3.sgml
+++ b/doc/src/sgml/release-9.3.sgml
@@ -3539,10 +3539,10 @@ Branch: REL9_0_STABLE [804983961] 2014-07-29 11:58:17 +0300
      <para>
 <!--
       The most notable oversight was
-      that <varname>recovery_min_apply_delay</> failed to delay application
-      of a two-phase commit.
+      that <varname>recovery_target_xid</> could not be used to stop at
+      a two-phase commit.
 -->
-最も注目すべき見過ごしは<varname>recovery_min_apply_delay</>がアプリケーションの２フェーズコミットの遅延適用に失敗していることでした。
+最も注目すべき見過ごしは、<varname>recovery_target_xid</>が２フェーズコミット(訳注: のコミット時点)で停止させるためには使用することができないということでした。
      </para>
     </listitem>
 


### PR DESCRIPTION
As pointed out by Michael Paquier, recovery_min_apply_delay didn't exist
in 9.0-9.3, making the release note text not very useful.  Instead make it
talk about recovery_target_xid, which did exist then.

9.0 is already out of support, but we can fix the text in the newer
branches' copies of its release notes.