### PR TITLE
func.sgmlのうち、マニュアルの9.3と9.4節に該当する部分の誤訳訂正と訳文の改善。

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -624,7 +624,7 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
     describe the actual behavior in subsequent sections.
 -->
 <productname>PostgreSQL</productname>の数多くの型に対する算術演算子が用意されています。
-標準算術表現法に従わない型（例えば、日付/時刻データ型）については、後続する節で実際の動作を説明します。
+標準算術表現法が存在しない型（例えば、日付/時刻データ型）については、後続する節で実際の動作を説明します。
    </para>
 
    <para>
@@ -772,7 +772,7 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
 <!--
        <entry>bitwise AND</entry>
 -->
-       <entry>バイナリのAND</entry>
+       <entry>ビットごとのAND</entry>
        <entry><literal>91 &amp; 15</literal></entry>
        <entry><literal>11</literal></entry>
       </row>
@@ -782,7 +782,7 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
 <!--
        <entry>bitwise OR</entry>
 -->
-       <entry>バイナリのOR</entry>
+       <entry>ビットごとのOR</entry>
        <entry><literal>32 | 3</literal></entry>
        <entry><literal>35</literal></entry>
       </row>
@@ -792,7 +792,7 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
 <!--
        <entry>bitwise XOR</entry>
 -->
-       <entry>バイナリのXOR</entry>
+       <entry>ビットごとのXOR</entry>
        <entry><literal>17 # 5</literal></entry>
        <entry><literal>20</literal></entry>
       </row>
@@ -802,7 +802,7 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
 <!--
        <entry>bitwise NOT</entry>
 -->
-       <entry>バイナリのNOT</entry>
+       <entry>ビットごとのNOT</entry>
        <entry><literal>~1</literal></entry>
        <entry><literal>-2</literal></entry>
       </row>
@@ -812,7 +812,7 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
 <!--
        <entry>bitwise shift left</entry>
 -->
-       <entry>バイナリの左シフト</entry>
+       <entry>ビットごとの左シフト</entry>
        <entry><literal>1 &lt;&lt; 4</literal></entry>
        <entry><literal>16</literal></entry>
       </row>
@@ -822,7 +822,7 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
 <!--
        <entry>bitwise shift right</entry>
 -->
-       <entry>バイナリの右シフト</entry>
+       <entry>ビットごとの右シフト</entry>
        <entry><literal>8 &gt;&gt; 2</literal></entry>
        <entry><literal>2</literal></entry>
       </row>
@@ -839,8 +839,8 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
     string types <type>bit</type> and <type>bit varying</type>, as
     shown in <xref linkend="functions-bit-string-op-table">.
 -->
-バイナリ演算子は内部データ型のみに使用できます。一方他の演算子は全ての数値データ型に使用できます。
-また、バイナリ演算子は<xref linkend="functions-bit-string-op-table">に示すように、<type>bit</type>、<type>bit varying</type>ビット文字列型に対しても使用することができます。
+ビット演算子は整数データ型のみに使用できます。一方他の演算子は全ての数値データ型に使用できます。
+また、ビット演算子は<xref linkend="functions-bit-string-op-table">に示すように、<type>bit</type>、<type>bit varying</type>ビット文字列型に対しても使用することができます。
    </para>
 
   <para>
@@ -858,8 +858,8 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
 <xref linkend="functions-math-func-table">に使用可能な算術関数を示します。
 この表内の<literal>dp</literal>は、<type>double precision</type>を意味します。
 これら関数の多くは、異なる引数型を持つ複数の形で提供されています。
-特別な場合を除き、ある任意形式の関数はその引数と同じデータ型を返します。
-<type>double precision</type>データに対する関数のほとんどはホストシステムのCライブラリの上層に実装されています。このため、境界近くの場合の精度と振舞いはホストシステムに依存して変わります。
+特に記述がある場合を除き、すべての形式の関数はその引数と同じデータ型を返します。
+<type>double precision</type>データに対する関数のほとんどはホストシステムのCライブラリの上層に実装されています。このため、精度と境界近くの場合の振舞いはホストシステムに依存して変わります。
   </para>
 
    <table id="functions-math-func-table">
