### PR TITLE
func.sgmlのマニュアル9.8節に該当する部分の誤訳訂正と翻訳改善。

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -7385,7 +7385,7 @@ BREにおいては、<literal>|</>、<literal>+</>、<literal>?</>は普通の�
 <!--
         <entry>convert string to numeric</entry>
 -->
-        <entry>文字列を数値に変換します</entry>
+        <entry>文字列を数値に変換</entry>
         <entry><literal>to_number('12,454.8-', '99G999D9S')</literal></entry>
        </row>
        <row>
@@ -7424,9 +7424,9 @@ BREにおいては、<literal>|</>、<literal>+</>、<literal>?</>は普通の�
     other functions), template patterns identify the values to be supplied by
     the input data string.
 -->
-（<function>to_char</>用）出力テンプレート文字列には、値に基づいて認識され、適切に整形されたデータで置き換えられるパターンがあります。
+<function>to_char</>用の出力テンプレート文字列には、値に基づいて認識され、適切に整形されたデータで置き換えられるパターンがあります。
 テンプレートパターンではない全てのテキストは単にそのままコピーされます。
-同様に、（その他の関数に対し）入力テンプレート文字列では、テンプレートパターンは入力されたデータ文字列で供給される値を特定します。
+同様に、（その他の関数用の）入力テンプレート文字列では、テンプレートパターンは入力されたデータ文字列で供給される値を特定します。
    </para>
 
   <para>
@@ -7539,7 +7539,7 @@ BREにおいては、<literal>|</>、<literal>+</>、<literal>?</>は普通の�
 <!--
         <entry>year (4 or more digits) with comma</entry>
 -->
-        <entry>句読点（コンマ）付き年（4桁以上）</entry>
+        <entry>コンマ付き年（4桁以上）</entry>
        </row>
        <row>
         <entry><literal>YYYY</literal></entry>
@@ -7574,7 +7574,7 @@ BREにおいては、<literal>|</>、<literal>+</>、<literal>?</>は普通の�
 <!--
         <entry>ISO 8601 week-numbering year (4 or more digits)</entry>
 -->
-        <entry>ISO 8601週番号年（4以上の桁）</entry>
+        <entry>ISO 8601週番号年（4桁以上）</entry>
        </row>
        <row>
         <entry><literal>IYY</literal></entry>
@@ -7626,21 +7626,21 @@ BREにおいては、<literal>|</>、<literal>+</>、<literal>?</>は普通の�
 <!--
         <entry>full upper case month name (blank-padded to 9 chars)</entry>
 -->
-        <entry>大文字での完全な月名（9文字になるように空白でパッド）</entry>
+        <entry>大文字での完全な月名（9文字になるように空白文字を埋める）</entry>
        </row>
        <row>
         <entry><literal>Month</literal></entry>
 <!--
         <entry>full capitalized month name (blank-padded to 9 chars)</entry>
 -->
-        <entry>大文字で書き始める完全な月名（9文字になるように空白でパッド）</entry>
+        <entry>大文字で書き始める完全な月名（9文字になるように空白文字を埋める）</entry>
        </row>
        <row>
         <entry><literal>month</literal></entry>
 <!--
         <entry>full lower case month name (blank-padded to 9 chars)</entry>
 -->
-        <entry>小文字での完全な月名（9文字になるように空白でパッド）</entry>
+        <entry>小文字での完全な月名（9文字になるように空白文字を埋める）</entry>
        </row>
        <row>
         <entry><literal>MON</literal></entry>
@@ -7675,21 +7675,21 @@ BREにおいては、<literal>|</>、<literal>+</>、<literal>?</>は普通の�
 <!--
         <entry>full upper case day name (blank-padded to 9 chars)</entry>
 -->
-        <entry>大文字での完全な曜日名（9文字になるように空白でパッド）</entry>
+        <entry>大文字での完全な曜日名（9文字になるように空白文字を埋める）</entry>
        </row>
        <row>
         <entry><literal>Day</literal></entry>
 <!--
         <entry>full capitalized day name (blank-padded to 9 chars)</entry>
 -->
-        <entry>大文字で書き始める完全な曜日名（9文字になるように空白でパッド）</entry>
+        <entry>大文字で書き始める完全な曜日名（9文字になるように空白文字を埋める）</entry>
        </row>
        <row>
         <entry><literal>day</literal></entry>
 <!--
         <entry>full lower case day name (blank-padded to 9 chars)</entry>
 -->
