### PR TITLE
ddl.sgml(5.3節 制約 の一部)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -444,7 +444,7 @@ CREATE TABLE products (
     Boolean (truth-value) expression.  For instance, to require positive
     product prices, you could use:
 -->
-検査制約は最も一般的な制約の種類です。
+検査制約は最も汎用的な制約の種類です。
 これを使用して、特定の列の値が論理値の式を満たす（真の値）ように指定できます。
 例えば、製品価格を必ず正数にするには以下のようにします。
 <programlisting>
@@ -746,7 +746,7 @@ CREATE TABLE products (
      In most database designs the majority of columns should be marked
      not null.
 -->
-ほとんどのデータベース設計において、列の大多数をNOT NULLとマークする必要があります。
+ほとんどのデータベース設計において、列の多くをNOT NULLとマークする必要があります。
     </para>
    </tip>
   </sect2>
@@ -833,7 +833,7 @@ CREATE TABLE example (
 <!--
     You can assign your own name for a unique constraint, in the usual way:
 -->
-一意性制約には、いつものように名前を割り当てることもできます。
+一意性制約には、通常の方法で名前を割り当てることもできます。
 <programlisting>
 CREATE TABLE products (
     product_no integer <emphasis>CONSTRAINT must_be_different</emphasis> UNIQUE,
@@ -878,7 +878,7 @@ CREATE TABLE products (
     careful when developing applications that are intended to be
     portable.
 -->
-一般に、制約の対象となる列について同じ値を持つ行が、テーブル内に１行を上回る場合は、一意性制約違反になります。
+一般に、制約の対象となるすべての列について同じ値を持つ行が、テーブル内に２行以上ある場合は、一意性制約違反になります。
 しかし、この比較では2つのNULL値は決して等価とはみなされません。
 つまり、一意性制約があったとしても、制約対象の列の少なくとも1つにNULL値を持つ行を複数格納することができるということです。
 この振舞いは標準SQLに準拠していますが、この規則に従わないSQLデータベースがあることを聞いたことがあります。
@@ -1134,7 +1134,7 @@ CREATE TABLE t1 (
     You can assign your own name for a foreign key constraint,
     in the usual way.
 -->
-外部キー制約には、いつものように名前を割り当てることもできます。
+外部キー制約には、通常の方法で名前を割り当てることもできます。
    </para>
 
    <para>


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) genericを「一般的」は文の意味として不自然だったので、「汎用的」に、修正
(2) majorityを「大多数」は言い過ぎなので「多く」に修正
(3) "in the usual way"を「いつものように」は変なので「通常の方法で」と修正
(4) allが訳出されていなかったので明示的に表現し、また「１行を上回る」は不自然なので「２行以上」に修正