@@ -970,7 +970,7 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
 <!--
        <entry>radians to degrees</entry>
 -->
-       <entry>ラジアンに対応する度</entry>
+       <entry>ラジアンを度に変換</entry>
        <entry><literal>degrees(0.5)</literal></entry>
        <entry><literal>28.6478897565412</literal></entry>
       </row>
@@ -1156,7 +1156,7 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
 <!--
        <entry>degrees to radians</entry>
 -->
-       <entry>度に対応するラジアン</entry>
+       <entry>度をラジアンに変換</entry>
        <entry><literal>radians(45.0)</literal></entry>
        <entry><literal>0.785398163397448</literal></entry>
       </row>
@@ -1186,7 +1186,7 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
 <!--
        <entry>round to <parameter>s</parameter> decimal places</entry>
 -->
-       <entry>小数点<parameter>s</parameter>の位まで四捨五入して切捨て</entry>
+       <entry>四捨五入して小数点第<parameter>s</parameter>位までにする</entry>
        <entry><literal>round(42.4382, 2)</literal></entry>
        <entry><literal>42.44</literal></entry>
       </row>
@@ -1254,7 +1254,7 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
 <!--
        <entry>truncate to <parameter>s</parameter> decimal places</entry>
 -->
-       <entry><parameter>s</parameter>の桁で切り捨て</entry>
+       <entry>小数点第<parameter>s</parameter>位までで切り捨て</entry>
        <entry><literal>trunc(42.4382, 2)</literal></entry>
        <entry><literal>42.43</literal></entry>
       </row>
@@ -1556,8 +1556,8 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
 -->
 本節では文字列の値の調査や操作のための関数と演算子について説明します。
 ここでの文字列とは<type>character</type>データ型、<type>character varying</type>データ型、および<type>text</type>データ型の値を含みます。
-補足説明のない限り、下記に挙げている全ての関数はこれら全てのデータ型に対して使用できますが、<type>character</type>データ型を使用した場合、自動的に空白文字がパッドされるという潜在的作用がありますので注意してください。
-バイナリ列データ型に対してもともとから存在するいくつかの関数もあります。
+補足説明のない限り、下記に挙げている全ての関数はこれら全てのデータ型に対して使用できますが、<type>character</type>データ型を使用した場合、自動的に空白文字が詰め込まれるという潜在的作用がありますので注意してください。
+ビット文字列データ型に対する専用の関数もいくつかあります。
    </para>
 
    <para>
@@ -1591,7 +1591,7 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
 <productname>PostgreSQL</productname> 8.3以前において、これらの関数はいくつかの非文字列データ型の値を警告なしに受け付けたのは、それらデータ型を暗黙的に<type>text</>型に型変換していたことによります。
 この強制的な変換は、頻繁に予期しない動作の原因となったので削除されました。
 しかし、文字列連結演算子（<literal>||</>）は<xref linkend="functions-string-sql">で示されるように、少なくともひとつの入力が文字列型であれば、依然として非文字列入力を受け付けます。
-その他の場合、以前と同じ動作を期待するのなら、<type>text</>への明示的な変換を行ってください。
+その他の場合、以前と同じ動作が必要なら、<type>text</>への明示的な変換を行ってください。
     </para>
    </note>
 
@@ -1661,7 +1661,7 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
 <!--
         String concatenation with one non-string input
 -->
-        ひとつの非文字列のある入力の文字列結合
+        ひとつの非文字列の入力がある文字列結合
        </entry>
        <entry><literal>'Value: ' || 42</literal></entry>
        <entry><literal>Value: 42</literal></entry>
