### PR TITLE
.travis.yml 必要ない行の削除

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,3 @@ script:
   - ./configure
   - make docs
   - make -C src/bin/psql sql_help.h
-  - cd doc/src/sgml
-  - xmllint --noout --valid postgres.xml


### PR DESCRIPTION
9.5.0では既にxmllintを実行をしているため再度実行する必要がない。
https://travis-ci.org/pgsql-jp/jpug-doc/builds/107846131#L630