### PR TITLE
advanced.sgml(3.6節 継承)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/advanced.sgml
+++ b/doc/src/sgml/advanced.sgml
@@ -824,7 +824,9 @@ SELECT sum(salary) OVER w, avg(salary) OVER w
     implicitly when you list all cities.  If you're really clever you
     might invent some scheme like this:
 -->
-2つのテーブルを作ってみましょう。<classname>cities（都市）</classname>テーブルと<classname>capitals（行政府所在地）</classname>テーブルです。行政府所在地は本来同時に都市でもありますので、全ての都市をリストする時は何もしなくても行政府所在地も表示する何らかの方法が必要です。賢い人なら次のような案を工夫するでしょう。
+2つのテーブル<classname>cities</classname>（都市）テーブルと<classname>capitals</classname>（行政府所在地）テーブルを作ってみましょう。
+行政府所在地は本来同時に都市でもありますので、全ての都市をリストする時は何もしなくても行政府所在地も表示する何らかの方法が必要です。
+賢い人なら次のような案を工夫するかもしれません。
 
 <programlisting>
 CREATE TABLE capitals (
@@ -852,7 +854,7 @@ CREATE VIEW cities AS
     This works OK as far as querying goes, but it gets ugly when you
     need to update several rows, for one thing.
 -->
-問い合わせを続ける分には問題はありませんが、たった1つ、いくつか複数の行を更新する時に醜くなります。
+問い合わせを続ける分には問題はありませんが、例えば、複数の行を更新する時に醜くなります。
    </para>
 
    <para>
@@ -888,7 +890,7 @@ CREATE TABLE capitals (
     <productname>PostgreSQL</productname>, a table can inherit from
     zero or more other tables.
 -->
-この例では、<classname>capitals（行政府所在地）</classname>テーブルの行は<firstterm>親</firstterm>の<classname>cities（都市）</classname>テーブルから全ての列、すなわち<structfield>name（都市名）</structfield>、<structfield>population（人口）</structfield>そして<structfield>altitude（標高）</structfield>を<firstterm>継承</firstterm>します。
+この例では、<classname>capitals</classname>テーブルの行は<firstterm>親</firstterm>の<classname>cities</classname>テーブルから全ての列、すなわち<structfield>name</structfield>（都市名）、<structfield>population</structfield>（人口）そして<structfield>altitude</structfield>（標高）を<firstterm>継承</firstterm>します。
 <structfield>name</structfield>列のデータ型は、可変長文字列のために<productname>PostgreSQL</productname>が初めから備えている<type>text</type>型です。
 州の行政府所在地のテーブルは、これに加えて州を示す<structfield>state</>列を持ちます。
 <productname>PostgreSQL</productname>では、テーブルは関連付けられたテーブルがあればそれぞれから属性を継承することができます。
@@ -900,7 +902,7 @@ CREATE TABLE capitals (
     including  state capitals, that are located at an altitude
     over 500 feet:
 -->
-以下の問い合わせの例は、行政府所在地を含む標高500フィート以上に位置する全ての都市を求めるものです。
+以下の問い合わせの例は、行政府所在地も含めて、標高500フィート以上に位置する全ての都市を求めるものです。
 
 <programlisting>
 SELECT name, altitude
@@ -957,7 +959,8 @@ SELECT name, altitude
     <command>DELETE</command> &mdash; support this <literal>ONLY</literal>
     notation.
 -->
-ここで<literal>cities（都市）</literal>の前に置かれた<literal>ONLY</literal>は、継承階層において<classname>cities（都市）</classname>テーブルの下層にあるテーブルではなく、<classname>cities（都市）</classname>テーブルのみを参照することを意味します。既に説明した<command>SELECT</command>、<command>UPDATE</command>および<command>DELETE</command>など数多くのコマンドは、この<literal>ONLY</literal>表記をサポートしています。
+ここで<literal>cities</literal>の前に置かれた<literal>ONLY</literal>は、継承階層において<classname>cities</classname>テーブルの下層にあるテーブルではなく、<classname>cities</classname>テーブルのみを参照することを意味します。
+既に説明した<command>SELECT</command>、<command>UPDATE</command>および<command>DELETE</command>など数多くのコマンドは、この<literal>ONLY</literal>表記をサポートしています。
    </para>
 
    <note>
@@ -967,7 +970,7 @@ SELECT name, altitude
      with unique constraints or foreign keys, which limits its usefulness.
      See <xref linkend="ddl-inherit"> for more detail.
 -->
-継承は便利ではありますが、一意性制約もしくは外部キーと一緒に使えないので万能ではありません。
+継承は多くの場合で便利ですが、一意性制約や外部キーと統合されていないので万能ではありません。
 詳細は<xref linkend="ddl-inherit">を参照してください。
     </para>
    </note>


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) コロンの前後で文を分けているのはわかりにくいので、1文にまとめ、ついでに改行をいくつか挿入しました。
(2) mightの訳語の「するでしょう」は違和感があったので「するかもしれません」としました。
(3) citiesやcapitalsなどテーブル名の後に「（都市）」などの注釈が入っているのを、classnameタグの外側に出しました。また、くどい感じがするので、2回目以降からは注釈を削りました。
(4) "for one thing"の訳語が適切でなかったので訂正しました。また「いくつか複数」は日本語としておかしいので、単に「複数」としました。
(5) 「『行政府所在地を含む』標高500フィート以上の…」は掛かり関係が曖昧なので、修正しました。
(6) "frequently"が訳出されていなかったので、明示的に訳し、また"integrated"の訳語を修正しました。