### PR TITLE
func.sgmlのマニュアル9.16節に該当する部分の誤訳訂正と翻訳改善。

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -14931,8 +14931,9 @@ JSONキーは対象の行の型の中の同一の列の名前と一致します�
    methods for obtaining successive sequence values from sequence
    objects.
 -->
-シーケンスオブジェクト、シーケンスジェネレータとも単にシーケンスとも呼ばれる、本節では<firstterm>シーケンスオブジェクト</firstterm>に対し演算を行う関数について説明します。
-シーケンスオブジェクトは特殊な一行テーブルで、<xref linkend="sql-createsequence">で作成されます。
+本節では<firstterm>シーケンスオブジェクト</firstterm>に対し演算を行う関数について説明します。
+シーケンスオブジェクトは、シーケンスジェネレータ、あるいは単にシーケンスとも呼ばれます。
+シーケンスオブジェクトは特殊な一行だけのテーブルで、<xref linkend="sql-createsequence">で作成されます。
 シーケンスオブジェクトは一般的にテーブルの行に一意の識別子を生成するために使用されます。
 <xref linkend="functions-sequence-table">に列挙されているシーケンス関数は、シーケンスオブジェクトから連続したシーケンス値を取得するための、簡易でマルチユーザに対応した関数です。
   </para>
@@ -14967,7 +14968,7 @@ JSONキーは対象の行の型の中の同一の列の名前と一致します�
         <entry>Return value most recently obtained with
         <function>nextval</function> for any sequence</entry>
 -->
-        <entry>どんなシーケンスに対してでも<function>nextval</function>により最も最近取得された値を返す</entry>
+        <entry>すべてのシーケンスに対して<function>nextval</function>により最も最近取得された値を返す</entry>
       </row>
       <row>
         <entry><literal><function>nextval(<type>regclass</type>)</function></literal></entry>
@@ -15009,10 +15010,10 @@ JSONキーは対象の行の型の中の同一の列の名前と一致します�
    <acronym>SQL</acronym> names, the string will be converted to lower case
    unless it contains double quotes around the sequence name.  Thus:
 -->
-シーケンス関数により操作されるシーケンスは<type>regclass</>引数で指定され、そしてそれは<structname>pg_class</>システムカタログ内のシーケンスのOIDに過ぎません。
+シーケンス関数により操作されるシーケンスは<type>regclass</>引数で指定されますが、それは<structname>pg_class</>システムカタログ内にある、そのシーケンスの単なるOIDです。
 しかしながら、手作業でOIDを検索する必要はなく、<type>regclass</>データ型の入力変換器が代わってその作業を行ってくれます。
-リテラル関数のように見えるするようにするため、単一引用符で括られたシーケンス名を記述するだけです。
-通常の<acronym>SQL</acronym>の名称での操作との互換のため、文字列はシーケンス名が二重引用符で括られている以外、小文字に変換されます。
+単一引用符で括られたシーケンス名を記述するだけで良いので、リテラル定数のように見えます。
+通常の<acronym>SQL</acronym>の名称での操作との互換のため、文字列はシーケンス名が二重引用符で括られていなければ、小文字に変換されます。
 よって、以下のようになります。
 <programlisting>
 <!--  
@@ -15072,10 +15073,11 @@ nextval('foo')              <lineannotation><literal>foo</literal>を検索パ�
     at run time.  To get late-binding behavior, force the constant to be
     stored as a <type>text</> constant instead of <type>regclass</>:
 -->
-ありのままのリテラル文字列としてシーケンス関数の引数を記述する時は、<type>regclass</>データ型の定数になります。
-これは単にOIDなので、後で名前付けが再び行われたとか、スキーマの再割り振りとかに係わらず、最初に特定されたシーケンスを引き継ぎます。
-この<quote>初期束縛</>の動作は、通常列のデフォルトとビュー参照するシーケンスにとって魅力があります
-。しかし、たまには実行時にシーケンス参照が解決されるような<quote>動的束縛</>が望まれます。動的束縛の動作を得るには、定数を<type>regclass</>ではなく<type>text</>定数としてその定数を保存させます。
+ありのままのリテラル文字列としてシーケンス関数の引数を記述すると、<type>regclass</>データ型の定数になります。
+これは単なるOIDなので、後で名前付けが再び行われたとか、スキーマの再割り振りとかに関わらず、最初に特定されたシーケンスを引き継ぎます。
+この<quote>初期束縛</>の動作は、列のデフォルトやビューからシーケンスを参照する場合は望ましいことが多いでしょう。
+しかし、実行時にシーケンス参照が解決されるような<quote>動的束縛</>が望まれる場合もあります。
+動的束縛の動作を得るには、その定数を<type>regclass</>ではなく<type>text</>定数として保存させます。
 <programlisting>
 <!--
 nextval('foo'::text)      <lineannotation><literal>foo</literal> is looked up at runtime</>
