### PR TITLE
ddl.sgmlの9.5.1対応です。

### DIFF
--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -808,14 +808,10 @@ CREATE TABLE products (
 
    <para>
 <!--
-    If a unique constraint refers to a group of columns, the columns ★9.5.0時原文
-    are listed separated by commas:★9.5.0時原文
-一意性制約が列のグループを参照する場合、各列はカンマで区切って列挙します。 ★9.5.0時翻訳文
-
     To define a unique constraint for a group of columns, write it as a
     table constraint with the column names separated by commas:
 -->
-★ここに翻訳文
+列の集合に対して一意性制約を定義するには、列名をカンマで区切り、表制約として記述します。
 <programlisting>
 CREATE TABLE example (
     a integer,
@@ -850,18 +846,13 @@ CREATE TABLE products (
    <para>
 <!--
     Adding a unique constraint will automatically create a unique B-tree
-    index on the column or group of columns used in the constraint.
-    A uniqueness constraint on only some rows can be enforced by creating ★9.5.0時原文
-    a <link linkend="indexes-partial">partial index</link>.★9.5.0時原文
-一意性制約を追加すると、制約で使われる列または列のグループに対して一意的なBツリーのインデックスが自動的に作られます。★9.5.0時翻訳文
-<link linkend="indexes-partial">部分インデックス</link>を作成することで、いくつかの行にだけ一意性制約を強制することができます。 ★9.5.0時翻訳文
-
     index on the column or group of columns listed in the constraint.
     A uniqueness restriction covering only some rows cannot be written as
     a unique constraint, but it is possible to enforce such a restriction by
     creating a unique <link linkend="indexes-partial">partial index</link>.
 -->
-★ここに翻訳文
+一意性制約を追加すると、制約で指定された列または列のグループに対して一意的なBツリーのインデックスが自動的に作られます。
+一部の行だけに適用される一意性の制限を一意性制約として作成することはできませんが、そのような制限を一意な<link linkend="indexes-partial">部分インデックス</link>を作成することで実現することは可能です。
    </para>
 
    <indexterm>
@@ -888,7 +879,7 @@ CREATE TABLE products (
     portable.
 -->
 一般に、制約の対象となる列について同じ値を持つ行が、テーブル内に１行を上回る場合は、一意性制約違反になります。 
-しかし、この比較では2つのNULL値は等価とはみなされません。
+しかし、この比較では2つのNULL値は決して等価とはみなされません。
 つまり、一意性制約があったとしても、制約対象の列の少なくとも1つにNULL値を持つ行を複数格納することができるということです。
 この振舞いは標準SQLに準拠していますが、この規則に従わないSQLデータベースがあることを聞いたことがあります。
 ですから、移植する予定のアプリケーションを開発する際には注意してください。
@@ -919,16 +910,14 @@ CREATE TABLE products (
 
    <para>
 <!--
-    Technically, a primary key constraint is simply a combination of a ★9.5.0時原文
-    unique constraint and a not-null constraint.  So, the following ★9.5.0時原文
-
     A primary key constraint indicates that a column, or group of columns,
     can be used as a unique identifier for rows in the table.  This
     requires that the values be both unique and not null.  So, the following
     two table definitions accept the same data:
 -->
-技術的には、プライマリキー制約は単純に一意性制約と非NULL制約を組み合わせたものです。 ★訳文変更の必要あり
-つまり、次の2つのテーブル定義は同じデータを受け入れます。 ★訳文変更の必要あり
+プライマリキー制約は、列または列のグループがテーブル内の行を一意に識別するものとして利用できることを意味します。
+これには値が一意で、かつNULLでないことが必要となります。
+つまり、次の2つのテーブル定義は同じデータを受け入れます。
 <programlisting>
 CREATE TABLE products (
     product_no integer UNIQUE NOT NULL,
@@ -948,12 +937,10 @@ CREATE TABLE products (
 
    <para>
 <!--
-    Primary keys can also constrain more than one column; the syntax ★9.5.0時原文
-
     Primary keys can span more than one column; the syntax
     is similar to unique constraints:
 -->
-プライマリキーでも複数の列を制約することができ、その構文は一意性制約に似ています。★訳文変更の必要あり
+プライマリキーも複数の列に渡ることがあり、その構文は一意性制約に似ています。
 <programlisting>
 CREATE TABLE example (
     a integer,
@@ -966,14 +953,12 @@ CREATE TABLE example (
 
    <para>
 <!--
-    Adding a primary key will automatically create a unique B-tree index ★9.5.0時原文
-    on the column or group of columns used in the primary key. ★9.5.0時原文
-
     Adding a primary key will automatically create a unique B-tree index
     on the column or group of columns listed in the primary key, and will
     force the column(s) to be marked <literal>NOT NULL</>.
 -->
-プライマリキーを追加すると、プライマリキーで使われる列または列のグループに対して一意的なBツリーのインデックスが自動的に作られます。 ★訳文9.5.0時訳文
+プライマリキーを追加すると、プライマリキーで指定された列または列のグループに対して一意的なBツリーのインデックスが自動的に作られます。
+また、その列について<literal>NOT NULL</>の印が強制されます。
    </para>
 
    <para>
@@ -988,7 +973,7 @@ CREATE TABLE example (
 -->
 1つのテーブルは最大1つのプライマリキーを持つことができます。
 （一意性制約および非NULL制約には個数の制限はありません。
-機能的には同じものですが、プライマリキーとして識別される制約は1つのみです。）
+機能的にはほとんど同じものですが、プライマリキーとして識別される制約は1つのみです。）
 リレーショナルデータベース理論では、全てのテーブルにプライマリキーが1つ必要とされています。
 この規則は<productname>PostgreSQL</productname>では強制されませんが、たいていの場合はこれに従うことが推奨されます。
    </para>
@@ -1004,14 +989,11 @@ CREATE TABLE example (
     the primary key defines the default target column(s) for foreign keys
     referencing its table.
 -->
-★9.5.0参考訳
-これは文書化、および、クライアントアプリケーションの両方の面で役に立ちます。
+プライマリキーは文書化、および、クライアントアプリケーションの両方の面で役に立ちます。
 例えば、行値の変更が可能なGUIアプリケーションが行を一意的に特定するためには、
 おそらくテーブルのプライマリキーを知る必要があります。
-               There are also various ways in which the database system
-    makes use of a primary key if one has been declared; for example,
-    the primary key defines the default target column(s) for foreign keys
-    referencing its table.
+他にもプライマリキーが宣言されているときにデータベースシステムがそれを利用する場面がいくつかあります。
+例えば、外部キーがそのテーブルを参照するとき、プライマリキーがデフォルトの対象列となります。
    </para>
   </sect2>
 
@@ -1345,7 +1327,7 @@ CREATE TABLE order_items (
     to index, declaration of a foreign key constraint does not
     automatically create an index on the referencing columns.
 -->
-外部キーは主キーであるかまたは一意制約を構成する列を参照しなければなりません。これは、被参照列は常に(主キーまたは一意制約の基礎となる)インデックスを持つことを意味します;このため、参照行が一致するかのチェックは効率的です。
+外部キーはプライマリキーであるかまたは一意性制約を構成する列を参照しなければなりません。これは、被参照列は常に(プライマリキーまたは一意性制約の基礎となる)インデックスを持つことを意味します;このため、参照行が一致するかのチェックは効率的です。
 被参照テーブルからの行の<command>DELETE</command>や被参照行の<command>UPDATE</command>は、古い値と一致する行に対して参照テーブルのスキャンを要求しますので、参照行にもインデックスを付けるのは大抵は良い考えです。
 これは常に必要という訳ではなく、また、インデックスの方法には多くの選択肢がありますので、外部キー制約の宣言では参照列のインデックスが自動的に作られるということはありません。
    </para>
@@ -2733,7 +2715,7 @@ UPDATE 1
    schemas and row level policies to avoid <quote>covert channel</> leaks of
    information through such referential integrity checks.
 -->
-一意制約、主キー制約、外部キー制約などの参照整合性確認は、データの整合性を維持するため、常に行セキュリティを無視します。
+一意性制約、プライマリキー制約、外部キー制約などの参照整合性確認は、データの整合性を維持するため、常に行セキュリティを無視します。
 スキーマと行単位セキュリティの開発において、このような参照整合性確認により<quote>カバートチャネル(covert channel)</>の情報漏洩が起こらないようにするため、注意が必要です。
   </para>
 
@@ -4393,7 +4375,7 @@ VALUES ('Albany', NULL, NULL, 'NY');
 -->
 このテーブルはデータを格納しません。
 このテーブルにはすべてのパーティションに対して適用されるつもりでなければ検査制約は定義しないでください。
-同様にインデックスや一意制約を定義することも意味がありません。
+同様にインデックスや一意性制約を定義することも意味がありません。
        </para>
       </listitem>
 
@@ -4477,7 +4459,7 @@ CHECK ( outletID BETWEEN 200 AND 300 )
         partition.)
 -->
 それぞれのパーティションにおいて、他のインデックスと同様にキーとなる列（列の集合）にインデックスを作成してください。
-（キーのインデックスは必ずしも必要でありませんが、たいていの場合に役立ちます。もしキー値が一意であることを意図するのであればいつでも、一意もしくは主キー制約をそれぞれのパーティションに作成してください。）
+（キーのインデックスは必ずしも必要でありませんが、たいていの場合に役立ちます。もしキー値が一意であることを意図するのであればいつでも、一意もしくはプライマリキー制約をそれぞれのパーティションに作成してください。）
        </para>
       </listitem>
 
@@ -5163,7 +5145,7 @@ ANALYZE measurement;
       target relation, not its child relations.
 -->
 <literal>ON CONFLICT</>句のある<command>INSERT</command>文は期待通りに動作しない可能性が高いです。
-なぜなら、<literal>ON CONFLICT</>の動作は指定した対象のリレーション上で一意制約違反が発生した場合にのみ起きるのであって、その子のリレーションでは起きないからです。
+なぜなら、<literal>ON CONFLICT</>の動作は指定した対象のリレーション上で一意性制約違反が発生した場合にのみ起きるのであって、その子のリレーションでは起きないからです。
      </para>
     </listitem>
 


### PR DESCRIPTION
そのついでに、"primary key", "unique constraint"の訳語をそれぞれ、
「プライマリキー」「一意性制約」に統一しました。
個人的には「主キー」「一意制約」の方が良いと思っているのですが、
現在の日本語マニュアルでは前者が圧倒的に多いので、とりあえず、それに統一。