### PR TITLE
catalogs.sgml 原文との差分を減らす修正

### DIFF
--- a/doc/src/sgml/catalogs.sgml
+++ b/doc/src/sgml/catalogs.sgml
@@ -28,8 +28,7 @@
 <productname>PostgreSQL</productname>のシステムカタログは通常のテーブルです。
 テーブルを削除したり再作成したり、列の追加および値の挿入や更新をすることは可能ですが、これらの操作でデータベースシステムを台なしにしてしまう可能性もあります。
 通常手作業でシステムカタログを変更してはいけません。
-その代わりとしてSQLコマンドを使用します
-（例えば<command>CREATE DATABASE</command>により<structname>pg_database</structname>カタログに1行挿入し、ディスク上にデータベースを実際に作成します）。
+その代わりとしてSQLコマンドを使用します（例えば<command>CREATE DATABASE</command>により<structname>pg_database</structname>カタログに1行挿入し、ディスク上にデータベースを実際に作成します）。
 しかしインデックスアクセスメソッドを追加するような特に難易度の高い操作の時などの例外があります。
   </para>
 
@@ -1480,12 +1479,12 @@
    an index, which are those with <structfield>amproclefttype</> and
    <structfield>amprocrighttype</> both equal to the index operator class's
    <structfield>opcintype</>.
+-->
 <structfield>amproclefttype</>と<structfield>amprocrighttype</>属性の通常の解釈は、それらが、特定のサポートプロシージャがサポートする演算子の左と右の入力型を識別することです。
 いくつかのアクセスメソッドに対して、これらはサポートプロシージャ自身の入力データ型に一致することもあります。
 また、そうでないものもあります。
 インデックスに対して<quote>デフォルト</>サポートプロシージャの概念があります。
 これは<structfield>amproclefttype</>と<structfield>amprocrighttype</>の両方が、インデックス演算クラスの<structfield>opcintype</>に等しい、という概念です。
--->
   </para>
 
  </sect1>
@@ -1936,13 +1935,11 @@ TOAST可能なデータ型では、格納ポリシーを制御するために列
       <entry><structfield>attfdwoptions</structfield></entry>
       <entry><type>text[]</type></entry>
       <entry></entry>
+      <entry>
 <!--
-      <entry>
        Attribute-level foreign data wrapper options, as <quote>keyword=value</> strings
-      </entry>
 -->
-      <entry>
-       <quote>keyword=value</>文字列のような、外部データラッパオプションの属性レベル
+<quote>keyword=value</>文字列のような、外部データラッパオプションの属性レベル
       </entry>
      </row>
 
@@ -2168,7 +2165,7 @@ TOAST可能なデータ型では、格納ポリシーを制御するために列
 -->
 （おそらく暗号化された）パスワード。無い場合はNULLです。
 パスワードが暗号化された場合、この列には<literal>md5</>という文字列の後に32文字の16進数表記のMD5ハッシュが含まれます。
-MD5ハッシュはユーザのパスワードとユーザ名を連結したものになります
+MD5ハッシュはユーザのパスワードとユーザ名を連結したものになります。
 例えばユーザ<literal>joe</>のパスワードが<literal>xyzzy</>の場合、<productname>PostgreSQL</>は<literal>xyzzyjoe</>をMD5でハッシュ化したものを格納します。
 この書式に従わないパスワードは暗号化されていないとみなされます。
       </entry>
@@ -2406,8 +2403,7 @@ NULLの場合には満了時間はありません。</entry>
        other cases.
 -->
 キャストがどの文脈で呼び出し可能かを示します。
-<literal>e</>は明示のキャストとしてのみ起動されることを意味します
-（<literal>CAST</>、<literal>::</>構文を使用します）。
+<literal>e</>は明示のキャストとしてのみ起動されることを意味します（<literal>CAST</>、<literal>::</>構文を使用します）。
 <literal>a</>は、対象となる列を明示的に特定するだけでなく暗黙的にも特定することを意味します。
 <literal>i</>は他の場合と同様に演算式内で暗黙的であることを意味します。
       </entry>
@@ -2572,7 +2568,7 @@ NULLの場合には満了時間はありません。</entry>
        The OID of the data type that corresponds to this table's row type,
        if any (zero for indexes, which have no <structname>pg_type</> entry)
 -->
-       もし何らかの（<structname>pg_type</>項目を持たないインデックスではゼロ）が存在した場合このテーブルの行の型に対応するデータ型のOID
+もし何らかの（<structname>pg_type</>項目を持たないインデックスではゼロ）が存在した場合このテーブルの行の型に対応するデータ型のOID
       </entry>
      </row>
 
@@ -3136,12 +3132,10 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
    entries for all locales available on the system, so it must be able to
    hold entries for all encodings that might ever be used in the cluster.
 -->
-このカタログの一意キーは(<structfield>collname</>, <structfield>collnamespace</>)だけではなく
-(<structfield>collname</>,<structfield>collencoding</>, <structfield>collnamespace</>)です。
+このカタログの一意キーは(<structfield>collname</>, <structfield>collnamespace</>)だけではなく(<structfield>collname</>,<structfield>collencoding</>, <structfield>collnamespace</>)です。
 <productname>PostgreSQL</productname>は通常、<structfield>collencoding</>が現在のデータベースのエンコード方式または-1と一致しない照合順序をすべて無視します。
 また、<structfield>collencoding</> = -1を持つ項目と名前が一致する新しい項目の作成は許されません。
-したがって照合順序を識別するためには、カタログの定義に従った一意ではない場合であっても、
-限定されたSQL名称(<replaceable>schema</>.<replaceable>name</>)を使用することで十分です。
+したがって照合順序を識別するためには、カタログの定義に従った一意ではない場合であっても、限定されたSQL名称(<replaceable>schema</>.<replaceable>name</>)を使用することで十分です。
 このようにカタログを定義した理由は、クラスタの初期化時に<application>initdb</> がシステムで利用可能なすべてのロケール用の項目でこのカタログにデータを投入するためです。
 その為、今後そのクラスタで使用される可能性があるすべてのエンコード方式のエントリーを保持できるようにしなければなりません。
   </para>
@@ -3153,8 +3147,7 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
    since they could match the encodings of databases later cloned from
    <literal>template0</>.  This would currently have to be done manually.
 -->
-後で<literal>template0</>から複製されるデータベースのエンコード方式と一致するかもしれないので、
-<literal>template0</>データベースのデータベースのエンコード方式と一致しないものの照合順を作成することが有用になるかもしれません。
+後で<literal>template0</>から複製されるデータベースのエンコード方式と一致するかもしれないので、<literal>template0</>データベースのデータベースのエンコード方式と一致しないものの照合順を作成することが有用になるかもしれません。
 現在これは手作業で行う必要があります。
   </para>
  </sect1>
@@ -5631,8 +5624,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
    by following chains of entries.)
 -->
 <structname>pg_inherits</>カタログは継承階層の情報を記録します。
-データベース内の、それぞれの直接の子テーブルに対して1つの記述があります
-（直接ではない継承は、記述の連鎖から決定されます）。
+データベース内の、それぞれの直接の子テーブルに対して1つの記述があります（直接ではない継承は、記述の連鎖から決定されます）。
   </para>
 
   <table>
@@ -7273,8 +7265,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
 関数の引数のデータ型を格納した配列。
 これは（<literal>OUT</literal>と<literal>INOUT</literal>引数を含んだ）全ての引数を含みます。
 しかし、すべての引数が<literal>IN</literal>であった場合は、この列はNULLになります。
-歴史的な理由から<structfield>proargtypes</>は0から番号が振られていますが、
-添字は1から始まっていることに注意してください。
+歴史的な理由から<structfield>proargtypes</>は0から番号が振られていますが、添字は1から始まっていることに注意してください。
       </entry>
      </row>
 
@@ -7342,8 +7333,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
 -->
       <entry>
 デフォルト値のための(<function>nodeToString()</function>表現の)演算式ツリー。
-これは<structfield>pronargdefaults</>の要素のリストで、最後の<replaceable>N</>個の<emphasis>入力</>引数と対応しています
-（つまり最後の<replaceable>N</> <structfield>proargtypes</>の位置ということです）。
+これは<structfield>pronargdefaults</>の要素のリストで、最後の<replaceable>N</>個の<emphasis>入力</>引数と対応しています（つまり最後の<replaceable>N</> <structfield>proargtypes</>の位置ということです）。
 もし引数にデフォルト値がない場合は、この列はNULLになります。
       </entry>
      </row>