@@ -15087,7 +15089,7 @@ nextval('foo'::text)      <lineannotation>実行時に<literal>foo</literal>を�
     <productname>PostgreSQL</productname> releases before 8.1, so you
     might need to do this to preserve the semantics of old applications.
 -->
-動的束縛は<productname>PostgreSQL</productname>のリリース8.1以前でサポートされた動作であったので、旧来のアプリケーションのセマンティクスを保ちたい場合このようにする必要があるかもしれません。
+<productname>PostgreSQL</productname>のリリース8.1以前では動的束縛のみがサポートされる動作だったので、旧来のアプリケーションのセマンティクスを保ちたい場合このようにする必要があるかもしれません。
    </para>
 
    <para>
@@ -15096,8 +15098,8 @@ nextval('foo'::text)      <lineannotation>実行時に<literal>foo</literal>を�
     as well as a constant.  If it is a text expression then the implicit
     coercion will result in a run-time lookup.
 -->
-もちろん、シーケンス関数の引数は定数とともに、評価式であることも可能です。
-もしテキスト式の場合は暗黙的強制型変換が実行時検索に用いられます。
+もちろん、シーケンス関数の引数は定数だけでなく、評価式とすることも可能です。
+テキスト式の場合は暗黙的型変換により、実行時検索が行われます。
    </para>
   </note>
 
@@ -15119,7 +15121,7 @@ nextval('foo'::text)      <lineannotation>実行時に<literal>foo</literal>を�
         a distinct sequence value.
 -->
 シーケンスオブジェクトをその次の値に進め、その値を返します。
-これは自動的に処理されます。複数のセッションが同時に<function>nextval</function>を実行したとしても、それぞれのセッションは個別のシーケンス値を間違いなく受け取ります。
+これは原子的に処理され、複数のセッションが同時に<function>nextval</function>を実行したとしても、それぞれのセッションは異なるシーケンス値を安全に受け取ります。
        </para>
 
        <para>
@@ -15147,7 +15149,7 @@ nextval('foo'::text)      <lineannotation>実行時に<literal>foo</literal>を�
 -->
 同一のシーケンスから数値を取得する同時実行トランザクション同士のブロックを防止するため、<function>nextval</function>演算は決してロールバックされません。
 と言うことは、たとえ<function>nextval</function>を実行したトランザクションが後にアボートしたとしても、値が一度取り出されたらそれは使用されたものと考えます。
-つまり、アボートされたトランザクションは、割り当てられた値のシーケンス内に未使用の<quote>欠損</quote>を残す可能性があります。
+つまり、中止されたトランザクションは、割り当てられた値のシーケンス内に未使用の<quote>欠損</quote>を残す可能性があります。
         </para>
        </important>
 
@@ -15169,7 +15171,7 @@ nextval('foo'::text)      <lineannotation>実行時に<literal>foo</literal>を�
 -->
 現在のセッションにおいて、そのシーケンスから<function>nextval</function>によって取得された直近の値を返します。
 （セッション内でそのシーケンスに対し<function>nextval</function>が呼ばれていない場合には、エラーが報告されます。）
-これはローカルのセッション値を返すことから、現在のセッションが実行してから別のセッションが<function>nextval</function>を実行してもしなくても、予想に違わない回答をもたらします。
+これはセッションごとの個別の値を返すので、現在のセッションが<function>nextval</function>を実行した後、他のセッションが<function>nextval</function>を実行したかどうかに関わらず、期待通りの回答をもたらします。
        </para>
       </listitem>
      </varlistentry>
@@ -15188,8 +15190,8 @@ nextval('foo'::text)      <lineannotation>実行時に<literal>foo</literal>を�
         <function>lastval</function> if <function>nextval</function>
         has not yet been called in the current session.
 -->
