### PR TITLE
improve translation of xplang

### DIFF
--- a/doc/src/sgml/xplang.sgml
+++ b/doc/src/sgml/xplang.sgml
@@ -328,9 +328,9 @@ CREATE TRUSTED PROCEDURAL LANGUAGE plperl
     <application>PL/PythonU</> handler is installed if Python support is
     configured, but these languages are not installed by default.
 -->
-デフォルトの<productname>PostgreSQL</productname>インストレーションでは、<application>PL/pgSQL</application>言語用のハンドラは構築され、<quote>library</quote>ディレクトリにインストールされます。
+デフォルトの<productname>PostgreSQL</productname>インストレーションでは、<application>PL/pgSQL</application>言語用のハンドラは構築され、<quote>ライブラリ</quote>ディレクトリにインストールされます。
 さらに、<application>PL/pgSQL</application>言語自体がデータベースすべてにインストールされます。
-<application>Tcl</>のサポート付きで構築した場合、<application>PL/Tcl</>と<application>PL/TclU</>用のハンドラも構築され同じ場所にインストールされますが、言語自体はデフォルトではどのデータベースにもインストールされません．
+<application>Tcl</>のサポート付きで構築した場合、<application>PL/Tcl</>と<application>PL/TclU</>用のハンドラも構築されライブラリディレクトリにインストールされますが、言語自体はデフォルトではどのデータベースにもインストールされません。
 同様に、Perlサポート付きで構築した場合は<application>PL/Perl</>と<application>PL/PerlU</>ハンドラが、Pythonサポート付きで構築した場合は<application>PL/PythonU</>ハンドラが構築され、インストールされますが、言語自体はデフォルトではインストールされません。
    </para>
 


### PR DESCRIPTION
xplang の訳の改善です。
libraryは引用符で囲まれていますが、libraryという名前のディレクトリがあるわけではない（あるのはlib）ので、「ライブラリ」としています。
ついでに . -> 。もやってます。