-        <entry>小文字での完全な曜日名（9文字になるように空白でパッド）</entry>
+        <entry>小文字での完全な曜日名（9文字になるように空白文字を埋める）</entry>
        </row>
        <row>
         <entry><literal>DY</literal></entry>
@@ -7731,21 +7731,21 @@ BREにおいては、<literal>|</>、<literal>+</>、<literal>?</>は普通の�
 <!--
         <entry>day of month (01-31)</entry>
 -->
-        <entry>ひと月通算の日にち番号（01〜31）</entry>
+        <entry>月内の日にち番号（01〜31）</entry>
        </row>
        <row>
         <entry><literal>D</literal></entry>
 <!--
         <entry>day of the week, Sunday (<literal>1</>) to Saturday (<literal>7</>)</entry>
 -->
-        <entry>1週通算の曜日番号、日曜日（<literal>1</>）から土曜日（<literal>7</>）まで</entry>
+        <entry>曜日番号、日曜日（<literal>1</>）から土曜日（<literal>7</>）まで</entry>
        </row>
        <row>
         <entry><literal>ID</literal></entry>
 <!--
         <entry>ISO 8601 day of the week, Monday (<literal>1</>) to Sunday (<literal>7</>)</entry>
 -->
-        <entry>ISO 8601週通算の曜日番号、月曜日（<literal>1</>）から日曜日（<literal>7</>）まで</entry>
+        <entry>ISO 8601の曜日番号、月曜日（<literal>1</>）から日曜日（<literal>7</>）まで</entry>
        </row>
        <row>
         <entry><literal>W</literal></entry>
@@ -7759,7 +7759,7 @@ BREにおいては、<literal>|</>、<literal>+</>、<literal>?</>は普通の�
 <!--
         <entry>week number of year (1-53) (the first week starts on the first day of the year)</entry>
 -->
-        <entry>年間を通じた週番号（1〜53）（元旦のある週が第1週）</entry>
+        <entry>年間を通じた週番号（1〜53）（元日のある週が第1週）</entry>
        </row>
        <row>
         <entry><literal>IW</literal></entry>
@@ -7787,21 +7787,21 @@ BREにおいては、<literal>|</>、<literal>+</>、<literal>?</>は普通の�
 <!--
         <entry>quarter (ignored by <function>to_date</> and <function>to_timestamp</>)</entry>
 -->
-        <entry>クォータ（四半期 : <function>to_date</>と<function>to_timestamp</>により無視されます）</entry>
+        <entry>四半期（<function>to_date</>と<function>to_timestamp</>は無視します）</entry>
        </row>
        <row>
         <entry><literal>RM</literal></entry>
 <!--
         <entry>month in upper case Roman numerals (I-XII; I=January)</entry>
 -->
-        <entry>大文字ローマ数字による月（I〜XII：I=1月）</entry>
+        <entry>大文字ローマ数字による月（I〜XII、Iは1月）</entry>
        </row>
        <row>
         <entry><literal>rm</literal></entry>
 <!--
         <entry>month in lower case Roman numerals (i-xii; i=January)</entry>
 -->
-        <entry>小文字ローマ数字による月（i〜xii：i=1月）</entry>
+        <entry>小文字ローマ数字による月（i〜xii、iは1月）</entry>
        </row>
        <row>
         <entry><literal>TZ</literal></entry>
@@ -7837,7 +7837,7 @@ BREにおいては、<literal>|</>、<literal>+</>、<literal>?</>は普通の�
     <xref linkend="functions-formatting-datetimemod-table"> shows the
     modifier patterns for date/time formatting.
 -->
-修飾子はどのようなテンプレートパターンに対しても、その振舞いを変更するために適用することができます。
+どのようなテンプレートパターンに対しても、その振舞いを変更するために修飾子を適用できます。
 例えば、<literal>FMMonth</literal>は<literal>FM</literal>修飾子の付いた<literal>Month</literal>パターンです。
 <xref linkend="functions-formatting-datetimemod-table">に、日付/時刻書式の修飾子パターンを示します。
    </para>
