### PR TITLE
create_view.sgmlの変更部分の翻訳です。

### DIFF
--- a/doc/src/sgml/ref/create_view.sgml
+++ b/doc/src/sgml/ref/create_view.sgml
@@ -212,7 +212,7 @@ CREATE VIEW <replaceable>name</> AS WITH RECURSIVE <replaceable>name</> (<replac
           This should be used if the view is intended to provide row-level
           security.  See <xref linkend="rules-privileges"> for full details.
 -->
-行レベルのセキュリティを提供することを意図したビューでは、これを有効にしなければなりません。
+行単位セキュリティを提供することを意図したビューでは、これを有効にしなければなりません。
 詳細については<xref linkend="rules-privileges">を参照してください。
          </para>
         </listitem>
@@ -492,7 +492,7 @@ CREATE VIEW vista AS SELECT text 'Hello World' AS hello;
     CONFLICT UPDATE</> clause are fully supported.
 -->
 ビューが自動更新可能であれば、システムはビューに対する<command>INSERT</>、<command>UPDATE</>または<command>DELETE</>文を基となるベースリレーションへの対応する文に変換します。
-★★★
+<literal>ON CONFLICT UPDATE</>句を持つ<command>INSERT</>文は完全にサポートされます。
    </para>
 
    <para>
@@ -514,7 +514,7 @@ CREATE VIEW vista AS SELECT text 'Hello World' AS hello;
 自動更新可能ビューが<literal>WHERE</>条件を持つ場合、
 ベースリレーションのどの行をビューに対する<command>UPDATE</>、<command>DELETE</>文により変更可能かをその条件が制限します。
 しかし<command>UPDATE</>による行の変更の結果<literal>WHERE</>を満たさなくなり、その結果、ビューからは参照することができなくなることがあります。
-同様に<command>INSERT</>コマンドは<literal>WHERE</>条件を満たさず、そのためビューを通して参照することができない行をベースリレーションに挿入する可能性があります。
+同様に<command>INSERT</>コマンドは<literal>WHERE</>条件を満たさず、そのためビューを通して参照することができない行をベースリレーションに挿入する可能性があります（<literal>ON CONFLICT UPDATE</>はビューを通して見えない既存の行に同様に影響を及ぼすかもしれません）。
 <literal>CHECK OPTION</>は<command>INSERT</>や<command>UPDATE</>がビューで見ることができない行を作るのを防ぐために使うことができます。
    </para>
 


### PR DESCRIPTION
9.5の変更分の他、既存の翻訳について、次の点を変更しました。
"row-level security"という語が9.4以前から存在していて「行レベルのセキュリティ」と訳していたのを「行単位セキュリティ」と直しました。