### PR TITLE
start.sgmlのマニュアル1.3節の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/start.sgml
+++ b/doc/src/sgml/start.sgml
@@ -214,7 +214,7 @@
 -->
 データベースサーバにアクセスできるかどうかがわかる最初の試験は、データベースの作成を試みることです。
 稼働中の<productname>PostgreSQL</productname>サーバは多くのデータベースを管理することができます。
-典型的には、プロジェクトやユーザごとにデータベースは分割されます。
+典型的には、プロジェクトやユーザごとに別々のデータベースが使用されます。
    </para>
 
    <para>
@@ -225,7 +225,7 @@
     to the next section.
 -->
 サイト管理者により使用できるデータベースが既に作成されている場合もあります。
-その場合、管理者は使用できるデータベースの名前をユーザに通知しなければなりません。
+管理者から、使用できるデータベースの名前の通知があったことでしょう。
 この場合、この段階を飛ばして、次の節まで進んでください。
    </para>
 
@@ -259,7 +259,7 @@ createdb: command not found
     installed at all or your shell's search path was not set to include it.
     Try calling the command with an absolute path instead:
 -->
-インストールがまったくされていないか使用しているシェルの検索パスが盛り込むように設定されていないのいずれかです。
+<productname>PostgreSQL</>がインストールされていないか、シェルの検索パスに含まれていないのいずれかです。
 代わりに絶対パスでそのコマンドを実行してみてください。
 <screen>
 <prompt>$</prompt> <userinput>/usr/local/pgsql/bin/createdb mydb</userinput>
@@ -314,10 +314,10 @@ createdb: could not connect to database postgres: FATAL:  role "joe" does not ex
     switch or set the <envar>PGUSER</> environment variable to specify your
     <productname>PostgreSQL</> user name.
 -->
-今回はログインした時のユーザ名が記載されています。
+ここでjoeのところには、ログインした時のユーザ名が記載されています。
 これは、管理者がそのユーザ用の<productname>PostgreSQL</>ユーザアカウントを作成していない時に起こります
-（<productname>PostgreSQL</>ユーザアカウントは、オペレーティングシステムのユーザアカウントとは異なります）。
-管理者であれば、アカウントの作成方法に関して<xref linkend="user-manag">を参照してください。
+（<productname>PostgreSQL</>ユーザアカウントは、オペレーティングシステムのユーザアカウントとは別です）。
+自身が管理者なら、アカウントの作成方法に関して<xref linkend="user-manag">を参照してください。
 最初のユーザアカウントを作成するためには、<productname>PostgreSQL</>をインストールした時のオペレーティングシステムのユーザ（通常<literal>postgres</>）になる必要があります。
 <productname>PostgreSQL</>ユーザアカウントがオペレーティングシステムのユーザ名と異なる名前で用意されているかもしれません。
 その場合は、<productname>PostgreSQL</>のユーザ名を指定するために、<option>-U</>スイッチを使用するか、<envar>PGUSER</>環境変数を設定する必要があります。
@@ -342,9 +342,9 @@ createdb: database creation failed: ERROR:  permission denied to create database
     under the user account that you started the server as.
 -->
 全てのユーザがデータベースを新規に作成できる権限を持っているわけではありません。
-<productname>PostgreSQL</productname>がデータベースの作成を拒否した場合、サイト管理者はデータベースを作成する権限をユーザに付与する必要があります。
+<productname>PostgreSQL</productname>がデータベースの作成を拒否した場合、サイト管理者からデータベースを作成する権限を付与してもらう必要があります。
 これが発生した場合はサイト管理者に相談してください。
-自身で<productname>PostgreSQL</productname>をインストールしたのであれば、このチュートリアルの目的のために、サーバを起動したユーザアカウントでログインしなければなりません。
+自身で<productname>PostgreSQL</productname>をインストールしたのであれば、このチュートリアルを実行する時は、サーバを起動したユーザアカウントでログインしてください。
 
     <footnote>
      <para>
@@ -364,9 +364,9 @@ createdb: database creation failed: ERROR:  permission denied to create database
       a <productname>PostgreSQL</productname> user name to connect as.
 -->
 何故これで上手くいくのかについての説明：<productname>PostgreSQL</productname>のユーザ名はオペレーティングシステムのユーザアカウントとは分離されています。
-データベースに接続する場合、接続に利用する<productname>PostgreSQL</productname>のユーザ名を選択します。
+データベースに接続するとき、接続に利用する<productname>PostgreSQL</productname>のユーザ名を選択します。
 選択しなければ、デフォルトで現在のオペレーティングシステムのアカウントと同じ名前となります。
-これにより、サーバを起動するオペレーティングシステムのユーザと同じ名前の<productname>PostgreSQL</productname>ユーザアカウントは、常に存在します。 
+これにより、サーバを開始したオペレーティングシステムのユーザと同じ名前の<productname>PostgreSQL</productname>ユーザアカウントが、常に存在するようになっています。 
 そしてまた、このユーザは常にデータベースを作成する権限を持ちます。
 そのユーザとしてログインする代わりに、<option>-U</option>オプションを毎回使用して、接続する<productname>PostgreSQL</productname>のユーザ名を選択することができます。
      </para>


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) "separate database is used"の訳が誤解を招きかねないものだったので、原文に忠実なものにした。
(2) "should"を義務のように訳していたのを修正。
(3) 「シェルの検索パスに『盛り込む』」は違和感が強かったので、表現を修正。
(4) 「今回は」では意味がわからないので、「joeのところに」と原文にない言葉を入れてわかりやすくしたが、ちょっとやり過ぎかも？
(5) 「管理者であれば」は意味がわからないので、「自身が」を補った。なお、"you"を「あなた」と訳した方がこの文自体はわかりやすくなるが、全体的な見直しが必要になるので避けた。
(6) サイト管理者の義務みたいな表現は違和感があったので、表現を訂正。
(7) "started the server"の部分は「インスタンスを作成したユーザ」を指しているが、違う解釈になっていたのでて訂正。