@@ -7920,7 +7920,7 @@ BREにおいては、<literal>|</>、<literal>+</>、<literal>?</>は普通の�
         <entry>translation mode (print localized day and month names based on
          <xref linkend="guc-lc-time">)</entry>
 -->
-        <entry>翻訳モード（<xref linkend="guc-lc-time">に基づき、現地語化された日付、月名を表示します)</entry>
+        <entry>翻訳モード（<xref linkend="guc-lc-time">に基づき、現地語化された曜日、月名を表示します)</entry>
         <entry><literal>TMMonth</literal></entry>
        </row>
        <row>
@@ -7956,8 +7956,8 @@ BREにおいては、<literal>|</>、<literal>+</>、<literal>?</>は普通の�
        specifications, and repeated <literal>FM</literal> modifiers
        toggle fill mode on and off.
 -->
-<literal>FM</literal>はパターンの出力を固定長にするため、先頭にはゼロ、末尾には空白を追加してしまう機能を無効にします。
-<productname>PostgreSQL</productname>では、<literal>FM</literal>はその次に記述されたものだけを変更します。一方Oracleでは、<literal>FM</literal>はそれに続く全ての記述に対して影響し、<literal>FM</literal>修飾詞の切り替えに応じて繰り返されます。
+<literal>FM</literal>は、先頭にはゼロ、末尾には空白を追加してパターンを固定長にする機能を無効にします。
+<productname>PostgreSQL</productname>では、<literal>FM</literal>はその次に記述されたものだけを変更します。一方Oracleでは、<literal>FM</literal>はそれに続く全ての記述に対して影響し、<literal>FM</literal>修飾詞を繰り返すと、ゼロや空白を埋めるモードのオンとオフが切り替わります。
       </para>
      </listitem>
 
@@ -7985,8 +7985,10 @@ BREにおいては、<literal>|</>、<literal>+</>、<literal>?</>は普通の�
        <literal>FX</literal> must be specified as the first item in
        the template.
 -->
-<literal>FX</literal>オプションがテンプレートが使用されている場合を除き、<function>to_timestamp</function>と<function>to_date</function>は入力文字列の複数の空白スペースを無視します。
-例えば、<function>to_timestamp</function>にはたった1つのスペースがあることになっているので、<literal>to_timestamp('2000&nbsp;&nbsp;&nbsp;&nbsp;JUN', 'YYYY MON')</literal>は動作しますが、<literal>to_timestamp('2000&nbsp;&nbsp;&nbsp;&nbsp;JUN','FXYYYY MON')</literal>はエラーを返します。<literal>FX</literal>はテンプレートの第1項目として指定される必要があります。
+<literal>FX</literal>オプションが使用されていない場合、<function>to_timestamp</function>と<function>to_date</function>は入力文字列内の複数の空白スペースを無視します。
+例えば、<literal>to_timestamp('2000&nbsp;&nbsp;&nbsp;&nbsp;JUN', 'YYYY MON')</literal>は動作しますが、<literal>to_timestamp('2000&nbsp;&nbsp;&nbsp;&nbsp;JUN','FXYYYY MON')</literal>はエラーを返します。
+後者の<function>to_timestamp</function>はスペースが1つだけあることを期待するからです。
+<literal>FX</literal>はテンプレートの第1項目として指定される必要があります。
       </para>
      </listitem>
 
@@ -8025,7 +8027,7 @@ BREにおいては、<literal>|</>、<literal>+</>、<literal>?</>は普通の�
        input characters contained in the string, e.g. <literal>"XX"</>
        skips two input characters.
 -->
-<function>to_char</function>テンプレートでは、通常のテキストが許され、そのまま出力されます。
+<function>to_char</function>テンプレートには、通常のテキストを入れることができ、それはそのまま出力されます。
 部分文字列を二重引用符で括ることで、部分文字列にパターン用のキーワードがあったとしても、強制的にリテラルテキストとして解釈させることができます。
 例えば、<literal>'"Hello Year "YYYY'</literal>では<literal>YYYY</literal>は年データに置換されてしまいますが、<literal>Year</literal>内の<literal>Y</literal>は置換されません。
 <function>to_date</>、<function>to_number</>、<function>to_timestamp</>では、二重引用符で括られた文字の数だけ入力された文字をスキップします。例えば<literal>"XX"</>が指定された場合は2文字がスキップされます。
