### PR TITLE
タイトルの訳抜け

### DIFF
--- a/doc/src/sgml/gist.sgml
+++ b/doc/src/sgml/gist.sgml
@@ -63,7 +63,10 @@ B-tree、R-treeやその他多くのインデックスの枠組みを<acronym>Gi
 </sect1>
 
 <sect1 id="gist-builtin-opclasses">
+<!--
  <title>Built-in Operator Classes</title>
+-->
+ <title>組込み演算子クラス</title>
 
  <para>
 <!--


### PR DESCRIPTION
9.4からですが、ここだけ抜けてました。