### PR TITLE
func.sgml(9.24節 集合を返す関数)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -19774,8 +19774,8 @@ SQL仕様では、結果が2つのNULL値、またはNULLと非NULLの比較に�
    set-returning functions.
 -->
 本節では、場合により複数行を返す関数について説明します。
-最も広く用いられているこのクラスの関数は、<xref linkend="functions-srf-series">、および<xref linkend="functions-srf-subscripts">にて詳細が触れられている、連続生成関数です。
-他方、より特化された集合を返す関数の記述がこのマニュアルのいたるところにあります。
+このクラスで最も広く用いられている関数は、<xref linkend="functions-srf-series">、および<xref linkend="functions-srf-subscripts">にて詳細が触れられている、連続値生成関数です。
+他方、より特化された集合を返す関数の記述がこのマニュアルの他の場所にあります。
 集合を返す関数を複数組み合わせる方法については<xref linkend="queries-tablefunctions">を参照してください。
   </para>
 
@@ -19962,7 +19962,7 @@ SELECT * FROM generate_series('2008-03-01 00:00'::timestamp,
 <!--
        Generate a series comprising the given array's subscripts.
 -->
-       指定した配列の添え字を構成するシリーズを生成します。
+       指定した配列の添え字を構成する連番を生成します。
       </entry>
      </row>
 
@@ -20020,7 +20020,7 @@ SELECT generate_subscripts('{NULL,1,NULL,2}'::int[], 1) AS s;
 &#045;- presenting an array, the subscript and the subscripted
 &#045;- value requires a subquery
 -->
--- ある配列では、添え字とその添え字が示す値は
+-- 配列、添え字とその添え字が示す値を表示するには
 -- 副問い合わせが必要です。
 SELECT * FROM arrays;
          a          


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) "most widely used"の掛かり先が明確になるよう訳文を変更しました。
(2) "elsewhere"の訳し方がおかしかったので、訂正しました。
(3) 「シリーズ」は意味がわかりにくいので、「連番」としました。
(4) プログラム例のコメントに構文解釈の誤りがあったので、訳し直しました。
