### PR TITLE
advanced.sgml(3.5節 ウインドウ関数)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/advanced.sgml
+++ b/doc/src/sgml/advanced.sgml
@@ -548,8 +548,8 @@ SELECT depname, empno, salary, avg(salary) OVER (PARTITION BY depname) FROM emps
     the window function is computed across the rows that fall into the
     same partition as the current row.
 -->
-ウィンドウ関数呼び出しは常に、ウィンドウ関数名と引数に直接伴われた<literal>OVER</>句を含みます。
-これが通常関数、または集約関数と構文的に区別されるところです。
+ウィンドウ関数呼び出しは常に、ウィンドウ関数名と引数の直後に続く<literal>OVER</>句を含みます。
+これが通常の関数、または集約関数と構文的に区別されるところです。
 <literal>OVER</>句は、ウィンドウ関数により処理のため問い合わせの行がどのように分解されるかを厳密に決定します。
 <literal>OVER</>内の<literal>PARTITION BY</>リストは、行を<literal>PARTITION BY</>式の同じ値を共有するグループ、すなわちパーティションに分割する指定を行います。
 それぞれの行に対し、ウィンドウ関数は現在行と同じパーティションに分類される行に渡って計算されます。
@@ -595,7 +595,7 @@ FROM empsalary;
     <function>rank</> needs no explicit parameter, because its behavior
     is entirely determined by the <literal>OVER</> clause.
 -->
-ここで示されたように、<function>rank</>関数は、それぞれの明確な<literal>ORDER BY</>の値に対する現在行のパーティション内における順位を、<literal>ORDER BY</>句で定義された順序で生成します。
+ここで示されたように、<function>rank</>関数は、それぞれの別々の<literal>ORDER BY</>の値に対する現在行のパーティション内における順位を、<literal>ORDER BY</>句で定義された順序で生成します。
 <function>rank</>は明示的なパラメータを必要としません。この動作は<literal>OVER</>句により完全に決定されるためです。
    </para>
 
@@ -610,7 +610,10 @@ FROM empsalary;
     in different ways by means of different <literal>OVER</> clauses, but
     they all act on the same collection of rows defined by this virtual table.
 -->
-ウィンドウ関数で考慮される行は、もし存在するのであればその<literal>WHERE</>、<literal>GROUP BY</>、および<literal>HAVING</>句でフィルターをかけられた問い合わせの<literal>FROM</>句によって生成された<quote>仮想テーブル</>です。例えば、<literal>WHERE</>条件に一致しないため削除された行はウィンドウ関数では見つけることができません。異なった<literal>OVER</>句を用いて、異なった方法によりデータを分割する複数のウィンドウ関数を問い合わせが含んでも構いません。しかし、この仮想テーブルで定義された行の同一の集まり上で全てが作動します。
+ウィンドウ関数で考慮される行は、その<literal>WHERE</>、<literal>GROUP BY</>、および<literal>HAVING</>句でフィルターをかけられた問い合わせの<literal>FROM</>句によって生成された<quote>仮想テーブル</>の行です。
+例えば、<literal>WHERE</>条件に一致しないため削除された行はウィンドウ関数からは見えません。
+異なった<literal>OVER</>句を用いて、異なった方法によりデータを分割する複数のウィンドウ関数を問い合わせが含んでも構いません。
+しかし、この仮想テーブルで定義された行の同一の集まり上で全てが作動します。
    </para>
 
    <para>
@@ -619,7 +622,7 @@ FROM empsalary;
     of rows is not important.  It is also possible to omit <literal>PARTITION
     BY</>, in which case there is just one partition containing all the rows.
 -->
-<literal>ORDER BY</>は、行の順序付けが重要でない場合割愛可能であることを見てきました。
+<literal>ORDER BY</>は、行の順序付けが重要でない場合、省略可能であることを見てきました。
 <literal>PARTITION BY</>も同様に割愛することができます。
 この場合、全ての行を含むたった一つのパーティションが存在します。
    </para>
@@ -636,10 +639,10 @@ FROM empsalary;
     <literal>ORDER BY</> clause.  When <literal>ORDER BY</> is omitted the
     default frame consists of all rows in the partition.
 -->
-ウィンドウ関数に関連したその他の重要な概念があります。
+ウィンドウ関数に関連した別の重要な概念があります。
 それぞれの行に対して、その<firstterm>ウィンドウフレーム</>と呼ばれる、そのパーティション内の行の集合が存在します。
 多くの（しかしすべてではありません）ウィンドウ関数は、パーティション全体ではなく、ウィンドウフレームの行のみに対して作用します。
-デフォルトでは、<literal>ORDER BY</>が指定されると、フレームは、パーティションの始めから現在の行までのすべての行と、その後にある<literal>ORDER BY</>句に従って現在の行と等しい行から構成されます。
+デフォルトでは、<literal>ORDER BY</>が指定されると、フレームは、パーティションの始めから現在の行までのすべての行、およびそれより後にあるが<literal>ORDER BY</>句に従うと現在の行とおなじ順序になるすべての行から構成されます。
 <literal>ORDER BY</>が省略された場合、デフォルトのフレームはそのパーティション内のすべての行を含みます。
      <footnote>
       <para>
@@ -729,7 +732,9 @@ SELECT salary, sum(salary) OVER (ORDER BY salary) FROM empsalary;
     include an aggregate function call in the arguments of a window function,
     but not vice versa.
 -->
-ウィンドウ関数は問い合わせの<literal>SELECT</literal>リストと<literal>ORDER BY</>句に限って許可されます。<literal>GROUP BY</>、<literal>HAVING</>、および<literal>WHERE</literal>のような句の中では禁止されています。その理由は、ウィンドウ関数は論理的に、ここに挙げたような句が処理された後に実行されるからです。
+ウィンドウ関数は問い合わせの<literal>SELECT</literal>リストと<literal>ORDER BY</>句に限って許可されます。
+<literal>GROUP BY</>、<literal>HAVING</>、および<literal>WHERE</literal>句などその他の場所では禁止されています。
+その理由は、ウィンドウ関数は論理的に、ここに挙げたような句が処理された後に実行されるからです。
 またウィンドウ関数は通常の集約関数の後に実行されます。
 これが意味する所は、ウィンドウ関数の引数に集約関数呼び出しを含めても有効ですが、その逆は成り立たないと言うことです。
    </para>


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) "directly following"の解釈がおかしかったので、訂正しました。
(2) distinctの訳語がおかしかったので、訂正しました。
(3) "if any"の訳として「もし存在するのであれば」は重すぎる上、何が存在するのかわからないので、単に削除しました。頑張って訳出するなら「～句があるなら、それらでフィルターして」などとするところかと思います。"is not seen"が「見つかりません」は違和感があったので、「見えません」としました。そのついでに、改行をいくつか追加しました。
(4) 「割愛」は違和感があったので「省略」としました。
(5) ウインドウフレームの説明がわかりにくかった(構文解釈の誤りもあった)ので、一部、言葉を補って訳し直しました。
(6) elsewhereが訳出されていなかったので、明示的に訳し、そのついでに改行をいくつか追加しました。