### PR TITLE
revise translation of "configuration"

### DIFF
--- a/doc/src/sgml/auto-explain.sgml
+++ b/doc/src/sgml/auto-explain.sgml
@@ -60,7 +60,7 @@ LOAD 'auto_explain';
   to do nothing, so you must set at least
   <varname>auto_explain.log_min_duration</varname> if you want any results.
 -->
-<filename>auto_explain</filename>の動作を制御するいくつかの構成パラメータが存在します。
+<filename>auto_explain</filename>の動作を制御するいくつかの設定パラメータが存在します。
 デフォルトの動作は何もしないことなので、なんらかの結果を望むのであれば少なくとも<varname>auto_explain.log_min_duration</varname>を設定しなければならないことに注意してください。
  </para>
 
@@ -72,7 +72,7 @@ LOAD 'auto_explain';
 <!--
       <primary><varname>auto_explain.log_min_duration</> configuration parameter</primary>
 -->
-      <primary><varname>auto_explain.log_min_duration</>構成パラメータ</primary>
+      <primary><varname>auto_explain.log_min_duration</>設定パラメータ</primary>
      </indexterm>
     </term>
     <listitem>

--- a/doc/src/sgml/backup.sgml
+++ b/doc/src/sgml/backup.sgml
@@ -912,7 +912,7 @@ WALデータをアーカイブする場合、完成したセグメントファ�
     character in the command.  The simplest useful command is something
     like:
 -->
-WALアーカイブを有効にするには<xref linkend="guc-wal-level">構成パラメータを<literal>archive</>（またはarchiveより高いパラメータ）に、<xref linkend="guc-archive-mode">を<literal>on</>に設定し、<xref linkend="guc-archive-command"> 構成パラメータで使用するシェルコマンドを指定します。
+WALアーカイブを有効にするには<xref linkend="guc-wal-level">設定パラメータを<literal>archive</>（またはarchiveより高いパラメータ）に、<xref linkend="guc-archive-mode">を<literal>on</>に設定し、<xref linkend="guc-archive-command">設定パラメータで使用するシェルコマンドを指定します。
 実行するには、これらの設定を <filename>postgresql.conf</filename> ファイルに常に置きます。
 <varname>archive_command</> では、<literal>%p</>はアーカイブするファイルのパス名に置換され、<literal>%f</>はファイル名部分のみに置換されます。
 （パス名は、サーバの現在の作業用ディレクトリ、つまり、クラスタのデータディレクトリから見て相対的なものです。）

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -12926,7 +12926,7 @@ SELECT xmlelement(name foo, xmlattributes('xyz' as bar),
 -->
 そのほかの型の内容は有効なXML文字データにフォーマットされます。
 これは特に文字&lt;、&gt;、および&amp;がエンティティに変換されることを意味します。
-バイナリデータ（データ型は<type>bytea</type>）は、構成パラメータ<xref linkend="guc-xmlbinary">の設定にしたがって、base64もしくは16進符号化方式で表現されます。
+バイナリデータ（データ型は<type>bytea</type>）は、設定パラメータ<xref linkend="guc-xmlbinary">の設定にしたがって、base64もしくは16進符号化方式で表現されます。
 個々のデータ型に対する特定の動作は、XMLスキーマ仕様でのSQLおよびPostgreSQLデータ型に調整するため展開されると期待されます。この時点でより詳細な記述が出現します。
     </para>
    </sect3>
@@ -22561,7 +22561,7 @@ SELECT collation for ('foo' COLLATE "de_DE");
     <xref linkend="functions-admin-set-table"> shows the functions
     available to query and alter run-time configuration parameters.
 -->
-<xref linkend="functions-admin-set-table">は、実行時構成パラメータの問い合わせや変更に使用できる関数を示しています。
+<xref linkend="functions-admin-set-table">は、実行時設定パラメータの問い合わせや変更に使用できる関数を示しています。
    </para>
 
    <table id="functions-admin-set-table">


### PR DESCRIPTION
"configuration parameter"の訳を「設定パラメータ」にしました。