### PR TITLE
doc_ja_9_5との差分修正

### DIFF
--- a/doc/src/sgml/brin.sgml
+++ b/doc/src/sgml/brin.sgml
@@ -93,9 +93,10 @@
 <!--
   <title>Index Maintenance</title>
 -->
-
   <title>インデックスの保守</title>
+
   <para>
+<!--
    At the time of creation, all existing index pages are scanned and a
    summary index tuple is created for each range, including the
    possibly-incomplete range at the end.

--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -7052,16 +7052,6 @@ LSNは例えば、<literal>16/B374D848</>のように２つのスラッシュで
        </row>
 
        <row>
-        <entry><type>event_trigger</></entry>
-        <entry>An event trigger function is declared to return <type>event_trigger.</></entry>
-       </row>
-
-       <row>
-        <entry><type>pg_ddl_command</></entry>
-        <entry>Identifies a representation of DDL commands that is available to event triggers.</entry>
-       </row>
-
-       <row>
         <entry><type>void</></entry>
 <!--
         <entry>Indicates that a function returns no value.</entry>

--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -850,7 +850,6 @@ CREATE TABLE products (
    <para>
 <!--
     Adding a unique constraint will automatically create a unique B-tree
-<<<<<<< HEAD
     index on the column or group of columns used in the constraint.
     A uniqueness constraint on only some rows can be enforced by creating ★9.5.0時原文
     a <link linkend="indexes-partial">partial index</link>.★9.5.0時原文
@@ -966,7 +965,6 @@ CREATE TABLE example (
    </para>
 
    <para>
-<<<<<<< HEAD
 <!--
     Adding a primary key will automatically create a unique B-tree index ★9.5.0時原文
     on the column or group of columns used in the primary key. ★9.5.0時原文
@@ -996,11 +994,21 @@ CREATE TABLE example (
    </para>
 
    <para>
+<!--
     Primary keys are useful both for
     documentation purposes and for client applications.  For example,
     a GUI application that allows modifying row values probably needs
     to know the primary key of a table to be able to identify rows
     uniquely.  There are also various ways in which the database system
+    makes use of a primary key if one has been declared; for example,
+    the primary key defines the default target column(s) for foreign keys
+    referencing its table.
+-->
+★9.5.0参考訳
+これは文書化、および、クライアントアプリケーションの両方の面で役に立ちます。
+例えば、行値の変更が可能なGUIアプリケーションが行を一意的に特定するためには、
+おそらくテーブルのプライマリキーを知る必要があります。
+               There are also various ways in which the database system
     makes use of a primary key if one has been declared; for example,
     the primary key defines the default target column(s) for foreign keys
     referencing its table.
@@ -2421,7 +2429,6 @@ REVOKE ALL ON accounts FROM PUBLIC;
    user running the query, although security-definer functions can be used
    to access data not available to the calling user.
 -->
-
 ポリシーでどの行が可視である、あるいは更新可能であるかを指定するために、ブーリアン値を返す式が必要です。
 ユーザの問い合わせにあるどの条件や関数よりも前に、この式が各行について評価されます。
 （この規則の例外は、情報リークがないことが保証される<literal>leakproof</literal>関数だけです。
@@ -2430,17 +2437,6 @@ REVOKE ALL ON accounts FROM PUBLIC;
 可視である行と変更可能な行について独立した制御ができるように、別々の式を指定することも可能です。
 ポリシーの式は問い合わせの一部分として、問い合わせをしているユーザの権限で実行されます。
 ただし、呼び出しユーザに利用できないデータにアクセスするために、セキュリティ定義関数を使うことができます。
-  </para>
-
-  <para>
-<!--
-   Superusers and roles with the <literal>BYPASSRLS</> attribute always
-   bypass the row security system when accessing a table.  Table owners
-   normally bypass row security as well, though a table owner can choose to
-   be subject to row security with <link linkend="sql-altertable">ALTER
-   TABLE ... FORCE ROW LEVEL SECURITY</>.
--->
-★翻訳が必要
   </para>
 
   <para>
@@ -2918,7 +2914,6 @@ SELECT * FROM information WHERE group_id = 2 FOR UPDATE;
    concurrent transactions to end after committing an update of the
    referenced table and before making changes that rely on the new security
    situation.
-<<<<<<< HEAD
 -->
 この問題を回避する方法はいくつかあります。
 一つの簡単な答は行セキュリティポリシーの副<command>SELECT</>で<literal>SELECT ... FOR SHARE</>を使うことです。

--- a/doc/src/sgml/ref/alter_policy.sgml
+++ b/doc/src/sgml/ref/alter_policy.sgml
@@ -69,14 +69,6 @@ ALTER POLICY <replaceable class="parameter">name</replaceable> ON <replaceable c
 <command>ALTER POLICY</command>の2番目の構文で、ロールのリスト、<replaceable class="parameter">using_expression</replaceable>、<replaceable class="parameter">check_expression</replaceable>が指定された時は、それぞれ独立して置換されます。
 それらの1つが省略された場合、ポリシーのその部分については変更されません。
   </para>
-
-  <para>
-   In the second form of <command>ALTER POLICY</command>, the role list,
-   <replaceable class="parameter">using_expression</replaceable>, and
-   <replaceable class="parameter">check_expression</replaceable> are replaced
-   independently if specified.  When one of those clauses is omitted, the
-   corresponding part of the policy is unchanged.
-  </para>
  </refsect1>
 
  <refsect1>

--- a/doc/src/sgml/release-9.5.sgml
+++ b/doc/src/sgml/release-9.5.sgml
@@ -1542,27 +1542,6 @@ Linuxの<acronym>OOM</> killerを新たな環境変数<link linkend="linux-memor
 
       <listitem>
 <!--
-2014-06-18 [df8b7bc] Tom Lane: Improve our mechanism for controlling the Linux..
--->
-       <para>
-        Control the Linux <acronym>OOM</> killer via new environment
-        variables <link
-        linkend="linux-memory-overcommit"><envar>PG_OOM_ADJUST_FILE</></>
-        and <link
-        linkend="linux-memory-overcommit"><envar>PG_OOM_ADJUST_VALUE</></>
-        (Gurjeet Singh)
-       </para>
-
-       <para>
-        The previous <acronym>OOM</> control infrastructure involved
-        compile-time options <literal>LINUX_OOM_SCORE_ADJ</> and
-        <literal>LINUX_OOM_ADJ</>, which are no longer supported.
-        The new behavior is available in all builds.
-       </para>
-      </listitem>
-
-      <listitem>
-<!--
 2014-12-03 [73c986a] Alvaro..: Keep track of transaction commit timestamps
 -->
        <para>
@@ -2058,13 +2037,6 @@ Linuxの<acronym>OOM</> killerを新たな環境変数<link linkend="linux-memor
         table sampling methods</>.
 -->
 この機能はSQL標準のテーブルサンプリングメソッドをサポートします。加えて、<link linkend="tablesample-method">ユーザ定義サンプリングメソッド</>を提供します。
-       </para>
-
-       <para>
-        This feature supports the SQL-standard table sampling methods.
-        In addition, there are provisions
-        for <link linkend="tablesample-method">user-defined
-        table sampling methods</>.
        </para>
       </listitem>
 

--- a/doc/src/sgml/replication-origins.sgml
+++ b/doc/src/sgml/replication-origins.sgml
@@ -33,8 +33,9 @@
      origin of a row; for example, to prevent loops in bi-directional
      replication setups</para>
    </listitem>
+  </itemizedlist>
 -->
-レプリケーション起点(replication origins)は、<link linkend="logicaldecoding">ロジカルデコーディング</link>の上に、ロジカルレプリケーションソリューションを実装しやすくすることを意図しています>。
+レプリケーション起点(replication origins)は、<link linkend="logicaldecoding">ロジカルデコーディング</link>の上に、ロジカルレプリケーションソリューションを実装しやすくすることを意図しています。
 以下の2つの良くある問題に対して解決の方策を提供します。
   <itemizedlist>
    <listitem><para>レプリケーション進捗をどうやって安全に追跡するか</para></listitem>


### PR DESCRIPTION
9.5.0->9.5.1では変更無し
 brin.sgml
 datatype.sgml
 ref/alter_policy.sgml
 replication-origins.smgl

ddl.sgml
 "<<<"行を削除
 分割移動されたエントリを参考に復活
  Superusers and roles 〜は変更無し

release-9.5.sgml
 9.5.0部分に入っていた余計なエントリを削除