@@ -1815,7 +1815,7 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
         <xref linkend="functions-matching"> for more information on pattern
         matching.
 -->
-POSIX正規表現に一致する副文字列を取り出します。
+POSIX正規表現に一致する部分文字列を取り出します。
 パターンマッチに関してより詳細は、<xref linkend="functions-matching">を参照してください。
        </entry>
        <entry><literal>substring('Thomas' from '...$')</literal></entry>
@@ -1854,7 +1854,7 @@ POSIX正規表現に一致する副文字列を取り出します。
         <parameter>characters</parameter> (a space by default) from the
         start/end/both ends of the <parameter>string</parameter>
 -->
-<parameter>characters</parameter>（デフォルトでは空白）で指定された文字のみを含む最も長い文字列を、<parameter>string</parameter>の先頭、末尾、そしてその両方から削除します。
+<parameter>characters</parameter>（デフォルトでは空白）で指定された文字のみを含む最も長い文字列を、<parameter>string</parameter>の先頭、末尾、あるいはその両方から削除します。
        </entry>
        <entry><literal>trim(both 'x' from 'xTomxx')</literal></entry>
        <entry><literal>Tom</literal></entry>
@@ -1905,7 +1905,7 @@ POSIX正規表現に一致する副文字列を取り出します。
     <acronym>SQL</acronym>-standard string functions listed in <xref linkend="functions-string-sql">.
 -->
 この他、<xref linkend="functions-string-other">に列挙する文字列操作関数が使えます。
-そのいくつかは、<xref linkend="functions-string-sql">で一覧した標準<acronym>SQL</acronym>の文字列関数を実装するため、内部的に使用されます。
+そのいくつかは、<xref linkend="functions-string-sql">で列挙した標準<acronym>SQL</acronym>の文字列関数を実装するため、内部的に使用されます。
    </para>
 
    <table id="functions-string-other">
@@ -1993,7 +1993,7 @@ POSIX正規表現に一致する副文字列を取り出します。
         allowed because text data types cannot store such bytes.
 -->
 与えられたコードの文字。<acronym>UTF8</acronym>では引数はUnicodeコードポイントとして扱われます。
-その他のマルチバイト符号化方式で引数は<acronym>ASCII</acronym>文字である必要があります。
+その他のマルチバイト符号化方式で引数は<acronym>ASCII</acronym>文字を指定するものである必要があります。
 NULL (0)文字はテキストデータ型がそのようなバイトを格納することができないので許可されません。
        </entry>
        <entry><literal>chr(65)</literal></entry>
@@ -2014,7 +2014,7 @@ NULL (0)文字はテキストデータ型がそのようなバイトを格納す
         Concatenate the text representations of all the arguments.
         NULL arguments are ignored.
 -->
-        すべての引数のテキスト表現の結合。ただしNULLは無視される。
+すべての引数のテキスト表現を結合します。NULLの引数は無視されます。
        </entry>
        <entry><literal>concat('abcde', 2, NULL, 22)</literal></entry>
        <entry><literal>abcde222</literal></entry>
@@ -2035,9 +2035,9 @@ NULL (0)文字はテキストデータ型がそのようなバイトを格納す
         Concatenate all but the first argument with separators. The first
         argument is used as the separator string. NULL arguments are ignored.
 -->
-第一引数を区切り文字とし、残りのすべての引数を結合する。
-最初の引数は区切り文字列として使われる。
-NULLは無視される。
+第一引数を除くすべての引数を、区切り文字を付けて結合します。
+第一引数は区切り文字列として使用されます。
+NULLの引数は無視されます。
        </entry>
        <entry><literal>concat_ws(',', 'abcde', 2, NULL, 22)</literal></entry>
        <entry><literal>abcde,2,22</literal></entry>
@@ -2068,7 +2068,7 @@ NULLは無視される。
 <parameter>string</parameter>はこの符号化方式で有効でなければなりません。
 変換は<command>CREATE CONVERSION</command>で定義されます。
 また、あらかじめ定義された変換もあります。
