### PR TITLE
func.sgml(9.22節)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -18815,7 +18815,7 @@ EXISTS (<replaceable>subquery</replaceable>)
    <quote>true</>; if the subquery returns no rows, the result of <token>EXISTS</token>
    is <quote>false</>.
 -->
-<token>EXISTS</token>の引数は、任意の<command>SELECT</>文または<firstterm>副問い合わせ</firstterm>です。
+<token>EXISTS</token>の引数は、任意の<command>SELECT</>文、つまり<firstterm>副問い合わせ</firstterm>です。
 副問い合わせはそれが何らかの行を返すか否かの決定のために評価されます。
 もし1つでも行を返すのであれば、<token>EXISTS</token>の結果は<quote>true（真）</>となり、副問い合わせが行を返さない場合、<token>EXISTS</token>の結果は<quote>false（偽）</>となります。
   </para>
@@ -18908,7 +18908,7 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
    As with <token>EXISTS</token>, it's unwise to assume that the subquery will
    be evaluated completely.
 -->
-<token>EXISTS</token>と同様、副問い合わせが完全に評価されると前提してはなりません。
+<token>EXISTS</token>と同様、副問い合わせが完全に評価されることを前提としてはなりません。
   </para>
 
 <synopsis>
@@ -18944,8 +18944,10 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
    If all the per-row results are either unequal or null, with at least one
    null, then the result of <token>IN</token> is null.
 -->
-行にあるNULL値はいつもSQLの論理式の標準規則で結合されます。
-２つの行は対応する全ての構成要素が非NULLかつ等しい場合に等しいとみなされます。１つでも対応する構成要素が非NULLかつ等しくないものがあれば、２つの行は等しくないとみなされます。それ以外その行の比較結果は不明（NULL）です。
+通常通り、行にあるNULL値はSQLの論理式の標準規則で結合されます。
+２つの行は対応する全ての構成要素が非NULLかつ等しい場合に等しいとみなされます。
+１つでも対応する構成要素が非NULLかつ等しくないものがあれば、２つの行は等しくないとみなされます。
+それ以外の場合、その行の比較結果は不明（NULL）です。
 行毎の結果すべてが不等もしくはNULLの場合、少なくとも１つのNULLがあると、<token>IN</token>の結果はNULLとなります。
   </para>
   </sect2>
@@ -18968,7 +18970,7 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
 -->
 右辺は括弧で括られた副問い合わせで、正確に１つの列を返さなければなりません。
 左辺の式は副問い合わせ結果の行それぞれに対して評価、比較されます。
-（副問い合わせが行を返さない場合を含む）等しくない副問い合わせの行だけがあると、<token>NOT IN</token>の結果は<quote>true（真）</>です。
+等しくない副問い合わせの行だけがある（副問い合わせが行を返さない場合を含む）と、<token>NOT IN</token>の結果は<quote>true（真）</>です。
 等しい行が1つでもあれば、結果は<quote>false（偽）</>です。
   </para>
 
@@ -18989,7 +18991,7 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
    As with <token>EXISTS</token>, it's unwise to assume that the subquery will
    be evaluated completely.
 -->
-<token>EXISTS</token>と同様、副問い合わせが完全に評価されると前提してはなりません。
+<token>EXISTS</token>と同様、副問い合わせが完全に評価されることを前提としてはなりません。
   </para>
 
 <synopsis>
@@ -19011,7 +19013,7 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
 <token>NOT IN</token>のこの形式の左辺は、<xref linkend="sql-syntax-row-constructors">で説明する行コンストラクタです。
 右辺は括弧で括られた副問い合わせで、左辺の行にある式の数と正確に同じ数の列を返さなければなりません。
 左辺の式は副問い合わせの結果のそれぞれの行に対し、評価、比較が行われます。
-（副問い合わせが行を返さない場合を含め）副問い合わせの行に不等のもののみが見つかった場合、<token>NOT IN</token>の結果は<quote>true（真）</>となります。
+副問い合わせの行に不等のもののみが見つかった場合（副問い合わせが行を返さない場合を含む）、<token>NOT IN</token>の結果は<quote>true（真）</>となります。
 等しい行が１つでも見つかった場合、結果は<quote>false（偽）</>です。
   </para>
 
@@ -19025,8 +19027,10 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
    If all the per-row results are either unequal or null, with at least one
    null, then the result of <token>NOT IN</token> is null.
 -->
-行にあるNULL値はいつもSQLの論理式の標準規則で結合されます。
-2つの行は対応する全ての構成要素が非NULLかつ等しい場合に等しいとみなされます。１つでも構成要素が非NULLかつ等しくない場合、２つの行は等しくないとみなされます。それ以外その行の比較結果は不明（NULL）です。
+通常通り、行にあるNULL値はSQLの論理式の標準規則で結合されます。
+2つの行は対応する全ての構成要素が非NULLかつ等しい場合に等しいとみなされます。
+１つでも構成要素が非NULLかつ等しくない場合、２つの行は等しくないとみなされます。
+それ以外の場合、その行の比較結果は不明（NULL）です。
 行毎の結果すべてが不等もしくはNULLの場合、少なくとも1つのNULLがあると、<token>NOT IN</token>の結果はNULLとなります。
   </para>
   </sect2>
