### PR TITLE
func.sgml(9.23節 行と配列の比較)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -19334,7 +19334,7 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
 -->
 本節では、値のグループ間で複数の比較を行う、さまざまな特殊化したコンストラクトについて説明します。
 この形式は構文的には、前節の副問い合わせ形式と関係しています。しかし、副問い合わせを含みません。
-配列副式を含むこの形式は<productname>PostgreSQL</productname>の拡張です。この他は<acronym>SQL</acronym>準拠です。
+配列副式を含む形式は<productname>PostgreSQL</productname>の拡張ですが、それ以外は<acronym>SQL</acronym>準拠です。
 本節で記載した全ての式形式は結果として論理値（真/偽）を返します。
   </para>
 
@@ -19414,7 +19414,7 @@ AND
    This is in accordance with SQL's normal rules for Boolean combinations
    of null values.
 -->
-左辺の式でNULLが生じる場合、または右側の値に等しいものがなく、少なくとも1つの右辺の式がNULLを生み出す場合、予想通り<token>NOT IN</token>構文の結果は真ではなくNULLとなることに注意してください。
+左辺の式でNULLが生じる場合、または右側の値に等しいものがなく、少なくとも1つの右辺の式がNULLを生み出す場合、<token>NOT IN</token>構文の結果は、一部の人が予想する真ではなく、NULLとなることに注意してください。
 これは、NULL値の論理的な組み合わせに対するSQLの標準規則に従うものです。
   </para>
 
@@ -19459,7 +19459,7 @@ AND
 右辺は括弧で括られた式で、配列値を返さなければなりません。
 左辺の式は配列要素それぞれに対して、指定された<replaceable>operator</replaceable>を使用して評価、比較されます。なお、<replaceable>operator</replaceable>は結果として論理値を生成する必要があります。
 真の結果が１つでもあると、<token>ANY</token>の結果は<quote>true（真）</>です。
-（配列の要素数がゼロである場合を含み）真の結果がないと、結果は<quote>false（偽）</>です。
+真の結果がない（配列の要素数がゼロである場合を含む）と、結果は<quote>false（偽）</>です。
   </para>
 
   <para>
@@ -19475,8 +19475,8 @@ AND
    of null values.
 -->
 配列式がNULL配列を生成する場合、<token>ANY</token>の結果はNULLになります。
-左辺式がNULLとなる場合、<token>ANY</token>の結果は通常NULLになります（あまり厳密でない比較演算子では異なる結果になるかもしれません）。
-また、右辺の配列にNULL要素が含まれ、かつ、比較した結果真でない値になった場合、<token>ANY</token>の結果は偽ではなくNULLになります（繰り返しになりますが、厳密な演算子の場合です）。
+左辺式がNULLとなる場合、<token>ANY</token>の結果は通常NULLになります（厳格でない比較演算子では異なる結果になるかもしれません）。
+また、右辺の配列にNULL要素が含まれ、かつ、比較の結果、真が得られなかった場合、<token>ANY</token>の結果は偽ではなくNULLになります（ここでも、厳格な演算子の場合です）。
 これは、NULLに対する、SQLの論理値組み合わせに関する標準規則に従うものです。
   </para>
 
@@ -19512,7 +19512,7 @@ AND
 -->
 右辺は括弧で括られた式で、配列値を返さなければなりません。
 左辺の式は配列の要素それぞれに対して、指定された<replaceable>operator</replaceable>を使用して評価、比較されます。なお、<replaceable>operator</replaceable>は結果として論理値を生成する必要があります。
-（配列の要素数がゼロである場合を含み）全ての比較が真になる場合、<token>ALL</token>の結果は<quote>true（真）</>です。
+全ての比較が真になる場合（配列の要素数がゼロである場合を含む）、<token>ALL</token>の結果は<quote>true（真）</>です。
 1つでも偽の結果があると、結果は<quote>false（偽）</>です。
   </para>
 
@@ -19529,8 +19529,8 @@ AND
    of null values.
 -->
 配列式がNULL配列を生成する場合、<token>ALL</token>の結果はNULLになります。