@@ -12046,7 +12036,7 @@ SQLから<xref linkend="sql-declare">文経由。
 指定されたトランザクションにより所有されているロックを表す行内では<structfield>granted</structfield>は真です。
 偽の場合はこのロックを獲得するため現在トランザクションが待機中であることを示しています。
 つまり、同じロック対象のオブジェクトに対して何らかの他のトランザクションが競合するロックを獲得していることを意味します。
-待機中のトランザクションはその別のトランザクションがロックを解放するまで活動を控えます
+待機中のトランザクションはその別のトランザクションがロックを解放するまで活動を控えます。
 （もしくはデッドロック状態が検出されることになります）。
 単一トランザクションでは一度に多くても1つのロックを獲得するために待機します。
   </para>
@@ -12065,7 +12055,7 @@ SQLから<xref linkend="sql-declare">文経由。
 -->
 すべてのトランザクションはそのすべての過程完了までその仮想トランザクションID上に排他的ロックをかけます。
 もしある永続IDがトランザクションに割り当てられる（普通はトランザクションがデータベースの状態を変化させるときのみに発生します）と、トランザクションは終了するまで永続トランザクションIDに対して排他ロックを保持します。
-あるトランザクションが他のトランザクションを特定して待機しなければならないと判断した場合、他とみなしたトランザクションのIDに対し共有ロックを獲得するように試み、目的を達します
+あるトランザクションが他のトランザクションを特定して待機しなければならないと判断した場合、他とみなしたトランザクションのIDに対し共有ロックを獲得するように試み、目的を達します。
 （仮想IDであるか永続IDであるかは、その状況によります）。
 これは、他とみなしたトランザクションが完了し、そしてロックを解放した場合のみ成功します。
   </para>
@@ -12132,9 +12122,7 @@ SQLから<xref linkend="sql-declare">文経由。
    information on the session holding or waiting to hold each lock,
    for example
 -->
-ロック保持もしくは保持を待機しているセッションのさらなる情報を入手するため
-<link linkend="pg-stat-activity-view"><structname>pg_stat_activity</structname></link>ビューの
-<structfield>pid</structfield>列と<structfield>pid</structfield>列を結合することができます。
+ロック保持もしくは保持を待機しているセッションのさらなる情報を入手するため<link linkend="pg-stat-activity-view"><structname>pg_stat_activity</structname></link>ビューの<structfield>pid</structfield>列と<structfield>pid</structfield>列を結合することができます。
 例えば、このような感じです。
 <programlisting>
 SELECT * FROM pg_locks pl LEFT JOIN pg_stat_activity psa
@@ -12150,11 +12138,9 @@ SELECT * FROM pg_locks pl LEFT JOIN pg_stat_activity psa
    but it continues to hold the locks it acquired while running.)
    For example:
 -->
-また、プリペアードトランザクションを使用している場合には、ロックを保持しているプリペアードトランザクションに関してより多くの情報を得るため、
-<structfield>virtualtransaction</>列は、<link linkend="view-pg-prepared-xacts"><structname>pg_prepared_xacts</structname></link>ビューの
-<structfield>transaction</structfield>列と結合することができます。
- （プリペアードトランザクションはロックを待つことはありませんが、実行時に獲得したロックを保持し続けます。）
- 例えば、このような感じです。
+また、プリペアードトランザクションを使用している場合には、ロックを保持しているプリペアードトランザクションに関してより多くの情報を得るため、<structfield>virtualtransaction</>列は、<link linkend="view-pg-prepared-xacts"><structname>pg_prepared_xacts</structname></link>ビューの<structfield>transaction</structfield>列と結合することができます。
+（プリペアードトランザクションはロックを待つことはありませんが、実行時に獲得したロックを保持し続けます。）
+例えば、このような感じです。
 <programlisting>
 SELECT * FROM pg_locks pl LEFT JOIN pg_prepared_xacts ppx
     ON pl.virtualtransaction = '-1/' || ppx.transaction;
@@ -12184,8 +12170,7 @@ SELECT * FROM pg_locks pl LEFT JOIN pg_prepared_xacts ppx
    possible for locks to be taken or released after we interrogate the regular
    lock manager and before we interrogate the predicate lock manager.
 -->
-<structname>pg_locks</structname>ビューは、異なるシステムにおける、通常のロックマネージャと
-述部ロックマネージャの両方からのデータを表示します。
+<structname>pg_locks</structname>ビューは、異なるシステムにおける、通常のロックマネージャと述部ロックマネージャの両方からのデータを表示します。
 さらに通常のロックマネージャではロックを通常ロックと<firstterm>近道</>ロックに細分化します。
 このデータが完全に一貫性があることは保証されません。
 ビューが問い合わせられると、近道ロック（<structfield>fastpath</> = <literal>true</>が真）は、ロックマネージャ全体の状態を凍結することなく、各バックエンドからひとつひとつ収集されます。
@@ -12570,8 +12555,7 @@ SQL経由で作成された準備済み文では、これはクライアント�
    information about transactions that are currently prepared for two-phase
    commit (see <xref linkend="sql-prepare-transaction"> for details).
 -->
-<structname>pg_prepared_xacts</structname>ビューは、現状で2相コミットのためにプリペアードトランザクションについての情報を表示します
-（詳細は<xref linkend="sql-prepare-transaction">を参照してください）。
+<structname>pg_prepared_xacts</structname>ビューは、現状で2相コミットのためにプリペアードトランザクションについての情報を表示します（詳細は<xref linkend="sql-prepare-transaction">を参照してください）。
   </para>
 
   <para>
@@ -13829,7 +13813,7 @@ SQL経由で作成された準備済み文では、これはクライアント�
        population.)
 -->
 列の値を満遍なく似たような数でグループに分配した値のリストです。
-<structfield>most_common_vals</>の値がもし存在すればこの度数分布計算は行われません
+<structfield>most_common_vals</>の値がもし存在すればこの度数分布計算は行われません。
 （列データ型が<literal>&lt;</>演算子を所有しない場合、もしくは<structfield>most_common_vals</>が全体の構成要素アカウントをリストしている場合、この列はNULLとなります）。
       </entry>
      </row>
@@ -13849,7 +13833,7 @@ SQL経由で作成された準備済み文では、これはクライアント�
 -->
 物理的な[訳注：ディスク上の]行の並び順と論理的な列の値の並び順に関する統計的相関です。
 この値は-1から+1の範囲です。
-値が-1もしくは+1の近辺にある時、ディスクにランダムアクセスする必要が少なくなるためこの列に対してのインデックススキャンは0近辺にある場合に比較して安価であると推定されます
+値が-1もしくは+1の近辺にある時、ディスクにランダムアクセスする必要が少なくなるためこの列に対してのインデックススキャンは0近辺にある場合に比較して安価であると推定されます。
 （列データ型に<literal>&lt;</>演算子がない場合、この列はNULLとなります）。
       </entry>
      </row>
@@ -13911,8 +13895,7 @@ SQL経由で作成された準備済み文では、これはクライアント�
    command, or globally by setting the
    <xref linkend="guc-default-statistics-target"> run-time parameter.
 -->
-配列の最大項目数は<command>ALTER TABLE SET STATISTICS</>コマンドで列ごとに設定されるか、
-もしくは<xref linkend="guc-default-statistics-target">実行時パラメータで包括的に設定されるかのいずれかです。
+配列の最大項目数は<command>ALTER TABLE SET STATISTICS</>コマンドで列ごとに設定されるか、もしくは<xref linkend="guc-default-statistics-target">実行時パラメータで包括的に設定されるかのいずれかです。
   </para>
 
  </sect1>

--- a/doc/src/sgml/catalogs.sgml
+++ b/doc/src/sgml/catalogs.sgml
@@ -31,7 +31,6 @@
 その代わりとしてSQLコマンドを使用します
 （例えば<command>CREATE DATABASE</command>により<structname>pg_database</structname>カタログに1行挿入し、ディスク上にデータベースを実際に作成します）。
 しかしインデックスアクセスメソッドを追加するような特に難易度の高い操作の時などの例外があります。
-
   </para>
 
  <sect1 id="catalogs-overview">
@@ -592,7 +591,6 @@
 -->
       <entry>集約関数の<structname>pg_proc</structname> OID</entry>
      </row>
-
      <row>
       <entry><structfield>aggkind</structfield></entry>
       <entry><type>char</type></entry>
@@ -627,7 +625,6 @@
 引数が数が<structfield>pronargs</>と同じ場合、最終的な直接引数同様、集約された引数として、集約関数の引数は、可変または可変長配列で記述しなければなりません。
 通常の集約関数は引数を取りません。</entry>
      </row>
-
      <row>
       <entry><structfield>aggtransfn</structfield></entry>
       <entry><type>regproc</type></entry>