-有効な変換については<xref linkend="conversion-names">を参照してください。
+利用可能な変換については<xref linkend="conversion-names">を参照してください。
        </entry>
        <entry><literal>convert('text_in_utf8', 'UTF8', 'LATIN1')</literal></entry>
 <!--
@@ -2140,8 +2140,8 @@ NULLは無視される。
         Decode binary data from textual representation in <parameter>string</>.
         Options for <parameter>format</> are same as in <function>encode</>.
 -->
-<parameter>string</parameter>からバイナリデータを復号します。
-オプションの<parameter>format</>は<function>encode()</>と同じです。
+<parameter>string</parameter>のテキスト表現からバイナリデータを復号します。
+<parameter>format</>のオプションは<function>encode()</>と同じです。
        </entry>
        <entry><literal>decode('MTIzAAE=', 'base64')</literal></entry>
        <entry><literal>\x3132330001</literal></entry>
@@ -2165,8 +2165,8 @@ NULLは無視される。
         doubles backslashes.
 -->
 バイナリデータをテキスト表現形式に符号化します。
-サポートされている形式は、<literal>base64</>、<literal>hex</>、<literal>escape</>です。
-<literal>escape</>は0バイトと最上位ビットがセットされているバイトを8進数のシーケンス(<literal>\</><replaceable>nnn</>)に変換し 、バックスラッシュを二重化します。
+サポートされているformatは、<literal>base64</>、<literal>hex</>、<literal>escape</>です。
+<literal>escape</>は0のバイトと最上位ビットがセットされているバイトを8進数のシーケンス(<literal>\</><replaceable>nnn</>)に変換し 、バックスラッシュを二重化します。
        </entry>
        <entry><literal>encode(E'123\\000\\001', 'base64')</literal></entry>
        <entry><literal>MTIzAAE=</literal></entry>
@@ -2209,7 +2209,7 @@ NULLは無視される。
         rest to lower case. Words are sequences of alphanumeric
         characters separated by non-alphanumeric characters.
 -->
-それぞれの単語の第一文字を大文字にし、残りは小文字のまま残します。
+それぞれの単語の第一文字を大文字に、残りは小文字に変換します。
 ここで単語とは、英数字以外の文字で区切られた、英数字からなる文字の並びのことです。
        </entry>
        <entry><literal>initcap('hi THOMAS')</literal></entry>
@@ -2231,7 +2231,7 @@ NULLは無視される。
         is negative, return all but last |<replaceable>n</>| characters.
 -->
 文字列の先頭から<replaceable>n</>文字を返します。
-<replaceable>n</>が負数の場合、|<replaceable>n</>|の数だけ文字列の末尾から切り取った文字列を返します。
+<replaceable>n</>が負数の場合、文字列の末尾から|<replaceable>n</>|文字を切り取った文字列を返します。
         </entry>
        <entry><literal>left('abcde', 2)</literal></entry>
        <entry><literal>ab</literal></entry>
@@ -2416,8 +2416,8 @@ NULLは無視される。
         Coerce the given value to text and then quote it as a literal.
         Embedded single-quotes and backslashes are properly doubled.
 -->
-与えられた値をテキストに強制し、そしてリテラルとして引用符付けします。
-組み込まれた一重引用符とバックスラッシュは適切に二重化されます。
+与えられた値をテキストに変換し、そしてリテラルとして引用符付けします。
+埋め込まれた一重引用符とバックスラッシュは適切に二重化されます。
        </entry>
        <entry><literal>quote_literal(42.5)</literal></entry>
        <entry><literal>'42.5'</literal></entry>
@@ -2439,7 +2439,7 @@ NULLは無視される。
         Embedded single-quotes and backslashes are properly doubled.
         See also <xref linkend="plpgsql-quote-literal-example">.
 -->
