### PR TITLE
planstats.sgmlの訳の改善および誤訳の修正です。

### DIFF
--- a/doc/src/sgml/planstats.sgml
+++ b/doc/src/sgml/planstats.sgml
@@ -35,14 +35,14 @@
 <!--
   <title>Row Estimation Examples</title>
 -->
-  <title>行推定の例</title>
+  <title>行数推定の例</title>
 
   <indexterm zone="row-estimation-examples">
 <!--
    <primary>row estimation</primary>
    <secondary>planner</secondary>
 -->
-   <primary>行推定</primary>
+   <primary>行数推定</primary>
    <secondary>プランナ</secondary>
   </indexterm>
 
@@ -107,8 +107,8 @@ SELECT relpages, reltuples FROM pg_class WHERE relname = 'tenk1';
 -->
 これらの値は最後にそのテーブルを<command>VACUUM</>または<command>ANALYZE</>を行った時点のものです。
 プランナはその後、テーブル内の実際のページ数を取り出します（これはテーブルスキャンを行わない安価な操作です）。
-それが<structfield>relpages</structfield>と異なる場合、現在の推定行数を求めるために、<structfield>reltuples</structfield>を得られたページ数の割合に応じて変更します。
-前の例では、<structfield>relpages</structfield>の値は最新のものですので、推定行は<structfield>reltuples</structfield>と同じです。
+それが<structfield>relpages</structfield>と異なる場合、<structfield>reltuples</structfield>を得られたページ数の割合に応じて変更して現在の推定行数を求めます。
+この例では、<structfield>relpages</structfield>の値は最新のものなので、推定行数は<structfield>reltuples</structfield>と同じです。
   </para>
 
   <para>

--- a/doc/src/sgml/planstats.sgml
+++ b/doc/src/sgml/planstats.sgml
@@ -4,7 +4,7 @@
 <!--
  <title>How the Planner Uses Statistics</title>
 -->
- <title>プランナが統計情報をどのように使用するか</title>
+ <title>プランナは統計情報をどのように使用するか</title>
 
   <para>
 <!--
@@ -83,7 +83,7 @@ EXPLAIN SELECT * FROM tenk1;
    <structname>pg_class</structname>:
 -->
 プランナがどのように<classname>tenk1</classname>の濃度を決定するかについては<xref linkend="planner-stats">で説明しました。
-しかし、ここで完全になるように繰り返し説明します。
+しかし、ここでは完全を期するために説明を繰り返します。
 ページ数および行数は<classname>pg_class</classname>から検索されます。
 
 <programlisting>
@@ -107,8 +107,8 @@ SELECT relpages, reltuples FROM pg_class WHERE relname = 'tenk1';
 -->
 これらの値は最後にそのテーブルを<command>VACUUM</>または<command>ANALYZE</>を行った時点のものです。
 プランナはその後、テーブル内の実際のページ数を取り出します（これはテーブルスキャンを行わない安価な操作です）。
-<structfield>relpages</structfield>と異なる場合、<structfield>reltuples</structfield>は現在の推定行数に達するまで増大されます。
-この場合、<structfield>relpages</structfield>の値は最新のものですので、推定行は<structfield>reltuples</structfield>と同じです。
+それが<structfield>relpages</structfield>と異なる場合、現在の推定行数を求めるために、<structfield>reltuples</structfield>を得られたページ数の割合に応じて変更します。
+前の例では、<structfield>relpages</structfield>の値は最新のものですので、推定行は<structfield>reltuples</structfield>と同じです。
   </para>
 
   <para>


### PR DESCRIPTION
"is scaled accordingly"を「増大させる」と訳していますが、必ずしも増える
とは限らないのでこの訳は不適切です。ここで言っているのは、プランナが取
得したページ数と、relpagesの比率の差分だけreltuplesの行数を増やすか減ら
すかする、ということです。

また、"In this case"を「この場合」と訳していますが、意味が通じないので
本家に確認したところ、"In this case"は上にある実行例を指していることが
わかったので、訳を修正しています。

"histogram"の訳問題には手を付けていません。