@@ -646,7 +643,6 @@
 -->
       <entry>最終関数（ない時はゼロ）</entry>
      </row>
-
      <row>
       <entry><structfield>aggmtransfn</structfield></entry>
       <entry><type>regproc</type></entry>
@@ -692,7 +688,6 @@
 -->
       <entry><structfield>aggfinalfn</structfield>に追加の仮引数を渡す場合はTrue</entry>
      </row>
-
      <row>
       <entry><structfield>aggsortop</structfield></entry>
       <entry><type>oid</type></entry>
@@ -711,7 +706,6 @@
 -->
       <entry>集約関数の内部遷移（状態）データのデータ型</entry>
      </row>
-
      <row>
       <entry><structfield>aggtransspace</structfield></entry>
       <entry><type>int4</type></entry>
@@ -742,7 +736,6 @@
 -->
       <entry>移動集約モードの、遷移状態データの推定平均サイズ（バイト）、またはデフォルトの推定値であるゼロ</entry>
      </row>
-
      <row>
       <entry><structfield>agginitval</structfield></entry>
       <entry><type>text</type></entry>
@@ -759,7 +752,6 @@
 フィールドがNULL値の場合、推移状態はNULL値で始まります。
       </entry>
      </row>
-
      <row>
       <entry><structfield>aggminitval</structfield></entry>
       <entry><type>text</type></entry>
@@ -1355,8 +1347,8 @@
    </para>
   </note>
 
-<!--
   <para>
