### PR TITLE
improve translation of "line"

### DIFF
--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -4816,10 +4816,13 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
 <!--
     <title>Lines</title>
 -->
-    <title>線</title>
+    <title>直線</title>
 
     <indexterm>
+<!--
      <primary>line</primary>
+-->
+     <primary>直線</primary>
     </indexterm>
 
     <para>
@@ -4829,10 +4832,8 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
      where <replaceable>A</> and <replaceable>B</> are not both zero.  Values
      of type <type>line</type> are input and output in the following form:
 -->
-線は以下の式で表現されます。
-等式　<replaceable>A</>x + <replaceable>B</>y + <replaceable>C</> = 0
-<replaceable>A</> と <replaceable>B</>は共に0ではありません。
- <type>line</type>型の値は以下の書式で入出力されます。
+直線は線形方程式<replaceable>A</>x + <replaceable>B</>y + <replaceable>C</> = 0で表現されます。ここで<replaceable>A</>と<replaceable>B</>は同時に0になることはありません。
+<type>line</type>型の値は以下の書式で入出力されます。
 <synopsis>
 { <replaceable>A</replaceable>, <replaceable>B</replaceable>, <replaceable>C</replaceable> }
 </synopsis>
@@ -4859,7 +4860,7 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
      <literal>(<replaceable>x1</replaceable>,<replaceable>y1</replaceable>)</literal>
 と
      <literal>(<replaceable>x2</replaceable>,<replaceable>y2</replaceable>)</literal>
-は1つの直線上の2つの異なる点です。
+はその直線上の2つの異なる点です。
     </para>
    </sect2>
 


### PR DESCRIPTION
lineの訳の部分の改善です。

線 -> 直線 は少しやり過ぎの気もしないでもないですが、元々の文でも変更部分の直後で「直線」とやっていますので悪くはないかなと。