### PR TITLE
dml.sgml(6章 データ操作)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/dml.sgml
+++ b/doc/src/sgml/dml.sgml
@@ -23,9 +23,9 @@
   from the database.
 -->
 前章では、データを保持するためのテーブルやその他の構造の作成方法について説明しました。
-いよいよ、テーブルにデータを挿入してみましょう。
+今度は、テーブルにデータを挿入してみましょう。
 本章では、テーブルのデータの挿入、更新、削除の方法について説明します。
-そして本章以降において、ずっと見つけられなかったデータをデータベースから抽出する方法について説明します。
+次章ではいよいよ、ずっと見つけられなかったデータをデータベースから抽出する方法について説明します。
  </para>
 
  <sect1 id="dml-insert">
@@ -56,7 +56,7 @@
 -->
 テーブルは、作成時にはデータを含んでいません。
 データベースを利用価値のあるものにするには、まずデータを挿入する必要があります。
-理論的には、データは一度に1行ずつ挿入されます。
+概念的には、データは一度に1行ずつ挿入されます。
 もちろんユーザは複数行を挿入することもできますが、1行未満を挿入することはできません。
 列の値が一部しかわかっていない場合でも、1行全体を作成しなければなりません。
   </para>
@@ -80,7 +80,7 @@ CREATE TABLE products (
 <!--
    An example command to insert a row would be:
 -->
-この場合、行を挿入するためのコマンドは以下のようになります。
+行を挿入するためのコマンド例は以下のようになります。
 <programlisting>
 INSERT INTO products VALUES (1, 'Cheese', 9.99);
 </programlisting>
@@ -89,7 +89,7 @@ INSERT INTO products VALUES (1, 'Cheese', 9.99);
    in the table, separated by commas.  Usually, the data values will
    be literals (constants), but scalar expressions are also allowed.
 -->
-データ値は、テーブルで列が表示される順序に従ってカンマで区切って列挙します。
+データ値は、テーブル内で列が存在する順序に従ってカンマで区切って列挙されています。
 通常、データ値はリテラル（定数）ですが、スカラ式も使用できます。
   </para>
 
@@ -100,7 +100,7 @@ INSERT INTO products VALUES (1, 'Cheese', 9.99);
    columns explicitly.  For example, both of the following commands
    have the same effect as the one above:
 -->
-上記の構文には、テーブル内の列の順序を知っていなければならないという難点があります。
+上記の構文には、テーブル内の列の順序を知っていなければならないという欠点があります。
 これを避けるには、列を明示的に列挙する方法があります。
 例えば、以下の2つのどちらのコマンドでも上記のコマンドと同等の効果が得られます。
 <programlisting>
@@ -202,7 +202,7 @@ INSERT INTO products (product_no, name, price) VALUES
    rows in a table, or a subset of all rows.  Each column can be
    updated separately; the other columns are not affected.
 -->
-既にデータベースに入っているデータを修正することを「更新する」と言います。
+既にデータベースに入っているデータを変更することを「更新(update)する」と言います。
 個別の行、テーブル内の全ての行、あるいは全ての行のサブセットを更新することができます。
 各列は、他の列に影響を及ぼすことなく個別に更新することができます。
   </para>
@@ -234,7 +234,7 @@ INSERT INTO products (product_no, name, price) VALUES
 <!--
      <para>Which row(s) to update</para>
 -->
-     <para>更新する行（複数も可）</para>
+     <para>更新する行</para>
     </listitem>
    </orderedlist>
   </para>
@@ -253,8 +253,8 @@ INSERT INTO products (product_no, name, price) VALUES
 -->
 <xref linkend="ddl">で説明した、一般にSQLでは行に対して一意のIDを指定しないことを思い出してください。
 従って、どの行を更新するかを直接指定することができない場合があります。
-その場合、更新される行が満たすべき条件を指定します。
-テーブルに主キーを設定している場合に限り（ユーザが宣言したのかどうかには依存しないで）、主キーと一致する条件を選択することで確実に個別の行を指定することができます。
+その代わりに、更新される行が満たすべき条件を指定します。
+テーブルに主キーを設定している場合に限り（ユーザが宣言したのかどうかには関係なく）、主キーと一致する条件を選択することで確実に個別の行を指定することができます。
 グラフィカルなデータベースアクセスツールは、この方法を使用して行を個別に更新することを可能にしています。
   </para>
 
@@ -310,10 +310,10 @@ UPDATE products SET price = price * 1.10;
    available (see <xref linkend="functions">).  But the expression
    needs to evaluate to a Boolean result.
 -->
-このように、新しい値を表す式で行の中の古い値（複数可）を参照することもできます。
+このように、新しい値を表す式で行の中の古い値を参照することもできます。
 ここでは、<literal>WHERE</literal>句を省略しました。
 <literal>WHERE</literal>句を省略すると、テーブル内の全ての行が更新されます。
-省略しない場合は、<literal>WHERE</literal>条件に一致する行のみが更新されます。
+省略しない場合は、<literal>WHERE</literal>条件に適合する行のみが更新されます。
 <literal>SET</literal>句内の等号が代入を表すのに対し、<literal>WHERE</literal>句内の等号は比較を表すことに注意してください。
 ただし、これによって曖昧さが生じることはありません。
 もちろん、必ずしも<literal>WHERE</literal>条件が等式でなければならないということはありません。
@@ -327,7 +327,7 @@ UPDATE products SET price = price * 1.10;
    <command>UPDATE</command> command by listing more than one
    assignment in the <literal>SET</literal> clause.  For example:
 -->
-<command>UPDATE</command>コマンドの<literal>SET</literal>句に複数の値を代入して、複数の列を更新することもできます。
+<command>UPDATE</command>コマンドの<literal>SET</literal>句に複数の代入式を列挙して、複数の列を更新することもできます。
 例を示します。
 <programlisting>
 UPDATE mytable SET a = 5, b = 3, c = 1 WHERE a &gt; 0;
@@ -367,10 +367,10 @@ UPDATE mytable SET a = 5, b = 3, c = 1 WHERE a &gt; 0;
    once.
 -->
 これまで、テーブルにデータを追加する方法と、データを変更する方法について説明してきました。
-これから取り上げるのは不要になったデータを削除する方法です。
+残っているのは不要になったデータを削除する方法です。
 データの追加が行単位でしか行えないのと同様、削除の場合も、行全体をテーブルから削除するしかありません。
 前節で、SQLでは個々の行を直接指定する方法がないということを説明しました。
-ですから行の削除の場合も、削除対象となる行の条件を指定する必要があります。
+ですから行の削除の場合も、削除対象となる行の条件を指定することでしかできません。
 テーブルに主キーが設定されている場合は、その行を正確に指定できます。
 しかし、条件を満たす複数の行、あるいは、テーブル内の全ての行を一度に削除することもできます。
   </para>


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) "the chapter after this"は単数なので、「本章以降」を「次章」に修正しました。また、"finally"が訳出されていなかったので、明示的に「いよいよ」としました。それに伴い、直前の"now"を「いよいよ」から「今度は」に変更しました。
(2) "appear"が「表示される」となっていましたが、画面に表示されるわけではないので「存在する」としました(もっと良い訳語がありそう)。また「列挙します」とありましたが、説明対象の例がそうなっていることを説明しているものなので、原文通り「列挙されています」としました。
(3) UPDATEの説明をしている部分について、modificationを「修正」とするの「は間違いを正す印象があるので「変更」としました。またupdatingを「更新する」と説明している部分は、さらに注をつけるイメージで"update"を追加しました。
(4) row(s)を「行（複数可）」とするのは訳しすぎで、かえって誤解を招くので、但し書きを削りました。
(5) WHERE条件に"match"する場合については「一致」を「適合」としました。
その他、なるべく原文に忠実な意味になるよう、訳語の変更などを行いました。