### PR TITLE
hypothetical-setの訳語を「仮想集合」で統一

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -18069,7 +18069,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
    <primary>hypothetical-set aggregate</primary>
    <secondary>built-in</secondary>
 -->
-   <primary>仮定集合集約</primary>
+   <primary>仮想集合集約</primary>
    <secondary>組み込み</secondary>
   </indexterm>
 
@@ -18085,14 +18085,14 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
    group of rows computed from the <replaceable>sorted_args</replaceable>.
 -->
 <xref linkend="functions-hypothetical-table">に列挙されている集約は、それぞれ<xref linkend="functions-window">で定義されている同じ名前のウィンドウ関数と関連します。
-それぞれの場合、集約結果は、そのような行が<replaceable>sorted_args</replaceable>から計算された行の整列されたグループに追加されるのであれば、<replaceable>args</replaceable>から構成される<quote>仮定の</>行のために関連するウィンドウ関数が返す値です。
+それぞれの場合、集約結果は、そのような行が<replaceable>sorted_args</replaceable>から計算された行の整列されたグループに追加されるのであれば、<replaceable>args</replaceable>から構成される<quote>仮想の</>行のために関連するウィンドウ関数が返す値です。
   </para>
 
   <table id="functions-hypothetical-table">
 <!--
    <title>Hypothetical-Set Aggregate Functions</title>
 -->
-   <title>仮定集合集約関数</title>
+   <title>仮想集合集約関数</title>
 
    <tgroup cols="5">
     <thead>
@@ -18121,7 +18121,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
 <!--
         <secondary>hypothetical</secondary>
 -->
-        <secondary>仮定の</secondary>
+        <secondary>仮想の</secondary>
        </indexterm>
        <function>rank(<replaceable class="parameter">args</replaceable>) WITHIN GROUP (ORDER BY <replaceable class="parameter">sorted_args</replaceable>)</function>
       </entry>
@@ -18138,7 +18138,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
 <!--
        rank of the hypothetical row, with gaps for duplicate rows
 -->
-       重複する行のギャップを含む仮定の行の順位
+       重複する行のギャップを含む仮想の行の順位
       </entry>
      </row>
 
@@ -18149,7 +18149,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
 <!--
         <secondary>hypothetical</secondary>
 -->
-        <secondary>仮定の</secondary>
+        <secondary>仮想の</secondary>
        </indexterm>
        <function>dense_rank(<replaceable class="parameter">args</replaceable>) WITHIN GROUP (ORDER BY <replaceable class="parameter">sorted_args</replaceable>)</function>
       </entry>
@@ -18166,7 +18166,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
 <!--
        rank of the hypothetical row, without gaps
 -->
-       ギャップを含まない仮定の行の順位
+       ギャップを含まない仮想の行の順位
       </entry>
      </row>
 
@@ -18177,7 +18177,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
 <!--
         <secondary>hypothetical</secondary>
 -->
-        <secondary>仮定の</secondary>
+        <secondary>仮想の</secondary>
        </indexterm>
        <function>percent_rank(<replaceable class="parameter">args</replaceable>) WITHIN GROUP (ORDER BY <replaceable class="parameter">sorted_args</replaceable>)</function>
       </entry>
@@ -18194,7 +18194,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
 <!--
        relative rank of the hypothetical row, ranging from 0 to 1
 -->
-       仮定の行の相対順位、0から1まで
+       仮想の行の相対順位、0から1まで
       </entry>
      </row>
 
@@ -18205,7 +18205,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
 <!--
         <secondary>hypothetical</secondary>
 -->
-        <secondary>仮定の</secondary>
+        <secondary>仮想の</secondary>
        </indexterm>
        <function>cume_dist(<replaceable class="parameter">args</replaceable>) WITHIN GROUP (ORDER BY <replaceable class="parameter">sorted_args</replaceable>)</function>
       </entry>
@@ -18223,7 +18223,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
        relative rank of the hypothetical row, ranging from
        1/<replaceable>N</> to 1
 -->
-       仮定の行の相対順位、1/<replaceable>N</>から1まで
+       仮想の行の相対順位、1/<replaceable>N</>から1まで
       </entry>
      </row>
 
@@ -18240,7 +18240,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
    they do not drop input rows containing nulls.  Null values sort according
    to the rule specified in the <literal>ORDER BY</> clause.
 -->
-各仮定集合集約に対して<replaceable>args</replaceable>で与えられる直接引数のリストは、<replaceable>sorted_args</replaceable>で与えられる集約された引数の数と型と一致しなければなりません。
+各仮想集合集約に対して<replaceable>args</replaceable>で与えられる直接引数のリストは、<replaceable>sorted_args</replaceable>で与えられる集約された引数の数と型と一致しなければなりません。
 ほとんどの組み込み集約とは異なり、この集約は厳格ではありません、すなわち、NULLを含む入力行を落としません。
 NULL値は<literal>ORDER BY</>節で指定されるルールに従って並べられます。
   </para>
