### PR TITLE
func.sgmlのマニュアル9.15節に該当する部分の翻訳改善

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -14209,7 +14209,7 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
 -->
 配列をJSON配列として返す。
 PostgreSQLの多次元配列はJSON配列の配列となる。
-<parameter>pretty_bool</parameter>が真の場合、次元数-1の要素の間にラインフィードが加えられる。
+<parameter>pretty_bool</parameter>が真の場合、次元数-1の要素の間に改行が加えられる。
        </entry>
        <entry><literal>array_to_json('{{1,5},{99,100}}'::int[])</literal></entry>
        <entry><literal>[[1,5],[99,100]]</literal></entry>
@@ -14224,7 +14224,7 @@ PostgreSQLの多次元配列はJSON配列の配列となる。
          level-1 elements if <parameter>pretty_bool</parameter> is true.
 -->
 行をJSONオブジェクトとして返す。
-<parameter>pretty_bool</parameter>が真の場合、レベル-1の要素の間にラインフィードが加えられる。
+<parameter>pretty_bool</parameter>が真の場合、レベル-1の要素の間に改行が加えられる。
        </entry>
        <entry><literal>row_to_json(row(1,'foo'))</literal></entry>
        <entry><literal>{"f1":1,"f2":"foo"}</literal></entry>

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -13834,7 +13834,7 @@ table2-mapping
    are available for use with the two JSON data types (see <xref
    linkend="datatype-json">).
 -->
-<xref linkend="functions-json-op-table">は2つのJSONデータ型(<xref linkend="datatype-json">を参照)で使用可能な演算子を示しています。
+<xref linkend="functions-json-op-table">に2つのJSONデータ型(<xref linkend="datatype-json">を参照)で使用可能な演算子を示します。
   </para>
 
   <table id="functions-json-op-table">
@@ -13907,7 +13907,7 @@ table2-mapping
 <!--
         <entry>Get JSON object at specified path</entry>
 -->
-        <entry>指定されたパスにてJSONオブジェクトを取得</entry>
+        <entry>指定されたパスにあるJSONオブジェクトを取得</entry>
         <entry><literal>'{"a": {"b":{"c": "foo"}}}'::json#&gt;'{a,b}'</literal></entry>
         <entry><literal>{"c": "foo"}</literal></entry>
        </row>
@@ -13917,7 +13917,7 @@ table2-mapping
 <!--
         <entry>Get JSON object at specified path as <type>text</></entry>
 -->
-        <entry>指定されたパスにてJSONオブジェクトを<type>text</>として取得</entry>
+        <entry>指定されたパスにあるJSONオブジェクトを<type>text</>として取得</entry>
         <entry><literal>'{"a":[1,2,3],"b":[4,5,6]}'::json#&gt;&gt;'{a,2}'</literal></entry>
         <entry><literal>3</literal></entry>
        </row>
@@ -13970,8 +13970,9 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
    describes how these operators can be used to effectively index
    <type>jsonb</> data.
 -->
-<xref linkend="functions-jsonb-op-table">に示されているように<type>jsonb</type>だけにはそれ以上の演算子も存在します。
-そのうちの多くの演算子は<type>jsonb</>演算子クラスでインデックス付けすることが可能です。
+ほかに<type>jsonb</type>だけで利用可能な演算子もいくつか存在します。
+それらを<xref linkend="functions-jsonb-op-table">に示します。
+これらのうち多くの演算子は<type>jsonb</>演算子クラスでインデックス付けすることが可能です。
 <type>jsonb</>の包含と存在の意味に関する完全な記述は<xref linkend="json-containment">を参照してください。
 <xref linkend="json-indexing">には、<type>jsonb</>データを効率的にインデックス付けするためにこれらの演算子をどのように利用できるかについて書いてあります。
   </para>
@@ -14206,7 +14207,9 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
          becomes a JSON array of arrays. Line feeds will be added between
          dimension-1 elements if <parameter>pretty_bool</parameter> is true.
 -->
-         配列をJSON配列として返す。PostgreSQLの多次元配列はJSON配列の配列となる。もし<parameter>pretty_bool</parameter>が真の場合、次元数-1の要素の間にラインフィードが加えられる。
+配列をJSON配列として返す。
+PostgreSQLの多次元配列はJSON配列の配列となる。
+<parameter>pretty_bool</parameter>が真の場合、次元数-1の要素の間にラインフィードが加えられる。
        </entry>
        <entry><literal>array_to_json('{{1,5},{99,100}}'::int[])</literal></entry>
        <entry><literal>[[1,5],[99,100]]</literal></entry>
@@ -14220,7 +14223,8 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
          Returns the row as a JSON object. Line feeds will be added between
          level-1 elements if <parameter>pretty_bool</parameter> is true.
 -->
-         行をJSONオブジェクトとして返す。もし<parameter>pretty_bool</parameter>が真の場合、レベル-1の要素の間にラインフィードが加えられる。
+行をJSONオブジェクトとして返す。
+<parameter>pretty_bool</parameter>が真の場合、レベル-1の要素の間にラインフィードが加えられる。
        </entry>
        <entry><literal>row_to_json(row(1,'foo'))</literal></entry>
        <entry><literal>{"f1":1,"f2":"foo"}</literal></entry>
@@ -14234,7 +14238,7 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
          Builds a possibly-heterogeneously-typed JSON array out of a variadic
          argument list.
 -->
-         異なる型から構成される可能性のあるJSON配列をvariadic引数一覧から作成。
+異なる型から構成される可能性のあるJSON配列をvariadic引数リストから作成。
        </entry>
        <entry><literal>json_build_array(1,2,'3',4,5)</literal></entry>
        <entry><literal>[1, 2, "3", 4, 5]</literal></entry>