-左辺式がNULLとなる場合、<token>ALL</token>の結果は通常NULLになります（厳密でない比較演算子では異なる結果になるかもしれません）。
-また、右辺の配列にNULL要素が含まれ、かつ、比較した結果偽でない値になった場合、<token>ALL</token>の結果は真ではなくNULLになります（繰り返しになりますが、厳密な演算子の場合です）。
+左辺式がNULLとなる場合、<token>ALL</token>の結果は通常NULLになります（厳格でない比較演算子では異なる結果になるかもしれません）。
+また、右辺の配列にNULL要素が含まれ、かつ、比較の結果、偽が得られなかった場合、<token>ALL</token>の結果は真ではなくNULLになります（ここでも、厳格な演算子の場合です）。
 これは、NULLに対する、SQLの論理値組み合わせに関する標準規則に従うものです。
   </para>
   </sect2>
@@ -19539,7 +19539,7 @@ AND
 <!--
    <title>Row Constructor Comparison</title>
 -->
-   <title>行コンストラクタに関しての比較</title>
+   <title>行コンストラクタの比較</title>
 
 <synopsis>
 <replaceable>row_constructor</replaceable> <replaceable>operator</replaceable> <replaceable>row_constructor</replaceable>
@@ -19574,7 +19574,7 @@ AND
     Errors related to the number or types of elements might not occur if
     the comparison is resolved using earlier columns.
 -->
-比較が先行する列で解決された場合、要素の数や型に関係するエラーは起きません．
+比較が先行する列で解決された場合、要素の数や型に関係するエラーは起きないこともあります。
    </para>
   </note>
 
@@ -19587,7 +19587,9 @@ AND
    otherwise the result of the row comparison is unknown (null).
 -->
 <literal>=</>と<literal>&lt;&gt;</>の場合、他と動作が多少異なります。
-2つの行は対応する全ての構成要素が非NULLかつ等しい場合に等しいとみなされます。１つでも構成要素が非NULLかつ等しくない場合、2つの行は等しくないとみなされます。それ以外その行の比較結果は不明（NULL）です。
+2つの行は対応する全ての構成要素が非NULLかつ等しい場合に等しいとみなされます。
+１つでも構成要素が非NULLかつ等しくない場合、2つの行は等しくないとみなされます。
+それ以外の場合、その行の比較結果は不明（NULL）です。
   </para>
 
   <para>
@@ -19683,7 +19685,7 @@ AND
    than a non-NULL.  This is necessary in order to have consistent sorting
    and indexing behavior for composite types.
 -->
-SQL仕様では、結果が2つのNULL値、またはNULLと非NULLの比較に基づくのであれば、行の観点からの比較はNULLを返すことを要求されています。
+SQL仕様では、結果が2つのNULL値、またはNULLと非NULLの比較に依存するのであれば、行の観点からの比較はNULLを返すことを要求されています。
 <productname>PostgreSQL</productname>は、(<xref linkend="row-wise-comparison">にあるように)２つの行コンストラクタの出力の比較を行う時、または副問い合わせの出力に対し(<xref linkend="functions-subquery">にあるように)行コンストラクタの比較を行う時のみこれを実施します。
 ２つの複合型の値が比較されるほかの状況では、２つのNULLフィールドの値は等しいと考えられ、NULLは非NULLより大きいとみなされます。
 複合型に対して、これは一貫した並び替えとインデックス付け動作担保のため必要です。
@@ -19732,8 +19734,8 @@ SQL仕様では、結果が2つのNULL値、またはNULLと非NULLの比較に�
    such as replication but are not intended to be generally useful for
    writing queries.
 -->
