### PR TITLE
syntax.sgmlのうち、マニュアルの4.1節の一部の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -220,7 +220,7 @@ SQL識別子とキーワードは、文字（<literal>a</literal>〜<literal>z</
     changing the <symbol>NAMEDATALEN</symbol> constant in
     <filename>src/include/pg_config_manual.h</filename>.
 -->
-システムは<symbol>NAMEDATALEN</symbol>-1バイトより長い文字数の識別子を使いません。 
+システムは<symbol>NAMEDATALEN</symbol>-1バイトより長い識別子を使いません。 
 より長い名前をコマンドで書くことはできますが、短く切られてしまいます。  
 デフォルトでは<symbol>NAMEDATALEN</symbol>は64なので、識別子は最長で63バイトです。
 この制限が問題になる場合は、<filename>src/include/pg_config_manual.h</filename>内の<symbol>NAMEDATALEN</symbol>定数の値を変更して増やすことができます。
@@ -399,7 +399,7 @@ U&amp;"d!0061t!+000061" UESCAPE '!'
 Unicodeエスケープ構文はサーバの符号化方式が<literal>UTF8</>の場合のみ有効です。
 他のサーバ符号化方式が用いられている場合、ASCII範囲（<literal>\007F</literal>まで）のコードポイントのみ指定できます。
 U+FFFFより大きなコードポイントを持つ文字を構成するUTF-16サロゲートペアを指定するために、4桁と6桁の形式の両方を使用することができますが、技術的には6桁形式の機能によりこれは不要になります。
-（サロゲートペアは直接格納されませんが、一つのコードポイントに結合されてから、UTF-8に符号化されます。）
+（サロゲートペアは直接格納されるわけではなく、一つのコードポイントに結合されてから、UTF-8に符号化されます。）
    </para>
 
    <para>
@@ -793,7 +793,7 @@ U+FFFFより大きなコードポイントを持つ文字を構成するUTF-16�
 <productname>PostgreSQL</productname>は同時に、文字コード番号で任意のUnicode文字を指定可能な文字列に対するもう一つのエスケープ構文を提供します。
 Unicodeエスケープ文字列定数は、<literal>U&amp;</literal>（大文字・小文字のUの後にアンパサンド）で始まり、その直後に、空白を間にはさまず、開始引用符が続きます。
 例えば、<literal>U&amp;'foo'</literal>となります。
-（これにより演算子<literal>&amp;</literal>との不明確性が生じることに注意してください。
+（これにより演算子<literal>&amp;</literal>との曖昧性が生じることに注意してください。
 この問題を回避するには空白を演算子の前後に入れます。）
 引用符の中で、Unicode文字はバックスラッシュとそれに続く４桁１６進数の文字コード番号で、またはもう１つの方法として、バックスラッシュに続いてプラス符号、そして続いた６桁１６進数の文字コード番号によりエスケープ形式で指定されます。
 例えば、文字列<literal>'data'</literal>は次のように書かれます。

--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -38,7 +38,7 @@
 <!--
   <title>Lexical Structure</title>
 -->
-  <title>語彙の構成</title>
+  <title>字句の構造</title>
 
   <indexterm>
 <!--
@@ -178,7 +178,7 @@ SQL構文は、どのトークンがコマンドを識別し、どれがオペ�
 <token>MY_TABLE</token>トークンや<token>A</token>トークンは<firstterm>識別子</firstterm>の一例です。
 これらは、使われるコマンドによって、テーブル、列、他のデータベースオブジェクトの名前を識別します。
 したがって、単に<quote>名前</quote>と呼ばれることもあります。
-キーワードと識別子は同じ語彙の構造を持つため、言語を知らなくてはトークンが識別子なのかキーワードなのかわからないということになります。
+キーワードと識別子は同じ字句の構造を持つため、言語を知らなくてはトークンが識別子なのかキーワードなのかわからないということになります。
 全てのキーワードのリストは<xref linkend="sql-keywords-appendix">にあります。
    </para>
 
