### PR TITLE
query.sgmlで、原文にない文があるのを削除

### DIFF
--- a/doc/src/sgml/query.sgml
+++ b/doc/src/sgml/query.sgml
@@ -498,7 +498,7 @@ SELECT city, temp_lo, temp_hi, prcp, date FROM weather;
     You can write expressions, not just simple column references, in the
     select list.  For example, you can do:
 -->
-選択リストには、単なる列参照だけではなく任意の式を指定することができます。
+選択リストには、単なる列参照だけではなく式を指定することもできます。
 例えば、以下を行うことができます。
 <programlisting>
 SELECT city, (temp_hi+temp_lo)/2 AS temp_avg, date FROM weather;
@@ -623,7 +623,7 @@ SELECT DISTINCT city
     You can ensure consistent results by using <literal>DISTINCT</literal> and
     <literal>ORDER BY</literal> together:
 -->
-繰り返しますが、結果行の順序は変動するかもしれません。
+ここでも、結果行の順序は変動するかもしれません。
 <literal>DISTINCT</literal>と<literal>ORDER BY</literal>を一緒に使用することで確実に一貫した結果を得ることができます。
      <footnote>
       <para>
@@ -646,7 +646,6 @@ SELECT DISTINCT city
     FROM weather
     ORDER BY city;
 </programlisting>
-もちろん、<literal>DISTINCT</literal>および<literal>ORDER BY</literal>は単体でも使用することができます。 
    </para>
   </sect1>
 


### PR DESCRIPTION
2.5節に相当する部分ですが、最後に原文にない文が入っていたのを削除しました。
また、原文に忠実でない翻訳が2箇所あったので訂正しました。
(1) 単なる"expression"を「任意の式」としていたので「任意の」を削除、また、原文に"too"や"also"はありませんが、自然な日本語の文章になるように「を」を「も」に変更。
(2) "Here again"は、前言を繰り返すという意味ではなく、前と同じ現象がここでも発生しますよ、という意味なので、訳文を修正。