### PR TITLE
リリースノートの再訂正

### DIFF
--- a/doc/src/sgml/release-9.5.sgml
+++ b/doc/src/sgml/release-9.5.sgml
@@ -1854,18 +1854,16 @@ Linuxの<acronym>OOM</> killerを新たな環境変数<link linkend="linux-memor
       <listitem>
 <!--
 2015-06-21 [ad89a5d] Alvaro..: Add transforms to pg_get_object_address and fr..
+このコミットは間違いでおそらく以下が正しい。
+2014-12-23 [7eca575] Alvaro..: get_object_address: separate domain constraints..
 -->
        <para>
 <!--
         Support comments on <link linkend="SQL-CREATEDOMAIN">domain
         constraints</> (&Aacute;lvaro Herrera)
 -->
-<link linkend="SQL-CREATEDOMAIN">ドメイン制約</>へのコメントに対応しました。
+<link linkend="SQL-CREATEDOMAIN">ドメインの制約</>へのコメントに対応しました。
 (&Aacute;lvaro Herrera)
-<!-- 原文が誤っている／9.4 でも DOMAIN に COMMENT は付くし、対応commit は TRANSFORM について対応したという内容である -->
-       </para>
-       <para>
-（訳注：原文が誤っていて本項目は必要のない項目です）
        </para>
       </listitem>
 


### PR DESCRIPTION
原文が言っているのは、DOMAIN自体へのコメントではなく、9.5で導入された
「ドメインの制約」にコメントが付けられるようになった、ということ。単に
ポイントしているコミットIDが間違っていただけ。正しいコミットIDをコメン
トに追記しておいた。