### PR TITLE
config.sgmlの軽微な誤訳の修正。

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -10339,7 +10339,7 @@ onの場合、演算子の優先順位の変更の結果、<productname>PostgreS
         backslashes to be treated as escape characters.
        -->
        標準SQLで規定されたように、通常の文字列リテラル（<literal>'...'</>）がバックスラッシュをそのまま取り扱うか否かを制御します。
-       <productname>PostgreSQL</productname> 9.1の初期においてデフォルトは<literal>on</>です（それ以前のリリースではデフォルトとして<literal>off</>でした）。
+       <productname>PostgreSQL</productname> 9.1からデフォルトは<literal>on</>になっています（それ以前のリリースでは<literal>off</>がデフォルトでした）。
        どのように文字列リテラルが処理されるかを決めるこのパラメータを、アプリケーションで検査することができます。
 このパラメータの存在は、エスケープ文字列構文（<literal>E'...'</>）がサポートされているかどうかを示すものとも考えられます。
 エスケープ文字列構文 (<xref linkend="sql-syntax-strings-escape">)は、アプリケーションでバックスラッシュをエスケープ文字として扱いたい場合に使用すべきです。


### PR DESCRIPTION
"Beggining in ..."は聞かないフレーズで、構文的にはやや不自然ですが、「デフォルトがonになるのが9.1から始まった(begin)」と捉えるべきです。