-現在のセッションの<function>nextval</>で戻される最新の値を返します。
-この関数は、現在のセッションの中で<function>nextval</function>によって使用される最後のシーケンスの値をフェッチする引数としてのシーケンス名を取ることを除いて、<function>currval</function>と同等です。
+現在のセッションの<function>nextval</>で直近に戻された値を返します。
+この関数は<function>currval</function>と同等ですが、引数としてシーケンス名をとる代わりに、現在のセッションで最後に<function>nextval</function>で使用されたシーケンスの値を取得するところが異なります。
 現在のセッションで<function>nextval</function>が未だ呼ばれていなければエラーになります。
        </para>
       </listitem>
@@ -15216,11 +15218,13 @@ nextval('foo'::text)      <lineannotation>実行時に<literal>foo</literal>を�
         <function>currval</> is not changed in this case.  For example,
 -->
 シーケンスオブジェクトの計数値をリセットします。
-２つのパラメータを所有する形式では、シーケンスの<literal>last_value</literal>フィールドを指定された値に設定し、<literal>is_called</literal>フィールドを<literal>true</literal>（真）に設定します。この意味は、次の<function>nextval</function>が値を返す前にシーケンスを進めるということです。
-<function>currval</>で報告された値も指定された値に設定されます。
-３パラメータ形式の場合、<literal>is_called</literal>を<literal>true</literal>（真）もしくは<literal>false</literal>（偽）に設定することができます。<literal>true</>（真）は２パラメータ形式と同じ効果があります。
-<literal>false</literal>（偽）に設定された場合、次の<function>nextval</function>が指定された正確な値を返し、シーケンスの進行は引き続く<function>nextval</function>から始まります。
-さらにこの場合、<function>currval</>で報告された値は変更されません。
+パラメータが２つの形式では、シーケンスの<literal>last_value</literal>フィールドを指定された値に設定し、<literal>is_called</literal>フィールドを<literal>true</literal>（真）に設定します。
+この意味は、次の<function>nextval</function>が値を返す前にシーケンスを進めるということです。
+<function>currval</>で報告される値も指定された値に設定されます。
+３パラメータ形式の場合、<literal>is_called</literal>を<literal>true</literal>（真）もしくは<literal>false</literal>（偽）に設定することができます。
+<literal>true</>（真）は２パラメータ形式と同じ効果があります。
+<literal>false</literal>（偽）に設定された場合、次の<function>nextval</function>は指定されたその値を返し、シーケンスの進行は引き続く<function>nextval</function>から始まります。
+さらにこの場合、<function>currval</>で報告される値は変更されません。
 例えば、次の例です。
 
 <screen>
@@ -15247,7 +15251,7 @@ SELECT setval('foo', 42, false);    <lineannotation>次の<function>nextval</>�
          <function>setval</function> are not undone if the transaction rolls
          back.
 -->
-シーケンスは非トランザクショナルに扱われるため、<function>setval</function>による変更は、そのトランザクションがロールバックされたとしても元に戻りません。
+シーケンスはトランザクションとは異なる扱いを受けるため、<function>setval</function>による変更は、そのトランザクションがロールバックされたとしても元に戻りません。
         </para>
        </important>
       </listitem>

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -1588,7 +1588,7 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
      linkend="functions-string-sql">.  For other cases, insert an explicit
      coercion to <type>text</> if you need to duplicate the previous behavior.
 -->
-<productname>PostgreSQL</productname> 8.3以前において、これらの関数はいくつかの非文字列データ型の値を警告なしに受け付けたのは、それらデータ型を暗黙的に<type>text</>型に型変換していたことによります。
+<productname>PostgreSQL</productname>の8.3より前において、これらの関数はいくつかの非文字列データ型の値を警告なしに受け付けたのは、それらデータ型を暗黙的に<type>text</>型に型変換していたことによります。
 この強制的な変換は、頻繁に予期しない動作の原因となったので削除されました。
 しかし、文字列連結演算子（<literal>||</>）は<xref linkend="functions-string-sql">で示されるように、少なくともひとつの入力が文字列型であれば、依然として非文字列入力を受け付けます。
 その他の場合、以前と同じ動作が必要なら、<type>text</>への明示的な変換を行ってください。
@@ -9856,7 +9856,7 @@ SELECT EXTRACT(ISOYEAR FROM DATE '2006-01-02');
 <!--
         This field is not available in PostgreSQL releases prior to 8.3.
 -->
-このフィールドは8.3以前のPostgreSQLリリースでは有効でありません。
+このフィールドは8.3より前のPostgreSQLリリースでは有効でありません。
        </para>
       </listitem>
      </varlistentry>
@@ -11085,7 +11085,7 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
      called <literal>~</> and <literal>@</>.  These names are still
      available, but are deprecated and will eventually be removed.
 -->
