### PR TITLE
improve translation of catalogs.sgml

### DIFF
--- a/doc/src/sgml/catalogs.sgml
+++ b/doc/src/sgml/catalogs.sgml
@@ -7195,9 +7195,9 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
        optimized away.)
 -->
 <structfield>provolatile</structfield>は、関数の結果が入力引数のみで決定されるか、または外部要素に影響されるかを示します。
-<literal>i</literal>は<quote>immutable</>関数を表し、同じ入力に対し常に同じ結果をもたらします。
-<literal>s</literal>は<quote>stable</>関数を表し、（固定入力に対する）結果はスキャン内で変わりません。
-<literal>v</literal>は<quote>volatile</>関数を表し、どのような場合にも結果は異なる可能性があります。
+<literal>i</literal>は<quote>immutable(不変)</>関数を表し、同じ入力に対し常に同じ結果をもたらします。
+<literal>s</literal>は<quote>stable(安定)</>関数を表し、（固定入力に対する）結果はスキャン内で変わりません。
+<literal>v</literal>は<quote>volatile(不安定)</>関数を表し、どのような場合にも結果は異なる可能性があります。
 （また、副作用を持つ関数に<literal>v</literal>を使用することで、その関数に対する呼び出しが最適化で消されないようにできます。）
       </entry>
      </row>

--- a/doc/src/sgml/catalogs.sgml
+++ b/doc/src/sgml/catalogs.sgml
@@ -1327,8 +1327,7 @@
    <structfield>amopsortfamily</structfield> column, which must reference
    a B-tree operator family for the operator's result type.
 -->
-<quote>順序付け</>用演算子の項目は、この演算子族のインデックスを
-<literal>ORDER BY</> <replaceable>indexed_column</> <replaceable>operator</> <replaceable>constant</>で表される順序で行を返すためのスキャンに使用することができることを示します。
+<quote>順序付け</>用演算子の項目は、この演算子族のインデックスを<literal>ORDER BY</> <replaceable>indexed_column</> <replaceable>operator</> <replaceable>constant</>で表される順序で行を返すためのスキャンに使用できることを示します。
 こうした演算子の左辺の入力型はインデックス列のデータ型に一致しなければならないことは同じですが、任意のソート可能なデータ型を返すことができます。
 <literal>ORDER BY</>の正確な意味は、この演算子の結果型用のB-tree演算子族を参照する必要がある<structfield>amopsortfamily</structfield>列により指定されます。
   </para>
@@ -7196,10 +7195,10 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
        optimized away.)
 -->
 <structfield>provolatile</structfield>は、関数の結果が入力引数のみで決定されるか、または外部要素に影響されるかを示します。
-<quote>immutable</>関数を表す<literal>i</literal>は同じ入力に対し常に同じ結果をもたらします。
-<quote>stable</>関数を表す<literal>s</literal>は（固定入力に対する）結果はスキャン内で変わりません。
-<quote>volatile</>関数を表す<literal>v</literal>は常に異なる結果を出す可能性があります
-（また、副作用を持つ関数に<literal>v</literal>を使用することで、その関数に対する呼び出しが最適化されないようにすることができます）。
+<literal>i</literal>は<quote>immutable</>関数を表し、同じ入力に対し常に同じ結果をもたらします。
+<literal>s</literal>は<quote>stable</>関数を表し、（固定入力に対する）結果はスキャン内で変わりません。
+<literal>v</literal>は<quote>volatile</>関数を表し、どのような場合にも結果は異なる可能性があります。
+（また、副作用を持つ関数に<literal>v</literal>を使用することで、その関数に対する呼び出しが最適化で消されないようにできます。）
       </entry>
      </row>
 
@@ -10139,7 +10138,7 @@ N番目の<quote>スロット</quote>に保存されている統計情報を引�
        Zero for non-composite types.
 -->
 もしこれが複合型（<structname>typtype</structname>を参照）であれば、この列は関連するテーブルを定義する<structfield>pg_class</structfield>項目を指します。
-（独立の複合型の場合、<structname>pg_class</structname>項目は実際にはテーブルを表しませんが、いずれにしても型の<structname>pg_attribute</structname>項目をリンクするために必要です）
+（独立の複合型の場合、<structname>pg_class</structname>項目は実際にはテーブルを表しませんが、いずれにしても型の<structname>pg_attribute</structname>項目をリンクするために必要です。）
 複合型でない場合はゼロです。
       </entry>
      </row>


### PR DESCRIPTION
catalogs.sgmlの翻訳の改善です。
（読んでいるうちに改善になっているかだんだん自信がなくなってきましたが、とにかくPR）

合わせて、
-  余分な改行の削除
- 「。」の追加
もしています。