### PR TITLE
fix typos in config.sgml

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -10173,17 +10173,17 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         スーパユーザのみこの設定を変更できます。       
        </para>
        <para>
-       <!--
+<!--
         Setting this variable does not disable all security checks related to
         large objects &mdash; only those for which the default behavior has
         changed in <productname>PostgreSQL</> 9.0.
         For example, <literal>lo_import()</literal> and
         <literal>lo_export()</literal> need superuser privileges regardless
         of this setting.
-       -->
-       この変数を設定してもラージオブジェクトに関連した全ての安全性チェックを無効にしません。
-       <productname>PostgreSQL</> 9.0.で変更されたデフォルトの動きに対してのみです。
-       例えば、<literal>lo_import()</literal>と<literal>lo_export()</literal>はこの設定に係わらずスーパユーザの権限を必要とします。
+-->
+この変数を設定してもラージオブジェクトに関連した全ての安全性チェックを無効にしません。
+<productname>PostgreSQL</> 9.0で変更されたデフォルトの動きに対してのみです。
+例えば、<literal>lo_import()</literal>と<literal>lo_export()</literal>はこの設定に係わらずスーパユーザの権限を必要とします。
        </para>
       </listitem>
      </varlistentry>
@@ -10210,13 +10210,16 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
 -->
 onの場合、演算子の優先順位の変更の結果、<productname>PostgreSQL</> 9.4以降で意味が変わる可能性のある構文に対して、パーサは警告を出力します。
 これは、優先順位の変更によりアプリケーションに何か不具合が起きないか監視するのに役立ちます。
-しかし、これはプロダクション環境でオンにしたままにしておくことを意味しません。
+しかし、これはプロダクション環境でオンにしたままにしておくためのものではありません。
 なぜなら、完全に正しいSQL標準準拠コードに対しても警告を発するからです。
 デフォルトは<literal>off</>です。
        </para>
 
        <para>
+<!--
         See <xref linkend="sql-precedence"> for more information.
+-->
+詳細は<xref linkend="sql-precedence">を見てください。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -10181,7 +10181,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         <literal>lo_export()</literal> need superuser privileges regardless
         of this setting.
 -->
-この変数を設定してもラージオブジェクトに関連した全ての安全性チェックを無効にしません。
+この変数を設定しても、ラージオブジェクトに関連した全ての安全性チェックを無効にする訳ではありません。
 <productname>PostgreSQL</> 9.0で変更されたデフォルトの動きに対してのみです。
 例えば、<literal>lo_import()</literal>と<literal>lo_export()</literal>はこの設定に係わらずスーパユーザの権限を必要とします。
        </para>


### PR DESCRIPTION
余分なピリオドの削除
be meant to do の訳の改善
訳漏れへの対応
です。