-与えられた文字列を、<acronym>SQL</acronym>問い合わせ文字列で文字リテラルとして使用できるように、適切な引用符を付けて返します。
+与えられた文字列を、<acronym>SQL</acronym>問い合わせ文字列で文字列リテラルとして使用できるように、適切な引用符を付けて返します。
 また、引数がNULLの場合、<literal>NULL</>を返します。
 埋め込まれた単一引用符およびバックスラッシュは適切に二重化されます。
 <xref linkend="plpgsql-quote-literal-example">も参照してください。
@@ -2457,7 +2457,7 @@ NULLは無視される。
         or, if the argument is null, return <literal>NULL</>.
         Embedded single-quotes and backslashes are properly doubled.
 -->
-与えられた値をテキストに強制し、そしてリテラルとして引用符付けします。そうでないと、引数がNULLの場合は<literal>NULL</>を返します。
+与えられた値をテキストに変換し、そしてリテラルとして引用符付けします。引数がNULLの場合は<literal>NULL</>を返します。
 埋め込まれた単一引用符とバックスラッシュは適切に二重化されます。
        </entry>
        <entry><literal>quote_nullable(42.5)</literal></entry>
@@ -2617,7 +2617,7 @@ POSIX正規表現を区切り文字に使って<parameter>string</parameter>を�
         is negative, return all but first |<replaceable>n</>| characters.
 -->
 文字列の末尾から<replaceable>n</>文字を返します。
-<replaceable>n</>が負数の場合は、|<replaceable>n</>|の数だけ文字列の末尾から切り取った文字列を返します。
+<replaceable>n</>が負数の場合は、文字列の先頭から|<replaceable>n</>|文字だけ切り取った文字列を返します。
        </entry>
        <entry><literal>right('abcde', 2)</literal></entry>
        <entry><literal>de</literal></entry>
@@ -2790,7 +2790,7 @@ POSIX正規表現を区切り文字に使って<parameter>string</parameter>を�
         <parameter>to</parameter>, occurrences of the extra characters in
         <parameter>from</parameter> are removed.
 -->
-<parameter>from</parameter>集合で指定された文字と一致する<parameter>string</parameter>にある全ての文字は、それに対応する<parameter>to</parameter>で指定された文字に置き換えられます。
+<parameter>from</parameter>集合内の文字と一致する<parameter>string</parameter>にある全ての文字は、<parameter>to</parameter>集合内のそれに対応する文字に置き換えられます。
 もし<parameter>from</parameter>が<parameter>to</parameter>より長い場合、<parameter>from</parameter>で指定される余分な文字に一致するものは削除されます。
        </entry>
        <entry><literal>translate('12345', '143', 'ax')</literal></entry>
@@ -3666,9 +3666,9 @@ POSIX正規表現を区切り文字に使って<parameter>string</parameter>を�
      and inserted into the result string according to the format specifier(s).
 -->
 <replaceable>formatstr</>は結果がどのようにフォーマットされるかを指定するフォーマット文字列です。
-<firstterm>フォーマット指示子</>が使用されている以外、フォーマット文字列のテキストは結果に直接コピーされます。
-引き続く関数の引数がどのようにフォーマットされなければならないか、そして結果に挿入されるべきかを定義して、フォーマット指示子は文字列の中で代替物のように振舞います。
-それぞれの<replaceable>formatarg</>引数はそのデータ型に対する通常の出力規定に従ってテキストに変換され、その後フォーマット指示子に従いフォーマットされ、結果文字列に挿入されます。
+<firstterm>フォーマット指示子</>が使用されている箇所を除き、フォーマット文字列のテキストは結果に直接コピーされます。
+フォーマット指示子は文字列中のプレースホルダとして振舞い、その後に引き続く関数引数がどのようにフォーマットされ、どのように結果に挿入されるかを定義します。
+それぞれの<replaceable>formatarg</>引数はそのデータ型に対する通常の出力規定に従ってテキストに変換され、その後フォーマット指示子に従って、結果文字列に挿入されます。
     </para>
 
     <para>