@@ -18378,7 +18378,7 @@ NULL値は<literal>ORDER BY</>節で指定されるルールに従って並べ�
    Aggregate functions act as window functions only when an <literal>OVER</>
    clause follows the call; otherwise they act as regular aggregates.
 -->
-これらの関数に加え、どんな組み込み、またはユーザ定義の通常の集約関数もウィンドウ関数として使用できます(ただし順序集合や仮定集合集約はそうではありません)。組み込み集約関数一覧は<xref linkend="functions-aggregate">を参照してください。
+これらの関数に加え、どんな組み込み、またはユーザ定義の通常の集約関数もウィンドウ関数として使用できます(ただし順序集合や仮想集合集約はそうではありません)。組み込み集約関数一覧は<xref linkend="functions-aggregate">を参照してください。
 集約関数は、呼び出しの後<literal>OVER</>句が続いた場合のみウィンドウ関数として動作します。それ以外、通常の集約関数として動作します。
   </para>
 

--- a/doc/src/sgml/ref/create_aggregate.sgml
+++ b/doc/src/sgml/ref/create_aggregate.sgml
@@ -291,12 +291,12 @@ NULL入力値を持つ行は無視されます。
    the values of those direct arguments to be added to the collection of
    aggregate-input rows as an additional <quote>hypothetical</> row.
 -->
-パラメータのリストに<literal>ORDER BY</literal>を含む構文は、<firstterm>順序集約</firstterm>と呼ばれる特別な種類の集約を作ります。
-また<literal>HYPOTHETICAL</>が指定されている場合は、<firstterm>仮想集約</firstterm>が作られます。
+パラメータのリストに<literal>ORDER BY</literal>を含む構文は、<firstterm>順序集合集約</firstterm>と呼ばれる特別な種類の集約を作ります。
+また<literal>HYPOTHETICAL</>が指定されている場合は、<firstterm>仮想集合集約</firstterm>が作られます。
 これらの集約は、ソートされた値のグループに対して、順序に依存した方法で作用するため、入力についてのソート順の指定は、呼び出しにおける本質的な部分になります。
 また、これらの集約は<firstterm>直接</>引数をとることができます。
 直接引数は、行毎に一度ではなく、集約に対して一度だけ評価されます。
-仮想集約は、順序集約のサブクラスで、直接引数のいくつかが、集約される引数の列と、数とデータ型についてマッチする必要があります。
+仮想集合集約は、順序集合集約のサブクラスで、直接引数のいくつかが、集約される引数の列と、数とデータ型についてマッチする必要があります。
 これにより、直接引数の値を、<quote>仮想的な</>行として、集約の入力行の集合に加えることができます。
   </para>
 
@@ -439,7 +439,7 @@ SELECT col FROM tab ORDER BY col USING sortop LIMIT 1;
 <command>CREATE AGGREGATE</>の旧構文では、入力データ型は集約の名前の次に記載されたものではなく<literal>basetype</>パラメータにより指定されます。
 この構文では入力パラメータを1つしかとれないことに注意してください。
 この構文で引数を持たない集約を定義するためには、<literal>basetype</>を<literal>"ANY"</> （<literal>*</>ではありません）と指定してください。
-順序集約関数は旧構文では定義できません。
+順序集合集約関数は旧構文では定義できません。
      </para>
     </listitem>
    </varlistentry>
@@ -475,7 +475,7 @@ SELECT col FROM tab ORDER BY col USING sortop LIMIT 1;
       aggregated arguments, not the direct arguments.  Otherwise it is the
       same.
 -->
-順序(仮想を含む)集約では、状態遷移関数は現在値と集約引数のみを受け取り、直接引数は受け取りません。
+順序集合(仮想集合を含む)集約では、状態遷移関数は現在値と集約引数のみを受け取り、直接引数は受け取りません。
 それ以外の点は全く同じです。
      </para>
     </listitem>
@@ -544,7 +544,7 @@ SELECT col FROM tab ORDER BY col USING sortop LIMIT 1;
       final function receives not only the final state value,
       but also the values of all the direct arguments.
 -->
-順序(仮想を含む)集約では、最終関数は終了時の状態値だけでなく、すべての直接引数の値も受け取ります。
+順序集合(仮想集合を含む)集約では、最終関数は終了時の状態値だけでなく、すべての直接引数の値も受け取ります。
      </para>
 
      <para>
@@ -710,7 +710,7 @@ SELECT col FROM tab ORDER BY col USING sortop LIMIT 1;
       run-time behavior, only on parse-time resolution of the data types and
       collations of the aggregate's arguments.
 -->
-順序集約についてのみ、このフラグは、仮想集約の要求に従って集約の引数が処理されることを指定します。
+順序集合集約についてのみ、このフラグは、仮想集合集約の要求に従って集約の引数が処理されることを指定します。
 つまり、最後のいくつかの引数が、集約される(<literal>WITHIN GROUP</>の)引数と適合しなければなりません。
 <literal>HYPOTHETICAL</literal>フラグは実行時の動作には何の影響もなく、集約の引数のデータ型と照合についての解析時の解決にのみ影響します。
      </para>
