### PR TITLE
ddl.sgml (5.3.5節 外部キー)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -1103,7 +1103,7 @@ CREATE TABLE orders (
     because in absence of a column list the primary key of the
     referenced table is used as the referenced column(s).
 -->
-列リストがないため、被参照テーブルの主キーが被参照列（複数可）として使用されます。
+列リストがないため、被参照テーブルの主キーが被参照列として使用されます。
    </para>
 
    <para>
@@ -1276,10 +1276,9 @@ CREATE TABLE order_items (
 <literal>RESTRICT</literal>は、被参照行が削除されるのを防ぎます。
 <literal>NO ACTION</literal>は、制約が検査された時に参照行がまだ存在していた場合に、エラーとなることを意味しています。
 これは、何も指定しない場合のデフォルトの振舞いとなります
-（これらの本来の違いは、<literal>NO ACTION</literal>では検査をトランザクション中で後回しにすることができるのに対し、<literal>RESTRICT</literal>では後回しにできないということです）。
-<literal>CASCADE</>は被参照行が削除された時、それを参照する行（複数可）も同様に削除されなければならないことを指定します。
-他にも2つのオプションがあります。
-<literal>SET NULL</literal>と<literal>SET DEFAULT</literal>です。
+（これらの本質的な違いは、<literal>NO ACTION</literal>では検査をトランザクション中で後回しにすることができるのに対し、<literal>RESTRICT</literal>では後回しにできないということです）。
+<literal>CASCADE</>は被参照行が削除された時、それを参照する行も同様に削除されることを指定します。
+他にも2つのオプション、<literal>SET NULL</literal>と<literal>SET DEFAULT</literal>があります。
 これらは、被参照行が削除された際に、参照行の参照列がそれぞれNULLか各列のデフォルト値に設定されるようになります。
 これらは制約を守ることを免除することではない、ということに注意してください。
 例えば、動作に<literal>SET DEFAULT</literal>を指定したとしても、デフォルト値が外部キー制約を満たさない場合には操作は失敗します。
@@ -1309,7 +1308,7 @@ CREATE TABLE order_items (
     to be able to avoid satisfying the foreign key constraint, declare the
     referencing column(s) as <literal>NOT NULL</>.
 -->
-通常、参照行はその参照列のいずれかがnullの場合は外部キー制約を満たす必要があります。
+通常、参照行はその参照列のいずれかがnullの場合は外部キー制約を満たす必要がありません。
 もし<literal>MATCH FULL</>が外部キー宣言に追加された場合、その参照列の全てがnullの場合にのみ参照行は制約を満たすことから逃れることができます(つまりnullと非nullの組み合わせは<literal>MATCH FULL</>制約に違反することが保証されます)。
 もし参照行が外部キー制約を満たさない可能性を排除したい場合は、参照列を<literal>NOT NULL</>として宣言してください。
    </para>
@@ -1328,8 +1327,10 @@ CREATE TABLE order_items (
     to index, declaration of a foreign key constraint does not
     automatically create an index on the referencing columns.
 -->
-外部キーは主キーであるかまたは一意性制約を構成する列を参照しなければなりません。これは、被参照列は常に(主キーまたは一意性制約の基礎となる)インデックスを持つことを意味します;このため、参照行が一致するかのチェックは効率的です。
-被参照テーブルからの行の<command>DELETE</command>や被参照行の<command>UPDATE</command>は、古い値と一致する行に対して参照テーブルのスキャンを要求しますので、参照行にもインデックスを付けるのは大抵は良い考えです。
+外部キーは主キーであるかまたは一意性制約を構成する列を参照しなければなりません。
+これは、被参照列は常に(主キーまたは一意性制約の基礎となる)インデックスを持つことを意味します。
+このため、参照行に一致する行があるかどうかのチェックは効率的です。
+被参照テーブルからの行の<command>DELETE</command>や被参照行の<command>UPDATE</command>は、古い値と一致する行に対して参照テーブルのスキャンが必要となるので、参照行にもインデックスを付けるのは大抵は良い考えです。
 これは常に必要という訳ではなく、また、インデックスの方法には多くの選択肢がありますので、外部キー制約の宣言では参照列のインデックスが自動的に作られるということはありません。
    </para>
 


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) "column(s)", "row(s)"など英文法的な都合上、仕方なく"(s)"がついているもので、敢えて「（複数可）」などと訳す必要のないもの（あることで不自然になるもの）は、単に「列」「行」としました。
(2) "essential"の訳語を「本来の」から「本質的な」に変更しました。
(3) コロンの前後で文を分けていて不自然だったので、1文にしました。
(4) "not"が訳出されていなかった（文の意味が反対になっていた）のを訂正しました。
(5) セミコロンがそのまま日本語文に出ていたのを直しました。"has a match"の訳し方を原文に忠実になるように変更しました（前の訳は"does match"みたいだった）。また、「要求する」は文脈上、違和感があったので「必要となる」に変更しました。
