### PR TITLE
syntax.sgml(4.2.9-10節 型キャスト、照合順序式)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -3217,7 +3217,7 @@ SELECT * FROM tbl WHERE a COLLATE "C" &gt; 'foo';
 <!--
     But this is an error:
 -->
-ただし、これはエラーになります。
+ただし、次の例はエラーになります。
 <programlisting>
 SELECT * FROM tbl WHERE (a &gt; 'foo') COLLATE "C";
 </programlisting>

--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -3084,7 +3084,7 @@ CAST ( <replaceable>expression</replaceable> AS <replaceable>type</replaceable> 
     explicit casting syntax.  This restriction is intended to prevent
     surprising conversions from being applied silently.
 -->
-通常（例えばテーブル列への代入時など）、評価式が生成しなければならない型に曖昧さがない場合、明示的な型キャストは省略することができます。
+評価式が生成しなければならない型に曖昧さがない場合（例えばテーブル列への代入時など）、明示的な型キャストは通常は省略することができます。
 その場合、システムは自動的に型キャストを適用します。
 しかし、自動キャストは、システムカタログに<quote>暗黙的に適用しても問題なし</>と示されている場合にのみ実行されます。
 その他のキャストは明示的なキャスト構文で呼び出す必要があります。
@@ -3153,7 +3153,8 @@ CAST ( <replaceable>expression</replaceable> AS <replaceable>type</replaceable> 
     The <literal>COLLATE</literal> clause overrides the collation of
     an expression.  It is appended to the expression it applies to:
 -->
-<literal>COLLATE</literal>句は式の照合順序規則を上書きします。適用するため次の様に式に加えます。
+<literal>COLLATE</literal>句は式の照合順序規則を上書きします。
+適用するため次の様に式の後に追記します。
 <synopsis>
 <replaceable>expr</replaceable> COLLATE <replaceable>collation</replaceable>
 </synopsis>
@@ -3163,7 +3164,9 @@ CAST ( <replaceable>expression</replaceable> AS <replaceable>type</replaceable> 
     clause binds tighter than operators; parentheses can be used when
     necessary.
 -->    
-<replaceable>collation</replaceable>はおそらくスキーマ部を含む識別子です。<literal>COLLATE</literal>句は演算子よりも優先度が低いため、必要に応じて括弧で囲います。
+ここで<replaceable>collation</replaceable>は識別子で、スキーマ修飾可能です。
+<literal>COLLATE</literal>句は演算子よりも結合優先度が高いです。
+必要に応じて括弧で囲うことができます。
    </para>
 
    <para>
@@ -3182,7 +3185,8 @@ CAST ( <replaceable>expression</replaceable> AS <replaceable>type</replaceable> 
     overriding the sort order in an <literal>ORDER BY</> clause, for
     example:
 -->
-例として、よく使われる<literal>COLLATE</literal>句による並び替え順序の上書きを挙げます。<literal>ORDER BY</>句を使う場合には、
+<literal>COLLATE</literal>句の主な使われ方が２つあります。
+１つは<literal>ORDER BY</>句での並び替え順序を上書きをするもので、例えば次のようにします。
 <programlisting>
 SELECT a, b, c FROM tbl WHERE ... ORDER BY a COLLATE "C";
 </programlisting>
@@ -3190,7 +3194,7 @@ SELECT a, b, c FROM tbl WHERE ... ORDER BY a COLLATE "C";
     and overriding the collation of a function or operator call that
     has locale-sensitive results, for example:
 -->
-とします。ロケール依存を伴った関数や演算子の呼び出しに対しての上書き方法例は
+もう一つは、計算結果がロケールに依存する関数や演算子の呼び出しについて、照合順序を上書きするもので、例えば次のようにします。
 <programlisting>
 SELECT * FROM tbl WHERE a &gt; 'foo' COLLATE "C";
 </programlisting>
@@ -3213,7 +3217,7 @@ SELECT * FROM tbl WHERE a COLLATE "C" &gt; 'foo';
 <!--
     But this is an error:
 -->
-ただし、これはエラーになります。正しくは次の様にします。
+ただし、これはエラーになります。
 <programlisting>
 SELECT * FROM tbl WHERE (a &gt; 'foo') COLLATE "C";
 </programlisting>
@@ -3222,7 +3226,7 @@ SELECT * FROM tbl WHERE (a &gt; 'foo') COLLATE "C";
     <literal>&gt;</> operator, which is of the non-collatable data type
     <type>boolean</>.
 -->
-なぜなら、照合順序を与えることができない<type>boolean</>型となる<literal>&gt;</>演算子の結果に対して。照合順序が適用されようとするからです。
+<literal>&gt;</>演算子の結果に対して照合順序を適用しようとしますが、<literal>&gt;</>演算子は照合不可能なデータ型である<type>boolean</>となるからです。
    </para>
   </sect2>
 


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) 語句の順番を並べ替えて、文の後方にある語句を参照しなくても読めるようにしました。
(2) appendが「加える」となっていましたが、足し算するイメージになってしまうので「追記する」に変更しました。また、句点のところで改行を挿入しました。
(3) "possibly"の解釈が間違っていたので修正しました。"binds tighter"の解釈が間違っていたので修正しました。また句点のところで改行を挿入しました。
(4) "The two common uses"から始まるプログラム例を2つ含む長い文の解釈が間違っていたので、全面的に訳し直しました。
(5) 原文にない語句(「正しくは次の様にします」)を削除(上の例が正しくて、次の例はエラーなので、これは二重に間違っていたことになる)。またその直前の"this"を「これ」とすると曖昧なので「次の例」に訳を変えました。
(6) 理由の説明がわかりにくかったので、関係詞節を訳し下げて、修正しました。