### PR TITLE
func.sgmlのマニュアル9.17節に該当する部分の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -15370,7 +15370,7 @@ SELECT a,
    expressions must be convertible to a single output type.
    See <xref linkend="typeconv-union-case"> for more details.
 -->
-全ての<replaceable>result</replaceable>式のデータ型は単一の出力型に互換性がなければなりません。
+全ての<replaceable>result</replaceable>式のデータ型は単一の出力型に変換可能でなければなりません。
 詳細は<xref linkend="typeconv-union-case">を参照してください。
   </para>
 
@@ -15398,7 +15398,7 @@ END
    <token>ELSE</token> clause (or a null value) is returned.  This is similar
    to the <function>switch</function> statement in C.
 -->
-最初の<replaceable>expression</replaceable>は計算され、そしてそれに等しいものが見つかるまで<token>WHEN</token>句のそれぞれの<replaceable>value</replaceable>式と比較されます。
+最初の<replaceable>expression</replaceable>が計算され、そしてそれに等しいものが見つかるまで<token>WHEN</token>句のそれぞれの<replaceable>value</replaceable>式と比較されます。
 等しいものが見つからない場合、<token>ELSE</token>句の<replaceable>result</replaceable>（もしくはNULL値）が返されます。
 これはC言語の<function>switch</function>文に似ています。
   </para>
@@ -15490,7 +15490,9 @@ SELECT COALESCE(description, short_description, '(none)') ...
    This returns <varname>description</> if it is not null, otherwise
    <varname>short_description</> if it is not null, otherwise <literal>(none)</>.
 -->
-これは<varname>description</>がNULLでなければをそれ返します。そうでない場合(NULLの場合)は、<varname>short_description</>がNULLでなければそれを返します。そうでもない場合は<literal>(none)</>が帰ります。
+これは<varname>description</>がNULLでなければそれを返します。
+そうでない場合（NULLの場合）は、<varname>short_description</>がNULLでなければそれを返します。
+それ以外の場合（short_descriptionもNULLの場合）は<literal>(none)</>が返ります。
   </para>
 
    <para>
@@ -15503,7 +15505,7 @@ SELECT COALESCE(description, short_description, '(none)') ...
     database systems.
 -->
 <token>CASE</token>式同様、<function>COALESCE</function>は結果を決定するために必要な引数のみを評価します。つまり、非NULL引数が見つかれば、その右側にある引数は評価されません。
-このSQL標準関数は<function>NVL</>と<function>IFNULL</>と類似の機能を提供し、他のいくつかのデータベースシステムで使用されています。
+このSQL標準関数は、他のいくつかのデータベースで使用されている<function>NVL</>および<function>IFNULL</>と類似の機能を提供します。
    </para>
   </sect2>
 
@@ -15575,8 +15577,8 @@ SELECT NULLIF(value, '(none)') ...
     in the list are ignored.  The result will be NULL only if all the
     expressions evaluate to NULL.
 -->
-<function>GREATEST</>と<function>LEAST</>関数は式の任意の数のリストから最大値もしくは最小値を選択します。
-評価される全ての式は、結果として得られるデータの型と共通の型に変換できなくてはなりません（詳細は<xref linkend="typeconv-union-case">を参照してください）。
+<function>GREATEST</>と<function>LEAST</>関数は任意の数の式のリストから最大値もしくは最小値を選択します。
+評価される全ての式は共通の型に変換できる必要があり、それが結果の型になります（詳細は<xref linkend="typeconv-union-case">を参照してください）。
 リストの中のNULL値は無視されます。
 全ての式がNULLと評価された場合に限って結果はNULLになります。
    </para>


### PR DESCRIPTION
助詞の誤りの訂正、掛かり関係の誤りの訂正など。