### PR TITLE
func.sgml 原文にない行の削除

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -16669,6 +16669,7 @@ NULL baz</literallayout>(3 rows)</entry>
   <indexterm zone="functions-aggregate">
 <!--
    <primary>aggregate function</primary>
+   <secondary>built-in</secondary>
 -->
    <primary>集約関数</primary>
    <secondary>組み込み</secondary>
@@ -16950,7 +16951,6 @@ NULL baz</literallayout>(3 rows)</entry>
       </entry>
 <!--
       <entry>aggregates values as a JSON array</entry>
-      <entry>aggregates records as a JSON array of objects</entry>
 -->
       <entry>JSON配列として値を集約</entry>
      </row>
@@ -21928,30 +21928,6 @@ pretty-printされた書式はより読みやすい半面、デフォルトの�
 
   <para>
 <!--
-   <function>pg_identify_object</function> returns a row containing enough information
-   to uniquely identify the database object specified by catalog OID, object OID and a
-   (possibly zero) sub-object ID.  This information is intended to be machine-readable,
-   and is never translated.
-   <parameter>type</> identifies the type of database object;
-   <parameter>schema</> is the schema name that the object belongs in, or
-   <literal>NULL</> for object types that do not belong to schemas;
-   <parameter>name</> is the name of the object, quoted if necessary, only
-   present if it can be used (alongside schema name, if pertinent) as a unique
-   identifier of the object, otherwise <literal>NULL</>;
-   <parameter>identity</> is the complete object identity, with the precise format
-   depending on object type, and each part within the format being
-   schema-qualified and quoted as necessary.
--->
-<function>pg_identify_object</function>はカタログOID, オブジェクトOID、そして（ゼロである可能性を有する）サブオブジェクトIDにより指定されるデータベースオブジェクトを一意的に特定するために充分な情報を所有する行を返します。
-この情報は機械による解読目的で決して翻訳されません。
-データベースオブジェクトの型を特定する<parameter>type</>識別子、
-オブジェクトが所属するスキーマの名前である<parameter>schema</>、またはスキーマに所属しないオブジェクト型の<literal>NULL</>、
-必要であれば引用符で括られたオブジェクトの名前の<parameter>name</>であって、そのオブジェクトに対する一意の識別子として（もし付属としてあるとした時、一緒にあるスキーマ名）使用されるもの。そうでなければ<literal>NULL</>。
-<parameter>identity</>はオブジェクト型に依存する詳細なフォーマットを持つ完結したオブジェクトの識別。そしてフォーマットの中のそれぞれの部分はスキーマ権限を与えられていて、必要な場合は括弧で括られる。  
-  </para>
-
-  <para>
-<!--
    <function>pg_typeof</function> returns the OID of the data type of the
    value that is passed to it.  This can be helpful for troubleshooting or
    dynamically constructing SQL queries.  The function is declared as
@@ -22048,7 +22024,6 @@ SELECT collation for ('foo' COLLATE "de_DE");
    database object identification and addressing.
 -->
 <xref linkend="functions-info-object-table">にデータベースオブジェクトの識別とアドレスに関連する関数を示します。
-   database object identification and addressing.
   </para>
 
    <table id="functions-info-object-table">


### PR DESCRIPTION
復活行:<secondary>built-in</secondary>
削除行:<entry>aggregates records as a JSON array of objects</entry>
<function>pg_identify_object</function>〜は移動していたため重複していま
した。新しく編集されていたエントリを残しました。