### PR TITLE
端末幅が640px以下の場合は左右のマージンを無くす

### DIFF
--- a/doc/src/sgml/stylesheet.css
+++ b/doc/src/sgml/stylesheet.css
@@ -2,19 +2,20 @@
 
 /* color scheme similar to www.postgresql.org */
 
+@media screen and (min-width: 641px) {
+    BODY > * {
+	width: 90%;
+	margin: auto	!important;
+	display: block;
+	text-align: left;
+    }
+}
+
 BODY {
 	color: #000000;
 	background: #FFFFFF;
 	font-family: verdana, sans-serif;
 }
-
-BODY > * {
-	width: 90%;
-	margin: auto	!important;
-	display: block;
-	text-align: left;
-}
-
 
 script {
         display: none;


### PR DESCRIPTION
幅が641以上のときのみ width: 90%; になるようにしました。 