### PR TITLE
fix system call

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -2995,16 +2995,16 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If this parameter is on, the <productname>PostgreSQL</> server
         will try to make sure that updates are physically written to
         disk, by issuing <function>fsync()</> system calls or various
         equivalent methods (see <xref linkend="guc-wal-sync-method">).
         This ensures that the database cluster can recover to a
         consistent state after an operating system or hardware crash.
-       -->
-       このパラメータがオンの場合、<productname>PostgreSQL</>サーバは<function>fsync()</>システム・コールを発行したり、もしくはこれに相当する方法で（<xref linkend="guc-wal-sync-method">を参照）更新が物理的にディスクに書き込まれたかの確証を得ようと試みます。
-       これは、オペレーティングシステムもしくはハードウェアがクラッシュした後、確実にデータベースクラスタを一貫した状態に復旧させることを保証します。
+-->
+このパラメータがオンの場合、<productname>PostgreSQL</>サーバは<function>fsync()</>システムコールを発行したり、もしくはこれに相当する方法（<xref linkend="guc-wal-sync-method">を参照）で、更新が物理的にディスクに書き込まれたかの確証を得ようと試みます。
+これは、オペレーティングシステムもしくはハードウェアがクラッシュした後、確実にデータベースクラスタを一貫した状態に復旧させることを保証します。
        </para>
 
        <para>


### PR DESCRIPTION
「システム・コール」の中黒を削除しました。（ここ以外はすべて「システムコール」と中黒なしのようです。）
あと行頭の空白の削除も。