### PR TITLE
.replaceableをスタイル追加

### DIFF
--- a/doc/src/sgml/stylesheet.css
+++ b/doc/src/sgml/stylesheet.css
@@ -24,10 +24,14 @@ A:visited	{ color:#004E66; }
 A:active	{ color:#0085B0; }
 A:hover		{ color:#000000; }
 
-p i, pre i, .emphasis em, code {
+p i, pre i, .emphasis em {
 	font-style: normal;
 	font-weight: bold;
 	color: #440000;
+}
+
+.replaceable code {
+	font-style: italic;
 }
 
 pre strong {

--- a/doc/src/sgml/stylesheet.xsl
+++ b/doc/src/sgml/stylesheet.xsl
@@ -40,7 +40,6 @@
   <xsl:choose>
     <xsl:when test="$html.original = 1">
       <span class="original" xmlns="http://www.w3.org/1999/xhtml">
-        <xsl:comment>$<xsl:value-of select="dbhtml-filename"/></xsl:comment>
         <xsl:value-of select="." />
       </span><br xmlns="http://www.w3.org/1999/xhtml"/>
     </xsl:when>


### PR DESCRIPTION
<code>の強調は止める
stylesheet.xslで不要な記述を削除