@@ -220,7 +220,7 @@ SQL識別子とキーワードは、文字（<literal>a</literal>〜<literal>z</
     changing the <symbol>NAMEDATALEN</symbol> constant in
     <filename>src/include/pg_config_manual.h</filename>.
 -->
-システムは<symbol>NAMEDATALEN</symbol>-1バイトより長い識別子の文字数を使いません。 
+システムは<symbol>NAMEDATALEN</symbol>-1バイトより長い文字数の識別子を使いません。 
 より長い名前をコマンドで書くことはできますが、短く切られてしまいます。  
 デフォルトでは<symbol>NAMEDATALEN</symbol>は64なので、識別子は最長で63バイトです。
 この制限が問題になる場合は、<filename>src/include/pg_config_manual.h</filename>内の<symbol>NAMEDATALEN</symbol>定数の値を変更して増やすことができます。
@@ -238,7 +238,7 @@ SQL識別子とキーワードは、文字（<literal>a</literal>〜<literal>z</
 <!--
     Key words and unquoted identifiers are case insensitive.  Therefore:
 -->
-キーワードと引用符付きでない(クォートされていない)識別子は大文字と小文字を区別しません。
+キーワードと引用符付きでない識別子は大文字と小文字を区別しません。
 したがって、
 <programlisting>
 UPDATE MY_TABLE SET A = 5;
@@ -254,7 +254,7 @@ uPDaTE my_TabLE SeT a = 5;
     A convention often used is to write key words in upper
     case and names in lower case, e.g.:
 -->
-慣習的には、キーワードを大文字で、名前を小文字で書きます。 
+慣習的によく使われる方法では、キーワードを大文字で、名前を小文字で書きます。 
 例えば下記のようになります。
 <programlisting>
 UPDATE my_table SET a = 5;
@@ -303,9 +303,9 @@ UPDATE "my_table" SET "a" = 5;
     otherwise not be possible, such as ones containing spaces or
     ampersands.  The length limitation still applies.
 -->
-引用符付き識別子は、文字コード0以外であればどのような文字でも使えます
+引用符付き識別子は、コード0の文字以外であればどのような文字でも使えます
 （二重引用符を含めたい場合は、二重引用符を2つ入力します）。
-この決まりがあることによって、普段使えない空白やアンパサンド（&amp;）を含むテーブル名や列名を作ることが可能です。
+これにより、空白やアンパサンド（&amp;）を含むテーブル名や列名など、この方法がなければ作れないような名前のものを作ることが可能になります。
 この場合においても長さの制限は適用されます。
    </para>
 
@@ -335,13 +335,13 @@ UPDATE "my_table" SET "a" = 5;
     hexadecimal code point number.  For example, the
     identifier <literal>"data"</literal> could be written as
 -->
-引用符付き識別子の変異体はそれらのコード番号で識別されるエスケープされたUnicode文字を含むことができます。
-この変異体は、二重引用符開始の直前に<literal>U&amp;</literal>（後にアンパサンドが付いた大文字・小文字のU）で始まります。
+引用符付き識別子には異形があり、コード番号で識別されるエスケープされたUnicode文字を含むことができます。
+この異形は、<literal>U&amp;</literal>（大文字または小文字のUの後にアンパサンド）で始まり、その直後に空白を間に入れずに二重引用符を続けます。
 例えば、<literal>U&amp;"foo"</literal>となります。
 （これにより演算子<literal>&amp;</literal>との不明確性が生じることに注意してください。
 この問題を回避するには空白を演算子の前後に入れます。）
 引用符の中で、Unicode文字はバックスラッシュとそれに続く４桁１６進数の文字コード番号で、またはもう１つの方法として、バックスラッシュに続いてプラス符号、そして続いた６桁１６進数の文字コード番号によりエスケープ形式で指定されます。
