### PR TITLE
func.sgmlのうち、マニュアルの9.5節に該当する部分の誤訳訂正と訳文の改善

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -4113,7 +4113,7 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
         <parameter>bytes</parameter> from the start
         and end of <parameter>string</parameter>
 -->
-文字列<parameter>string</parameter>の先頭から末尾<parameter>bytes</parameter>のバイトのみを含む最長の文字列を削除します。
+文字列<parameter>string</parameter>の先頭および末尾から<parameter>bytes</parameter>のバイトのみを含む最長の文字列を削除します。
        </entry>
        <entry><literal>trim(E'\\000'::bytea from E'\\000Tom\\000'::bytea)</literal></entry>
        <entry><literal>Tom</literal></entry>
@@ -4193,7 +4193,7 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
        Decode binary data from textual representation in <parameter>string</>.
        Options for <parameter>format</> are same as in <function>encode</>.
 -->
-<parameter>string</>で表現されているテキストデータをバイナリデータに復号化します。
+<parameter>string</>で表現されているテキストデータをバイナリデータに復号します。
 <parameter>format</>のオプションは<function>encode</>と同じです。
       </entry>
       <entry><literal>decode(E'123\\000456', 'escape')</literal></entry>
@@ -4219,7 +4219,7 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
 -->
 バイナリデータをテキスト表現形式に符号化します。
 サポートされている形式は、<literal>base64</>、<literal>hex</>、<literal>escape</>です。
-<literal>escape</>は0バイトと最上位ビットがセットされているバイトを8進数のシーケンス(<literal>\</><replaceable>nnn</>)に変換し 、バックスラッシュを二重化します。
+<literal>escape</>は0のバイトと最上位ビットがセットされているバイトを8進数のシーケンス(<literal>\</><replaceable>nnn</>)に変換し 、バックスラッシュを二重化します。
       </entry>
       <entry><literal>encode(E'123\\000456'::bytea, 'escape')</literal></entry>
       <entry><literal>123\000456</literal></entry>


### PR DESCRIPTION
(1) trim()の説明の誤訳を訂正
(2) decodeの訳語を「復号化」から「復号」に修正
(3) encode()の説明で"zero bytes"を「0バイト」から「0のバイト」に修正