### PR TITLE
syntax.sgml(主に4.2.6)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -2233,7 +2233,7 @@ $1[10:42]
     If an expression yields a value of a composite type (row type), then a
     specific field of the row can be extracted by writing
 -->
-式が複合型（行型）の値を生成する場合、行の特定のフィールドは以下のように記述することで展開できます。
+式が複合型（行型）の値を生成する場合、行の特定のフィールドは以下のように記述することで抽出できます。
 <synopsis>
 <replaceable>expression</replaceable>.<replaceable>fieldname</replaceable>
 </synopsis>
@@ -2261,7 +2261,8 @@ $1.somecolumn
     of the field selection syntax.)  An important special case is
     extracting a field from a table column that is of a composite type:
 -->
-   （したがって、修飾された列参照は実際のところ、単なるこのフィールド選択構文の特殊な場合です。）重要となる特殊な場合としては、複合型のテーブル列からフィールドを抽出するときです。
+（したがって、修飾された列参照は実際のところ、単なるこのフィールド選択構文の特殊な場合です。）
+重要となる特殊な場合としては、複合型のテーブル列からフィールドを抽出するときです。
 
 <programlisting>
 (compositecol).somefield
@@ -2274,7 +2275,7 @@ $1.somecolumn
     or that <structname>mytable</> is a table name not a schema name
     in the second case.
 -->
-    <structfield>compositecol</>がテーブル名でなく列名であること、または２番目の場合の<structname>mytable</>がスキーマ名でなくテーブル名であることを示すため丸括弧が要求されます。
+<structfield>compositecol</>がテーブル名でなく列名であること、または２番目の場合の<structname>mytable</>がスキーマ名でなくテーブル名であることを示すため丸括弧が要求されます。
    </para>
 
    <para>
@@ -2408,7 +2409,11 @@ sqrt(2)
      emulate <quote>computed fields</>.  For more information see
      <xref linkend="xfunc-sql-composite-functions">.
 -->
-複合型の単一引数をとる関数はフィールド選択構文をオプショナルに使って呼び出すことができます。反対に関数形式でフィールド選択を記述することもできます。この記述方法は<literal>col(table)</>や<literal>table.col</>となり、どちらを使っても変わりありません。<productname>PostgreSQL</>では<quote>計算された領域</>のエミュレートをする関数の利用が可能なため、これはSQL標準の振る舞いではなく<productname>PostgreSQL</>独自機能となります。詳しくは<xref linkend="xfunc-sql-composite-functions">を参照してください。
+複合型の単一引数をとる関数はフィールド選択の構文を使っても呼び出すことができます。
+反対にフィールド選択を関数形式で記述することもできます。
+つまり、<literal>col(table)</>や<literal>table.col</>のどちらを使っても良いということです。
+この動作は標準SQLにはありませんが、<productname>PostgreSQL</>では、これにより<quote>計算されたフィールド</>のエミュレートをする関数の利用が可能になるため、提供しています。
+詳しくは<xref linkend="xfunc-sql-composite-functions">を参照してください。
     </para>
    </note>
   </sect2>


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) extractを「展開」と訳していたので、「抽出」に訂正
(2) 行頭にあった空白を削除し、さらに句点で改行。
(3) 4.2.6節の注記の翻訳を全面的に見直し