@@ -8069,9 +8071,9 @@ BREにおいては、<literal>|</>、<literal>+</>、<literal>?</>は普通の�
        <literal>to_date('20000-1131', 'YYYY-MMDD')</literal> or
        <literal>to_date('20000Nov31', 'YYYYMonDD')</literal>.
 -->
-文字列を<type>timestamp</type>型もしくは<type>date</type>型にする<literal>YYYY</literal>変換は、4桁以上の年数値を処理するとき制限が加えられます。
-このような場合、数字以外の文字または<literal>YYYY</literal>の後にテンプレートを使わなければなりません。 そうしないと年は常に4桁と解釈されます。
-例えば（20000年として）、<literal>to_date('200001131', 'YYYYMMDD')</literal>は4桁の年と解釈されるので、<literal>to_date('20000-1131', 'YYYY-MMDD')</literal>または<literal>to_date('20000Nov31', 'YYYYMonDD')</literal>のように数字でない区切り符号の使用をお勧めします。
+文字列を<type>timestamp</type>型もしくは<type>date</type>型にする<literal>YYYY</literal>変換は、5桁以上の年数値を処理するときに制限事項があります。
+このような場合、<literal>YYYY</literal>の後に数字以外の文字またはテンプレートを使わなければなりません。 そうしないと年は常に4桁と解釈されます。
+例えば（20000年として）、<literal>to_date('200001131', 'YYYYMMDD')</literal>は4桁の年と解釈されるので、代わりに<literal>to_date('20000-1131', 'YYYY-MMDD')</literal>または<literal>to_date('20000Nov31', 'YYYYMonDD')</literal>のように数字でない区切り文字を使用してください。
       </para>
      </listitem>
 
@@ -8100,7 +8102,7 @@ BREにおいては、<literal>|</>、<literal>+</>、<literal>?</>は普通の�
        can be specified to <function>to_timestamp</function> and
        <function>to_date</function> in one of two ways:
 -->
-ISO 8601週番号日は（グレゴリオ暦の日付とは異なって）<function>to_timestamp</function>と<function>to_date</function>の２つの方法のうちのひとつで指定できます。
+ISO 8601週番号日は（グレゴリオ暦の日付とは異なって）<function>to_timestamp</function>と<function>to_date</function>で２つの方法のうちのひとつで指定できます。
        <itemizedlist>
         <listitem>
          <para>
@@ -8110,7 +8112,7 @@ ISO 8601週番号日は（グレゴリオ暦の日付とは異なって）<funct
           returns the date <literal>2006-10-19</literal>.
           If you omit the weekday it is assumed to be 1 (Monday).
 -->
-年、通年の週番号、週の曜日番号。
+年、通年の週番号、曜日番号。
 例えば、<literal>to_date('2006-42-4', 'IYYY-IW-ID')</literal>は、日付<literal>2006-10-19</literal>を返します。
 曜日番号を省略した場合、1（月曜日）と想定されます。
          </para>
@@ -8121,7 +8123,7 @@ ISO 8601週番号日は（グレゴリオ暦の日付とは異なって）<funct
           Year and day of year:  for example <literal>to_date('2006-291',
           'IYYY-IDDD')</literal> also returns <literal>2006-10-19</literal>.
 -->
-年と通年の日付番号。例えば、<literal>to_date('2006-291', 'IYYY-IDDD')</literal>のは、同様<literal>2006-10-19</literal>を返します。
+年と通年の日付番号。例えば、<literal>to_date('2006-291', 'IYYY-IDDD')</literal>も<literal>2006-10-19</literal>を返します。
          </para>
         </listitem>
        </itemizedlist>
@@ -8136,7 +8138,7 @@ ISO 8601週番号日は（グレゴリオ暦の日付とは異なって）<funct
        meaning.
 -->
 ISO 8601週番号とグレゴリオ暦日のフィールドを混在して使用して日付を構築する試みは無意味なことで、エラーの原因になります。
-ISO 8601週番号年の文脈によると、<quote>月</>、あるいは<quote>月中日付番号</>は意味を持ちません。
+ISO 8601週番号年の文脈では、<quote>月</>、あるいは<quote>月内の日付番号</>は意味を持ちません。
 グレゴリオ暦の年の文脈では、ISO週番号は意味を持ちません。
       </para>
       <caution>