@@ -19053,7 +19057,7 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
 右辺は括弧で括られた副問い合わせで、正確に1つの列を返さなければなりません。
 左辺の式は副問い合わせの結果行それぞれに対して、指定された<replaceable>operator</replaceable>を使用して評価、比較されます。なお、<replaceable>operator</replaceable>は結果として論理値を生成する必要があります。
 真の結果が１つでもあると、<token>ANY</token>の結果は<quote>true（真）</>です。
-（副問い合わせが行を返さない場合を含む）真の結果がないと、結果は<quote>false（偽）</>です。
+真の結果がない（副問い合わせが行を返さない場合を含む）と、結果は<quote>false（偽）</>です。
   </para>
 
   <para>
@@ -19110,8 +19114,8 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
 <token>ANY</token>のこの形式の左辺は、<xref linkend="sql-syntax-row-constructors">で説明されている行コンストラクタです。
 右辺は括弧で括られた副問い合わせで、左辺の行にある式の数と正確に同じ数の列を返さなければなりません。
 左辺の式は副問い合わせの結果のそれぞれの行に対し、与えられた<replaceable>operator</replaceable>を使用して行に関する評価、比較が行われます。
-比較の結果、副問い合わせのいかなる行に対して真となる場合、<token>ANY</token>の結果は<quote>true（真）</>です。
-比較の結果、副問い合わせの全ての行に対して偽となる場合（副問い合わせが行を返さないという場合も含めて）、結果は<quote>false（偽）</>です。
+比較の結果、副問い合わせの行のどれかに対して真となる場合、<token>ANY</token>の結果は<quote>true（真）</>です。
+比較の結果、副問い合わせの全ての行に対して偽となる場合（副問い合わせが行を返さないという場合も含む）、結果は<quote>false（偽）</>です。
 比較の結果、いかなる行でも真を返さず、かつ、少なくとも１つの行がNULLを返す場合、結果はNULLになります。
   </para>
 
@@ -19146,9 +19150,9 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
 -->
 右辺は括弧で括られた副問い合わせで、正確に１つの列を返さなければなりません。
 左辺の式は副問い合わせの結果行それぞれに対して、指定された<replaceable>operator</replaceable>を使用して評価、比較されます。なお、<replaceable>operator</replaceable>は結果として論理値を生成する必要があります。
-（副問い合わせが行を返さない場合を含む）全ての行が真になる場合、<token>ALL</token>の結果は<quote>true（真）</>です。
+全ての行が真になる場合（副問い合わせが行を返さない場合を含む）、<token>ALL</token>の結果は<quote>true（真）</>です。
 1つでも偽の結果があると、結果は<quote>false（偽）</>です。
-比較がすべての行で偽を返さず、かつ、少なくとも1つの行でNULLを返した場合、結果はNULLとなります。
+比較がどの行でも偽を返さず、かつ、少なくとも1つの行でNULLを返した場合、結果はNULLとなります。
   </para>
 
   <para>
@@ -19163,7 +19167,7 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
    As with <token>EXISTS</token>, it's unwise to assume that the subquery will
    be evaluated completely.
 -->
-<token>EXISTS</token>と同様、副問い合わせが完全に評価されると前提してはなりません。
+<token>EXISTS</token>と同様、副問い合わせが完全に評価されることを前提としてはなりません。
   </para>
 
 <synopsis>
@@ -19190,7 +19194,7 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
 <token>ALL</token>のこの形式の左辺は、<xref linkend="sql-syntax-row-constructors">で説明する行コンストラクタです。
 右辺は括弧で括られた副問い合わせで、左辺の行にある式の数と正確に同じ数の列を返さなければなりません。
 左辺の式は副問い合わせの結果のそれぞれの行に対し、与えられた<replaceable>operator</replaceable>を使用して行に関する評価、比較が行われます。
-比較した結果、すべての副問い合わせ行に対して真を返す場合（副問い合わせが行を返さないという場合も含めて）、<token>ALL</token>の結果は<quote>true（真）</>となります。
+比較した結果、すべての副問い合わせ行に対して真を返す場合（副問い合わせが行を返さないという場合も含む）、<token>ALL</token>の結果は<quote>true（真）</>となります。
 比較した結果、いずれかの副問い合わせ行で偽を返す場合、この結果は<quote>false（偽）</>となります。
 比較結果がすべての副問い合わせ行に対して偽を返さず、少なくとも１行でNULLを返す場合、結果はNULLとなります。
   </para>


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) 言い換えの"or"を「または」と訳していたので訂正
(2) 「評価されると前提して」という言い回しに違和感があったので「評価されることを前提として」と修正
(3) 「それ以外その行は」という言い回しに違和感があったので「それ以外の場合、その行は」と修正し、ついでに句点で改行
(4) "if only unequal subquery rows are found (including the case where the subquery returns no rows)"というパターンの文の訳文を「等しくない副問い合わせの行だけがある（副問い合わせが行を返さない場合を含む）」というパターンに統一