### PR TITLE
func.sgmlのマニュアル9.20節に該当する部分の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -16711,7 +16711,7 @@ NULL baz</literallayout>(3 rows)</entry>
    Consult <xref linkend="tutorial-agg"> for additional introductory
    information.
 -->
-<firstterm>集約関数</firstterm>は複数の入力値から単一の結果を計算します。
+<firstterm>集約関数</firstterm>は入力値の集合から単一の結果を計算します。
 <xref linkend="functions-aggregate-table">および<xref linkend="functions-aggregate-statistics-table">に通常の組み込み集約関数を示します。
 <xref linkend="functions-orderedset-table">および<xref linkend="functions-hypothetical-table">には組み込みの順序集合集約関数を示します。
 <xref linkend="functions-grouping-table">には、集約関数と密接に関係するグループ化演算を示します。
@@ -16802,9 +16802,12 @@ NULL baz</literallayout>(3 rows)</entry>
        <function>avg(<replaceable class="parameter">expression</replaceable>)</function>
       </entry>
       <entry>
+<!--
        <type>smallint</type>, <type>int</type>,
        <type>bigint</type>, <type>real</type>, <type>double
        precision</type>, <type>numeric</type>, or <type>interval</type>
+-->
+       <type>smallint</type>、<type>int</type>、<type>bigint</type>、<type>real</type>、<type>double precision</type>、<type>numeric</type>、または<type>interval</type>
       </entry>
       <entry>
 <!--
@@ -16828,8 +16831,11 @@ NULL baz</literallayout>(3 rows)</entry>
        <function>bit_and(<replaceable class="parameter">expression</replaceable>)</function>
       </entry>
       <entry>
+<!--
        <type>smallint</type>, <type>int</type>, <type>bigint</type>, or
        <type>bit</type>
+-->
+       <type>smallint</type>、<type>int</type>、<type>bigint</type>、または<type>bit</type>
       </entry>
       <entry>
 <!--
@@ -16925,7 +16931,10 @@ NULL baz</literallayout>(3 rows)</entry>
 
      <row>
       <entry><function>count(<replaceable class="parameter">expression</replaceable>)</function></entry>
+<!--
       <entry>any</entry>
+-->
+      <entry>任意の型</entry>
       <entry><type>bigint</type></entry>
       <entry>
 <!--
@@ -17009,7 +17018,7 @@ NULL baz</literallayout>(3 rows)</entry>
 <!--
       <entry>aggregates name/value pairs as a JSON object</entry>
 -->
-      <entry>名前/値の対をJSONオブジェクトとして集約</entry>
+      <entry>名前／値の対をJSONオブジェクトとして集約</entry>
      </row>
 
      <row>
@@ -17176,7 +17185,7 @@ NULL baz</literallayout>(3 rows)</entry>
 -->
 上記の関数は、<function>count</function>関数を除き、1行も選択されなかった場合NULL値を返すことに注意してください。
 特に、行の選択がない<function>sum</function>関数は、予想されるであろうゼロではなくNULLを返し、そして<function>array_agg</function>は、入力行が存在しない場合に、空配列ではなくNULLを返します。
-必要であれば、NULLをゼロまたは空配列と交換する目的で<function>coalesce</function>関数を使うことができます。
+必要であれば、NULLをゼロまたは空配列と置換する目的で<function>coalesce</function>関数を使うことができます。
   </para>
 
   <note>
@@ -17435,7 +17444,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
       <entry>average of the dependent variable
       (<literal>sum(<replaceable class="parameter">Y</replaceable>)/<replaceable class="parameter">N</replaceable></literal>)</entry>
 -->
-      <entry>依存変数の平均値
+      <entry>従属変数の平均値
       (<literal>sum(<replaceable class="parameter">Y</replaceable>)/<replaceable class="parameter">N</replaceable></literal>)</entry>
      </row>
 
@@ -17483,7 +17492,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
       class="parameter">X</replaceable>, <replaceable
       class="parameter">Y</replaceable>) pairs</entry>
 -->
-      <entry>(<replaceable class="parameter">X</replaceable>, <replaceable class="parameter">Y</replaceable>)の組み合わせで決まる、線型方程式に対する最小二乗法のY切片</entry>
+      <entry>(<replaceable class="parameter">X</replaceable>, <replaceable class="parameter">Y</replaceable>)の組み合わせで決まる、最小二乗法による線形方程式のY切片</entry>
      </row>
 
      <row>
@@ -17502,7 +17511,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
 <!--
       <entry>square of the correlation coefficient</entry>
 -->
-      <entry>相関係数自乗値</entry>
+      <entry>相関係数の二乗</entry>
      </row>
 
      <row>
@@ -17529,7 +17538,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
       by the (<replaceable class="parameter">X</replaceable>,
       <replaceable class="parameter">Y</replaceable>) pairs</entry>
 -->