-例えば、識別子<literal>"data"</literal>は次のように書かれます。
+例えば、識別子<literal>"data"</literal>は次のように書くことができます。
 <programlisting>
 U&amp;"d\0061t\+000061"
 </programlisting>
@@ -349,7 +349,7 @@ U&amp;"d\0061t\+000061"
     The following less trivial example writes the Russian
     word <quote>slon</quote> (elephant) in Cyrillic letters:
 -->
-次のより一般的でない例はロシア語の<quote>slon</quote>（象）をキリル語で書いたものです。
+次の少し意味のある例はロシア語の<quote>slon</quote>（象）をキリル文字で書いたものです。
 <programlisting>
 U&amp;"\0441\043B\043E\043D"
 </programlisting>
@@ -362,7 +362,7 @@ U&amp;"\0441\043B\043E\043D"
     the <literal>UESCAPE</literal><indexterm><primary>UESCAPE</primary></indexterm>
     clause after the string, for example:
 -->
-バックスラッシュではない異なるエスケープ文字を使用したい場合、文字列の後に<literal>UESCAPE</literal><indexterm><primary>UESCAPE</primary></indexterm>句を使用して指定することが可能です。例をあげます。
+バックスラッシュ以外のエスケープ文字を使用したい場合、文字列の後に<literal>UESCAPE</literal><indexterm><primary>UESCAPE</primary></indexterm>句を使用して指定することが可能です。例をあげます。
 <programlisting>
 U&amp;"d!0061t!+000061" UESCAPE '!'
 </programlisting>
@@ -398,8 +398,8 @@ U&amp;"d!0061t!+000061" UESCAPE '!'
 -->
 Unicodeエスケープ構文はサーバの符号化方式が<literal>UTF8</>の場合のみ有効です。
 他のサーバ符号化方式が用いられている場合、ASCII範囲（<literal>\007F</literal>まで）のコードポイントのみ指定できます。
-技術的には6桁形式の機能によりこれは不要になりますが、4桁または6桁の形式は、U+FFFFより大きなコードポイントを持つ文字を構成するUTF-16サロゲートペアを指定するために使用することができます。
-（サロゲートペアは直接格納されませんが、UTF-8に符号化される場合には一つのコードポイントに結合されます。）
+U+FFFFより大きなコードポイントを持つ文字を構成するUTF-16サロゲートペアを指定するために、4桁と6桁の形式の両方を使用することができますが、技術的には6桁形式の機能によりこれは不要になります。
+（サロゲートペアは直接格納されませんが、一つのコードポイントに結合されてから、UTF-8に符号化されます。）
    </para>
 
    <para>
@@ -494,7 +494,7 @@ Unicodeエスケープ構文はサーバの符号化方式が<literal>UTF8</>の
      <!-- 原文中のコメント font-lock sanity: " -->
 SQLにおける文字列定数は、単一引用符（<literal>'</literal>）で括られた任意の文字の並びです。
 例えば、<literal>'This is a string'</literal>です。
