### PR TITLE
hstore.sgml and ltree.sgml for 9.5.0

### DIFF
--- a/doc/src/sgml/hstore.sgml
+++ b/doc/src/sgml/hstore.sgml
@@ -644,7 +644,7 @@ CREATE INDEX hidx ON testhstore USING GIN (h);
 <type>hstore</>はまた、<literal>=</>演算子向けに<type>btree</>または<type>hash</>インデックスをサポートします。
 これにより<type>hstore</>の列を<literal>UNIQUE</>と宣言すること、また、<literal>GROUP BY</>、<literal>ORDER BY</>、<literal>DISTINCT</>の式で使用することができます。
 <type>hstore</>値のソート順序付けはあまり有用ではありません。
-しかしこれらのインデックスは等価値の検索の際に有用になるかもしれません。
+しかしこれらのインデックスは同値検索の際に有用になるかもしれません。
 <literal>=</>比較用のインデックスを以下のように作成します。
   </para>
 <programlisting>
@@ -848,9 +848,13 @@ ALTER TABLE tablename ALTER hstorecol TYPE hstore USING hstorecol || '';
  </sect2>
 
  <sect2>
+<!--
   <title>Transforms</title>
+-->
+  <title>変換</title>
 
   <para>
+<!--
    Additional extensions are available that implement transforms for
    the <type>hstore</type> type for the languages PL/Perl and PL/Python.  The
    extensions for PL/Perl are called <literal>hstore_plperl</literal>
@@ -863,6 +867,12 @@ ALTER TABLE tablename ALTER hstorecol TYPE hstore USING hstorecol || '';
    (see <xref linkend="plpython-python23"> for the PL/Python naming
    convention).  If you use them, <type>hstore</type> values are mapped to
    Python dictionaries.
+-->
+PL/Perl言語やPL/Python言語向けに<type>hstore</type>型の変換を実装した追加の拡張が入手可能です。
+PL/Perl向けの拡張は、信頼されたPL/Perlに対しては<literal>hstore_plperl</literal>という名前で、信頼されないものに対しては<literal>hstore_plperlu</literal>という名前です。
+関数を作成するときにこの変換をインストールして指定していれば、<type>hstore</type>の値はPerlのハッシュにマップされます。
+PL/Python向けの拡張は<literal>hstore_plpythonu</literal>、<literal>hstore_plpython2u</literal>、<literal>hstore_plpython3u</literal>という名前です(PL/Pythonの命名規約については<xref linkend="plpython-python23">を参照してください)。
+この拡張を使うと<type>hstore</type>の値はPythonの辞書型にマップされます。
   </para>
  </sect2>
 

--- a/doc/src/sgml/ltree.sgml
+++ b/doc/src/sgml/ltree.sgml
@@ -997,7 +997,7 @@ ltreetest=&gt; SELECT ins_label(path,2,'Space') FROM test WHERE path &lt;@ 'Top.
 -->
 PL/Python言語向けに<type>ltree</type>型の変換を実装した追加の拡張が入手可能です。
 その拡張は、<literal>ltree_plpythonu</literal>、<literal>ltree_plpython2u</literal>、<literal>ltree_plpython3u</literal>という名前です(PL/Pythonの命名規約については<xref linkend="plpython-python23">を参照してください)。
-関数を作成するときにこの変換をインストールして指定していれば、<type>ltree</type>の値はPythonのリストハッシュにマップされます。
+関数を作成するときにこの変換をインストールして指定していれば、<type>ltree</type>の値はPythonのリストにマップされます。
 (しかしながら、その逆は今のところサポートされていません。)
   </para>
  </sect2>

--- a/doc/src/sgml/ltree.sgml
+++ b/doc/src/sgml/ltree.sgml
@@ -979,9 +979,13 @@ ltreetest=&gt; SELECT ins_label(path,2,'Space') FROM test WHERE path &lt;@ 'Top.
  </sect2>
 
  <sect2>
+<!--
   <title>Transforms</title>
+-->
+  <title>変換</title>
 
   <para>
+<!--
    Additional extensions are available that implement transforms for
    the <type>ltree</type> type for PL/Python.  The extensions are
    called <literal>ltree_plpythonu</literal>, <literal>ltree_plpython2u</literal>,
@@ -990,6 +994,11 @@ ltreetest=&gt; SELECT ins_label(path,2,'Space') FROM test WHERE path &lt;@ 'Top.
    convention).  If you install these transforms and specify them when
    creating a function, <type>ltree</type> values are mapped to Python lists.
    (The reverse is currently not supported, however.)
+-->
+PL/Python言語向けに<type>ltree</type>型の変換を実装した追加の拡張が入手可能です。
+その拡張は、<literal>ltree_plpythonu</literal>、<literal>ltree_plpython2u</literal>、<literal>ltree_plpython3u</literal>という名前です(PL/Pythonの命名規約については<xref linkend="plpython-python23">を参照してください)。
+関数を作成するときにこの変換をインストールして指定していれば、<type>ltree</type>の値はPythonのリストハッシュにマップされます。
+(しかしながら、その逆は今のところサポートされていません。)
   </para>
  </sect2>
 


### PR DESCRIPTION
以下のファイルの9.5.0対応です。

hstore.sgml
ltree.sgml 

ほぼ似たようなものが追加になっていますので、組み合わせてのPRは（他のものより）意味は有るかと。