-      <entry><replaceable class="parameter">X</replaceable>, <replaceable class="parameter">Y</replaceable>)の組み合わせで決まる、最小自乗法に合う線型方程式の傾き</entry>
+      <entry><replaceable class="parameter">X</replaceable>, <replaceable class="parameter">Y</replaceable>)の組み合わせで決まる、最小二乗法による線型方程式の傾き</entry>
      </row>
 
      <row>
@@ -17556,7 +17565,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
       class="parameter">X</replaceable>^2) - sum(<replaceable
       class="parameter">X</replaceable>)^2/<replaceable
       class="parameter">N</replaceable></literal>
-     （依存変数の<quote>二乗和</quote>）
+     （従属変数の<quote>二乗和</quote>）
      </entry>
      </row>
 
@@ -17589,7 +17598,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
       class="parameter">X</replaceable>) * sum(<replaceable
       class="parameter">Y</replaceable>)/<replaceable
       class="parameter">N</replaceable></literal> 
-     （依存変数×独立変数の<quote>和</quote>）
+     （従属変数と独立変数の<quote>積の和</quote>）
       </entry>
      </row>
 
@@ -17617,7 +17626,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
       class="parameter">Y</replaceable>^2) - sum(<replaceable
       class="parameter">Y</replaceable>)^2/<replaceable
       class="parameter">N</replaceable></literal>
-     （独立変数の<quote>自乗和</quote>）</entry>
+     （独立変数の<quote>二乗和</quote>）</entry>
      </row>
 
      <row>
@@ -17802,7 +17811,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
 <!--
       <entry>population variance of the input values (square of the population standard deviation)</entry>
 -->
-      <entry>入力値に対する母分散（母標準偏差の自乗）</entry>
+      <entry>入力値に対する母分散（母標準偏差の二乗）</entry>
      </row>
 
      <row>
@@ -18083,8 +18092,8 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
    simply produces a null result.
 -->
 <xref linkend="functions-orderedset-table">に列挙された集約はすべて整列された入力内のNULL値を無視します。
-<replaceable>fraction</replaceable>パラメータを取るものでは、割合値は0と1の間でなければなりません。そうでなければエラーが投げられます。
-しかしながら、割合値のNULLは単に結果のNULLを生じます。
+<replaceable>fraction</replaceable>パラメータを取るものでは、fraction（割合）の値は0と1の間でなければなりません。そうでなければエラーが投げられます。
+しかしながら、franctionの値がNULLなら単にNULLという結果になります。
   </para>
 
   <indexterm>
@@ -18108,7 +18117,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
    group of rows computed from the <replaceable>sorted_args</replaceable>.
 -->
 <xref linkend="functions-hypothetical-table">に列挙されている集約は、それぞれ<xref linkend="functions-window">で定義されている同じ名前のウィンドウ関数と関連します。
-それぞれの場合、集約結果は、そのような行が<replaceable>sorted_args</replaceable>から計算された行の整列されたグループに追加されるのであれば、<replaceable>args</replaceable>から構成される<quote>仮想の</>行のために関連するウィンドウ関数が返す値です。
+どの場合も、集約結果は、<replaceable>args</replaceable>から構築される<quote>仮想的な</>行に対して、関連するウィンドウ関数が返す値で、そのような行が<replaceable>sorted_args</replaceable>から計算されるソートされた行のグループに追加される場合を想定します。
   </para>
 
   <table id="functions-hypothetical-table">


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) "a set of"を「複数の」と訳していたのを「の集合」に修正。
(2) avg()とbit_and()の引数データの型で、原文中の"or"がそのままになっていたので、翻訳。なお、読点だけにして、"or"は明示的に訳出しないというのもアリだと思うが、他の部分に合わせて「または」とした。
(3) count()の引数データの型で、原文中の"any"がそのままになっていたので「任意の型」と翻訳。なお、"(type)any(/)"という形式のものも多数ある。「any型」というデータ型があるわけではないので、本質的には「任意の型」などと訳すべきだと思うが、これについては現状のままとした。
(4) 「名前／値」でスラッシュが全角のものと半角のものがあったので、全角に統一。
(5) "substitute"の訳語で「交換」は違和感が強かったので「置換」に変更。
(6) "dependent variable"の訳語が「依存変数」となっていたが、より一般的な「従属変数」に変更。
(7) "least-square-fit linear equation"について誤訳訂正。
(8) "square"の訳語で「自乗」と「二乗」が混在していたが、現代的な「二乗」で統一。
(9) 関数引数のfractionについて話をしているときに、「割合」という訳語だけが出てきても意味がわかりにくいので、1つ目は「fraction（割合）」、2つ目は単に「fraction」に変更。