### PR TITLE
func.sgmlの既存部分の誤訳の修正と翻訳の改善。

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -48,7 +48,7 @@
    not exhaustive;  additional functions appear in relevant sections of
    the manual.
 -->
-もし移植性が気になるのであれば、本章で説明する大多数の関数と演算子は、ほとんどの基本的算術演算子、比較演算子およびいくつかの明示的に印を付けた関数を除いて、標準<acronym>SQL</acronym>で規定されていない点に注意してください。
+もし移植性が気になるのであれば、最も基本的な算術および比較演算子と、いくつかの明示的に印を付けた関数を除き、本章で説明する大多数の関数と演算子は、標準<acronym>SQL</acronym>で規定されていない点に注意してください。
 この拡張機能のいくつかは、他の<acronym>SQL</acronym>データベース管理システムにも備わっており、多くの場合この機能には各種実装間で互換性と整合性があります。
 同時に、本節は完全なものではありません。追加の関数はマニュアルの関連のある節に出てきます。
   </para>
@@ -139,7 +139,7 @@
     false, and <literal>null</>, which represents <quote>unknown</quote>.
     Observe the following truth tables:
 -->
-<acronym>SQL</acronym>はtrue、false、そして<quote>不明</quote>を意味する<literal>NULL値</>の3値のロジックシステムを使用します。
+<acronym>SQL</acronym>はtrue、false、そして<quote>不明</quote>を意味する<literal>null</>の3値の論理システムを使用します。
 以下の真理値表を参照してください。
 
     <informaltable>
@@ -262,7 +262,7 @@
     The usual comparison operators are available, shown in <xref
     linkend="functions-comparison-table">.
 -->
-<xref linkend="functions-comparison-table">に示す、通常の比較演算子は使用可能です。
+<xref linkend="functions-comparison-table">に示す、通常の比較演算子が使用可能です。
    </para>
 
    <table id="functions-comparison-table">
@@ -360,7 +360,7 @@
     <literal>3</literal>).
 -->
 比較演算子は関連性のある全てのデータ型で使用できます。
-全ての比較演算子は二項演算子で、<type>boolean</type>データ型を返します。<literal>1 &lt; 2 &lt; 3</literal>のような式は（ブール値と<literal>3</literal>を比較する<literal>&lt;</literal>演算子がないので）無効です。
+全ての比較演算子は二項演算子で、<type>boolean</type>型の値を返します。<literal>1 &lt; 2 &lt; 3</literal>のような式は（ブール値と<literal>3</literal>を比較する<literal>&lt;</literal>演算子がないので）無効です。
    </para>
 
    <para>
@@ -412,7 +412,7 @@
     a nonempty range is always implied.
 -->
 <literal>BETWEEN SYMMETRIC</>は、<literal>AND</>の左側の引数が右側の引数より小さいか、もしくは等しいという必要性が無い点を除き<literal>BETWEEN</>と同じです。
-この条件を満たしていない場合、2つの引数は自動的に置き換えられますので、常に空ではない範囲となります。
+この条件を満たしていない場合、2つの引数は自動的に交換されますので、常に空ではない範囲となります。
    </para>
 
    <para>
@@ -500,7 +500,7 @@
     inconsistent behavior exhibited by <productname>PostgreSQL</productname>
     versions prior to 8.2.
 -->
-<replaceable>expression</replaceable>が行値の場合、行式自体がNULLまたは、行のフィールドすべてがNULLの場合に<literal>IS NULL</>は真となります。一方<literal>IS NOT NULL</>は、行式自体が非NULLまたは、行のフィールドすべてが非NULLの場合に真となります。
+<replaceable>expression</replaceable>が行値の場合、行式自体がNULLまたは、行のフィールドすべてがNULLの場合に<literal>IS NULL</>は真となります。一方<literal>IS NOT NULL</>は、行式自体が非NULLかつ、行のフィールドすべてが非NULLの場合に真となります。
 この動作により、<literal>IS NULL</>および<literal>IS NOT NULL</>は行値評価式に対し常に反対の結果を返しません。つまりNULLと非NULLの値の両方を含む行値式はどちらの試験でも偽を返します。
 この定義は標準SQLに従ったもので、8.2より前のバージョンの<productname>PostgreSQL</productname>における一貫性のない動作から変更されました。
    </para>
@@ -520,7 +520,7 @@
     this behavior is not suitable, use the
     <literal>IS <optional> NOT </> DISTINCT FROM</literal> constructs:
 -->
-入力のどちらかが真または偽ではなくNULLの場合、通常の比較演算子は（<quote>不明</>を意味する）nullを生成します。
+入力のどちらかがNULLの場合、通常の比較演算子は真や偽ではなく（<quote>不明</>を意味する）nullを生成します。
 例えば<literal>7 = NULL</>はnullになります。<literal>7 &lt;&gt; NULL</>も同様です。
 この動作が適切でない場合は、<literal>IS <optional> NOT </> DISTINCT FROM</literal>構文を使用してください。
 <synopsis>


### PR DESCRIPTION
(1) "most trivial ... operators"におけるtrivialの修飾先の誤りを修正
(2) literalタグ内のnullが「NULL値」と翻訳されているのを元に戻した
(3) swapの訳語を「置き換え」から「交換」に変更
(4) andが「または」となっていたのを「かつ」に修正
(5) "not true or false"の掛かり先の誤りを修正
その他、小さな修正が2ヶ所。