### PR TITLE
syntax.sgml（主に4.2.3節：添え字）の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -1910,7 +1910,7 @@ SELECT 3 OPERATOR(pg_catalog.+) 4;
       A positional parameter reference, in the body of a function definition
       or prepared statement
 -->
-関数宣言の本体やプリペアド文における、位置パラメータ参照
+関数定義の本体やプリペアド文における、位置パラメータ参照
      </para>
     </listitem>
 
@@ -2083,7 +2083,7 @@ SELECT 3 OPERATOR(pg_catalog.+) 4;
     is unique across all the tables being used in the current query.  (See also <xref linkend="queries">.)
 -->
 <replaceable>correlation</replaceable>は、テーブル名（スキーマで修飾されている場合もあります）、あるいは<literal>FROM</literal>句で定義されたテーブルの別名です。
-相関名と区切り用のドットは、もし列名が現在の問い合わせで使われる全てのテーブルを通して一意である場合は省略することができます。
+correlationの名前と区切り用のドットは、もし列名が現在の問い合わせで使われる全てのテーブルを通して一意である場合は省略することができます。
 （<xref linkend="queries">も参照してください）。
    </para>
   </sect2>
@@ -2166,7 +2166,7 @@ CREATE FUNCTION dept(text) RETURNS dept
     If an expression yields a value of an array type, then a specific
     element of the array value can be extracted by writing
 -->
-配列の値を与える式の場合、特定の配列要素の値は以下のように記述することで展開されます。
+式が配列型の値となる場合、配列値の特定要素は以下のように記述することで抽出できます。
 <synopsis>
 <replaceable>expression</replaceable>[<replaceable>subscript</replaceable>]
 </synopsis>
@@ -2174,7 +2174,7 @@ CREATE FUNCTION dept(text) RETURNS dept
     or multiple adjacent elements (an <quote>array slice</>) can be extracted
     by writing
 -->
-また、複数の要素をまたがる（<quote>配列の一部分</>）場合は以下のように記述することで展開されます。
+また、隣接する複数の要素（<quote>配列の一部分</>）は以下のように記述することで抽出できます。
 <synopsis>
 <replaceable>expression</replaceable>[<replaceable>lower_subscript</replaceable>:<replaceable>upper_subscript</replaceable>]
 </synopsis>
@@ -2183,8 +2183,8 @@ CREATE FUNCTION dept(text) RETURNS dept
     Each <replaceable>subscript</replaceable> is itself an expression,
     which must yield an integer value.
 -->
-（ここで大括弧<literal>[ ]</literal>はリテラルとして現れています。）
-各<replaceable>subscript</replaceable>は自身が式であり、整数値を生成しなければなりません。
+（ここで大括弧<literal>[ ]</literal>は文字通りに記述してください（訳注：オプション部分を表す大括弧ではありません）。）
+各<replaceable>subscript</replaceable>はそれ自体が式であり、整数値を生成しなければなりません。
    </para>
 
    <para>
@@ -2196,7 +2196,7 @@ CREATE FUNCTION dept(text) RETURNS dept
     is multidimensional.
     For example:
 -->
-一般的には、配列<replaceable>expression</replaceable>は括弧で括らなければなりませんが、添字が付いた式が単なる列参照や位置パラメータであった場合、その括弧を省略することができます。
+一般的には、配列<replaceable>expression</replaceable>は括弧で括らなければなりませんが、添字が付けるそのexpressionが単なる列参照や位置パラメータであった場合、その括弧を省略することができます。
 以下に例を示します。
 
 <programlisting>

--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -2183,7 +2183,7 @@ CREATE FUNCTION dept(text) RETURNS dept
     Each <replaceable>subscript</replaceable> is itself an expression,
     which must yield an integer value.
 -->
-（ここで大括弧<literal>[ ]</literal>は文字通りに記述してください（訳注：オプション部分を表す大括弧ではありません）。）
+（ここで大括弧<literal>[ ]</literal>は文字通りに記述してください（訳注：これはオプション部分を表す大括弧ではありません）。）
 各<replaceable>subscript</replaceable>はそれ自体が式であり、整数値を生成しなければなりません。
    </para>
 
@@ -2196,7 +2196,7 @@ CREATE FUNCTION dept(text) RETURNS dept
     is multidimensional.
     For example:
 -->
-一般的には、配列<replaceable>expression</replaceable>は括弧で括らなければなりませんが、添字が付けるそのexpressionが単なる列参照や位置パラメータであった場合、その括弧を省略することができます。
+一般的には、配列<replaceable>expression</replaceable>は括弧で括らなければなりませんが、添字を付けるそのexpressionが単なる列参照や位置パラメータであった場合、その括弧を省略することができます。
 以下に例を示します。
 
 <programlisting>

--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -2197,6 +2197,7 @@ CREATE FUNCTION dept(text) RETURNS dept
     For example:
 -->
 一般的には、配列<replaceable>expression</replaceable>は括弧で括らなければなりませんが、添字を付けるそのexpressionが単なる列参照や位置パラメータであった場合、その括弧を省略することができます。
+また、元の配列が多次元の場合は複数の添字を連結することができます。
 以下に例を示します。
 
 <programlisting>


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) 4.2節で"function definition"の訳語を「関数宣言」→「関数定義」とした。
(2) 4.2.1節で"correlation.columnname"の説明をしているときに、"correlation name"を「相関名」としても意味が通じないので、"correlationの名前」とした。
(3) 4.2.3節の訳文を全面的に見直した。
