### PR TITLE
ddl.sgml(主に5.1-5.2節)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -76,7 +76,7 @@ SQLではテーブル内の行の順序は保証されません。
 テーブルを読み込むと、明示的に並び替えが要求されない限り、行は不特定な順序で返されます。
 これについては<xref linkend="queries">を参照してください。
 さらに、SQLでは行に固有の識別子が割り当てられないので、テーブル内にまったく同一の行がいくつも存在することがあり得ます。
-これは、SQLの基礎をなす算術モデルの結果ですが、通常は好ましいことではありません。
+これは、SQLの基礎をなす数学的モデルの帰結ですが、通常は好ましいことではありません。
 この問題の対処法については、本章で後述します。
   </para>
 
@@ -162,7 +162,7 @@ CREATE TABLE my_first_table (
 最初の列の名前は<literal>first_column</literal>で、そのデータ型は<type>text</type>です。
 2番目の列の名前は<literal>second_column</literal>で、そのデータ型は<type>integer</type>です。
 テーブル名および列名は、<xref linkend="sql-syntax-identifiers">で説明した識別子の構文に従います。
-通常、型名は識別子でもありますが、例外もあります。
+型名も通常は識別子ですが、例外もあります。
 列リストはカンマで区切り、括弧で囲むことに注意してください。
   </para>
 
@@ -198,7 +198,7 @@ CREATE TABLE products (
     instance, there is a choice of using singular or plural nouns for
     table names, both of which are favored by some theorist or other.
 -->
-相関するテーブルを数多く作成する場合は、テーブルと列の名前を一貫させるのが賢明です。
+相関するテーブルを数多く作成する場合は、テーブルと列の命名規則を一貫させるのが賢明です。
 例えば、テーブル名に単数形あるいは複数形どちらの名詞を使用するかという選択肢があります（これは論者によって好みが分かれています）。
    </para>
   </tip>
@@ -354,7 +354,8 @@ CREATE TABLE products (
    linkend="functions-sequence">). This arrangement is sufficiently common
    that there's a special shorthand for it:
 -->
-ここで、<literal>nextval()</>関数が、<firstterm>シーケンスオブジェクト</>から連続した値を生成します（<xref linkend="functions-sequence">を参照してください）。特に省略した形として以下のようにも記述できます。
+ここで、<literal>nextval()</>関数が、<firstterm>シーケンスオブジェクト</>から連続した値を生成します（<xref linkend="functions-sequence">を参照してください）。
+これは非常によく使われるやり方なので、以下のような特別な短縮記法が用意されています。
 <programlisting>
 CREATE TABLE products (
     product_no <emphasis>SERIAL</emphasis>,


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) "a consequence of the mathematical model"の訳語に違和感があったので、一般的と思われる「数学的モデルの帰結」としました。
(2) "also"の掛かり先の解釈が誤っていたので、訳文を修正しました。
(3) "naming pattern"の"pattern"が訳出されていなかったので、訳文を修正しました。
(4) "This arrangement is sufficiently common"という節が訳出されていないようだったので、訳出すると同時に、文全体の訳を修正しました。