### PR TITLE
訳し過ぎと訳抜けの修正

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -14789,7 +14789,7 @@ NULL値を持つオブジェクトフィールドを削除した<replaceable>fro
       done; but for <type>json</> input, this may result in throwing an error,
       as noted in <xref linkend="datatype-json">.
 -->
-これらの多くの関数や演算子はデータベースエンコードがUTF8の時は、JSON文字列のUnicodeのエスケープを適切な一文字に変換します。
+これらの多くの関数や演算子は、JSON文字列のUnicodeのエスケープを適切な一文字に変換します。
 これは入力が<type>jsonb</>型であれば、変換は既に行なわれていますので、重要な問題ではありません。しかし、<type>json</>の入力に対しては、<xref linkend="datatype-json">で言及したようにこれはエラーを発生させる結果になるかもしれません．
     </para>
   </note>
@@ -14805,7 +14805,7 @@ NULL値を持つオブジェクトフィールドを削除した<replaceable>fro
       appear in the target row type will be omitted from the output, and
       target columns that do not match any JSON field will simply be NULL.
 -->
-<function>json_to_record</>と<function>json_to_recordset</>、JSONからの型強制は<quote>最善努力</>であり、ある型では望んだ結果にならないかもしれません。
+<function>json_populate_record</>、<function>json_populate_recordset</>、<function>json_to_record</>および<function>json_to_recordset</>におけるJSONからの型強制は<quote>最善努力</>であり、ある型では望んだ結果にならないかもしれません。
 JSONキーは対象の行の型の中の同一の列の名前と一致します。
 対象の行の型に現れないJSONフィールドは出力から省略され、JSONフィールドに一致しない対象の列は単にNULLになります。
     </para>


### PR DESCRIPTION
「データベースエンコードが～」は原文にないので削除。
json_populate_record/recordsetが訳文から落ちていたので追加。