-<productname>PostgreSQL</productname> 8.2より前では、包含演算子<literal>@&gt;</>および<literal>&lt;@</>はそれぞれ<literal>~</>および<literal>@</>という名前でした。
+<productname>PostgreSQL</productname>の8.2より前では、包含演算子<literal>@&gt;</>および<literal>&lt;@</>はそれぞれ<literal>~</>および<literal>@</>という名前でした。
 これらの名前はまだ利用できますが、削除予定であり最終的にはなくなるでしょう。
     </para>
    </note>
@@ -15057,7 +15057,7 @@ nextval('foo')              <lineannotation><literal>foo</literal>を検索パ�
     coercion from <type>text</> to <type>regclass</> before the function is
     invoked.
 -->
-<productname>PostgreSQL</productname> 8.1以前においては、シーケンス関数の引数は<type>regclass</>型ではなく、<type>text</>型で、そして上記のテキスト文字列からOID値への変換はそれぞれの呼び出し実行時に起こりました。
+<productname>PostgreSQL</productname>の8.1より前においては、シーケンス関数の引数は<type>regclass</>型ではなく、<type>text</>型で、そして上記のテキスト文字列からOID値への変換はそれぞれの呼び出し実行時に起こりました。
 後方互換性のため、この仕組みはまだ存在しますが、内部的には関数が実行される前に<type>text</>から<type>regclass</>への暗黙的強制型変換として現在処理されています。
    </para>
 
@@ -15089,7 +15089,7 @@ nextval('foo'::text)      <lineannotation>実行時に<literal>foo</literal>を�
     <productname>PostgreSQL</productname> releases before 8.1, so you
     might need to do this to preserve the semantics of old applications.
 -->
-<productname>PostgreSQL</productname>のリリース8.1以前では動的束縛のみがサポートされる動作だったので、旧来のアプリケーションのセマンティクスを保ちたい場合このようにする必要があるかもしれません。
+<productname>PostgreSQL</productname>のリリース8.1より前では動的束縛のみがサポートされる動作だったので、旧来のアプリケーションのセマンティクスを保ちたい場合このようにする必要があるかもしれません。
    </para>
 
    <para>
@@ -18552,7 +18552,7 @@ NULL値は<literal>ORDER BY</>節で指定されるルールに従って並べ�
        <replaceable class="parameter">offset</replaceable> defaults to 1 and
        <replaceable class="parameter">default</replaceable> to null
 -->
-パーティション内の現在行以前の<replaceable class="parameter">offset</replaceable>行である行で評価された<replaceable class="parameter">value</replaceable>を返します。該当する行がない場合、その代わりとして<replaceable class="parameter">default</replaceable>(<replaceable class="parameter">value</replaceable>と同じ型でなければなりません)を返します。
+パーティション内の現在行より前の<replaceable class="parameter">offset</replaceable>行である行で評価された<replaceable class="parameter">value</replaceable>を返します。該当する行がない場合、その代わりとして<replaceable class="parameter">default</replaceable>(<replaceable class="parameter">value</replaceable>と同じ型でなければなりません)を返します。
 <replaceable class="parameter">offset</replaceable>と<replaceable class="parameter">default</replaceable>は共に現在行について評価されます。
 省略された場合、<replaceable class="parameter">offset</replaceable>は1となり、<replaceable class="parameter">default</replaceable>はNULLになります。
       </entry>
@@ -19606,7 +19606,7 @@ AND
     whereas the correct behavior is equivalent to
     <literal>a &lt; c OR (a = c AND b &lt; d)</>.
 -->
-<productname>PostgreSQL</productname> 8.2以前では、<literal>&lt;</>、<literal>&lt;=</>、<literal>&gt;</> 、<literal>&gt;=</>の場合SQL仕様に従っていませんでした。
+<productname>PostgreSQL</productname>の8.2より前では、<literal>&lt;</>、<literal>&lt;=</>、<literal>&gt;</> 、<literal>&gt;=</>の場合SQL仕様に従っていませんでした。
 <literal>ROW(a,b) &lt; ROW(c,d)</>などの比較は正しくは<literal>a &lt; c OR (a = c AND b &lt; d)</>ですが、<literal>a &lt; c AND b &lt; d</>として実装されていました。
    </para>
   </note>


### PR DESCRIPTION
誤訳の訂正、わかりにくい表現の改善、不自然な訳語の変更などを行いました。