### PR TITLE
xhtml版のcss更新

### DIFF
--- a/doc/src/sgml/stylesheet.css
+++ b/doc/src/sgml/stylesheet.css
@@ -256,6 +256,10 @@ table.CALSTABLE th {
 	padding: 0.5ex 0.5ex;
 }
 
+.informaltable table td {
+	background-color: #FFF;
+}
+
 .table-contents table tr:hover td,
 .informaltable table tr:hover td,
 table.CALSTABLE tr:hover td {

--- a/doc/src/sgml/stylesheet.css
+++ b/doc/src/sgml/stylesheet.css
@@ -15,6 +15,7 @@ BODY > * {
 	text-align: left;
 }
 
+
 script {
         display: none;
 }
@@ -96,12 +97,12 @@ p {
 
 /* center some titles */
 
-.BOOK .TITLE, .BOOK .CORPAUTHOR, .BOOK .COPYRIGHT {
+.BOOK .TITLE, .BOOK .CORPAUTHOR, .BOOK .COPYRIGHT, .book .titlepage {
 	text-align: center;
 }
 
 /* decoration for formal examples */
-DIV.EXAMPLE {
+DIV.EXAMPLE, div.example {
 	padding-left: 15px;
 	border-style: solid;
 	border-width: 0px;
@@ -273,8 +274,20 @@ td.c6 {
 	padding: 1ex 2ex 0;
 }
 
+table.simplelist {
+	border-collapse: collapse;
+}
+table.simplelist th, table.simplelist td {
+	border: 1px solid #ccc;
+	padding: 10px;
+}
+
+.original {
+	display: block;
+	color: #00ee00;
+}
+
 .COMMENT,.comment { color: red; }
-.original	{ color: #00ee00; }
 
 VAR		{ font-family: monospace; font-style: italic; }
 /* Konqueror's standard style for ACRONYM is italic. */

--- a/doc/src/sgml/stylesheet.css
+++ b/doc/src/sgml/stylesheet.css
@@ -199,7 +199,7 @@ table.CAUTION {
 	border-color: #DEDFA7;
 }
 
-table.WARNING {
+table.WARNING, div.warning {
 	background-color: #FFD7D7;
 	border-color: #DF421E;
 }

--- a/doc/src/sgml/stylesheet.xsl
+++ b/doc/src/sgml/stylesheet.xsl
@@ -41,7 +41,7 @@
     <xsl:when test="$html.original = 1">
       <span class="original" xmlns="http://www.w3.org/1999/xhtml">
         <xsl:value-of select="." />
-      </span><br xmlns="http://www.w3.org/1999/xhtml"/>
+      </span>
     </xsl:when>
     <xsl:otherwise>
       <xsl:comment><xsl:value-of select="." /></xsl:comment>


### PR DESCRIPTION
最初のページのタイトルをcenterに修正
例(div.example)のブロックが効いてなかったのを修正
「簡単なリスト」の表示を改善
原文表示を &lt;br/&gt;ではなくcssのdisplay:blockに変更