@@ -827,13 +827,13 @@ SELECT col FROM tab ORDER BY col USING sortop LIMIT 1;
     ones; any preceding parameters represent additional direct arguments
     that are not constrained to match the aggregated arguments.
 -->
-順序集約の構文では、<literal>VARIADIC</>を最後の直接パラメータと、最後の集約(<literal>WITHIN GROUP</>)パラメータの両方について指定することができます。
+順序集合集約の構文では、<literal>VARIADIC</>を最後の直接パラメータと、最後の集約(<literal>WITHIN GROUP</>)パラメータの両方について指定することができます。
 しかし、現在の実装では<literal>VARIADIC</>の使用を2つの方法に制限しています。
-1つ目は、順序集約では、<literal>VARIADIC "any"</>のみが利用でき、他のvariadicの配列型は利用できないことです。
+1つ目は、順序集合集約では、<literal>VARIADIC "any"</>のみが利用でき、他のvariadicの配列型は利用できないことです。
 2つ目は、最後の直接パラメータが<literal>VARIADIC "any"</>の場合、集約パラメータは1つだけしか使えず、かつそれも<literal>VARIADIC "any"</>でなければならない、ということです。
 (システムカタログで使われる表現において、これらの2つのパラメータは、1つの<literal>VARIADIC "any"</>要素に統合されています。
 なぜなら、<structname>pg_proc</>は2つ以上の<literal>VARIADIC</>パラメータがある関数を表現できないからです。)
-仮想集約の場合、<literal>VARIADIC "any"</>パラメータに対応する直接引数は仮想的なパラメータで、それより前のパラメータは、集約引数に対応する制約のない、追加の直接引数となります。
+仮想集合集約の場合、<literal>VARIADIC "any"</>パラメータに対応する直接引数は仮想的なパラメータで、それより前のパラメータは、集約引数に対応する制約のない、追加の直接引数となります。
    </para>
 
    <para>
@@ -841,7 +841,7 @@ SELECT col FROM tab ORDER BY col USING sortop LIMIT 1;
     Currently, ordered-set aggregates do not need to support
     moving-aggregate mode, since they cannot be used as window functions.
 -->
-現在は、順序集約は、ウィンドウ関数として使うことはできないので、移動集約モードをサポートする必要はありません。
+現在は、順序集合集約は、ウィンドウ関数として使うことはできないので、移動集約モードをサポートする必要はありません。
    </para>
  </refsect1>
 

--- a/doc/src/sgml/ref/drop_aggregate.sgml
+++ b/doc/src/sgml/ref/drop_aggregate.sgml
@@ -138,7 +138,7 @@ DROP AGGREGATE [ IF EXISTS ] <replaceable>name</replaceable> ( <replaceable>aggr
 -->
 集約関数の操作対象となる入力データ型です。
 引数を持たない関数を参照する場合は、引数指定の一覧の場所に<literal>*</>を記述してください。
-順序集約関数を参照する場合は、直接引数と集約引数の指定の間に<literal>ORDER BY</>を記述してください。
+順序集合集約関数を参照する場合は、直接引数と集約引数の指定の間に<literal>ORDER BY</>を記述してください。
      </para>
     </listitem>
    </varlistentry>
@@ -182,7 +182,7 @@ DROP AGGREGATE [ IF EXISTS ] <replaceable>name</replaceable> ( <replaceable>aggr
     Alternative syntaxes for referencing ordered-set aggregates
     are described under <xref linkend="sql-alteraggregate">.
 -->
-順序集約を参照するための代替となる構文については、<xref linkend="sql-alteraggregate">に記述されています。
+順序集合集約を参照するための代替となる構文については、<xref linkend="sql-alteraggregate">に記述されています。
    </para>
  </refsect1>
 
@@ -209,7 +209,7 @@ DROP AGGREGATE myavg(integer);
    which takes an arbitrary list of ordering columns and a matching list
    of direct arguments:
 -->
-順序列の任意のリストと直接引数の適合するリストをとる、仮想集約関数<literal>myrank</>を削除します。
+順序列の任意のリストと直接引数の適合するリストをとる、仮想集合集約関数<literal>myrank</>を削除します。
 <programlisting>
 DROP AGGREGATE myrank(VARIADIC "any" ORDER BY VARIADIC "any");
 </programlisting>


### PR DESCRIPTION
func.sgmlで"hypothetical-set"を「仮定集合」と訳していたのを、他のファイルに合わせて「仮想集合」としました。また、単独の"hypothetical"も「仮定の」から「仮想の」に変更しました。
同時に、ｒｅｆのcreate/drop_aggregate.sgmlで"ordered-set aggregate"と"hypothetical-set aggregate"を「順序集約」「仮想集約」と訳していたのですが、それぞれ「順序集合集約」「仮想集合集約」としました。