### PR TITLE
query.sgmlの翻訳改善

### DIFF
--- a/doc/src/sgml/query.sgml
+++ b/doc/src/sgml/query.sgml
@@ -26,7 +26,7 @@
 本章では、<acronym>SQL</acronym>を使用した簡単な操作方法について、その概要を説明します。
 このチュートリアルは単なる入門用であり、<acronym>SQL</acronym>についての完全な教科書ではありません。
 <xref linkend="MELT93">や<xref linkend="DATE97">など、<acronym>SQL</acronym>を説明した書籍は多くあります。
-<productname>PostgreSQL</productname>言語が持つ機能の中には標準を拡張したものがあることには注意してください。
+<productname>PostgreSQL</productname>の言語機能の中には標準を拡張したものがあることには注意してください。
    </para>
 
    <para>
@@ -48,7 +48,7 @@
     files, first change to that directory and run <application>make</>:
 -->
 このマニュアルで示す例は、<productname>PostgreSQL</productname>ソース配布物に含まれており、<filename>src/tutorial/</filename>以下に展開されます。
-（<productname>PostgreSQL</productname>のバイナリ配布物ではこのファイルはコンパイルされていないかも知れません。）
+（<productname>PostgreSQL</productname>のバイナリ配布物ではこのファイルは含まれていないかも知れません。）
 このファイルを使用するためには、以下に示すように、まずこのディレクトリに移動し、<application>make</>を実行してください。
 
 <screen>
@@ -81,7 +81,7 @@
     <filename>basics.sql</filename>.
 -->
 <literal>\i</literal>は、指定したファイルからコマンドを読み込みます。
-<command>psql</command>の<literal>-s</>オプションによって、それぞれの文をサーバに送る前に一時停止する、シングルステップモードとなります。
+<command>psql</command>の<literal>-s</>オプションによって、シングルステップモードとなり、それぞれの文をサーバに送る前に一時停止します。
 本節で使用するコマンドは<filename>basics.source</filename>ファイル内にあります。
    </para>
   </sect1>


### PR DESCRIPTION
(1) "PostgreSQL language features"で、「PostgreSQL言語の～」はおかしいので修正しました。
(2) カタカナで「コンパイル」とすると、ソースファイルをオブジェクトに変換する操作を指しますが、この"compile"は「同梱する」などの意味なので修正しました。
(3) 関係詞節で、意味的には訳し上げでも訳し下げでも同じですが、文を読む時の理解しやすさの点で、訳し下げる方が良いと感じたので、変更してみました。