### PR TITLE
query.sgmlの誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/query.sgml
+++ b/doc/src/sgml/query.sgml
@@ -119,7 +119,7 @@
     operating systems form an example of a hierarchical database.  A
     more modern development is the object-oriented database.
 -->
-<productname>PostgreSQL</productname>は<firstterm>リレーショナルデータベースマネージメントシステム</firstterm>（<acronym>RDBMS</acronym>）です。
+<productname>PostgreSQL</productname>は<firstterm>リレーショナルデータベース管理システム</firstterm>（<acronym>RDBMS</acronym>）です。
 これは<firstterm>リレーション</firstterm>の中に格納されたデータを管理するシステムであることを意味しています。
 リレーションは基本的には<firstterm>テーブル</firstterm>を表す数学用語です。
 テーブルにデータを格納することは今日では平凡なことですので、わかりきったものだと思われるかもしれませんが、データベースを構成する方法には他にも多くの方式があります。
@@ -222,7 +222,7 @@ CREATE TABLE weather (
     above).
 -->
 SQLコマンドでは空白文字（つまり空白、タブ、改行）を自由に使用できます。
-つまり、上で示したコマンドとは異なる形で入力できることを意味します。
+つまり、上で示したコマンドとは異なる整列で入力しても良いことを意味します。
 全てを1行で入力することさえできます。
 連続した2つのハイフン（<quote><literal>--</literal></quote>）はコメントの始まりです。
 その後に入力したものは、行末まで無視されます。
@@ -243,8 +243,8 @@ SQLはキーワードと識別子に対して大文字小文字を区別しま�
 <type>varchar(80)</type>は、80文字までの任意の文字列を格納できるデータ型を指定しています。
 <type>int</type>は一般的な整数用の型です。
 <type>real</type>は単精度浮動小数点数値を格納する型です。
-<type>date</type>（日付）はその名前からわかるでしょう
-（わかると思いますが、<type>date</type>型の列は<structfield>date</structfield>と名付けられています。
+<type>date</type>はその名前からわかるとおり日付です。
+（わかると思いますが、<type>date</type>型の列の名前も<structfield>date</structfield>になっています。
 これはわかりやすいかもしれませんし、逆に混乱を招くかもしれません。
 これは好みによります）。
    </para>
@@ -381,7 +381,7 @@ INSERT INTO weather (date, city, temp_hi, temp_lo)
     Many developers consider explicitly listing the columns better
     style than relying on the order implicitly.
 -->
-多くの開発者は、暗黙的な順番に依存するよりも、列のリストを明示的に指定する方を好んで使用します。
+多くの開発者は、暗黙的な順番に依存するよりも、列のリストを明示的に指定する方が良いやり方だと考えています。
    </para>
 
    <para>
@@ -467,7 +467,7 @@ SELECT * FROM weather;
        queries, it is widely considered bad style in production code,
        since adding a column to the table would change the results.
 -->
-<literal>SELECT *</literal>は即興的な問い合わせで有用ですが、製品レベルのコードでは、テーブルに列を追加することにより結果が異なってしまいますので、通常好まれません。
+<literal>SELECT *</literal>は即興的な問い合わせで有用ですが、テーブルに列を追加することにより結果が変わってしまいますので、実用システムのコードでは悪いやり方であると一般的には考えられています。
       </para>
      </footnote>
 <!--


### PR DESCRIPTION
マニュアルの2.2節から2.4節の翻訳改善です。
(1) 他のファイルではすべて「データベース管理システム」でしたが、この1箇所だけ「データベースマネージメントシステム」だったので統一しました。
(2) alignedの訳の意味がわかりにくかったので、明確になるようにしました。
(3) date型の列名をdateにしているのが、この場だけの話なのに、一般的にそうするものだ、みたいに解釈されかねない訳文になっていたので、修正しました。
(4) considerの訳し方が不適切だったので修正しました。なお、widelyについてはちょっと悩みましたが、文字通りに「広く」としても意味がわかりにくいので、英英辞典にあった"by many people"なども参考に「一般的には」としました。