@@ -3676,7 +3676,7 @@ POSIX正規表現を区切り文字に使って<parameter>string</parameter>を�
      Format specifiers are introduced by a <literal>%</> character and have
      the form
 -->
-フォーマット指示子は<literal>%</>文字で導入され、以下の形式です。
+フォーマット指示子は<literal>%</>文字で始まり、以下の形式をとります。
 <synopsis>
 %[<replaceable>position</>][<replaceable>flags</>][<replaceable>width</>]<replaceable>type</>
 </synopsis>
@@ -3690,7 +3690,7 @@ POSIX正規表現を区切り文字に使って<parameter>string</parameter>を�
 <!--
        <term><replaceable>position</replaceable> (optional)</term>
 -->
-       <term><replaceable>position</replaceable> (任意)</term>
+       <term><replaceable>position</replaceable> (省略可能)</term>
        <listitem>
         <para>
 <!--
@@ -3711,7 +3711,7 @@ POSIX正規表現を区切り文字に使って<parameter>string</parameter>を�
 <!--
        <term><replaceable>flags</replaceable> (optional)</term>
 -->
-       <term><replaceable>flags</replaceable> (任意)</term>
+       <term><replaceable>flags</replaceable> (省略可能)</term>
        <listitem>
         <para>
 <!--
@@ -3732,7 +3732,7 @@ POSIX正規表現を区切り文字に使って<parameter>string</parameter>を�
 <!--
        <term><replaceable>width</replaceable> (optional)</term>
 -->
-       <term><replaceable>width</replaceable> (任意)</term>
+       <term><replaceable>width</replaceable> (省略可能)</term>
        <listitem>
         <para>
 <!--
@@ -3747,7 +3747,7 @@ POSIX正規表現を区切り文字に使って<parameter>string</parameter>を�
          use the <replaceable>n</>th function argument as the width.
 -->
 フォーマット指示子の出力を表示する<emphasis>最小</>文字数を指定します。
-出力は（<literal>-</> flagによって）幅を満たすのに必要な空白が左または右に埋め込まれます。
+出力は、幅を満たすのに必要な空白が左または右（flagの<literal>-</>による）に埋め込まれます。
 幅が小さすぎても出力が切り詰められることはなく、単に無視されます。
 幅は次のいずれかでも指定できます。それらは、正の整数、幅としての次の関数引数として使用する星印 (<literal>*</>)、または<replaceable>n</>番目の関数引数を幅として使用する<literal>*<replaceable>n</>$</>という形式の文字列です。
         </para>
@@ -3761,7 +3761,7 @@ POSIX正規表現を区切り文字に使って<parameter>string</parameter>を�
          field of length <function>abs</>(<replaceable>width</replaceable>).
 -->
 幅を関数引数から取得する場合、その引数はフォーマット指示子の値に使用される引数より先に消費されます。
-幅の引数が負の場合、フィールド長<function>abs</>(<replaceable>width</replaceable>)の範囲内で結果は（あたかも<literal>-</> flagが指定されたように）左詰めになります。
+幅の引数が負の場合、フィールド長<function>abs</>(<replaceable>width</replaceable>)の範囲内で結果は（あたかもflagで<literal>-</>が指定されたように）左詰めになります。
         </para>
        </listitem>
       </varlistentry>
@@ -3854,7 +3854,7 @@ SELECT format('INSERT INTO %I VALUES(%L)', 'locations', E'C:\\Program Files');
      Here are examples using <replaceable>width</replaceable> fields
      and the <literal>-</> flag:
 -->
-<replaceable>width</replaceable>フィールドと<literal>-</> flagを使用した例は以下のようです。
+<replaceable>width</replaceable>フィールドとflagの<literal>-</>を使用した例を以下に示します。
 
 <screen>
 SELECT format('|%10s|', 'foo');