@@ -14249,7 +14253,8 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
          convention, the argument list consists of alternating
          keys and values.
 -->
-         variadic引数一覧からJSONオブジェクトを作成。慣例により引数一覧はキーと値が交互に並んだもの。
+variadic引数リストからJSONオブジェクトを作成。
+慣例により引数リストはキーと値が交互に並んだもの。
        </entry>
        <entry><literal>json_build_object('foo',1,'bar',2)</literal></entry>
        <entry><literal>{"foo": 1, "bar": 2}</literal></entry>
@@ -14266,7 +14271,8 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
          such that each inner array has exactly two elements, which
          are taken as a key/value pair.
 -->
-         テキスト配列からJSONオブジェクトを作成。配列は、以下のどちらかでなければならない。偶数個の要素からなる1次元、この場合にはキー/値の対が交互に並んでいるものと扱われる。内側の配列が2つの要素を持つ2次元、2つの要素がキー/値の対として扱われる。
+テキスト配列からJSONオブジェクトを作成。
+配列は、偶数個の要素からなる1次元（キー／値の対が交互に並んでいるものと扱われる)）あるいは内側の配列が2つの要素を持つ2次元（2つの要素がキー／値の対として扱われる）のいずれかでなければならない。
        </entry>
        <entry><para><literal>json_object('{a, 1, b, "def", c, 3.5}')</></para>
         <para><literal>json_object('{{a, 1},{b, "def"},{c, 3.5}}')</></para></entry>
@@ -14281,7 +14287,8 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
          This form of <function>json_object</> takes keys and values pairwise from two separate
          arrays. In all other respects it is identical to the one-argument form.
 -->
-        この形の<function>json_object</>は2つの別々の配列からキーと値の対を取る。他の点ではすべて、引数1つの形と同じ。
+この形の<function>json_object</>は2つの別々の配列からキーと値の対を取る。
+他の点ではすべて、引数1つの形と同じ。
        </entry>
        <entry><literal>json_object('{a, b}', '{1,2}')</literal></entry>
        <entry><literal>{"a": "1", "b": "2"}</literal></entry>
@@ -14537,7 +14544,7 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
 <!--
           Returns set of keys in the outermost JSON object.
 -->
-        最も外側のJSONオブジェクトの中のキー一式を返す。
+        最も外側のJSONオブジェクトの中のキーの集合を返す。
        </entry>
        <entry><literal>json_object_keys('{"f1":"abc","f2":{"f3":"a", "f4":"b"}}')</literal></entry>
        <entry>
@@ -14606,7 +14613,7 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
 <!--
          Expands a JSON array to a set of JSON values.
 -->
-        JSON配列をJSON値の集合に展開する。
+JSON配列をJSON値の集合に展開する。
        </entry>
        <entry><literal>select * from json_array_elements('[1,true, [2,false]]')</literal></entry>
        <entry>
@@ -14628,7 +14635,7 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
 <!--
          Expands a JSON array to a set of <type>text</> values.
 -->
-        JSON配列を<type>text</>値の集合に展開する。
+JSON配列を<type>text</>値の集合に展開する。
        </entry>
        <entry><literal>select * from json_array_elements_text('["foo", "bar"]')</literal></entry>
        <entry>
@@ -14652,7 +14659,8 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
          <literal>object</>, <literal>array</>, <literal>string</>, <literal>number</>,
          <literal>boolean</>, and <literal>null</>.
 -->
-         最も外側のJSON値の型をテキスト文字列として返す。取りうる型は<literal>object</>、 <literal>array</>、 <literal>string</>、 <literal>number</>、<literal>boolean</>、<literal>null</>である。
+最も外側のJSON値の型をテキスト文字列として返す。
+取りうる型は<literal>object</>、 <literal>array</>、 <literal>string</>、 <literal>number</>、<literal>boolean</>、<literal>null</>である。
        </entry>
        <entry><literal>json_typeof('-123.4')</literal></entry>
        <entry><literal>number</literal></entry>
@@ -14669,7 +14677,8 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
          explicitly define the structure of the record with an <literal>AS</>
          clause.
 -->
-        JSONオブジェクトから任意のレコードを作成します(下記の注釈を参照してください)。<type>record</>を返す関数すべてと同様、呼び出し側が<literal>AS</>句でレコードの構造を明示的に決めなければなりません。
+JSONオブジェクトから任意のレコードを作成する（下記の注釈を参照）。
+<type>record</>を返す関数すべてと同様、呼び出し側が<literal>AS</>句でレコードの構造を明示的に決める必要がある。
        </entry>
        <entry><literal>select * from json_to_record('{"a":1,"b":[1,2,3],"c":"bar"}') as x(a int, b text, d text) </literal></entry>
        <entry>
@@ -14692,7 +14701,8 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
          caller must explicitly define the structure of the record with
          an <literal>AS</> clause.
 -->
-        オブジェクトの配列のJSONから任意のレコードを作成します(下記の注釈を参照してください)。<type>record</>を返す関数すべてと同様、呼び出し側が<literal>AS</>句でレコードの構造を明示的に決めなければなりません。
+オブジェクトの配列のJSONから任意のレコードの集合を作成する（下記の注釈を参照）。
+<type>record</>を返す関数すべてと同様、呼び出し側が<literal>AS</>句でレコードの構造を明示的に決める必要がある。
        </entry>
        <entry><literal>select * from json_to_recordset('[{"a":1,"b":"foo"},{"a":"2","c":"bar"}]') as x(a int, b text);</literal></entry>
        <entry>


### PR DESCRIPTION
誤訳訂正と言えるものはほとんどありませんが、不自然な日本語の改善、訳語の改善、
訳文のインデントを削除（そのついでに、複数文がある場合は改行を挿入）などの
修正を行いました。