@@ -8173,7 +8175,7 @@ ISO 8601週番号年の文脈によると、<quote>月</>、あるいは<quote>�
        <literal>12:003</literal>, which the conversion counts as
        12 + 0.003 = 12.003 seconds.
 -->
-文字列型から<type>timestamp</type>型への変換に際し、ミリ秒<literal>MS</literal>またはマイクロ秒<literal>US</literal>の値は小数点の位置の後の秒の桁として使用されます。
+文字列型から<type>timestamp</type>型への変換に際し、ミリ秒(<literal>MS</literal>)またはマイクロ秒(<literal>US</literal>)の値は小数点の位置の後の秒の桁として使用されます。
 例えば、<literal>to_timestamp('12:3', 'SS:MS')</literal>は3ミリ秒ではなく300ミリ秒です。なぜなら変換においてこれは12 + 0.3と計算されるからです。
 ということは、<literal>SS:MS</literal>書式に対して入力値である<literal>12:3</literal>、<literal>12:30</literal>、および<literal>12:300</literal>は同じミリ秒数を指定します。
 3ミリ秒数が必要な場合には<literal>12:003</literal>のようにしなければなりません。この時、変換において12 + 0.003 = 12.003秒と計算します。
@@ -8212,7 +8214,9 @@ ISO 8601週番号年の文脈によると、<quote>月</>、あるいは<quote>�
         and 36 hours output as <literal>12</>, while <literal>HH24</>
         outputs the full hour value, which can exceed 23 for intervals.
 -->
-<function>to_char(interval)</function>関数は、<literal>HH</>と<literal>HH12</>により、すなわち0時と36時を<literal>12</>とするような、12時間表示の出力をします。一方<literal>HH24</>はインターバル間で23を超えることが可能な24時間表示の出力をします。
+<function>to_char(interval)</function>関数は、<literal>HH</>と<literal>HH12</>を12時間の時計に表示されるように整形します。
+すなわち0時間と36時間を<literal>12</>として出力します。
+一方<literal>HH24</>は時間の値をそのまま出力し、時間間隔は23を超えることが可能です。
       </para>
      </listitem>
 
@@ -8224,7 +8228,7 @@ ISO 8601週番号年の文脈によると、<quote>月</>、あるいは<quote>�
    <xref linkend="functions-formatting-numeric-table"> shows the
    template patterns available for formatting numeric values.
 -->
-<xref linkend="functions-formatting-numeric-table">に、数値型の値の書式設定に使用可能なテンプレートパターンを示します。
+<xref linkend="functions-formatting-numeric-table">に、数値の書式設定に使用可能なテンプレートパターンを示します。
   </para>
 
     <table id="functions-formatting-numeric-table">
@@ -8286,28 +8290,28 @@ ISO 8601週番号年の文脈によると、<quote>月</>、あるいは<quote>�
 <!--
         <entry>sign anchored to number (uses locale)</entry>
 -->
-        <entry>（ロケール使用の）符号付き値</entry>
+        <entry>符号付き値（ロケールを使用）</entry>
        </row>
        <row>
         <entry><literal>L</literal></entry>
 <!--
         <entry>currency symbol (uses locale)</entry>
 -->
-        <entry>（ロケール使用の）通貨記号</entry>
+        <entry>通貨記号（ロケールを使用）</entry>
        </row>
        <row>
         <entry><literal>D</literal></entry>
 <!--
         <entry>decimal point (uses locale)</entry>
 -->
-        <entry>（ロケール使用の）小数点</entry>
+        <entry>小数点（ロケールを使用）</entry>
        </row>
        <row>
         <entry><literal>G</literal></entry>
 <!--
         <entry>group separator (uses locale)</entry>
 -->
-        <entry>（ロケール使用の）グループ区切り文字</entry>
+        <entry>グループ区切り文字（ロケールを使用）</entry>
        </row>
        <row>
         <entry><literal>MI</literal></entry>
@@ -8335,7 +8339,7 @@ ISO 8601週番号年の文脈によると、<quote>月</>、あるいは<quote>�
 <!--
         <entry>Roman numeral (input between 1 and 3999)</entry>
 -->
-        <entry>（1〜3999の入力値による）ローマ数字</entry>
+        <entry>ローマ数字（入力は1～3999）</entry>
        </row>
        <row>
 <!--
