### PR TITLE
advanced.sgml(3章)の3.2節(ビュー)までの誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/advanced.sgml
+++ b/doc/src/sgml/advanced.sgml
@@ -24,7 +24,7 @@
 -->
 前章では、<productname>PostgreSQL</productname>で<acronym>SQL</acronym>を使用してデータを保存したりアクセスしたりする基本について説明しました。
 ここでは、管理を単純化しデータの喪失や破壊を防止する<acronym>SQL</acronym>のいくつかのより高度な機能について論議します。
-最後に<productname>PostgreSQL</productname>のくつかの拡張に触れます。
+最後に<productname>PostgreSQL</productname>のいくつかの拡張に触れます。
    </para>
 
    <para>

--- a/doc/src/sgml/advanced.sgml
+++ b/doc/src/sgml/advanced.sgml
@@ -24,7 +24,7 @@
 -->
 前章では、<productname>PostgreSQL</productname>で<acronym>SQL</acronym>を使用してデータを保存したりアクセスしたりする基本について説明しました。
 ここでは、管理を単純化しデータの喪失や破壊を防止する<acronym>SQL</acronym>のいくつかのより高度な機能について論議します。
-最後に<productname>PostgreSQL</productname>が拡張しているいくらかの機能に触れます。
+最後に<productname>PostgreSQL</productname>のくつかの拡張に触れます。
    </para>
 
    <para>
@@ -39,7 +39,7 @@
     how to use the file.)
 -->
 本章では折々<xref linkend="tutorial-sql">にある例題に変更や改善を加えますので、その章を読んでおくことは役立ちます。
-本章にあるいくつかの例題は、配付物を解凍した時にできるsrc/tutorialディレクトリの<filename>advanced.sql</filename>に入っています。ここでは繰り返しませんが、このファイルにはロードして使ってみることができるサンプルデータもあります。
+本章にあるいくつかの例題は、配付物を解凍した時にできるtutorialディレクトリの<filename>advanced.sql</filename>に入っています。ここでは繰り返しませんが、このファイルにはロードして使ってみることができるサンプルデータもあります。
 （ファイルの使い方は<xref linkend="tutorial-sql-intro">を参照してください。）
    </para>
   </sect1>
@@ -68,8 +68,8 @@
     the query that you can refer to like an ordinary table:
 -->
 <xref linkend="tutorial-join">の問い合わせをもう一度参照してください。
-天候の記録と都市の所在場所の組み合わせ一覧を得ることが今作っているアプリケーションにとって特に重要なのですが、この組み合わせの一覧を必要とする度に問い合わせを打ち込みたくはないとしましょう。
-結果を求める問い合わせに対して<firstterm>ビュー</firstterm>を作成し、名前を付けると、通常のテーブル参照のように結果を入手できるようになります。
+天候の記録と都市の所在場所を結合したリストを得ることが今作っているアプリケーションにとって特に重要なのですが、この結合リストを必要とする度に問い合わせを打ち込みたくはないとしましょう。
+この問い合わせに対して<firstterm>ビュー</firstterm>を作成し、通常のテーブルのように参照できる問い合わせに名前を付けることができます。
 
 <programlisting>
 CREATE VIEW myview AS
@@ -88,7 +88,7 @@ SELECT * FROM myview;
     structure of your tables, which might change as your application
     evolves, behind consistent interfaces.
 -->
-SQLデータベースを設計する上で押さえておかなければならないのは、ビューを自由に使えるようにするという項目です。
+ビューを自由に利用することは、SQLデータベースの良い設計における重要な項目です。
 ビューはテーブル構造の詳細をカプセル化しますので、アプリケーションが発展するに従いテーブル構造が変わったとしても、一貫したインタフェースを保てます。
    </para>
 
@@ -97,7 +97,8 @@ SQLデータベースを設計する上で押さえておかなければなら�
     Views can be used in almost any place a real table can be used.
     Building views upon other views is not uncommon.
 -->
-ビューは実テーブルが使用できるほとんどの場合で使えます。他のビューに対するビューの作成も珍しくはありません。
+ビューは実テーブルが使用できるほとんどの場所で使えます。
+他のビューに対するビューの作成も珍しくはありません。
    </para>
   </sect1>
 

--- a/doc/src/sgml/advanced.sgml
+++ b/doc/src/sgml/advanced.sgml
@@ -38,8 +38,8 @@
     repeated here.  (Refer to <xref linkend="tutorial-sql-intro"> for
     how to use the file.)
 -->
-本章では折々<xref linkend="tutorial-sql">にある例題に変更や改善を加えますので、その章を読んでおくことは役立ちます。
-本章にあるいくつかの例題は、配付物を解凍した時にできるtutorialディレクトリの<filename>advanced.sql</filename>に入っています。ここでは繰り返しませんが、このファイルにはロードして使ってみることができるサンプルデータもあります。
+本章では折々<xref linkend="tutorial-sql">にある例に変更や改善を加えますので、その章を読んでおくことは役立ちます。
+本章にあるいくつかの例は、tutorialディレクトリの<filename>advanced.sql</filename>に入っています。ここでは繰り返しませんが、このファイルにはロードして使ってみることができるサンプルデータもあります。
 （ファイルの使い方は<xref linkend="tutorial-sql-intro">を参照してください。）
    </para>
   </sect1>
@@ -193,8 +193,8 @@ DETAIL:  Key (city)=(Berkeley) is not present in table "cities".
     foreign keys will definitely improve the quality of your database
     applications, so you are strongly encouraged to learn about them.
 -->
-外部キーによる振舞いでアプリケーションが見事にチューニングされました。
-このチュートリアルではこの簡単な例題より先には進みませんが、さらに情報がほしい方は<xref linkend="ddl">をご覧ください。
+外部キーの動作はアプリケーションごとに細かく調整できます。
+このチュートリアルではこの簡単な例より先には進みませんが、さらに情報がほしい方は<xref linkend="ddl">をご覧ください。
 外部キーを正しく使用するようにすると、間違いなくデータベースアプリケーションの質を向上させますので身に付くように励んでください。
    </para>
   </sect1>


### PR DESCRIPTION
誤訳の訂正、原文と微妙に意味が違うものについて原文になるべく忠実になるような修正を行いました。
(1) "some extensions"はこのままでも良かったかな、と思いつつ、違和感があったので修正しました。
(2) ディレクトリ名で原文には"src/"が付いていなかったので削除
(3) "combined listing"の訳し方を修正、また、ビューの説明を原文に忠実な文に修正
(4) "Making liberal use..."の文の意図が原文と違うように感じたので訳し直し
(5) "place"が「場合」になっていたので「場所」に修正し、ついでに、改行を挿入