### PR TITLE
create_role.sgmlでrow-level securityの訳語を変更

### DIFF
--- a/doc/src/sgml/ref/create_role.sgml
+++ b/doc/src/sgml/ref/create_role.sgml
@@ -276,7 +276,7 @@ CREATE ROLE <replaceable class="PARAMETER">name</replaceable> [ [ WITH ] <replac
         permissions, an error will be returned.  The superuser and owner of the
         table being dumped always bypass RLS.
 -->
-これらの構文は、ロールがすべての行レベルセキュリティ(RLS)ポリシーを無視するかどうかを決定します。
+これらの構文は、ロールがすべての行単位セキュリティ(RLS)ポリシーを無視するかどうかを決定します。
 <literal>NOBYPASSRLS</literal>がデフォルトです。
 pg_dumpはテーブルのすべての内容が確実にダンプされるようにするため、<literal>row_security</literal>をデフォルトで<literal>OFF</literal>に設定することに注意してください。
 pg_dumpを実行するユーザが適切な権限を持っていなければ、エラーが返されます。


### PR DESCRIPTION
「行レベルセキュリティ」を「行単位セキュリティ」としました。