### PR TITLE
func.sgmlのウインドウ関数の節に関する誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -18411,7 +18411,7 @@ NULL値は<literal>ORDER BY</>節で指定されるルールに従って並べ�
    clause follows the call; otherwise they act as regular aggregates.
 -->
 これらの関数に加え、どんな組み込み、またはユーザ定義の通常の集約関数もウィンドウ関数として使用できます(ただし順序集合や仮想集合集約はそうではありません)。組み込み集約関数一覧は<xref linkend="functions-aggregate">を参照してください。
-集約関数は、呼び出しの後<literal>OVER</>句が続いた場合のみウィンドウ関数として動作します。それ以外、通常の集約関数として動作します。
+集約関数は、呼び出しの後に<literal>OVER</>句が続いた場合のみウィンドウ関数として動作します。それ以外の場合は、通常の集約関数として動作します。
   </para>
 
   <table id="functions-window-table">
@@ -18448,7 +18448,7 @@ NULL値は<literal>ORDER BY</>節で指定されるルールに従って並べ�
 <!--
       <entry>number of the current row within its partition, counting from 1</entry>
 -->
-      <entry>1から数えたパーティション内の現在行の数</entry>
+      <entry>現在行のパーティション内での行番号（１から数える）</entry>
      </row>
 
      <row>
@@ -18464,7 +18464,7 @@ NULL値は<literal>ORDER BY</>節で指定されるルールに従って並べ�
 <!--
       <entry>rank of the current row with gaps; same as <function>row_number</> of its first peer</entry>
 -->
-      <entry>ギャップを含んだ現在行の順位で、その最初の（対となる）ピアの<function>row_number</>と同一</entry>
+      <entry>ギャップを含んだ現在行の順位。先頭ピアの<function>row_number</>と同じになる。</entry>
      </row>
 
      <row>
@@ -18480,7 +18480,7 @@ NULL値は<literal>ORDER BY</>節で指定されるルールに従って並べ�
 <!--
       <entry>rank of the current row without gaps; this function counts peer groups</entry>
 -->
-      <entry>ギャップを含まない現在行の順位で、この関数は（対となる）ピアグループ数を計算する</entry>
+      <entry>ギャップを含まない現在行の順位、この関数はピアのグループ数を数える。</entry>
      </row>
 
      <row>
@@ -18512,7 +18512,7 @@ NULL値は<literal>ORDER BY</>節で指定されるルールに従って並べ�
 <!--
       <entry>relative rank of the current row: (number of rows preceding or peer with current row) / (total rows)</entry>
 -->
-      <entry>現在行の相対順位。 (先行する行または現在の行を持つピアの番号) / (総行数)</entry>
+      <entry>現在行の相対順位。 (現在行より先行する行およびピアの行数) / (総行数)</entry>
      </row>
 
      <row>
@@ -18529,7 +18529,7 @@ NULL値は<literal>ORDER BY</>節で指定されるルールに従って並べ�
       <entry>integer ranging from 1 to the argument value, dividing the
        partition as equally as possible</entry>
 -->
-       <entry>できるだけ等価にパーティションで割り算した、1から引数値までの整数</entry>
+       <entry>できるだけ等価にパーティションを分割した、1から引数値までの整数</entry>
      </row>
 
      <row>
@@ -18563,9 +18563,10 @@ NULL値は<literal>ORDER BY</>節で指定されるルールに従って並べ�
        <replaceable class="parameter">offset</replaceable> defaults to 1 and
        <replaceable class="parameter">default</replaceable> to null
 -->
-パーティション内の現在行より前の<replaceable class="parameter">offset</replaceable>行である行で評価された<replaceable class="parameter">value</replaceable>を返します。該当する行がない場合、その代わりとして<replaceable class="parameter">default</replaceable>(<replaceable class="parameter">value</replaceable>と同じ型でなければなりません)を返します。
-<replaceable class="parameter">offset</replaceable>と<replaceable class="parameter">default</replaceable>は共に現在行について評価されます。
-省略された場合、<replaceable class="parameter">offset</replaceable>は1となり、<replaceable class="parameter">default</replaceable>はNULLになります。
+パーティション内の現在行より<replaceable class="parameter">offset</replaceable>行だけ前の行で評価された<replaceable class="parameter">value</replaceable>を返す。
+該当する行がない場合、その代わりとして<replaceable class="parameter">default</replaceable>(<replaceable class="parameter">value</replaceable>と同じ型でなければならない)を返す。
+<replaceable class="parameter">offset</replaceable>と<replaceable class="parameter">default</replaceable>は共に現在行について評価される。
+省略された場合、<replaceable class="parameter">offset</replaceable>は1となり、<replaceable class="parameter">default</replaceable>はNULLになる。
       </entry>
      </row>
 
@@ -18600,9 +18601,10 @@ NULL値は<literal>ORDER BY</>節で指定されるルールに従って並べ�
        <replaceable class="parameter">offset</replaceable> defaults to 1 and
        <replaceable class="parameter">default</replaceable> to null
 -->
-パーティション内の現在行以降の<replaceable class="parameter">offset</replaceable>行である行で評価された<replaceable class="parameter">value</replaceable>を返します。該当する行がない場合、その代わりとして<replaceable class="parameter">default</replaceable>(<replaceable class="parameter">value</replaceable>と同じ型でなければなりません)を返します。
-<replaceable class="parameter">offset</replaceable>と<replaceable class="parameter">default</replaceable>は共に現在行について評価されます。
-省略された場合、<replaceable class="parameter">offset</replaceable>は1となり、<replaceable class="parameter">default</replaceable>はNULLになります。
+パーティション内の現在行より<replaceable class="parameter">offset</replaceable>行だけ後の行で評価された<replaceable class="parameter">value</replaceable>を返す。
+該当する行がない場合、その代わりとして<replaceable class="parameter">default</replaceable>(<replaceable class="parameter">value</replaceable>と同じ型でなければならない)を返す。
+<replaceable class="parameter">offset</replaceable>と<replaceable class="parameter">default</replaceable>は共に現在行について評価される。
+省略された場合、<replaceable class="parameter">offset</replaceable>は1となり、<replaceable class="parameter">default</replaceable>はNULLになる。
       </entry>
      </row>
 
@@ -18724,7 +18726,7 @@ NULL値は<literal>ORDER BY</>節で指定されるルールに従って並べ�
    Other frame specifications can be used to obtain other effects.
 -->
 集約関数をウィンドウ関数として使用する場合、現在の行のウィンドウフレーム内の行に渡って集約処理を行います。
-<literal>ORDER BY</>を付けた集約、および、デフォルトのウィンドウフレーム定義では、<quote>中間和</>のような動作を行います。これが望まれる場合もあれば、望まれない場合もあります。
+<literal>ORDER BY</>および、デフォルトのウィンドウフレーム定義を使用した集約では、<quote>中間和</>のような動作を行います。これが望まれる場合もあれば、望まれない場合もあります。
 パーティション全体に渡る集約処理を行うためには、<literal>ORDER BY</>を省略するか<literal>ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING</>を使用してください。
 他のフレーム指定を使用することで様々な結果を得ることができます。
   </para>


### PR DESCRIPTION
9.21節の誤訳訂正と翻訳改善、主な変更点は以下の通りです。
(1) rank(), dense_rank(), cume_dist()の説明の誤訳訂正
(2) ntile()の説明でdivideを「割り算」としていたのを「分割」に修正
(3) lag(), lead()のoffsetに関する説明を改善し、また他の関数の解説に合わせて、である調に統一
(4) "aggregate used with"の掛かり先の解釈が間違っていたのを修正
