### PR TITLE
斉藤さんのconfig.sgmlに対する指摘([jpug-doc: 4906])に対応

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -3380,7 +3380,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
 <!--
        <primary><varname>wal_compression</> configuration parameter</primary>
 -->
-       <primary><varname>wal_compression</>コンフィグレーションパラメータ</primary>
+       <primary><varname>wal_compression</>設定パラメータ</primary>
       </indexterm>
       </term>
       <listitem>
@@ -4082,7 +4082,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
 <!--
        <primary><varname>track_commit_timestamp</> configuration parameter</primary>
 -->
-       <primary><varname>track_commit_timestamp</>コンフィグレーションパラメータ</primary>
+       <primary><varname>track_commit_timestamp</>設定パラメータ</primary>
       </indexterm>
       </term>
       <listitem>
@@ -4493,7 +4493,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
 <!--
        <primary><varname>wal_retrieve_retry_interval</> configuration parameter</primary>
 -->
-       <primary><varname>wal_retrieve_retry_interval</>コンフィグレーションパラメータ</primary>
+       <primary><varname>wal_retrieve_retry_interval</>設定パラメータ</primary>
       </indexterm>
       </term>
       <listitem>
@@ -4522,11 +4522,11 @@ WALデータがソース(ストリーミングレプリケーション、ロー�
         to access WAL archives, something useful for example in cloud
         environments where the amount of times an infrastructure is accessed
         is taken into account.
+-->
 このパラメータは、リカバリ対象のノードにおいて、新しいWALデータが読み込み可能になるまでの待ち時間を制御する必要のある時に有用です。
 たとえば、アーカイブリカバリにおいては、このパラメータの値を小さくすることにより、新しいWALログファイルを検出する際にリカバリの応答を早くすることができます。
 WALの生成頻度が少ないシステムでは、この値を大きくすることにより、WALアーカイブへのアクセス頻度を減らすことができます。
 これは、たとえば基盤へのアクセス回数が課金対象になるクラウド環境において、有用です。
--->
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
「設定パラメータ」と「コンフィグレーションパラメータ」の混在は、以前か
ら使われている「設定パラメータ」に合せました。