### PR TITLE
fix typo for ddl.sgml

### DIFF
--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -4065,7 +4065,7 @@ VALUES ('Albany', NULL, NULL, 'NY');
    of an inheritance hierarchy then any operations not supported by
    the foreign table are not supported on the whole hierarchy either.
 -->
-外部テーブル（<xref linkend="ddl-foreign-data">参照）も通常のテーブルと同様、親テーブルあるいはこテーブルとして継承の階層の一部となりえます。
+外部テーブル（<xref linkend="ddl-foreign-data">参照）も通常のテーブルと同様、親テーブルあるいは子テーブルとして継承の階層の一部となりえます。
 外部テーブルが継承の階層の一部となっている場合、外部テーブルがサポートしない操作は、その継承全体でもサポートされません。
   </para>
 


### PR DESCRIPTION
「こテーブル」→「子テーブル」だけの修正です。