### PR TITLE
Grouping operationの訳語を「グループ化操作」から「グループ化演算」に変更

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -18249,7 +18249,7 @@ NULL値は<literal>ORDER BY</>節で指定されるルールに従って並べ�
 <!--
    <title>Grouping Operations</title>
 -->
-   <title>グループ化操作</title>
+   <title>グループ化演算</title>
 
    <tgroup cols="3">
     <thead>
@@ -18300,8 +18300,8 @@ NULL値は<literal>ORDER BY</>節で指定されるルールに従って並べ�
     expression is included in the grouping criteria of the grouping set generating
     the result row, and 1 if it is not.  For example:
 -->
-グループ化操作はグループ化セット（<xref linkend="queries-grouping-sets">参照）と一書に使われ、結果の行を区別するものです。
-<literal>GROUPING</>操作の引数は実際には評価されませんが、関連する問い合わせの<literal>GROUP BY</>句にある式と正確に一致する必要があります。
+グループ化演算はグループ化セット（<xref linkend="queries-grouping-sets">参照）と演算に使われ、結果の行を区別するものです。
+<literal>GROUPING</>演算の引数は実際には評価されませんが、関連する問い合わせの<literal>GROUP BY</>句にある式と正確に一致する必要があります。
 最も右側の引数が最下位ビットになるようにビットが割り当てられます。
 各ビットは、対応する式が結果の行を生成するグループ化セットのグループ化条件に含まれていれば0、そうでなければ1です。
 例えば以下のようになります。

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -18300,7 +18300,7 @@ NULL値は<literal>ORDER BY</>節で指定されるルールに従って並べ�
     expression is included in the grouping criteria of the grouping set generating
     the result row, and 1 if it is not.  For example:
 -->
-グループ化演算はグループ化セット（<xref linkend="queries-grouping-sets">参照）と演算に使われ、結果の行を区別するものです。
+グループ化演算はグループ化セット（<xref linkend="queries-grouping-sets">参照）と一緒に使われ、結果の行を区別するものです。
 <literal>GROUPING</>演算の引数は実際には評価されませんが、関連する問い合わせの<literal>GROUP BY</>句にある式と正確に一致する必要があります。
 最も右側の引数が最下位ビットになるようにビットが割り当てられます。
 各ビットは、対応する式が結果の行を生成するグループ化セットのグループ化条件に含まれていれば0、そうでなければ1です。


### PR DESCRIPTION
9.5で追加された部分の修正です。
「一緒」が「一書」になっていた誤変換だけ修正しても良かったのですが、それと同時に「操作」では違和感が強い(実態は関数であって、何かの操作をするわけではない)ことに気付いたので、「演算」に修正しました。
operatorが演算子なので、当然ながらoperationには演算という意味があります。