### PR TITLE
syntax.sgml (4.2節 評価式)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -3691,7 +3691,7 @@ SELECT somefunc() OR true;
     <quote>short-circuiting</quote> of Boolean operators that is found
     in some programming languages.
 -->
-これは一部のプログラミング言語に見られる、ブーリアン演算子での左から右への<quote>短絡回路</quote>とは異なることに注意してください。
+これは一部のプログラミング言語に見られる、ブーリアン演算子での左から右への<quote>短絡評価</quote>とは異なることに注意してください。
    </para>
 
    <para>

--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -3280,7 +3280,7 @@ SELECT * FROM tbl WHERE (a &gt; 'foo') COLLATE "C";
     For example, the following finds the largest city population in each
     state:
 -->
-例えば、以下は各州で最も人口の多い都市を検索します。
+例えば、以下は各州の最大都市の人口を検索します。
 <programlisting>
 SELECT name, (SELECT max(pop) FROM cities WHERE cities.state = states.name)
     FROM states;
@@ -3349,7 +3349,7 @@ SELECT ARRAY[1,2,22.7]::integer[];
     element type individually.
     For more on casting, see <xref linkend="sql-syntax-type-casts">.
 -->
-これはそれぞれの式を配列型に個別にキャストするのと同じ効果があります。
+これはそれぞれの式を配列要素の型に個別にキャストするのと同じ効果があります。
 キャストについてより多くは<xref linkend="sql-syntax-type-casts">を参照してください。
    </para>
 
@@ -3384,7 +3384,7 @@ SELECT ARRAY[[1,2],[3,4]];
     Any cast applied to the outer <literal>ARRAY</> constructor propagates
     automatically to all the inner constructors.
 -->
-多次元配列は四角形配列でなければなりませんので、同一レベルの内部コンストラクタは同一次元の副配列を生成しなければなりません。外部<literal>ARRAY</>コンストラクタに適用される全てのキャストは自動的に全ての内部コンストラクタに伝播します。
+多次元配列は長方形配列でなければなりませんので、同一レベルの内部コンストラクタは同一次元の副配列を生成しなければなりません。外部<literal>ARRAY</>コンストラクタに適用される全てのキャストは自動的に全ての内部コンストラクタに伝播します。
   </para>
 
   <para>
@@ -3522,7 +3522,7 @@ SELECT ROW(1,2.5,'this is a test');
     The key word <literal>ROW</> is optional when there is more than one
     expression in the list.
 -->
-<literal>ROW</>キーワードは、1つ以上の式がリスト内にある場合は省略することができます。
+<literal>ROW</>キーワードは、2つ以上の式がリスト内にある場合は省略することができます。
    </para>
 
    <para>
@@ -3555,9 +3555,9 @@ SELECT ROW(t.f1, t.f2, 42) FROM t;
      <literal>ROW(t, 42)</>.
 -->
 <productname>PostgreSQL</productname> 8.2より前では、<literal>.*</literal>構文は展開されませんでした。
-<literal>ROW(t.*, 42)</>と記述すると、1つ目のフィールドに別の行値を持つ、2つのフィールドからなる行が作成されました。
+<literal>ROW(t.*, 42)</>と記述すると、1つ目のフィールドにもう一つの行値を持つ、2つのフィールドからなる行が作成されました。
 たいていの場合、新しい動作はより使いやすくなっています。
-入れ子状の行値という古い動作が必要であれば、<literal>.*</literal>を使用せずに、たとえば<literal>ROW(t, 42)</>といった、内部行値を記述してください。
+入れ子状の行値という古い動作が必要であれば、内側の行値には<literal>.*</literal>を使用せずに、たとえば<literal>ROW(t, 42)</>と記述してください。
     </para>
    </note>
 
@@ -3570,8 +3570,8 @@ SELECT ROW(t.f1, t.f2, 42) FROM t;
     to avoid ambiguity.  For example:
 -->
 デフォルトでは、<literal>ROW</>式により作成される値は匿名レコード型になります。
-必要に応じて、名前付きの複合型、テーブルの行型、もしくは<command>CREATE TYPE AS</>で作成された複合型にキャストすることができます。
-明示的なキャストは曖昧性を防止するために必要となることもあります。
+必要に応じて、名前付きの複合型、つまりテーブルの行型あるいは<command>CREATE TYPE AS</>で作成された複合型にキャストすることができます。
+曖昧性を防止するために明示的なキャストが必要となることもあります。
 以下に例を示します。
 <programlisting>
 CREATE TABLE mytable(f1 int, f2 float, f3 text);
@@ -3636,7 +3636,7 @@ SELECT ROW(table.*) IS NULL FROM table;  -- すべてがNULLの行を検出し�
    as discussed in <xref linkend="functions-subquery">.
 -->
 詳細は<xref linkend="functions-comparisons">を参照してください。
-行コンストラクタは、<xref linkend="functions-subquery">で説明した、副問い合わせと一緒に使用することもできます。
+行コンストラクタは、<xref linkend="functions-subquery">で説明するように、副問い合わせと一緒に使用することもできます。
   </para>
 
   </sect2>
@@ -3672,7 +3672,7 @@ SELECT ROW(table.*) IS NULL FROM table;  -- すべてがNULLの行を検出し�
     evaluating only some parts of it, then other subexpressions
     might not be evaluated at all.  For instance, if one wrote:
 -->
-さらに、その式の一部を評価しただけで式の結果を判断できる場合には、他の副式がまったく評価されないこともあります。
+さらに、その式の一部を評価しただけで式の結果を決定できる場合には、他の副式がまったく評価されないこともあります。
 例えば、
 <programlisting>
 SELECT true OR somefunc();
@@ -3691,7 +3691,7 @@ SELECT somefunc() OR true;
     <quote>short-circuiting</quote> of Boolean operators that is found
     in some programming languages.
 -->
-これは一部のプログラミング言語に見られる、ブーリアン演算子での左から右への<quote>ショートサーキット</quote>とは異なることに注意してください。
+これは一部のプログラミング言語に見られる、ブーリアン演算子での左から右への<quote>短絡回路</quote>とは異なることに注意してください。
    </para>
 
    <para>


### PR DESCRIPTION
見直したのは4.2.10節以降で、主な修正点は以下の通りです。
(1) "largest city population"の誤訳訂正(SELECT文を見ればわかるように、州の名前と、最大都市の人口しか検索していない)。
(2) 原文が"array ELEMENT type"なので忠実に訳すようにした。
(3) "rectangular"の訳を「四角形」から「長方形」に変更(配列なので、四角形なら長方形に決まっているかも知れないが…)
(4) "more than one"の誤訳訂正
(5) "another"を「別の」としていたが、「(t.*, 42)という行値の中に、"t.*"という"another row value"がある」ということなので、「もう一つの」と訳語を変更(大して変わらないかも知れないが、文脈上、「別の」は、上にある"t.*"とは「異なる」ものである感じがする)
(6) "inner row value"の訳語を変更すると同時に、構文解釈の怪しげな部分を変更。
(7) ダッシュ記号の解釈の誤りを訂正
(8) "as discussed"の参照先が9章なので、訳し方を訂正
(9) 式の値の話なので、determineの訳語を「判断」から「決定」に変更
(10) 「ショートサーキット」を日本語に変更
