### PR TITLE
delete ZENKAKU-spaces

### DIFF
--- a/doc/src/sgml/chkpass.sgml
+++ b/doc/src/sgml/chkpass.sgml
@@ -71,7 +71,7 @@
   Note that the <type>chkpass</type> data type is not indexable.
 -->
 <type>chkpass</type>データ型のインデックス付けができないことに注意してください。
-  <!--　原文コメント
+  <!-- 原文コメント
   I haven't worried about making this type indexable.  I doubt that anyone
   would ever need to sort a file in order of encrypted password.
   -->

--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -2530,12 +2530,12 @@ HOUR TO MINUTE
 HOUR TO SECOND
 MINUTE TO SECOND
 </literallayout>
-　　<!--
+<!--
     Note that if both <replaceable>fields</replaceable> and
     <replaceable>p</replaceable> are specified, the
     <replaceable>fields</replaceable> must include <literal>SECOND</>,
     since the precision applies only to the seconds.
-    -->
+-->
 <replaceable>fields</replaceable>および<replaceable>p</replaceable>が共に指定されると、精度は秒のみに適用されるので、<replaceable>fields</replaceable>は<literal>SECOND</>を含まなければならないことに注意してください。
    </para>
 
@@ -6929,9 +6929,7 @@ LSNは例えば、<literal>16/B374D848</>のように２つのスラッシュで
         <entry>Indicates that a function accepts any data type
         (see <xref linkend="extend-types-polymorphic">).</entry>
 -->
-<entry>関数がどのような入力データ型でも受け入れることを示します。
-(参照　 <xref linkend="extend-types-polymorphic">)
-</entry>
+<entry>関数がどのような入力データ型でも受け入れることを示します(<xref linkend="extend-types-polymorphic">を参照)。</entry>
        </row>
 
        <row>

--- a/doc/src/sgml/release-8.1.sgml
+++ b/doc/src/sgml/release-8.1.sgml
@@ -4301,7 +4301,7 @@ Fix backslash escaping in /contrib/dbmirror
 <!--
 Minor fixes in /contrib/dblink and /contrib/tsearch2
 -->
-contrib/dblink および /contrib/tsearch2　に多少の修正を加えました。
+contrib/dblinkおよび/contrib/tsearch2に多少の修正を加えました。
 </para>
 </listitem>
 <listitem><para>

--- a/doc/src/sgml/release-8.1.sgml
+++ b/doc/src/sgml/release-8.1.sgml
@@ -4301,7 +4301,7 @@ Fix backslash escaping in /contrib/dbmirror
 <!--
 Minor fixes in /contrib/dblink and /contrib/tsearch2
 -->
-contrib/dblinkおよび/contrib/tsearch2に多少の修正を加えました。
+/contrib/dblinkおよび/contrib/tsearch2に多少の修正を加えました。
 </para>
 </listitem>
 <listitem><para>


### PR DESCRIPTION
全角の空白を削除しました。特に問題を生みそうなところに入っていた訳ではないですが、予防措置です。ついでに訳も少し見直しています。

全角の空白は実はもう一ヶ所有りまして、そこは #470 でついでに直しています。