### PR TITLE
原文の文字色を暗めに変更

### DIFF
--- a/doc/src/sgml/stylesheet.css
+++ b/doc/src/sgml/stylesheet.css
@@ -288,7 +288,7 @@ table.simplelist th, table.simplelist td {
 
 .original {
 	display: block;
-	color: #00ee00;
+	color: #008800;
 }
 
 .COMMENT,.comment { color: red; }


### PR DESCRIPTION
原文が白地に明るい緑で見づらいと感じましたので、文字色を暗めの緑に変更してみました。
変更箇所は合っていると思うのですが、すこし自信がありません。(間違っていたらすいません)

細かい点で、かつ環境にも左右されるところでもあり、
恐縮ですがご検討いただければと思います。
よろしくお願いします。