### PR TITLE
indices.sgml and install-windows.sgml for 9.5

### DIFF
--- a/doc/src/sgml/indices.sgml
+++ b/doc/src/sgml/indices.sgml
@@ -191,7 +191,7 @@ CREATE INDEX test1_id_index ON test1 (id);
    By default, the <command>CREATE INDEX</command> command creates
    B-tree indexes, which fit the most common situations.
 -->
-<productname>PostgreSQL</productname>では、B-tree、Hash、GiST、SP-GiST、GINといった複数の種類のインデックスを使用可能です。
+<productname>PostgreSQL</productname>では、B-tree、Hash、GiST、SP-GiST、GIN、BRINといった複数の種類のインデックスを使用可能です。
 インデックスの各種類は、異なる種類の問い合わせに最も適した、異なるアルゴリズムを使用します。
 デフォルトで<command>CREATE INDEX</command>コマンドは、B-treeインデックスを作成し、それはほとんどの一般的状況に適合します。
   </para>
@@ -398,7 +398,6 @@ SELECT * FROM places ORDER BY location <-> point '(101,456)' LIMIT 10;
    to do this is again dependent on the particular operator class being used.
    In <xref linkend="gist-builtin-opclasses-table">, operators that can be
    used in this way are listed in the column <quote>Ordering Operators</>.
-
 -->
 これは指定された対象地点に最も近い１０箇所を見つけ出します。
 繰り返しますが、これができるかどうかは使用される特定の演算子クラスに依存します。
@@ -509,13 +508,21 @@ GiSTやSP-GiST同様、GINも多くの異なるユーザ定義のインデック
 
   <para>
    <indexterm>
+<!--
+    <primary>index</primary>
+-->
+    <primary>インデックス</primary>
     <primary>index</primary>
     <secondary>BRIN</secondary>
    </indexterm>
    <indexterm>
     <primary>BRIN</primary>
+<!--
     <see>index</see>
+-->
+    <see>インデックス</see>
    </indexterm>
+<!--
    BRIN indexes (a shorthand for Block Range indexes)
    store summaries about the values stored in consecutive table physical block ranges.
    Like GiST, SP-GiST and GIN,
@@ -526,6 +533,10 @@ GiSTやSP-GiST同様、GINも多くの異なるユーザ定義のインデック
    corresponds to the minimum and maximum values of the
    values in the column for each block range,
    which support indexed queries using these operators:
+-->
+BRINインデックス(ブロックレンジインデックス(Block Range index)を縮めたものです)は
+GiST、SP-GiST、GINと同じように、BRINは多くの異なるインデックス戦略をサポートし、BRINインデックスが使用できる具体的な演算子はインデックス戦略によって変化します。
+線形のソート順を持つデータ型では、インデックス付けされたデータは各ブロックレンジの列の中の値の最小値と最大値に対応しており、以下の演算子を使用したインデックス付けされた問い合わせをサポートします。
 
    <simplelist>
     <member><literal>&lt;</literal></member>
@@ -535,9 +546,13 @@ GiSTやSP-GiST同様、GINも多くの異なるユーザ定義のインデック
     <member><literal>&gt;</literal></member>
    </simplelist>
 
+<!--
    The BRIN operator classes included in the standard distribution are
    documented in <xref linkend="brin-builtin-opclasses-table">.
    For more information see <xref linkend="BRIN">.
+-->
+標準配布物に含まれるBRIN演算子クラスは<xref linkend="brin-builtin-opclasses-table">.に記載されています。
+詳細は<xref linkend="BRIN">を参照してください。
   </para>
  </sect1>
 
@@ -1012,10 +1027,7 @@ NULL 値は同じ値とはみなされません。
     create indexes on unique columns; doing so would just duplicate
     the automatically-created index.
 -->
-★★★
-テーブルに一意性制約を追加するためによく使用される方法は、<literal>ALTER TABLE ... ADD CONSTRAINT</literal>です。
-一意性制約を課すためのインデックスの用法は、直接アクセスしてはならない実装の細部とみなされることがあります。
-しかし、手作業で一意列に対しインデックスを作成する必要がないことには注意してください。
+手作業で一意列に対しインデックスを作成する必要はありません。
 これは、単に自動作成されるインデックスを二重にするだけです。
    </para>
   </note>
@@ -1637,7 +1649,6 @@ SELECT am.amname AS index_method,
     each operator class belongs to:
 -->
 この前述のクエリで拡張されたバージョンはどの演算子も含まれる演算子の種類に属します。
-
 <programlisting>
 SELECT am.amname AS index_method,
        opc.opcname AS opclass_name,

--- a/doc/src/sgml/indices.sgml
+++ b/doc/src/sgml/indices.sgml
@@ -512,7 +512,6 @@ GiSTやSP-GiST同様、GINも多くの異なるユーザ定義のインデック
     <primary>index</primary>
 -->
     <primary>インデックス</primary>
-    <primary>index</primary>
     <secondary>BRIN</secondary>
    </indexterm>
    <indexterm>

--- a/doc/src/sgml/install-windows.sgml
+++ b/doc/src/sgml/install-windows.sgml
@@ -351,7 +351,7 @@ MinGWコンパイラツール自体をPATHに追加しないでください。
 
      <note>
       <para>
-      <!--
+<!--
         The Bison distribution from GnuWin32 appears to have a bug that
         causes Bison to malfunction when installed in a directory with
         spaces in the name, such as the default location on English
@@ -696,12 +696,16 @@ $ENV{CONFIG}="Debug";
   </para>
 
   <para>
+<!--
    Running the regression tests on client programs, with "vcregress bincheck",
    requires an additional Perl module to be installed:
+-->
+クライアントプログラムで"vcregress bincheck"によりリグレッションテストを実行するには、追加のPerlモジュールをインストールしておかなければなりません。
    <variablelist>
     <varlistentry>
      <term><productname>IPC::Run</productname></term>
      <listitem><para>
+<!--
       As of this writing, <literal>IPC::Run</> is not included in the
       ActiveState Perl installation, nor in the ActiveState Perl Package
       Manager (PPM) library. To install, download the
@@ -710,6 +714,11 @@ $ENV{CONFIG}="Debug";
       uncompress. Edit the <filename>buildenv.pl</> file, and add a PERL5LIB
       variable to point to the <filename>lib</> subdirectory from the
       extracted archive. For example:
+-->
+これを書いている時点では、<literal>IPC::Run</>はActiveState PerlインストレーションにもActiveState Perl Package Manager(PPM)ライブラリにも含まれていません。
+インストールするためには、<ulink url="http://search.cpan.org/dist/IPC-Run/"></>でCPANから<filename>IPC-Run-&lt;version&gt;.tar.gz</>ソースアーカイブをダウンロードして、展開してください。
+<filename>buildenv.pl</>を編集して、取り出されたアーカイブから<filename>lib</>サブディレクトリを指すように変数PERL5LIBを追加してください。
+例えば以下の通りです。
 <programlisting>
 $ENV{PERL5LIB}=$ENV{PERL5LIB} . ';c:\IPC-Run-0.94\lib';
 </programlisting>
@@ -816,7 +825,6 @@ $ENV{DOCROOT}='c:\docbook';
   <productname>Borland C++</productname></title>
 -->
   <title><productname>Visual C++</productname>または<productname>Borland C++</productname>を使用した<application>libpq</application>の構築</title>
-
 
  <para>
 <!--


### PR DESCRIPTION
以下のファイルの9.5.0対応です。

indices.sgml
install-windows.sgml