@@ -8384,8 +8388,8 @@ ISO 8601週番号年の文脈によると、<quote>月</>、あるいは<quote>�
        <literal>MI</literal>.
 -->
 <literal>SG</literal>、<literal>PL</literal>、または<literal>MI</literal>で整形された符号は、数値と関連付けられません。
-例えば、<literal>to_char(-12, 'MI9999')</literal>は<literal>'&nbsp;&nbsp;-12'</literal>となる一方、<literal>to_char(-12, 'S9999')</literal>は<literal>'&nbsp;&nbsp;-12'</literal>となります。
-Oracleの実装では<literal>9</literal>の前の<literal>MI</literal>が置かれてはならず、<literal>9</literal>の後に<literal>MI</literal>が置かれることを要求しています。
+例えば、<literal>to_char(-12, 'MI9999')</literal>は<literal>'-&nbsp;&nbsp;12'</literal>となる一方、<literal>to_char(-12, 'S9999')</literal>は<literal>'&nbsp;&nbsp;-12'</literal>となります。
+Oracleの実装では<literal>9</literal>の前に<literal>MI</literal>が置かれてはならず、<literal>9</literal>の後に<literal>MI</literal>が置かれることを要求しています。
       </para>
      </listitem>
 
@@ -8436,7 +8440,7 @@ Oracleの実装では<literal>9</literal>の前の<literal>MI</literal>が置か
 -->
 <literal>V</literal>は入力値を実質的に<literal>10^<replaceable>n</replaceable></literal>乗します。
 ここで<replaceable>n</replaceable>は<literal>V</literal>に続く桁数です。
-<function>to_char</function>関数は小数点と<literal>V</literal>との混在をサポートしません（例えば、<literal>99.9V99</literal> は許可されません）。
+<function>to_char</function>関数は小数点と<literal>V</literal>との混在をサポートしません（例えば、<literal>99.9V99</literal> とはできません）。
       </para>
      </listitem>
 
@@ -8448,7 +8452,7 @@ Oracleの実装では<literal>9</literal>の前の<literal>MI</literal>が置か
        modifiers other than digit and decimal point patterns, and must be at the end of the format string
        (e.g., <literal>9.99EEEE</literal> is a valid pattern).
 -->
-<literal>EEEE</literal>(科学技術表記)は、他の書式パターンや桁と小数点のパターンを除く修飾子との組み合わせで使うことはできず、また必ず書式文字列の最後に位置しなければなりません(例えば、<literal>9.99EEEE</literal>は正しい表記となります)。
+<literal>EEEE</literal>(科学技術表記)は、桁と小数点のパターンを除き、他の書式パターンや修飾子と組み合わせて使うことはできず、また必ず書式文字列の最後に位置しなければなりません(例えば、<literal>9.99EEEE</literal>は正しい表記となります)。
       </para>
      </listitem>
     </itemizedlist>
@@ -8463,7 +8467,7 @@ Oracleの実装では<literal>9</literal>の前の<literal>MI</literal>が置か
     <xref linkend="functions-formatting-numericmod-table"> shows the
     modifier patterns for numeric formatting.
 -->
-ある修飾子をその動作を変えるために、任意のテンプレートに適用することができます。
+すべてのテンプレートについて、その動作を変えるために、いくつかの修飾子を適用できます。
 例えば、<literal>FM9999</literal>は<literal>FM</literal>修飾子が付いた<literal>9999</literal>パターンです。
 <xref linkend="functions-formatting-numericmod-table">に、数値の書式用の修飾子パターンを示します。
    </para>
@@ -8495,7 +8499,7 @@ Oracleの実装では<literal>9</literal>の前の<literal>MI</literal>が置か
 <!--
         <entry>fill mode (suppress leading zeroes and padding blanks)</entry>
 -->
-        <entry>字詰めモード（先頭の0、およびを空白のパディングを無効）</entry>
+        <entry>字詰めモード（先頭の0、および空白の埋め字を無効）</entry>
         <entry><literal>FM9999</literal></entry>
        </row>
        <row>


### PR DESCRIPTION
誤訳訂正の他、意味がとりにくい（誤解を招く）表現を修正する、
なるべく原文に近い意味にする、文体を周りに合わせる、などの変更をしました。