-デフォルトB-tree演算子クラスを持たない要素を含む行の一致をサポートするために、以下の演算子が複合型の比較のために定義されています。
-<literal>*=</>、<literal>*&lt;&gt;</>、<literal>*&lt;</>、<literal>*&lt;=</>、<literal>*&gt;</>、<literal>*&gt;=</>。
+デフォルトのB-tree演算子クラスを持たない要素を含む行の一致をサポートするために、いくつかの演算子が複合型の比較のために定義されています。
+それは<literal>*=</>、<literal>*&lt;&gt;</>、<literal>*&lt;</>、<literal>*&lt;=</>、<literal>*&gt;</>、<literal>*&gt;=</>です。
 上記の演算子は2つの行の内部バイナリ表現を比較します。
 2つの行の等価演算子での比較が真であっても、2つの行はバイナリ表現が異なるかもしれません。
 上記の比較演算子での行の順序は決定論的ですが、それ以外は意味がありません。

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -18273,7 +18273,7 @@ SELECT xmlagg(x) FROM (SELECT x FROM test ORDER BY y DESC) AS tab;
    to the rule specified in the <literal>ORDER BY</> clause.
 -->
 各仮想集合集約に対して<replaceable>args</replaceable>で与えられる直接引数のリストは、<replaceable>sorted_args</replaceable>で与えられる集約された引数の数と型と一致しなければなりません。
-ほとんどの組み込み集約とは異なり、この集約は厳格ではありません、すなわち、NULLを含む入力行を落としません。
+ほとんどの組み込み集約とは異なり、この集約はSTRICTではありません、すなわち、NULLを含む入力行を落としません。
 NULL値は<literal>ORDER BY</>節で指定されるルールに従って並べられます。
   </para>
 
@@ -19414,7 +19414,7 @@ AND
    This is in accordance with SQL's normal rules for Boolean combinations
    of null values.
 -->
-左辺の式でNULLが生じる場合、または右側の値に等しいものがなく、少なくとも1つの右辺の式がNULLを生み出す場合、<token>NOT IN</token>構文の結果は、一部の人が予想する真ではなく、NULLとなることに注意してください。
+左辺の式でNULLが生じる場合、または右辺の値に左辺の式と等しいものがなく、かつ少なくとも1つの右辺の式がNULLを生じる場合、<token>NOT IN</token>構文の結果は、一部の人が予想する真ではなく、NULLとなることに注意してください。
 これは、NULL値の論理的な組み合わせに対するSQLの標準規則に従うものです。
   </para>
 
@@ -19475,8 +19475,8 @@ AND
    of null values.
 -->
 配列式がNULL配列を生成する場合、<token>ANY</token>の結果はNULLになります。
-左辺式がNULLとなる場合、<token>ANY</token>の結果は通常NULLになります（厳格でない比較演算子では異なる結果になるかもしれません）。
-また、右辺の配列にNULL要素が含まれ、かつ、比較の結果、真が得られなかった場合、<token>ANY</token>の結果は偽ではなくNULLになります（ここでも、厳格な演算子の場合です）。
+左辺式がNULLとなる場合、<token>ANY</token>の結果は通常NULLになります（STRICTでない比較演算子では異なる結果になるかもしれません）。
+また、右辺の配列にNULL要素が含まれ、かつ、比較の結果、真が得られなかった場合、<token>ANY</token>の結果は偽ではなくNULLになります（ここでも、STRICTな演算子の場合です）。
 これは、NULLに対する、SQLの論理値組み合わせに関する標準規則に従うものです。
   </para>
 


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) 拡張と標準準拠の説明の文章がしっくりこなかったので、表現を修正。
(2) "as one might naively expect"の意味が誤解されるような訳文になっていたので訂正。
(3) "including ..."の訳し方を全体的に統一
(4) strictの訳語の「厳密」がしっくりこなかったので、「厳格」に変更
(5) againの訳し方がおかしかったので、訂正
(6) 「比較した結果真(偽)でない値になった場合」は解釈が間違っていたので訂正
(7) 「それ以外その行」は意味がわかりにくかったので、「それ以外の場合、その行」と修正したついでに、改行をいくつか挿入。
(8) コロンを「以下の」として文を分けると、HTMLで改行がなくなると意味がわかりにくいので、訳文を改善。