### PR TITLE
[jpug-doc: 4921]の指摘に対応

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -7787,7 +7787,8 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
 例えば、これを<literal>250ms</literal>に設定すると、250ms以上かかって実行されたautovacuumや解析はすべてログに残ります。
         さらに、<literal>-1</literal>以外の値にこのパラメータが設定された場合、競合するロックの存在によりオートバキューム動作が省略されるとメッセージはログに記録されます。
         このパラメータを有効にすることは、autovacuum活動の追跡に役に立ちます。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。★★★
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
> 斉藤 登です。
>
> 小出しになりまして済みません。
>
> 9.5.0で修正して欲しい箇所で★入れてましたが、★が
> 残ってました。
> https://pgsql-jp.github.io/jpug-doc/9.5.0/html/runtime-config-autovacuum.html
>
> This parameter can only be set in the <filename>postgresql.conf</> file or on the server command line; but the setting can be overridden for individual tables by changing table storage parameters.
>
> このパラメータを有効にすることは、autovacuum活動の追跡に役に立ちます。 このパラメータはpostgresql.confファイル、または、サーバのコマンドラインでのみで設定されます。★★★
>
> の部分です。