### PR TITLE
func.sgmlのうち、マニュアルの9.10節に該当する部分の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -10690,7 +10690,7 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
 <!--
        <entry>Returns the first value of the input enum type</entry>
 -->
-       <entry>最初の入力列挙型の値を返す</entry>
+       <entry>入力列挙型の最初の値を返す</entry>
        <entry><literal>enum_first(null::rainbow)</literal></entry>
        <entry><literal>red</literal></entry>
       </row>
@@ -10704,7 +10704,7 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
 <!--
        <entry>Returns the last value of the input enum type</entry>
 -->
-       <entry>最後の入力列挙型の値を返す</entry>
+       <entry>入力列挙型の最後の値を返す</entry>
        <entry><literal>enum_last(null::rainbow)</literal></entry>
        <entry><literal>purple</literal></entry>
       </row>
@@ -10718,7 +10718,7 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
 <!--
        <entry>Returns all values of the input enum type in an ordered array</entry>
 -->
-       <entry>ある順序付けられた配列にもとづいて入力列挙型の全ての値を返す</entry>
+       <entry>入力列挙型の全ての値を順序配列として返す</entry>
        <entry><literal>enum_range(null::rainbow)</literal></entry>
        <entry><literal>{red,orange,yellow,green,blue,purple}</literal></entry>
       </row>
@@ -10733,10 +10733,10 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
         If the second parameter is null, the result will end with the last
         value of the enum type.
 -->
-与えられた２つの列挙型値の範囲を、ある順序付けられた配列として返す。
+与えられた２つの列挙型値の範囲を、順序配列として返す。
 値は同一の列挙型に拠らなければならない。
-始めのパラメータがNULLの場合、結果は列挙型の最初の値から始まる。
-２番目のパラメータがNULLの場合、結果は列挙型の最後の値で終端する。
+１番目のパラメータがNULLの場合、結果は列挙型の最初の値から始まる。
+２番目のパラメータがNULLの場合、結果は列挙型の最後の値で終わる。
        </entry>
        <entry><literal>enum_range('orange'::rainbow, 'green'::rainbow)</literal></entry>
        <entry><literal>{orange,yellow,green}</literal></entry>
@@ -10762,9 +10762,9 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
     apply these functions to a table column or function argument than to
     a hardwired type name as suggested by the examples.
 -->
-<function>enum_range</>の２引数形式を除いて、関数に渡された特定の値はそれら関数が無視することに注意してください。関数は宣言されたデータ型のみ配慮します。
-NULLまたはその型の特定値のみが渡され、同一の結果をもたらします。
-例が示唆しているように、組み込まれている型名に対してではなく、テーブル列もしくは関数引数にこれらの関数を適用することがより一般的です。
+<function>enum_range</>の２引数の形式を除き、これらの関数は、渡された特定の値を無視することに注意してください。関数は宣言されたデータ型のみ配慮します。
+その型のNULLまたは特定の値を渡すことができ、同一の結果が得られます。
+例で示したような直書きした型名に対してではなく、テーブル列もしくは関数引数にこれらの関数を適用することがより一般的です。
    </para>
  </sect1>
 


### PR DESCRIPTION
列挙型の関数の説明ですが、日本語の意味がわかりにくい部分が多かったので、かなり直しました。