### PR TITLE
func.sgmlのうち、マニュアルの9.7節に該当する部分の誤訳訂正と訳文の改善

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -4741,7 +4741,7 @@ cast(-44 as bit(12))           <lineannotation>111111010100</lineannotation>
      any backslashes you write in literal string constants will need to be
      doubled.  See <xref linkend="sql-syntax-strings"> for more information.
 -->
-もし<xref linkend="guc-standard-conforming-strings">パラメータをoffにしていた場合、リテラル文字列定数に記述するバックスラッシュは2倍必要となります。
+<xref linkend="guc-standard-conforming-strings">パラメータをoffにしている場合、リテラル文字列定数に記述するバックスラッシュを二重にする必要があります。
 詳細は<xref linkend="sql-syntax-strings">を参照してください。
     </para>
    </note>
@@ -4839,7 +4839,7 @@ SQLの正規表現は、<function>LIKE</function>表記と一般的な正規表�
     comparable to <literal>.</> and <literal>.*</> in POSIX regular
     expressions).
 -->
-<function>LIKE</function>と同様、<function>SIMILAR TO</function>演算子は、そのパターンが文字列全体に一致した場合のみ処理を行います。これは、パターンが文字列の一部分であっても一致する、一般的な正規表現の動作とは異なっています。
+<function>LIKE</function>と同様、<function>SIMILAR TO</function>演算子は、そのパターンが文字列全体に一致した場合のみ真を返します。これは、パターンが文字列の一部分であっても一致する、一般的な正規表現の動作とは異なっています。
 また、<function>LIKE</function>と同様、<function>SIMILAR TO</function>では、<literal>%</>および<literal>_</>を、それぞれ任意の文字列および任意の単一文字を意味するワイルドカード文字として使用します（これらは、POSIX正規表現での<literal>.*</>および<literal>.</>に相当します）。
    </para>
 
@@ -4866,7 +4866,7 @@ SQLの正規表現は、<function>LIKE</function>表記と一般的な正規表�
       <literal>*</literal> denotes repetition of the previous item zero
       or more times.
 -->
-<literal>*</literal>は、直前の項目の0回以上複数の繰り返しを意味します。
+<literal>*</literal>は、直前の項目の0回以上の繰り返しを意味します。
      </para>
     </listitem>
     <listitem>
@@ -4875,7 +4875,7 @@ SQLの正規表現は、<function>LIKE</function>表記と一般的な正規表�
       <literal>+</literal> denotes repetition of the previous item one
       or more times.
 -->
-<literal>+</literal>は、直前の項目の1回以上複数の繰り返しを意味します。
+<literal>+</literal>は、直前の項目の1回以上の繰り返しを意味します。
      </para>
     </listitem>
     <listitem>
@@ -5170,7 +5170,7 @@ substring('foobar' from '#"o_b#"%' for '#')    <lineannotation>NULL</lineannotat
 -->
 2つのパラメータを持つ<function>substring</>関数、<function>substring(<parameter>string</parameter> from <replaceable>pattern</replaceable>)</function>を使用して、POSIX正規表現パターンに一致する部分文字列を取り出すことができます。
 この関数は、一致するものがない場合にはNULLを返し、ある場合はパターンにマッチしたテキストの一部を返します。
-しかし、任意の丸括弧を持つパターンの場合、最初の丸括弧内部分正規表現（左丸括弧が最初に来るもの）に一致するテキストの一部が返されます。
+しかし、丸括弧を持つパターンの場合、最初の丸括弧内部分正規表現（左丸括弧が最初に来るもの）に一致するテキストの一部が返されます。
 この例外を起こさずにパターン中に丸括弧を使用したいのであれば、常に正規表現全体を丸括弧で囲むことができます。
 パターン内の抽出対象の部分文字列より前に丸括弧が必要な場合、後述の捕捉されない丸括弧を参照してください。
     </para>
@@ -5215,15 +5215,14 @@ substring('foobar' from 'o(.)b')   <lineannotation>o</lineannotation>
      described in <xref linkend="posix-embedded-options-table">.
 -->
 <function>regexp_replace</>関数は、POSIX正規表現パターンに一致する部分文字列を新規テキストと置換します。
-構文は、<function>regexp_replace</function>（<replaceable>source</>、<replaceable>pattern</>、<replaceable>replacement</> <optional>、<replaceable>flags</> </optional>）です。
+構文は、<function>regexp_replace</function>(<replaceable>source</>, <replaceable>pattern</>, <replaceable>replacement</> <optional>, <replaceable>flags</> </optional>)です。
 <replaceable>pattern</>にマッチしない場合は、<replaceable>source</>文字列がそのまま返されます。
 一致すると、マッチ部分文字列を<replaceable>replacement</>文字列で置換した<replaceable>source</>文字列が返されます。
-<replaceable>replacement</>は<literal>\</><replaceable>n</>を含むことができます。
-ここで<replaceable>n</>は、<replaceable>n</>番目に丸括弧で括られたパターンの部分表現に一致する元の部分文字列を示す、1から9までの数です。
-<literal>\&amp;</>が含まれた場合、パターン全体と一致する部分文字列が挿入されることを示します。
+<replaceable>replacement</>文字列に<literal>\</><replaceable>n</>（<replaceable>n</>は1から9までの数字）を入れて、パターン内の<replaceable>n</>番目の丸括弧つき部分表現に一致する元の部分文字列を挿入することができます。
+また、<literal>\&amp;</>を入れて、パターン全体と一致する部分文字列を挿入することもできます。
 置換テキスト内にバックスラッシュそのものを挿入する必要がある時は<literal>\\</>と記述します。
 <replaceable>flags</>パラメータは、関数の動作を変更するゼロもしくはそれ以上の1文字フラグを含むオプションのテキスト文字列です。フラグ<literal>i</>は大文字小文字を区別しない一致を指定する一方、フラグ<literal>g</>は、最初に一致したもののみではなく、それぞれ一致した部分文字列の置換を指定します。
