### PR TITLE
インデックスの各章で訳語の統一([jpug-doc: 4936])

### DIFF
--- a/doc/src/sgml/brin.sgml
+++ b/doc/src/sgml/brin.sgml
@@ -124,7 +124,7 @@
 <!--
  <title>Built-in Operator Classes</title>
 -->
- <title>組み込みオペレータクラス</title>
+ <title>組込み演算子クラス</title>
 
  <para>
 <!--
@@ -151,7 +151,7 @@
 <!--
   <title>Built-in <acronym>BRIN</acronym> Operator Classes</title>
 -->
-  <title>組み込み<acronym>BRIN</acronym>演算子クラス</title>
+  <title>組込み<acronym>BRIN</acronym>演算子クラス</title>
 
   <tgroup cols="3">
    <thead>
@@ -163,7 +163,7 @@
 -->
      <entry>名前</entry>
      <entry>インデックスされるデータ型</entry>
-     <entry>インデックス可能なオペレータ</entry>
+     <entry>インデックス可能な演算子</entry>
     </row>
    </thead>
    <tbody>
@@ -678,8 +678,8 @@ Scankeyがある範囲のインデックス値と一致しているかどうか�
   <xref linkend="brin-extensibility-minmax-table">.
   All operator class members (procedures and operators) are mandatory.
 -->
-<xref linkend="brin-extensibility-minmax-table">で示すように、全順序集合を実装するデータ型のための演算子クラスを書くために、関連するオペレータとともにminmaxサポート関数を使うことができます。
-オペレータクラスのメンバー(手続きとオペレータ)はすべて必須です。
+<xref linkend="brin-extensibility-minmax-table">で示すように、全順序集合を実装するデータ型のための演算子クラスを書くために、関連する演算子とともにminmaxサポート関数を使うことができます。
+演算子クラスのメンバー(手続きと演算子)はすべて必須です。
  </para>
 
  <table id="brin-extensibility-minmax-table">
@@ -750,7 +750,7 @@ Scankeyがある範囲のインデックス値と一致しているかどうか�
   are optional.  Some operators require other operators, as shown as
   dependencies on the table.
 -->
-<xref linkend="brin-extensibility-inclusion-table">で示すように、他のデータ型の値を含む複合データ型の演算子クラスを書くには、関連するオペレータとともに、inclusionサポート関数を使うことができます。
+<xref linkend="brin-extensibility-inclusion-table">で示すように、他のデータ型の値を含む複合データ型の演算子クラスを書くには、関連する演算子とともに、inclusionサポート関数を使うことができます。
 任意の言語で書かれたたったひとつの関数を追加するだけです。
 機能を追加するために関数を追加できます。
 すべての演算子はオプションです。
@@ -930,7 +930,7 @@ Scankeyがある範囲のインデックス値と一致しているかどうか�
     some operations when the union is not changed, using this
     function can improve index performance.
 -->
-サポート関数番号12と14は、組み込みデータ型の例外事象をサポートするために提供されます
+サポート関数番号12と14は、組込みデータ型の例外事象をサポートするために提供されます
 サポート関数番号12は、マージできない異なるファミリーのネットワークアドレスをサポートするために使用されます。
 サポート関数番号14は、空のレンジをサポートするために使用されます。
 サポート関数番号13はオプションで、和関数に渡される前に新しい値のチェックを行うためのものとして推奨されます。

--- a/doc/src/sgml/gin.sgml
+++ b/doc/src/sgml/gin.sgml
@@ -132,8 +132,8 @@
       <entry>Indexable Operators</entry>
 -->
       <entry>名前</entry>
-      <entry>インデックス付けするデータ型</entry>
-      <entry>インデックス可能演算子</entry>
+      <entry>インデックスされるデータ型</entry>
+      <entry>インデックス可能な演算子</entry>
      </row>
     </thead>
     <tbody>

--- a/doc/src/sgml/gist.sgml
+++ b/doc/src/sgml/gist.sgml
@@ -18,7 +18,7 @@
 <!--
  <title>Introduction</title>
 -->
- <title>序文</title>
+ <title>はじめに</title>
 
  <para>
 <!--
@@ -95,8 +95,8 @@ B-tree、R-treeやその他多くのインデックスの枠組みを<acronym>Gi
       <entry>Ordering Operators</entry>
 -->
       <entry>名前</entry>
-      <entry>インデックス付けするデータ型</entry>
-      <entry>インデックス可能演算子</entry>
+      <entry>インデックスされるデータ型</entry>
+      <entry>インデックス可能な演算子</entry>
       <entry>順序付け演算子</entry>
      </row>
     </thead>
@@ -1280,7 +1280,7 @@ CREATE INDEXコマンドの<literal>buffering</literal>パラメータによっ�
   operator classes:
 -->
 <productname>PostgreSQL</productname>のソース配布物には<acronym>GiST</acronym>を使用したインデックスメソッドの実装のいくつかの事例が含まれています。
-コアシステムは現在全文検索サポート（<type>tsvector</>と<type>tsquery</>のインデックス付け）や組み込みの幾何データ型の一部に対するR-Treeと等価な機能を提供します
+コアシステムは現在全文検索サポート（<type>tsvector</>と<type>tsquery</>のインデックス付け）や組込みの幾何データ型の一部に対するR-Treeと等価な機能を提供します
 （<filename>src/backend/access/gist/gistproc.c</>を参照してください）。
 以下の<filename>contrib</>モジュールも同時に<acronym>GiST</acronym>演算子クラスを含みます。
 

--- a/doc/src/sgml/spgist.sgml
+++ b/doc/src/sgml/spgist.sgml
@@ -88,7 +88,7 @@
 <!--
  <title>Built-in Operator Classes</title>
 -->
- <title>ビルトインの演算子クラス</title>
+ <title>組込み演算子クラス</title>
 
  <para>
 <!--
@@ -103,7 +103,7 @@
 <!--
    <title>Built-in <acronym>SP-GiST</acronym> Operator Classes</title>
 -->
-   <title>ビルトインの<acronym>SP-GiST</acronym>の演算子クラス</title>
+   <title>組込み<acronym>SP-GiST</acronym>演算子クラス</title>
    <tgroup cols="3">
     <thead>
      <row>


### PR DESCRIPTION
オペレータ->演算子
ビルトイン->組込み
インデックス付けするデータ型->インデックスされるデータ型
インデックス可能演算子->インデックス可能な演算子
序文->はじめに