@@ -3907,7 +3907,7 @@ SELECT format('|%1$*2$s|', 'foo', 10, 'bar');
      function arguments to be used in the format string.
      For example:
 -->
-標準C関数<function>sprintf</>とは違って、<productname>PostgreSQL</>の <function>format</>関数はフォーマット指示子に対し、同一のフォーマット文字列の中で<replaceable>position</>フィールドがあっても無くっても問題としません。
+標準C関数<function>sprintf</>とは違って、<productname>PostgreSQL</>の<function>format</>関数は、同一のフォーマット文字列の中で<replaceable>position</>フィールドがあるフォーマット指示子と、それがないフォーマット指示子の混在を許容します。
 <replaceable>position</>フィールドが無いフォーマット指示子は常に最終の引数が消費された後に次の引数を使用します。
 さらに、<function>format</>関数はフォーマット文字列で使用されるべき全ての関数引数を要求しません。
 例を示します。
@@ -3924,7 +3924,7 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
      useful for safely constructing dynamic SQL statements.  See
      <xref linkend="plpgsql-quote-literal-example">.
 -->
-<literal>%I</> および <literal>%L</>のフォーマット指示子は特に動的SQL命令を構築する場合に便利です。
+<literal>%I</> および <literal>%L</>のフォーマット指示子は特に動的SQL命令を安全に構築する場合に便利です。
 <xref linkend="plpgsql-quote-literal-example">を参照してください。
     </para>
    </sect2>

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -2417,7 +2417,7 @@ NULLの引数は無視されます。
         Embedded single-quotes and backslashes are properly doubled.
 -->
 与えられた値をテキストに変換し、そしてリテラルとして引用符付けします。
-埋め込まれた一重引用符とバックスラッシュは適切に二重化されます。
+埋め込まれた単一引用符とバックスラッシュは適切に二重化されます。
        </entry>
        <entry><literal>quote_literal(42.5)</literal></entry>
        <entry><literal>'42.5'</literal></entry>


### PR DESCRIPTION
(1) 算術演算子の解説の冒頭の誤訳を訂正
(2) bitwiseの訳語を「バイナリ」から「ビット」「ビットごと」に変更（ファイル内および他のファイルと統一）
(3) degrees()とradians()の説明を改善
(4) round()とtrunc()の説明を改善
(5) padの訳語を「パッドする」から「詰め込む」に変更
(6) needの訳語を「期待」から「必要」に変更
(7) ||演算子の説明の軽微な誤訳を訂正
(8) substringの訳語を「副文字列」から「部分文字列」に変更(他と統一)
(9) trim()の説明の軽微な誤訳を訂正
(10) 動詞の"list"が連続する箇所について、訳語を「列挙する」で統一
(11) chr()の説明の軽微な誤訳を訂正
(12) concat()およびconcat_ws()の説明を他に合わせて「ですます」調にし、また原文に忠実な訳文に変更
(13) convert()の軽微な誤訳を訂正
(14) decode()の軽微な誤訳を訂正
(15) encode()の軽微な誤訳を訂正
(16) initcap()の誤訳を訂正
(17) left()の説明を改善
(18) quote_literal()などでのcoerceの訳語を「強制」から「変換」に変更（coersionの訳語と語感を統一）
(19) quote_nullable()の説明を改善
(20) right()の誤訳を訂正すると同時に説明を改善
(21) translate()の説明を原文に忠実なものに変更
(22) formatstrの解説における"except where..."の誤訳を訂正
(23) introduceの訳語を「始まる」に変更
(24) フォーマット指示子の解説でのoptionalを「任意」から「省略可能」に変更
(25) フォーマット指示子の解説で"- flag"の訳を「flagの-」に変更し、関連する訳文も一部修正
(26) Cのsprintfとの違いの説明が原文に忠実でない（誤訳に近い）のを修正
(27) safelyが訳抜けしているのを補完