### PR TITLE
postgres.sgml(sql.html)の誤訳訂正（原文と違うことが書いてある部分を直しました）

### DIFF
--- a/doc/src/sgml/postgres.sgml
+++ b/doc/src/sgml/postgres.sgml
@@ -113,7 +113,7 @@ Unixやプログラミングに関する経験は必要ありません。
     Readers looking for a complete description of a particular command
     should see <xref linkend="reference">.
 -->
-ここでの内容は、初心者のユーザでも他の入門書などを参照することなく、最初から最後まで全てのトピックを理解できるような構成になっています。
+ここでの内容は、初心者のユーザでも先のページを何度もを参照することなく、最初から最後まで全てのトピックを理解できるような構成になっています。
 各章ごとに内容が独立していますので、上級ユーザは必要な章だけを選んで読むことができます。
 ここではトピックに関する説明が中心となっていますので、特定のコマンドの完全な記述が必要なユーザは<xref linkend="reference">を参照してください。
    </para>
@@ -129,8 +129,8 @@ Unixやプログラミングに関する経験は必要ありません。
     <application>psql</application>, but other programs that have
     similar functionality can be used as well.
 -->
-対象読者は、<productname>PostgreSQL</>データベースへの接続および<acronym>SQL</acronym>コマンド発行に慣れ親しんでいるユーザです。
-まだこれらについて熟知していないユーザは、本書の前に<xref linkend="tutorial">をお読みになることをお勧めします。
+対象読者は、<productname>PostgreSQL</>データベースへの接続および<acronym>SQL</acronym>コマンド発行の方法を知っているユーザです。
+まだこれらについて慣れていないユーザは、本書の前に<xref linkend="tutorial">をお読みになることをお勧めします。
 <acronym>SQL</acronym>コマンドは通常<productname>PostgreSQL</>の対話式端末<application>psql</application>を使用して入力しますが、同様の機能を備えた他のプログラムも使用することができます。
    </para>
   </partintro>


### PR DESCRIPTION
パートIIの冒頭部分です。
(1) "refer forward"は、まだ読んでいない先の方のページを参照することを指していると思いますが、「他の入門書など」となっていたので修正しました。同時に"too many times"を訳出しました。
(2) 対象読者について"should know how to connect to a PostgreSQL database and issue SQL commands"なので、「方法を知っていれば良い」としか言っていませんが「慣れ親しんでいる」とかなり高いハードルを設定する訳になっていたので修正しました。続く文の"unfamiliar"を「熟知していない」としているのも、同じくハードルが高いので修正しました。