-文字列定数内の単一引用符の記述方法は、2つ続けて単一引用符を記述することです。
+文字列定数内に単一引用符を含めるには、2つ続けて単一引用符を記述します。
 例えば、<literal>'Dianne''s horse'</literal>です。
 二重引用符(<literal>"</>)とは同一では<emphasis>ない</>点に注意してください。<!-- font-lock sanity: " -->
     </para>
@@ -506,7 +506,7 @@ SQLにおける文字列定数は、単一引用符（<literal>'</literal>）で
      and effectively treated as if the string had been written as one
      constant.  For example:
 -->
-2つの文字列定数が、<emphasis>少なくとも1つの改行</emphasis>を含んだ空白で区切られている場合は、2つの定数は連結され、実質的に1つの定数として書かれたように処理されます。
+2つの文字列定数が、<emphasis>少なくとも1つの改行</emphasis>を含んだ空白のみで区切られている場合は、2つの定数は連結され、実質的に1つの定数として書かれたように処理されます。
 例を示します。
 <programlisting>
 SELECT 'foo'
@@ -569,11 +569,11 @@ SELECT 'foo'      'bar';
      of backslash and following character(s) represent a special byte
      value, as shown in <xref linkend="sql-backslash-table">.
 -->
-<productname>PostgreSQL</productname>では、また、<quote>エスケープ</>文字定数を受け付けます。
+<productname>PostgreSQL</productname>では、また、<quote>エスケープ</>文字列定数を受け付けます。
 これは標準SQLの拡張です。
-エスケープ文字定数は、開始単一引用符の直前に<literal>E</literal>(大文字でも小文字でもかまいません)を記述することで指定されます。
+エスケープ文字列定数は、<literal>E</literal>(大文字でも小文字でもかまいません)を開始単一引用符の直前に記述することで指定されます。
 例えば<literal>E'foo'</>です。
-（複数行に渡るエスケープ文字定数では、最初の開始引用符の前にのみ<literal>E</>を記述してください。）
+（複数行に渡るエスケープ文字列定数では、最初の開始引用符の前にのみ<literal>E</>を記述してください。）
 エスケープ文字列の中では、バックスラッシュ文字（<literal>\</>）によりC言語のような<firstterm>バックスラッシュ</>シーケンスが開始し、その中でバックスラッシュとそれに続く文字の組み合わせが（<xref linkend="sql-backslash-table">で示したように）特別なバイト値を表現します。
     </para>
 
@@ -678,7 +678,7 @@ SELECT 'foo'      'bar';
 -->
 バックスラッシュの後のそのほかの全ての文字はそのまま扱われます。
 従って、バックスラッシュ文字を含ませるときは２つのバックスラッシュ（<literal>\\</>）を記載します。
-同時に、エスケープ文字列の中の１つの単一引用符は、通常の方法の<literal>''</>に加え、<literal>\'</literal>として含むことができます。
+同時に、エスケープ文字列の中では、単一引用符を、通常の方法の<literal>''</>に加え、<literal>\'</literal>としても含めることができます。
     </para>
 
     <para>
@@ -692,9 +692,9 @@ SELECT 'foo'      'bar';
      instead.  (The alternative would be doing the UTF-8 encoding by
      hand and writing out the bytes, which would be very cumbersome.)
 -->
-特に10進数や16進数エスケープを用いて作成されるバイトシーケンスが、サーバ文字セット符号化方式において有効な文字で構成されていることはコードを書く人の責任です。
-サーバ符号化方式がUTF-8の場合、Unicodeエスケープか、<xref linkend="sql-syntax-strings-uescape">で説明したもう一方のUnicodeエスケープ構文を代わりとして使用すべきです。
-（代案は手作業でUTF-8符号化を行い、書き出さなくてはならないのでとても厄介です。）
+特に8進数や16進数エスケープを用いて作成されるバイトシーケンスが、サーバ文字セット符号化方式において有効な文字で構成されていることはコードを書く人の責任です。
+サーバ符号化方式がUTF-8の場合、Unicodeエスケープか、<xref linkend="sql-syntax-strings-uescape">で説明するもう一つのUnicodeエスケープ構文を代わりとして使用すべきです。
+（後者は手作業でUTF-8符号化を行い、書き出さなくてはならないのでとても厄介です。）
     </para>
 
     <para>
@@ -712,7 +712,7 @@ SELECT 'foo'      'bar';
 -->
 Unicodeエスケープ構文は、サーバの符号化方式が<literal>UTF8</>である場合のみ、完全に動作します。
 他のサーバ符号化方式が使用されている場合、ASCII範囲（<literal>\u007F</>まで）のコードポイントのみを指定することができます。
-技術的には8桁形式の機能によりこれは不要になりますが、4桁または8桁の形式は、U+FFFFより大きなコードポイントを持つ文字を構成するUTF-16サロゲートペアを指定するために使用することができます。
+U+FFFFより大きなコードポイントを持つ文字を構成するUTF-16サロゲートペアを指定するために、4桁と8桁の両方の形式を使用することができますが、技術的には8桁形式の機能によりこれは不要になります。
 （サーバの符号化方式が<literal>UTF8</>の場合にサロゲートペアが使用される時、まず単一のコードポイントに組み合わされ、その後にUTF-8に符号化されます。）
     </para>
 
@@ -732,7 +732,7 @@ Unicodeエスケープ構文は、サーバの符号化方式が<literal>UTF8</>
      escapes.  If you need to use a backslash escape to represent a special
      character, write the string constant with an <literal>E</>.
 -->
-設定パラメータ<xref linkend="guc-standard-conforming-strings">が <literal>off</>の場合、<productname>PostgreSQL</productname>はバックスラッシュエスケープを通常の文字定数とエスケープ文字定数の両方で認識します。
+設定パラメータ<xref linkend="guc-standard-conforming-strings">が <literal>off</>の場合、<productname>PostgreSQL</productname>はバックスラッシュエスケープを通常の文字列定数とエスケープ文字列定数の両方で認識します。
 しかし、<productname>PostgreSQL</>9.1からデフォルトは<literal>on</>になりました。これはバックスラッシュエスケープはエスケープ文字列でのみ認識されるということになります。
 この振る舞いはSQL標準仕様に即していますが、バックスラッシュエスケープを常に認識するという歴史的な動作に依存しているアプリケーションは動作しなくなるでしょう。
 回避策として、このパラメータを<literal>off</>にすることはできますが、バックスラッシュエスケープの使用を避けるよう移植するのが良いでしょう。
@@ -790,8 +790,8 @@ Unicodeエスケープ構文は、サーバの符号化方式が<literal>UTF8</>
      followed by a six-digit hexadecimal code point number.  For
      example, the string <literal>'data'</literal> could be written as
 -->
-<productname>PostgreSQL</productname>は同時に、文字コード番号で任意のUnicode文字を指定可能な別の文字列に対するエスケープ構文を提供します。
-Unicodeエスケープ文字列定数は、開始引用符の直前に<literal>U&amp;</literal>（後にアンパサンドが付いた大文字・小文字のU）で始まります。
+<productname>PostgreSQL</productname>は同時に、文字コード番号で任意のUnicode文字を指定可能な文字列に対するもう一つのエスケープ構文を提供します。
+Unicodeエスケープ文字列定数は、<literal>U&amp;</literal>（大文字・小文字のUの後にアンパサンド）で始まり、その直後に、空白を間にはさまず、開始引用符が続きます。
 例えば、<literal>U&amp;'foo'</literal>となります。
 （これにより演算子<literal>&amp;</literal>との不明確性が生じることに注意してください。
 この問題を回避するには空白を演算子の前後に入れます。）
@@ -804,7 +804,7 @@ U&amp;'d\0061t\+000061'
      The following less trivial example writes the Russian
      word <quote>slon</quote> (elephant) in Cyrillic letters:
 -->
-次のより一般的でない例はロシア語の<quote>slon</quote>（象）をキリル文字で書いたものです。
+次の少し意味のある例はロシア語の<quote>slon</quote>（象）をキリル文字で書いたものです。
 <programlisting>
 U&amp;'\0441\043B\043E\043D'
 </programlisting>
@@ -817,7 +817,7 @@ U&amp;'\0441\043B\043E\043D'
      the <literal>UESCAPE</literal><indexterm><primary>UESCAPE</primary></indexterm>
      clause after the string, for example:
 -->
-バックスラッシュではない異なるエスケープ文字を使用したい場合、文字列の後に<literal>UESCAPE</literal><indexterm><primary>UESCAPE</primary></indexterm>句を使用して指定することが可能です。例をあげます。
+バックスラッシュ以外のエスケープ文字を使用したい場合、文字列の後に<literal>UESCAPE</literal><indexterm><primary>UESCAPE</primary></indexterm>句を使用して指定することが可能です。例をあげます。
 <programlisting>
 U&amp;'d!0061t!+000061' UESCAPE '!'
 </programlisting>
@@ -844,7 +844,7 @@ U&amp;'d!0061t!+000061' UESCAPE '!'
 -->
 Unicodeエスケープ構文はサーバの符号化方式が<literal>UTF8</>の場合のみ有効です。
 他のサーバ符号化方式が用いられている場合、ASCII範囲（<literal>\007F</literal>まで）のコードポイントのみ指定できます。
-技術的には6桁形式の機能によりこれは不要になりますが、4桁または6桁の形式は、U+FFFFより大きなコードポイントを持つ文字を構成するUTF-16サロゲートペアを指定するために使用することができます。
+U+FFFFより大きなコードポイントを持つ文字を構成するUTF-16サロゲートペアを指定するために、4桁と6桁の両方の形式を使用することができますが、技術的には6桁形式の機能によりこれは不要になります。
 （サーバの符号化方式が<literal>UTF8</>の場合にサロゲートペアが使用される時、まず単一のコードポイントに組み合わされ、その後にUTF-8に符号化されます。）
     </para>
 
@@ -859,9 +859,9 @@ Unicodeエスケープ構文はサーバの符号化方式が<literal>UTF8</>の
      parameter is set to off, this syntax will be rejected with an
      error message.
 -->
-同様に、文字列定数に対するユニコードエスケープ構文は設定パラメータ<xref linkend="guc-standard-conforming-strings">が有効なときのみ動作します。
-そうでないとこの構文は、SQLインジェクションと、類似したセキュリティ問題に繋がる時点までSQL文を構文解釈するクライアントを惑わすことになるからです。
-パラメータがoffに設定されていれば、この構文はエラーメッセージとともに拒絶されます。
+また、文字列定数に対するユニコードエスケープ構文は設定パラメータ<xref linkend="guc-standard-conforming-strings">が有効なときのみ動作します。
+そうでないとこの構文は、SQL文を構文解釈するクライアントを混乱させ、SQLインジェクションや、それに類似したセキュリティ問題に繋がることさえあるからです。
+パラメータがoffに設定されていれば、この構文はエラーメッセージを出して拒絶されます。
     </para>
 
     <para>
@@ -869,7 +869,7 @@ Unicodeエスケープ構文はサーバの符号化方式が<literal>UTF8</>の
      To include the escape character in the string literally, write it
      twice.
 -->
-文字列の中に、文字どおりにエスケープ文字を包括するにはエスケープ文字を２回書きます。
+文字列の中に、エスケープ文字をそのまま含めるにはエスケープ文字を２回書きます。
     </para>
    </sect3>
 


### PR DESCRIPTION
以下、主な変更箇所です。
(1) 2箇所ある"lexical structure"について、lexicalは「語彙」を「字句」に変更、structureは「構造」に統一
(2) 不自然な日本語の言い回しを改善
(3) 「クォートされていない」の注は不要なので削除
(4) "often"を明示的に訳出
(5) 「普段使えない」は原文と意図が違うので修正
(6) variantの訳語を「変異体」から「異形」に変更
(7) 「XXの直前にYY」というタイプの表現を「YYの直後にXX」という表現に変更
(8) "less trivial"が誤訳されていたので修正、「前の例ほど重要度は低くない」という感じの意味ですが「少し意味のある」という訳をひねり出しました。
(9) サロゲートペア関連の説明で、訳し上げているため、文中で前方参照することになっていたのを、訳し下げることで理解しやすい文に修正。
(10) string constantが、なぜか「文字定数」となっていた部分がいくつかあったので「文字列定数」に訂正