+<!--
    An entry's <structfield>amopmethod</> must match the
    <structname>opfmethod</> of its containing operator family (including
    <structfield>amopmethod</> here is an intentional denormalization of the
@@ -1364,9 +1356,7 @@
    <structfield>amoplefttype</> and <structfield>amoprighttype</> must match
    the <structfield>oprleft</> and <structfield>oprright</> fields of the
    referenced <structname>pg_operator</> entry.
-  </para>
 -->
-  <para>
 項目の<structfield>amopmethod</>は、項目を含む演算子族の<structname>opfmethod</>に一致しなくてはいけません。
 （ここでの<structfield>amopmethod</>は、性能上の理由からカタログ構造を意図的に非正規化したものも含みます。）
 また、<structfield>amoplefttype</>と<structfield>amoprighttype</>は、参照されている<structname>pg_operator</>項目の<structfield>oprleft</>と<structfield>oprright</>に一致しなくてはいけません。
@@ -1479,8 +1469,8 @@
    </tgroup>
   </table>
 
-<!--
   <para>
+<!--
    The usual interpretation of the
    <structfield>amproclefttype</> and <structfield>amprocrighttype</> fields
    is that they identify the left and right input types of the operator(s)
@@ -1490,14 +1480,12 @@
    an index, which are those with <structfield>amproclefttype</> and
    <structfield>amprocrighttype</> both equal to the index operator class's
    <structfield>opcintype</>.
-  </para>
--->
-  <para>
 <structfield>amproclefttype</>と<structfield>amprocrighttype</>属性の通常の解釈は、それらが、特定のサポートプロシージャがサポートする演算子の左と右の入力型を識別することです。
 いくつかのアクセスメソッドに対して、これらはサポートプロシージャ自身の入力データ型に一致することもあります。
 また、そうでないものもあります。
 インデックスに対して<quote>デフォルト</>サポートプロシージャの概念があります。
 これは<structfield>amproclefttype</>と<structfield>amprocrighttype</>の両方が、インデックス演算クラスの<structfield>opcintype</>に等しい、という概念です。
+-->
   </para>
 
  </sect1>
@@ -1714,7 +1702,7 @@
        to collect, and the target number of histogram bins to create.
 -->
 <structfield>attstattarget</structfield>は<xref linkend="sql-analyze">によるこの列に対する蓄積された統計情報をどの程度詳しく管理するかを規定します。
-値がゼロの場合は統計情報を収集しません。 
+値がゼロの場合は統計情報を収集しません。
 負の値の場合は、システムのデフォルトの統計目標を使用すべきであるということです。
 正の値が厳密に意味するところはデータ型に依存します。
 スカラデータ型に対して<structfield>attstattarget</structfield>は収集する<quote>最も一般的な値</quote>の目標となる数であり、また作成する度数分布ビンの目標数でもあります。
@@ -2317,8 +2305,8 @@ NULLの場合には満了時間はありません。</entry>
 ここには、組み込みのパスとユーザ定義のパスが存在します。
   </para>
 
-<!--
   <para>
+<!--
    It should be noted that <structname>pg_cast</structname> does not represent
    every type conversion that the system knows how to perform; only those that
    cannot be deduced from some generic rule.  For example, casting between a
@@ -2328,9 +2316,7 @@ NULLの場合には満了時間はありません。</entry>
    type's own I/O functions to convert to or from <type>text</> or other
    string types, are not explicitly represented in
    <structname>pg_cast</structname>.
-  </para>
 -->
-  <para>
 <structname>pg_cast</structname>は、システムがどのように動作するかわかっているような、あらゆる型変換を表しているわけではないということに注意してください。
 いくつかの一般的な規則から推測できないような型変換についてのみ表しています。
 例えば、ドメインとその基本の型は明示的に<structname>pg_cast</structname>内で表されていません。
@@ -2426,7 +2412,6 @@ NULLの場合には満了時間はありません。</entry>
 <literal>i</>は他の場合と同様に演算式内で暗黙的であることを意味します。
       </entry>
      </row>
-
      <row>
       <entry><structfield>castmethod</structfield></entry>
       <entry><type>char</type></entry>
@@ -2693,16 +2678,14 @@ NULLの場合には満了時間はありません。</entry>
       <entry><structfield>relallvisible</structfield></entry>
       <entry><type>int4</type></entry>
       <entry></entry>
-<!--
       <entry>
+<!--
        Number of pages that are marked all-visible in the table's
        visibility map.  This is only an estimate used by the
        planner.  It is updated by <command>VACUUM</command>,
        <command>ANALYZE</command>, and a few DDL commands such as
        <command>CREATE INDEX</command>.
-      </entry>
 -->
-      <entry>
 テーブル内の可視マップ内で全て可視とマークされているページ数。
 これはプランナで使用される単なる見積です。
 これは<command>VACUUM</command>、<command>ANALYZE</command>さらに<command>CREATE INDEX</command>といったいくつかのDDLコマンドで更新されます。
@@ -2910,9 +2893,7 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
       <entry>True if relation is populated (this is true for all
        relations other than some materialized views)</entry>
 -->
-      <entry>
-リレーションにデータが投入されている場合に真（マテリアライズドビュー以外のすべてのリレーションでは真です。）
-      </entry>
+<entry>リレーションにデータが投入されている場合に真（マテリアライズドビュー以外のすべてのリレーションでは真です。）</entry>
      </row>
 
      <row>
@@ -2932,7 +2913,6 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
        <literal>n</> 無し、
        <literal>f</> 全カラム、
        <literal>i</> インデックスと <structfield>indisreplident</structfield>のセット、またはデフォルト
-
       </entry>
      </row>
 
@@ -3091,7 +3071,7 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
 <!--
        The OID of the namespace that contains this collation
 -->
-この照合順序を含む名前空間のOID 
+この照合順序を含む名前空間のOID
       </entry>
      </row>
 
@@ -3174,8 +3154,8 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
    <literal>template0</>.  This would currently have to be done manually.
 -->
 後で<literal>template0</>から複製されるデータベースのエンコード方式と一致するかもしれないので、
-<literal>template0</>データベースのデータベースのエンコード方式と一致しないものの照合順を作成することが有用になるかもしれません。 
-現在これは手作業で行う必要があります。 
+<literal>template0</>データベースのデータベースのエンコード方式と一致しないものの照合順を作成することが有用になるかもしれません。
+現在これは手作業で行う必要があります。
   </para>
  </sect1>
 
@@ -3198,7 +3178,7 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
 <structname>pg_constraint</structname>カタログはテーブル上の検査制約、プライマリキー制約、一意性制約、外部キー制約、排他制約を格納します
 （列制約は特別扱いされていません。
 全ての列制約は何らかのテーブル制約と同等です。）
-非NULL制約はここではなく、<structname>pg_attribute</>カタログで示されます。 
+非NULL制約はここではなく、<structname>pg_attribute</>カタログで示されます。
   </para>
 
   <para>
@@ -3387,7 +3367,7 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
             <literal>c</> = cascade,
             <literal>n</> = set null,
             <literal>d</> = set default
-</entry>
+          </entry>
      </row>
 
      <row>
@@ -3476,7 +3456,6 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
 この制約はリレーションのためにローカルで定義されます。これは非継承制約です。
       </entry>
      </row>
-
 
      <row>
       <entry><structfield>conkey</structfield></entry>
@@ -3603,7 +3582,6 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
 <literal>pg_class.relchecks</literal>はそれぞれのリレーションに対してこのテーブルで検出された検査制約の項目数と一致しなければなりません。
    </para>
   </note>
-
  </sect1>
 
 
@@ -3972,18 +3950,16 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry><structfield>datacl</structfield></entry>
       <entry><type>aclitem[]</type></entry>
       <entry></entry>
-<!--
       <entry>
+<!--
        Access privileges; see
        <xref linkend="sql-grant"> and
        <xref linkend="sql-revoke">
        for details
-      </entry>
 -->
-<entry>
 アクセス権限。
 <xref linkend="sql-grant">と<xref linkend="sql-revoke">を参照してください。
-</entry>
+      </entry>
      </row>
     </tbody>
    </tgroup>
@@ -4252,7 +4228,6 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
     <thead>
      <row>
 <!--
-
       <entry>Name</entry>
       <entry>Type</entry>
       <entry>References</entry>
@@ -4380,7 +4355,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
 個別に作成されたオブジェクト間の通常の関係です。
 依存するオブジェクトは参照されるオブジェクトに影響を与えずに削除できます。
 参照されるオブジェクトは<literal>CASCADE</>を指定することによってのみ削除することができます。
-この場合は依存するオブジェクトも削除されます。 
+この場合は依存するオブジェクトも削除されます。
 例：テーブルの列はそのデータ型に対して通常の依存関係を持ちます。
       </para>
      </listitem>
@@ -4593,15 +4568,13 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
    <primary>pg_enum</primary>
   </indexterm>
 
-<!--
   <para>
+<!--
    The <structname>pg_enum</structname> catalog contains entries
    showing the values and labels for each enum type. The
    internal representation of a given enum value is actually the OID
    of its associated row in <structname>pg_enum</structname>.
-  </para>
 -->
-  <para>
 <structname>pg_enum</structname>カタログは、各列挙型についてその値とラベルを示す項目を含みます。
 ある与えられた列挙値の内部表現は、実際には<structname>pg_enum</structname>内の関連付けられた行のOIDです。
   </para>
@@ -4816,7 +4789,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
         Command tags for which this trigger will fire.  If NULL, the firing
         of this trigger is not restricted on the basis of the command tag.
 -->
-このトリガを発行するコマンドタグです。 NULLの場合、このトリガの発行はコマンドタグに基づいて制限されていません。 
+このトリガを発行するコマンドタグです。 NULLの場合、このトリガの発行はコマンドタグに基づいて制限されていません。
       </entry>
      </row>
     </tbody>
@@ -4981,17 +4954,13 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
    <primary>pg_foreign_data_wrapper</primary>
   </indexterm>
 
-
-<!--
   <para>
+<!--
    The catalog <structname>pg_foreign_data_wrapper</structname> stores
    foreign-data wrapper definitions.  A foreign-data wrapper is the
    mechanism by which external data, residing on foreign servers, is
    accessed.
-  </para>
-
 -->
-  <para>
 <structname>pg_foreign_data_wrapper</structname>カタログは外部データラッパの定義を保存します。
 外部データラッパは外部サーバにあるデータにアクセスするための機構です。
   </para>
@@ -5043,7 +5012,6 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry><structfield>fdwowner</structfield></entry>
       <entry><type>oid</type></entry>
       <entry><literal><link linkend="catalog-pg-authid"><structname>pg_authid</structname></link>.oid</literal></entry>
-
 <!--
       <entry>Owner of the foreign-data wrapper</entry>
 -->
@@ -5069,17 +5037,14 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry><structfield>fdwvalidator</structfield></entry>
       <entry><type>oid</type></entry>
       <entry><literal><link linkend="catalog-pg-proc"><structname>pg_proc</structname></link>.oid</literal></entry>
-
-<!--
       <entry>
+<!--
        References a validator function that is responsible for
        checking the validity of the options given to the
        foreign-data wrapper, as well as options for foreign servers and user
        mappings using the foreign-data wrapper.  Zero if no validator
        is provided
-      </entry>
 -->
-      <entry>
 外部サーバや外部データラッパを使用するユーザマップと同様に外部データラッパに対して与えられたオプションの正当性を検査する有効性検証関数。
 有効性検証関数がない場合はゼロになります。
       </entry>
@@ -5089,15 +5054,13 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry><structfield>fdwacl</structfield></entry>
       <entry><type>aclitem[]</type></entry>
       <entry></entry>
-<!--
       <entry>
+<!--
        Access privileges; see
        <xref linkend="sql-grant"> and
        <xref linkend="sql-revoke">
        for details
-      </entry>
 -->
-     <entry>
 アクセス権限。
 詳細は<xref linkend="sql-grant">と<xref linkend="sql-revoke">を参照してください。
       </entry>
@@ -5107,13 +5070,10 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry><structfield>fdwoptions</structfield></entry>
       <entry><type>text[]</type></entry>
       <entry></entry>
-
+      <entry>
 <!--
-      <entry>
        Foreign-data wrapper specific options, as <quote>keyword=value</> strings
-      </entry>
 -->
-      <entry>
        外部データラッパの<quote>keyword=value</>のような特定のオプション。
       </entry>
      </row>
@@ -5130,16 +5090,13 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
    <primary>pg_foreign_server</primary>
   </indexterm>
 
-
-<!--
   <para>
+<!--
    The catalog <structname>pg_foreign_server</structname> stores
    foreign server definitions.  A foreign server describes a source
    of external data, such as a remote server.  Foreign
    servers are accessed via foreign-data wrappers.
-  </para>
 -->
-  <para>
 <structname>pg_foreign_server</structname>カタログは外部サーバの定義を保存します。
 外部サーバはリモートサーバなど外部データの源を記述します。
 外部サーバは外部データラッパを介してアクセスされます。
@@ -5182,7 +5139,6 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry><structfield>srvname</structfield></entry>
       <entry><type>name</type></entry>
       <entry></entry>
-
 <!--
       <entry>Name of the foreign server</entry>
 -->
@@ -5193,7 +5149,6 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry><structfield>srvowner</structfield></entry>
       <entry><type>oid</type></entry>
       <entry><literal><link linkend="catalog-pg-authid"><structname>pg_authid</structname></link>.oid</literal></entry>
-
 <!--
       <entry>Owner of the foreign server</entry>
 -->
@@ -5204,7 +5159,6 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry><structfield>srvfdw</structfield></entry>
       <entry><type>oid</type></entry>
       <entry><literal><link linkend="catalog-pg-foreign-data-wrapper"><structname>pg_foreign_data_wrapper</structname></link>.oid</literal></entry>
-
 <!--
       <entry>OID of the foreign-data wrapper of this foreign server</entry>
 -->
@@ -5225,7 +5179,6 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry><structfield>srvversion</structfield></entry>
       <entry><type>text</type></entry>
       <entry></entry>
-
 <!--
       <entry>Version of the server (optional)</entry>
 -->
@@ -5236,16 +5189,13 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry><structfield>srvacl</structfield></entry>
       <entry><type>aclitem[]</type></entry>
       <entry></entry>
-
-<!--
       <entry>
+<!--
        Access privileges; see
        <xref linkend="sql-grant"> and
        <xref linkend="sql-revoke">
        for details
-      </entry>
 -->
-      <entry>
 アクセス権限。
 詳細は<xref linkend="sql-grant">と<xref linkend="sql-revoke">を参照してください。
       </entry>
@@ -5490,7 +5440,6 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry>
 <!--
        If true, the index is currently valid for queries.  False means the
-       true, the index is currently valid for queries.  False means the
        index is possibly incomplete: it must still be modified by
        <command>INSERT</>/<command>UPDATE</> operations, but it cannot safely
        be used for queries. If it is unique, the uniqueness property is not
@@ -5507,15 +5456,13 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry><structfield>indcheckxmin</structfield></entry>
       <entry><type>bool</type></entry>
       <entry></entry>
-<!--
       <entry>
+<!--
        If true, queries must not use the index until the <structfield>xmin</>
        of this <structname>pg_index</> row is below their <symbol>TransactionXmin</symbol>
        event horizon, because the table may contain broken HOT chains with
        incompatible rows that they can see
-      </entry>
 -->
-      <entry>
 真の場合、<structname>pg_index</>行の<structfield>xmin</>が<symbol>TransactionXmin</symbol>イベント境界値を下回るまで、問い合わせはインデックスを使用してはいけません。
 なぜなら、テーブルは互換性の無い行と共に破壊されたHOTチェインを含み、それらが可視であるかもしれないからです。
       </entry>
@@ -5525,14 +5472,12 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry><structfield>indisready</structfield></entry>
       <entry><type>bool</type></entry>
       <entry></entry>
-<!--
       <entry>
+<!--
        If true, the index is currently ready for inserts.  False means the
        index must be ignored by <command>INSERT</>/<command>UPDATE</>
        operations.
-      </entry>
 -->
-      <entry>
 真の場合、インデックスは挿入に対する準備ができています。
 偽の場合はインデックスは<command>INSERT</>/<command>UPDATE</>操作により無視されなければならないことを意味します。
       </entry>
@@ -5874,7 +5819,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
        executing all functions that are written in the particular
        language
 -->
-       内部言語でない場合、特定の言語で作成されたすべての関数の実行に責任を持つ特別な関数である言語ハンドラを参照します。   
+内部言語でない場合、特定の言語で作成されたすべての関数の実行に責任を持つ特別な関数である言語ハンドラを参照します。
       </entry>
      </row>
 
@@ -6011,8 +5956,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry>Page number of this page within its large object
       (counting from zero)</entry>
 -->
-      <entry>ラージオブジェクト内の（ゼロから数えた）このページのページ番号
-</entry>
+      <entry>ラージオブジェクト内の（ゼロから数えた）このページのページ番号</entry>
      </row>
 
      <row>
@@ -6129,9 +6073,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
     </tbody>
    </tgroup>
   </table>
-
  </sect1>
-
 
  <sect1 id="catalog-pg-namespace">
   <title><structname>pg_namespace</structname></title>
@@ -6278,7 +6220,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
      <entry>名前</entry>
      <entry>型</entry>
      <entry>参照先</entry>
-     <entry>説明</entry> 
+     <entry>説明</entry>
      </row>
     </thead>
     <tbody>
@@ -6377,16 +6319,14 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
    </tgroup>
   </table>
 
-<!--
   <para>
+<!--
    An operator class's <structfield>opcmethod</> must match the
    <structname>opfmethod</> of its containing operator family.
    Also, there must be no more than one <structname>pg_opclass</structname>
    row having <structname>opcdefault</> true for any given combination of
    <structname>opcmethod</> and <structname>opcintype</>.
-  </para>
 -->
-  <para>
 演算子クラスの<structfield>opcmethod</>は、演算子クラスが含んでいる演算子族の<structname>opfmethod</>に一致しなければいけません。
 また、任意の<structname>opcmethod</>と<structname>opcintype</>の組み合わせに対して<structname>opcdefault</>が真となるような<structname>pg_opclass</structname>行が複数存在してはいけません。
   </para>
@@ -6613,8 +6553,8 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
    <primary>pg_opfamily</primary>
   </indexterm>
 
-<!--
   <para>
+<!--
    The catalog <structname>pg_opfamily</structname> defines operator families.
    Each operator family is a collection of operators and associated
    support routines that implement the semantics specified for a particular
@@ -6623,21 +6563,17 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
    The operator family concept allows cross-data-type operators to be used
    with indexes and to be reasoned about using knowledge of access method
    semantics.
-  </para>
 -->
-  <para>
 <structname>pg_opfamily</structname>カタログは演算子族を定義します。
 それぞれの演算子族は、演算子とサポートルーチン(特定のインデックスアクセスメソッドのために特化されたセマンティクスを実装するような関連付けられたもの)を集めたものです。
 さらに、演算子族内の演算子はすべて、アクセスメソッドにより特定される方法において<quote>互換性</>があります。
 演算子族の概念は、データ型を跨る演算子がインデックスで使用されることを許可し、さらにアクセスメソッドのセマンティクスの知識を使用することについて理由付けすることも許可します。
   </para>
 
+  <para>
 <!--
-  <para>
    Operator families are described at length in <xref linkend="xindex">.
-  </para>
 -->
-  <para>
 演算子族については<xref linkend="xindex">で詳しく説明します。
   </para>
 
@@ -6718,17 +6654,15 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
    </tgroup>
   </table>
 
-<!--
   <para>
+<!--
    The majority of the information defining an operator family is not in its
    <structname>pg_opfamily</structname> row, but in the associated rows in
    <link linkend="catalog-pg-amop"><structname>pg_amop</structname></link>,
    <link linkend="catalog-pg-amproc"><structname>pg_amproc</structname></link>,
    and
    <link linkend="catalog-pg-opclass"><structname>pg_opclass</structname></link>.
-  </para>
 -->
-  <para>
 演算子族を定義している情報の大部分が、<structname>pg_opfamily</structname>行にあるわけではなく、<link linkend="catalog-pg-amop"><structname>pg_amop</structname></link>や<link linkend="catalog-pg-amproc"><structname>pg_amproc</structname></link>や<link linkend="catalog-pg-opclass"><structname>pg_opclass</structname></link>行にあります。
   </para>
 
@@ -6787,7 +6721,6 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry>説明</entry>
      </row>
     </thead>
-
 
     <tbody>
      <row>
@@ -7152,7 +7085,6 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry><structfield>provariadic</structfield></entry>
       <entry><type>oid</type></entry>
       <entry><literal><link linkend="catalog-pg-type"><structname>pg_type</structname></link>.oid</literal></entry>
-
 <!--
       <entry>Data type of the variadic array parameter's elements,
        or zero if the function does not have a variadic parameter</entry>
@@ -7186,13 +7118,11 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry><structfield>proiswindow</structfield></entry>
       <entry><type>bool</type></entry>
       <entry></entry>
-
 <!--
       <entry>Function is a window function</entry>
 -->
       <entry>関数はウィンドウ関数です。</entry>
      </row>
-
 
      <row>
       <entry><structfield>prosecdef</structfield></entry>
@@ -7418,7 +7348,6 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       </entry>
      </row>
 
-
      <row>
       <entry><structfield>protrftypes</structfield></entry>
       <entry><type>oid[]</type></entry>
@@ -7477,17 +7406,16 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry><structfield>proacl</structfield></entry>
       <entry><type>aclitem[]</type></entry>
       <entry></entry>
-<!--
       <entry>
+<!--
        Access privileges; see
        <xref linkend="sql-grant"> and
        <xref linkend="sql-revoke">
        for details
-      </entry>
 -->
-      <entry>
 アクセス権限。
-<xref linkend="sql-grant">と<xref linkend="sql-revoke">を参照してください。</entry>
+<xref linkend="sql-grant">と<xref linkend="sql-revoke">を参照してください。
+      </entry>
      </row>
     </tbody>
    </tgroup>
@@ -7564,7 +7492,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry><structfield>rngsubtype</structfield></entry>
       <entry><type>oid</type></entry>
       <entry><literal><link linkend="catalog-pg-type"><structname>pg_type</structname></link>.oid</literal></entry>
-<!--      
+<!--
       <entry>OID of the element type (subtype) of this range type</entry>
 -->
       <entry>この範囲型の要素型(派生元型)のOID</entry>
@@ -7622,7 +7550,6 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
    type.  <structfield>rngcanonical</> is used when the element type is
    discrete.  <structfield>rngsubdiff</> is optional but should be supplied to
    improve performance of GiST indexes on the range type.
-  </para>
 -->
    <structfield>rngsubopc</> (および、要素型が照合可能である場合は<structfield>rngcollation</>)は
    範囲型で使用されるソートの順番を決定します。<structfield>rngcanonical</>は要素型が離散的である場合に使用されます。
@@ -7699,19 +7626,6 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
      </row>
 
      <row>
-      <entry><structfield>ev_attr</structfield></entry>
-      <entry><type>int2</type></entry>
-      <entry></entry>
-<!--
-      <entry>The column this rule is for (currently, always -1 to
-      indicate the whole table)</entry>
--->
-      <entry>
-      ルールを適用する列（現在は常にテーブル全体を表す-1）
-      </entry>
-     </row>
-
-     <row>
       <entry><structfield>ev_type</structfield></entry>
       <entry><type>char</type></entry>
       <entry></entry>
@@ -7721,7 +7635,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
        <command>UPDATE</>, 3 = <command>INSERT</>, 4 =
        <command>DELETE</>
 -->
-       ルールを適用するイベントの型： 
+       ルールを適用するイベントの型：
        1 = <command>SELECT</>、
        2 = <command>UPDATE</>、
        3 = <command>INSERT</>、
@@ -7797,7 +7711,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
     <literal>pg_class.relhasrules</literal>
     must be true if a table has any rules in this catalog.
 -->
-   テーブルがこのカタログ内のルールを持つ場合、<literal>pg_class.relhasrules</literal>は真でなければなりません。 
+   テーブルがこのカタログ内のルールを持つ場合、<literal>pg_class.relhasrules</literal>は真でなければなりません。
    </para>
   </note>
 
@@ -8158,7 +8072,6 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
 -->
 <link linkend="catalog-pg-shseclabel"><structname>pg_shseclabel</structname></link>を参照してください。
 これは、データベースクラスタ間で共有されたデータベースオブジェクトにおけるセキュリティラベルのための類似した機能を提供します。
-
   </para>
 
   <table>
@@ -8356,7 +8269,6 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       </entry>
      </row>
 
-
      <row>
       <entry><structfield>refclassid</structfield></entry>
       <entry><type>oid</type></entry>
@@ -8480,7 +8392,6 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
 
  </sect1>
 
-
  <sect1 id="catalog-pg-shdescription">
   <title><structname>pg_shdescription</structname></title>
 
@@ -8510,7 +8421,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
   </para>
 
   <para>
-<!-- 
+<!--
    Unlike most system catalogs, <structname>pg_shdescription</structname>
    is shared across all databases of a cluster: there is only one
    copy of <structname>pg_shdescription</structname> per cluster, not
@@ -8636,8 +8547,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry>名前</entry>
       <entry>型</entry>
       <entry>参照先</entry>
-      <entry>説明</entry>     
-
+      <entry>説明</entry>
      </row>
     </thead>
     <tbody>
@@ -8692,17 +8602,15 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
    <primary>pg_statistic</primary>
   </indexterm>
 
-<!--
   <para>
+<!--
    The catalog <structname>pg_statistic</structname> stores
    statistical data about the contents of the database.  Entries are
    created by <xref linkend="sql-analyze">
    and subsequently used by the query planner.  Note that all the
    statistical data is inherently approximate, even assuming that it
    is up-to-date.
-  </para>
 -->
-  <para>
 <structname>pg_statistic</structname>カタログはデータベースの内容に関する統計データを保存します。
 項目は<xref linkend="sql-analyze">で作成され、後に問い合わせプランナで使用されます。
 最新のものと思ってもすべての統計データは本質的に大雑把なものであることに注意してください。
@@ -8796,7 +8704,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
       <entry>名前</entry>
       <entry>型</entry>
       <entry>参照先</entry>
-      <entry>説明</entry>     
+      <entry>説明</entry>
      </row>
     </thead>
 
@@ -9433,8 +9341,8 @@ N番目の<quote>スロット</quote>に保存されている統計情報を引�
    <primary>pg_ts_config</primary>
   </indexterm>
 
-<!--
   <para>
+<!--
    The <structname>pg_ts_config</structname> catalog contains entries
    representing text search configurations.  A configuration specifies
    a particular text search parser and a list of dictionaries to use
@@ -9442,21 +9350,17 @@ N番目の<quote>スロット</quote>に保存されている統計情報を引�
    in the <structname>pg_ts_config</structname> entry, but the
    token-to-dictionary mapping is defined by subsidiary entries in <link
    linkend="catalog-pg-ts-config-map"><structname>pg_ts_config_map</structname></link>.
-  </para>
 -->
-  <para>
 <structname>pg_ts_config</structname>カタログは、テキスト検索の設定を表す項目を含みます。
 設定は、特定のテキスト検索パーサと、それぞれのパーサの出力トークン型のために使用される辞書の一覧を指定します。
 パーサは<structname>pg_ts_config</structname>項目内に示されていますが、トークンと辞書の対応付けは、<link linkend="catalog-pg-ts-config-map"><structname>pg_ts_config_map</structname></link>内の補助項目内に定義されています。
   </para>
 
-<!--
   <para>
+<!--
    <productname>PostgreSQL</productname>'s text search features are
    described at length in <xref linkend="textsearch">.
-  </para>
 -->
-  <para>
    <productname>PostgreSQL</productname>のテキスト検索機能については<xref linkend="textsearch">で詳しく説明します。
   </para>
 
@@ -9549,26 +9453,22 @@ N番目の<quote>スロット</quote>に保存されている統計情報を引�
    <primary>pg_ts_config_map</primary>
   </indexterm>
 
-<!--
   <para>
+<!--
    The <structname>pg_ts_config_map</structname> catalog contains entries
    showing which text search dictionaries should be consulted, and in
    what order, for each output token type of each text search configuration's
    parser.
-  </para>
 -->
-  <para>
 <structname>pg_ts_config_map</structname>カタログは、どのテキスト検索辞書を参照するべきかを示す項目を含みます。
 さらに、それぞれのテキスト検索設定のパーサの出力トークンをどの順番で参照すべきかを示す項目を含みます。
   </para>
 
-<!--
   <para>
+<!--
    <productname>PostgreSQL</productname>'s text search features are
    described at length in <xref linkend="textsearch">.
-  </para>
 -->
-  <para>
    <productname>PostgreSQL</productname>のテキスト検索機能については<xref linkend="textsearch">で詳しく説明します。
   </para>
 
@@ -9648,8 +9548,8 @@ N番目の<quote>スロット</quote>に保存されている統計情報を引�
    <primary>pg_ts_dict</primary>
   </indexterm>
 
-<!--
   <para>
+<!--
    The <structname>pg_ts_dict</structname> catalog contains entries
    defining text search dictionaries.  A dictionary depends on a text
    search template, which specifies all the implementation functions
@@ -9658,9 +9558,7 @@ N番目の<quote>スロット</quote>に保存されている統計情報を引�
    dictionaries to be created by unprivileged users.  The parameters
    are specified by a text string <structfield>dictinitoption</>,
    whose format and meaning vary depending on the template.
-  </para>
 -->
-  <para>
 <structname>pg_ts_dict</structname>カタログは、テキスト検索辞書を定義する項目を含みます。
 辞書は、必要な実装関数すべてを指定するテキスト検索のテンプレートに依存します。
 辞書自身は、テンプレートによりサポートされている、ユーザが設定可能なパラメータ値を提供します。
@@ -9669,13 +9567,11 @@ N番目の<quote>スロット</quote>に保存されている統計情報を引�
 その書式と意味はテンプレートにより変化します。
   </para>
 
-<!--
   <para>
+<!--
    <productname>PostgreSQL</productname>'s text search features are
    described at length in <xref linkend="textsearch">.
-  </para>
 -->
-  <para>
    <productname>PostgreSQL</productname>のテキスト検索機能については<xref linkend="textsearch">で詳しく説明します。
   </para>
 
@@ -9778,28 +9674,24 @@ N番目の<quote>スロット</quote>に保存されている統計情報を引�
    <primary>pg_ts_parser</primary>
   </indexterm>
 
-<!--
   <para>
+<!--
    The <structname>pg_ts_parser</structname> catalog contains entries
    defining text search parsers.  A parser is responsible for splitting
    input text into lexemes and assigning a token type to each lexeme.
    Since a parser must be implemented by C-language-level functions,
    creation of new parsers is restricted to database superusers.
-  </para>
 -->
-  <para>
 <structname>pg_ts_parser</structname>カタログはテキスト検索パーサを定義する項目を含みます。
 パーサは、入力テキストを字句に分割することとトークン型を字句に割り当てることに責任を持ちます。
 パーサはC言語レベルの関数で実装されていなくてはいけないため、新規のパーサの作成はデータベースのスーパーユーザに制限されています。
   </para>
 
-<!--
   <para>
+<!--
    <productname>PostgreSQL</productname>'s text search features are
    described at length in <xref linkend="textsearch">.
-  </para>
 -->
-  <para>
    <productname>PostgreSQL</productname>のテキスト検索機能については<xref linkend="textsearch">で詳しく説明します。
   </para>
 
@@ -9922,28 +9814,24 @@ N番目の<quote>スロット</quote>に保存されている統計情報を引�
    <primary>pg_ts_template</primary>
   </indexterm>
 
-<!--
   <para>
+<!--
    The <structname>pg_ts_template</structname> catalog contains entries
    defining text search templates.  A template is the implementation
    skeleton for a class of text search dictionaries.
    Since a template must be implemented by C-language-level functions,
    creation of new templates is restricted to database superusers.
-  </para>
 -->
-  <para>
 <structname>pg_ts_template</structname>カタログはテキスト検索テンプレートを定義する項目を含みます。
 テンプレートはテキスト検索辞書クラスの骨格を実装したものです。
 テンプレートはC言語レベルの関数で実装されなくてはいけないため、新規のテンプレートの作成はデータベースのスーパーユーザに制限されています。
   </para>
 
-<!--
   <para>
+<!--
    <productname>PostgreSQL</productname>'s text search features are
    described at length in <xref linkend="textsearch">.
-  </para>
 -->
-  <para>
    <productname>PostgreSQL</productname>のテキスト検索機能については<xref linkend="textsearch">で詳しく説明します。
   </para>
 
@@ -10213,7 +10101,6 @@ N番目の<quote>スロット</quote>に保存されている統計情報を引�
 型が<structfield>typcategory</structfield>内で選択されたキャスト対象である場合に真となります。
       </entry>
      </row>
-
 
      <row>
       <entry><structfield>typisdefined</structfield></entry>
@@ -10637,20 +10524,17 @@ N番目の<quote>スロット</quote>に保存されている統計情報を引�
 アクセス特権。詳細は<xref linkend="sql-grant">と<xref linkend="sql-revoke">を参照してください。
       </entry>
      </row>
-     
     </tbody>
    </tgroup>
   </table>
 
-<!--
   <para>
+<!--
    <xref linkend="catalog-typcategory-table"> lists the system-defined values
    of <structfield>typcategory</>.  Any future additions to this list will
    also be upper-case ASCII letters.  All other ASCII characters are reserved
    for user-defined categories.
-  </para>
 -->
-  <para>
 <xref linkend="catalog-typcategory-table">はシステムで定義された<structfield>typcategory</>の値の一覧です。
 今後この一覧に追加されるものは同様に大文字のASCII文字になります。
 他のすべてのASCII文字はユーザ定義のカテゴリのために予約されています。
@@ -10665,7 +10549,6 @@ N番目の<quote>スロット</quote>に保存されている統計情報を引�
    <tgroup cols="2">
     <thead>
      <row>
-
 <!--
       <entry>Code</entry>
       <entry>Category</entry>
@@ -10685,7 +10568,6 @@ N番目の<quote>スロット</quote>に保存されている統計情報を引�
      </row>
      <row>
       <entry><literal>B</literal></entry>
-
 <!--
       <entry>Boolean types</entry>
 -->
@@ -10786,7 +10668,6 @@ N番目の<quote>スロット</quote>に保存されている統計情報を引�
    </tgroup>
   </table>
 
-
  </sect1>
 
 
@@ -10797,17 +10678,14 @@ N番目の<quote>スロット</quote>に保存されている統計情報を引�
    <primary>pg_user_mapping</primary>
   </indexterm>
 
-
-<!--
   <para>
+<!--
    The catalog <structname>pg_user_mapping</structname> stores
    the mappings from local user to remote.  Access to this catalog is
    restricted from normal users, use the view
    <link linkend="view-pg-user-mappings"><structname>pg_user_mappings</structname></link>
    instead.
-  </para>
 -->
-  <para>
 <structname>pg_user_mapping</structname>カタログはローカルのユーザから遠隔のユーザへのマッピングを保持します。
 一般ユーザからのこのカタログへのアクセスは制限されています。
 代わりに<link linkend="view-pg-user-mappings"><structname>pg_user_mappings</structname></link>を使用してください。
@@ -10850,7 +10728,6 @@ N番目の<quote>スロット</quote>に保存されている統計情報を引�
       <entry><structfield>umuser</structfield></entry>
       <entry><type>oid</type></entry>
       <entry><literal><link linkend="catalog-pg-authid"><structname>pg_authid</structname></link>.oid</literal></entry>
-
 <!--
       <entry>OID of the local role being mapped, 0 if the user mapping is public</entry>
 -->
@@ -12060,9 +11937,6 @@ SQLから<xref linkend="sql-declare">文経由。
       <entry><literal><link linkend="catalog-pg-class"><structname>pg_class</structname></link>.oid</literal></entry>
       <entry>
 <!--
-       OID of the system catalog containing the object, or null if the
-       object is not a general database object
-       
        OID of the system catalog containing the lock target, or null if the
        target is not a general database object
 -->
@@ -12143,12 +12017,11 @@ SQLから<xref linkend="sql-declare">文経由。
 -->
       <entry>ロックが保持されている場合は真、ロックが待ち状態の場合は偽</entry>
      </row>
-     
      <row>
       <entry><structfield>fastpath</structfield></entry>
       <entry><type>boolean</type></entry>
       <entry></entry>
-<!--      
+<!--
       <entry>True if lock was taken via fast path, false if taken via main
        lock table</entry>
 -->
@@ -12156,7 +12029,6 @@ SQLから<xref linkend="sql-declare">文経由。
       ファストパス経由でロックが獲得されている場合は真、メインロックテーブル経由で獲得されている場合は偽。
       </entry>
      </row>
-     
     </tbody>
    </tgroup>
   </table>
@@ -12190,7 +12062,6 @@ SQLから<xref linkend="sql-declare">文経由。
    the other transaction ID (either virtual or permanent ID depending on the
    situation). That will succeed only when the other transaction
    terminates and releases its locks.
-
 -->
 すべてのトランザクションはそのすべての過程完了までその仮想トランザクションID上に排他的ロックをかけます。
 もしある永続IDがトランザクションに割り当てられる（普通はトランザクションがデータベースの状態を変化させるときのみに発生します）と、トランザクションは終了するまで永続トランザクションIDに対して排他ロックを保持します。
@@ -12260,22 +12131,6 @@ SQLから<xref linkend="sql-declare">文経由。
    view to get more
    information on the session holding or waiting to hold each lock,
    for example
-<programlisting>
-SELECT * FROM pg_locks pl LEFT JOIN pg_stat_activity psa
-    ON pl.pid = psa.pid;
-</programlisting>
-   Also, if you are using prepared transactions, the
-   <structfield>virtualtransaction</> column can be joined to the
-   <structfield>transaction</structfield> column of the <link
-   linkend="view-pg-prepared-xacts"><structname>pg_prepared_xacts</structname></link>
-   view to get more information on prepared transactions that hold locks.
-   (A prepared transaction can never be waiting for a lock,
-   but it continues to hold the locks it acquired while running.)
-   For example:
-<programlisting>
-SELECT * FROM pg_locks pl LEFT JOIN pg_prepared_xacts ppx
-    ON pl.virtualtransaction = '-1/' || ppx.transaction;
-</programlisting>
 -->
 ロック保持もしくは保持を待機しているセッションのさらなる情報を入手するため
 <link linkend="pg-stat-activity-view"><structname>pg_stat_activity</structname></link>ビューの
@@ -12285,10 +12140,20 @@ SELECT * FROM pg_locks pl LEFT JOIN pg_prepared_xacts ppx
 SELECT * FROM pg_locks pl LEFT JOIN pg_stat_activity psa
     ON pl.pid = psa.pid;
 </programlisting>
+<!--
+   Also, if you are using prepared transactions, the
+   <structfield>virtualtransaction</> column can be joined to the
+   <structfield>transaction</structfield> column of the <link
+   linkend="view-pg-prepared-xacts"><structname>pg_prepared_xacts</structname></link>
+   view to get more information on prepared transactions that hold locks.
+   (A prepared transaction can never be waiting for a lock,
+   but it continues to hold the locks it acquired while running.)
+   For example:
+-->
 また、プリペアードトランザクションを使用している場合には、ロックを保持しているプリペアードトランザクションに関してより多くの情報を得るため、
 <structfield>virtualtransaction</>列は、<link linkend="view-pg-prepared-xacts"><structname>pg_prepared_xacts</structname></link>ビューの
 <structfield>transaction</structfield>列と結合することができます。
- （プリペアードトランザクションはロックを待つことはありませんが、実行時に獲得したロックを保持し続けます。） 
+ （プリペアードトランザクションはロックを待つことはありませんが、実行時に獲得したロックを保持し続けます。）
  例えば、このような感じです。
 <programlisting>
 SELECT * FROM pg_locks pl LEFT JOIN pg_prepared_xacts ppx
@@ -12830,7 +12695,6 @@ SQL経由で作成された準備済み文では、これはクライアント�
    The view <structname>pg_roles</structname> provides access to
    information about database roles.  This is simply a publicly
    readable view of
-
    <link linkend="catalog-pg-authid"><structname>pg_authid</structname></link>
    that blanks out the password field.
 -->
@@ -13094,7 +12958,7 @@ SQL経由で作成された準備済み文では、これはクライアント�
    <structname>pg_views</> and <structname>pg_matviews</>.
 -->
 <structname>pg_rules</structname>ビューは、ビューおよびマテリアライズドビューに対する<literal>ON SELECT</>ルールを除外します。
-これらは<structname>pg_views</structname>および<structname>pg_matviews</>にあります。 
+これらは<structname>pg_views</structname>および<structname>pg_matviews</>にあります。
   </para>
 
  </sect1>
@@ -13316,7 +13180,6 @@ SQL経由で作成された準備済み文では、これはクライアント�
       <entry><type>text</type></entry>
 <!--
       <entry>Additional, more detailed, description of the parameter</entry>
-
 -->
       <entry>追加で、より詳細なパラメータについての説明</entry>
      </row>
@@ -13333,9 +13196,7 @@ SQL経由で作成された準備済み文では、これはクライアント�
       <entry><type>text</type></entry>
 <!--
       <entry>Parameter type (<literal>bool</>, <literal>enum</>,
-
        <literal>integer</>, <literal>real</>, or <literal>string</>)
-
       </entry>
 -->
       <entry>パラメータの型（<literal>bool</>、<literal>enum</>、<literal>integer</>、<literal>real</>もしくは<literal>string</>）
@@ -13379,7 +13240,6 @@ SQL経由で作成された準備済み文では、これはクライアント�
      <row>
       <entry><structfield>boot_val</structfield></entry>
       <entry><type>text</type></entry>
-
 <!--
       <entry>Parameter value assumed at server startup if the parameter is
       not otherwise set</entry>
@@ -13389,7 +13249,6 @@ SQL経由で作成された準備済み文では、これはクライアント�
      <row>
       <entry><structfield>reset_val</structfield></entry>
       <entry><type>text</type></entry>
-
 <!--
       <entry>Value that <command>RESET</command> would reset the parameter to
       in the current session</entry>
@@ -13950,9 +13809,6 @@ SQL経由で作成された準備済み文では、これはクライアント�
        A list of the frequencies of the most common values,
        i.e., number of occurrences of each divided by total number of rows.
        (Null when <structfield>most_common_vals</structfield> is.)
-       For some data types such as <type>tsvector</>, it can also store some
-       additional information, making it longer than the
-       <structfield>most_common_vals</> array.
 -->
 最も一般的な値の出現頻度のリストで、つまり行の総数で出現数を割算した数字です（<structfield>most_common_vals</structfield>がNULLの時はNULLとなります）。
       </entry>
@@ -13998,16 +13854,15 @@ SQL経由で作成された準備済み文では、これはクライアント�
       </entry>
      </row>
 
-
      <row>
       <entry><structfield>most_common_elems</structfield></entry>
       <entry><type>anyarray</type></entry>
       <entry></entry>
       <entry>
-      <!--
+<!--
        A list of non-null element values most often appearing within values of
        the column. (Null for scalar types.)
-       -->
+-->
 列の値の中で最もよく出現する非NULLの要素値のリストです。（スカラ型の場合はNULLです。）
       </entry>
      </row>
@@ -14017,14 +13872,14 @@ SQL経由で作成された準備済み文では、これはクライアント�
       <entry><type>real[]</type></entry>
       <entry></entry>
       <entry>
-      <!--
+<!--
        A list of the frequencies of the most common element values, i.e., the
        fraction of rows containing at least one instance of the given value.
        Two or three additional values follow the per-element frequencies;
        these are the minimum and maximum of the preceding per-element
        frequencies, and optionally the frequency of null elements.
        (Null when <structfield>most_common_elems</structfield> is.)
-       -->
+-->
 最も一般的な要素値の出現頻度のリストで、与えられた値の少なくとも1つのインスタンスを含む行の断片です。
 2つもしくは3つの追加の値が1つの要素ごとの出現頻度に続きます。
 最小で最大の要素ごとの出現頻度があります。さらにオプションとしてNULL要素の出現頻度もあります。
@@ -14037,15 +13892,14 @@ SQL経由で作成された準備済み文では、これはクライアント�
       <entry><type>real[]</type></entry>
       <entry></entry>
       <entry>
-      <!--
+<!--
        A histogram of the counts of distinct non-null element values within the
        values of the column, followed by the average number of distinct
        non-null elements.  (Null for scalar types.)
-       -->
+-->
        列の値でNULLではない要素値の個別数のヒストグラム。これは個別のNULLではない平均値が後に続きます。(スカラ型の場合はNULLです。)
       </entry>
      </row>
-     
     </tbody>
    </tgroup>
   </table>
@@ -14158,7 +14012,6 @@ SQL経由で作成された準備済み文では、これはクライアント�
       <entry><structfield>hastriggers</structfield></entry>
       <entry><type>boolean</type></entry>
       <entry><literal><link linkend="catalog-pg-class"><structname>pg_class</structname></link>.relhastriggers</literal></entry>
-
 <!--
       <entry>True if table has (or once had) triggers</entry>
 -->
@@ -14232,7 +14085,6 @@ SQL経由で作成された準備済み文では、これはクライアント�
       <entry>Offset from UTC (positive means east of Greenwich)</entry>
 -->
       <entry>UTCからのオフセット(正はグリニッジより西側を意味する)</entry>
-
      </row>
      <row>
       <entry><structfield>is_dst</structfield></entry>
@@ -14459,7 +14311,7 @@ SQL経由で作成された準備済み文では、これはクライアント�
 <!--
       <entry>Session defaults for run-time configuration variables</entry>
 -->
-       <entry>実行時設定変数に対するセッションデフォルト</entry>  
+       <entry>実行時設定変数に対するセッションデフォルト</entry>
      </row>
     </tbody>
    </tgroup>
@@ -14474,18 +14326,15 @@ SQL経由で作成された準備済み文では、これはクライアント�
    <primary>pg_user_mappings</primary>
   </indexterm>
 
-
-<!--
   <para>
+<!--
    The view <structname>pg_user_mappings</structname> provides access
    to information about user mappings.  This is essentially a publicly
    readable view of
    <link linkend="catalog-pg-user-mapping"><structname>pg_user_mapping</structname></link>
    that leaves out the options field if the user has no rights to use
    it.
-  </para>
 -->
-  <para>
 <structname>pg_user_mappings</structname>ビューはユーザマッピングについての情報へのアクセスを提供します。
 これはユーザが使用する権利を持っていないオプションフィールドを取り除いた、基本的には公開されていて読み取り可能な<link linkend="catalog-pg-user-mapping"><structname>pg_user_mapping</structname></link>のビューです。
   </para>
@@ -14514,10 +14363,8 @@ SQL経由で作成された準備済み文では、これはクライアント�
       <entry><structfield>umid</structfield></entry>
       <entry><type>oid</type></entry>
       <entry><literal><link linkend="catalog-pg-user-mapping"><structname>pg_user_mapping</structname></link>.oid</literal></entry>
-
 <!--
       <entry>OID of the user mapping</entry>
-
 -->
       <entry>ユーザマッピングのOID</entry>
      </row>
@@ -14526,12 +14373,10 @@ SQL経由で作成された準備済み文では、これはクライアント�
       <entry><structfield>srvid</structfield></entry>
       <entry><type>oid</type></entry>
       <entry><literal><link linkend="catalog-pg-foreign-server"><structname>pg_foreign_server</structname></link>.oid</literal></entry>
+      <entry>
 <!--
-      <entry>
        The OID of the foreign server that contains this mapping
-      </entry>
 -->
-      <entry>
        マッピングを含んでいる外部サーバのOID
       </entry>
      </row>
@@ -14540,12 +14385,10 @@ SQL経由で作成された準備済み文では、これはクライアント�
       <entry><structfield>srvname</structfield></entry>
       <entry><type>name</type></entry>
       <entry><literal><link linkend="catalog-pg-foreign-server"><structname>pg_foreign_server</structname></link>.srvname</literal></entry>
+      <entry>
 <!--
-      <entry>
        Name of the foreign server
-      </entry>
 -->
-      <entry>
        外部サーバの名称
       </entry>
      </row>
@@ -14574,15 +14417,14 @@ SQL経由で作成された準備済み文では、これはクライアント�
       <entry><structfield>umoptions</structfield></entry>
       <entry><type>text[]</type></entry>
       <entry></entry>
-<!--
       <entry>
+<!--
        User mapping specific options, as <quote>keyword=value</>
        strings, if the current user is the owner of the foreign
        server, else null
-      </entry>
 -->
-      <entry>
-       もし現状のユーザが外部サーバの所有者であれば<quote>keyword=value</>文字列のようなユーザマッピングの特定オプション。他の場合はNULLとなります。</entry>
+       もし現状のユーザが外部サーバの所有者であれば<quote>keyword=value</>文字列のようなユーザマッピングの特定オプション。他の場合はNULLとなります。
+      </entry>
      </row>
     </tbody>
    </tgroup>


### PR DESCRIPTION
原文にない行の削除
  5493行 true, the index is currently valid for queries.  False means the
13953行〜       For some data types such as <type>tsvector</>, it can also store some〜

<para>外から<para>内にコメント開始を移動
余分な空行、スペースを削除