### PR TITLE
postgres.sgml(tutorial.html)の誤訳修正

### DIFF
--- a/doc/src/sgml/postgres.sgml
+++ b/doc/src/sgml/postgres.sgml
@@ -66,7 +66,7 @@ Unixやプログラミングに関する経験は必要ありません。
     <productname>PostgreSQL</productname>.  Those who set up and
     manage their own server should also read <xref linkend="admin">.
 -->
-このチュートリアルの内容を読んだ後、SQL言語のより形式的な知識を学習したいのであれば、<xref linkend="sql">を、<productname>PostgreSQL</productname>用のアプリケーションの開発に関する情報を学習したいのであれば、<xref linkend="client-interfaces">を続いて読んでください。
+このチュートリアルの内容を読んだ後、SQL言語のより本格的な知識を学習したいのであれば、<xref linkend="sql">を、<productname>PostgreSQL</productname>用のアプリケーションの開発に関する情報を学習したいのであれば、<xref linkend="client-interfaces">を続いて読んでください。
 また、サーバをセットアップおよび管理される方は、<xref linkend="admin">も参照してください。 
    </para>
   </partintro>

--- a/doc/src/sgml/postgres.sgml
+++ b/doc/src/sgml/postgres.sgml
@@ -66,7 +66,7 @@ Unixやプログラミングに関する経験は必要ありません。
     <productname>PostgreSQL</productname>.  Those who set up and
     manage their own server should also read <xref linkend="admin">.
 -->
-このチュートリアルの内容を読んだ後、SQL言語のより本格的な知識を学習したいのであれば、<xref linkend="sql">を、<productname>PostgreSQL</productname>用のアプリケーションの開発に関する情報を学習したいのであれば、<xref linkend="client-interfaces">を続いて読んでください。
+このチュートリアルの内容を読んだ後、SQL言語のより体系的な知識を学習したいのであれば、<xref linkend="sql">を、<productname>PostgreSQL</productname>用のアプリケーションの開発に関する情報を学習したいのであれば、<xref linkend="client-interfaces">を続いて読んでください。
 また、サーバをセットアップおよび管理される方は、<xref linkend="admin">も参照してください。 
    </para>
   </partintro>


### PR DESCRIPTION
「形式的な」という言葉は、表面的で中身がない、という意味になってしまいます。
この場合の"formal"は「正式な」という意味なので、ぴったりした訳語の選択が難しいですが「本格的な」に変更しました。