### PR TITLE
delete inappropriate newlines

### DIFF
--- a/doc/src/sgml/high-availability.sgml
+++ b/doc/src/sgml/high-availability.sgml
@@ -2857,7 +2857,7 @@ if (!triggered)
          standby transactions whose snapshots can still <quote>see</> any of
          the rows to be removed.
 -->
-WALのバキュームクリーンアップレコードの適用は、その適用により削除されるすべての行を<quote>見る</>ことができるスナップショットを持つスタンバイでのトランザクションとコンフリクトします。
+WALからのバキュームクリーンアップレコードの適用は、その適用により削除される行のどれか1つでも<quote>見る</>ことができるスナップショットを持つスタンバイでのトランザクションとコンフリクトします。
         </para>
        </listitem>
        <listitem>

--- a/doc/src/sgml/high-availability.sgml
+++ b/doc/src/sgml/high-availability.sgml
@@ -2857,9 +2857,7 @@ if (!triggered)
          standby transactions whose snapshots can still <quote>see</> any of
          the rows to be removed.
 -->
-WALのバキュームクリーンアップレコードの適用は、その適用により削除さ
-れるすべての行を<quote>見る</>ことができるスナップショットを持つスタン
-バイでのトランザクションとコンフリクトします。
+WALのバキュームクリーンアップレコードの適用は、その適用により削除されるすべての行を<quote>見る</>ことができるスナップショットを持つスタンバイでのトランザクションとコンフリクトします。
         </para>
        </listitem>
        <listitem>


### PR DESCRIPTION
語の途中での改行を削除。

すみません、とってもせこいですが、、、、
日本語訳の途中での改行は好ましくないかな程度で済みますが、流石に語の途中での改行は許せないかな、と。