-有効なフラグは(<literal>g</>はそうではありませんが)<xref linkend="posix-embedded-options-table">に記述されています。
+有効なフラグは(<literal>g</>を除く)<xref linkend="posix-embedded-options-table">に記述されています。
     </para>
 
    <para>
@@ -5269,13 +5268,13 @@ regexp_replace('foobarbaz', 'b(..)', E'X\\1Y', 'g')
 -->
 <function>regexp_matches</>関数はPOSIX正規表現パターンマッチの結果捕捉された全ての部分文字列のテキスト配列を返します。
 <function>regexp_matches</function>(<replaceable>string</>, <replaceable>pattern</> <optional>, <replaceable>flags</> </optional>)の構文になります。
-この関数は何も行を返さない、1行を返す、複数行を返すといったことができます。下記の<literal>g</>フラグを参照して下さい。
+この関数は何も行を返さない、1行を返す、複数行を返す（下記の<literal>g</>フラグを参照）といったことができます。
 もし<replaceable>pattern</>に対して一致しない場合、関数は行を返しません。
 もし、パターンが丸括弧に括られた部分文字列を含まない場合、結果はパターン全体に一致する部分文字列を含む単一要素のテキスト配列となります。
-もし、パターンが丸括弧に括られた部分文字列を含む場合、関数はパターンの<replaceable>n</>番目に丸括弧で括られた部分文字列に一致する、<replaceable>n</>番目の要素が部分文字列であるテキスト配列を返します（<quote>捕捉されない</>丸括弧は数えません。詳細は下を見てください。）。
+もし、パターンが丸括弧に括られた部分文字列を含む場合、関数はテキスト配列を返し、その<replaceable>n</>番目の要素は、パターンの<replaceable>n</>番目に丸括弧で括られた部分文字列に一致する部分文字列となります（<quote>捕捉されない</>丸括弧は数えません。詳細は下を見てください。）。
 <replaceable>flags</>パラメータは、関数の動作を変更するゼロもしくは複数の単一文字フラグを含むオプションのテキスト文字列です。
-フラグ<literal>g</>は関数に、最初のマッチだけでなく文字列の中で全てのマッチを検出させ、それら一致の行を返させます。
-有効なフラグは(<literal>g</>はそうではありませんが)<xref linkend="posix-embedded-options-table">に記載されています。
+フラグ<literal>g</>を指定すると、関数は最初のマッチだけでなく文字列の中で全てのマッチを検出し、それぞれの一致について1行を返します。
+有効なフラグは(<literal>g</>を除く)<xref linkend="posix-embedded-options-table">に記載されています。
     </para>
 
    <para>
@@ -5312,8 +5311,8 @@ SELECT regexp_matches('foobarbequebaz', 'barbeque');
     in a <literal>SELECT</> target list when you want all rows
     returned, even non-matching ones:
 -->
-副問い合わせを使用することで、<function>regexp_matches()</>が常に1行しか返さないように強制することが可能です。
-これは、<literal>SELECT</>対象のリストに対し、マッチするものが無い場合であっても全ての行を返したい場合に特に有用です。
+副問い合わせを使用することで、<function>regexp_matches()</>が常に1行を返すように強制することが可能です。
+これは、<literal>SELECT</>の対象リスト内で、マッチするものが無い行も含めて全ての行を返して欲しい場合に特に有用です。
 <programlisting>
 SELECT col1, (SELECT regexp_matches(col2, '(bar)(beque)')) FROM tab;
 </programlisting>
@@ -5354,6 +5353,7 @@ SELECT col1, (SELECT regexp_matches(col2, '(bar)(beque)')) FROM tab;
 -->
 <function>regexp_split_to_array</>関数は、<function>regexp_split_to_array</>がその結果を<type>text</>配列で返すことを除いて、<function>regexp_split_to_table</>と同じ動作をします。
 <function>regexp_split_to_array</function>(<replaceable>string</>, <replaceable>pattern</> <optional>, <replaceable>flags</> </optional>)の構文になります。
+パラメータは<function>regexp_split_to_table</>のものと同じです。
     </para>
 
    <para>


### PR DESCRIPTION
(1) doubledの訳語を「2倍」から「二重」に修正し、さらに訳文を一部修正
(2) similar toの解説で、succeedを「処理を行う」から「真を返す」に修正
(3) 「0回以上複数の繰り返し」「1回以上複数の繰り返し」の「複数」を削除
(4) anyを「任意の」と訳していた誤りを修正（日本語では不要なので訳出しない）
(5) regexp_replaceの構文説明の括弧とカンマは半角にする
(6) \n, \&の説明がわかりにくいので書き直した
(7) "though not g"の訳が不自然なので修正
(8) regexp_matchの解説で括弧つきの注を原文に合わせて括弧つきにした
(9) 配列を返すパターンの説明がわかりにくいので書き直した
(10) gフラグで複数マッチしたときの、「それら一致の行を返させます」は誤訳なので訂正すると同時に、不自然な使役表現を修正
(11) sub-selectでregexp_matchesを使う例の解説文を訳し直した
(12) regexp_split_to_arrayの説明の最後の文が訳抜けしていたので翻訳した