### PR TITLE
syntax.sgml (4.3節 関数呼び出し)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -3853,7 +3853,7 @@ SELECT CASE WHEN min(employees) > 0
     parameters can be omitted; while in positional notation parameters can
     only be omitted from right to left.
 -->
-どちらの表記でも、関数定義時にデフォルト値を与えられていれるパラメータについては、呼び出し時に記述される必要はありません。
+どちらの表記でも、関数定義時にデフォルト値を与えられているパラメータについては、呼び出し時に記述される必要はありません。
 しかしこれは、名前付け表記で特に有用です。
 なぜなら、パラメータ群の任意の組み合わせを省略できるからです。
 一方、位置表記のパラメータは右から左へ省略していくことしかできません。

--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -3839,10 +3839,10 @@ SELECT CASE WHEN min(employees) > 0
     declaration.  In named notation, the arguments are matched to the
     function parameters by name and can be written in any order.
 -->
-<productname>PostgreSQL</productname>は<firstterm>位置</firstterm>と<firstterm>名前付け</firstterm>表記による名前付けパラメータを関数に持たせることが可能です。
-特に名前付け表記は、多数のパラメータを持つ関数においてパラメータと引数の関連をより明確・確実にするのに有用です。
-位置表記では、関数定義の際に定義されたものと同じ並び順の引数が、関数呼び出しに記述されることになります。
-名前付け表記では、引数と関数パラメータの名前を一致させることになり、引数はどのような並び順でも構いません。
+<productname>PostgreSQL</productname>では名前付きパラメータを持つ関数について、<firstterm>位置</firstterm>表記と<firstterm>名前付け</firstterm>表記のいずれでも呼び出すことが可能です。
+名前付け表記は、パラメータと引数の関連をより明確・確実にするので、多数のパラメータを持つ関数において特に有用です。
+位置表記の関数呼び出しでは、関数宣言で定義されたのと同じ並び順で、引数を記述します。
+名前付け表記では、引数と関数パラメータは名前で対応付けられ、引数はどのような並び順で書いても構いません。
    </para>
 
    <para>
@@ -3853,8 +3853,9 @@ SELECT CASE WHEN min(employees) > 0
     parameters can be omitted; while in positional notation parameters can
     only be omitted from right to left.
 -->
-どちらの表記でも、パラメータが関数定義時にデフォルト値を与えられていれば呼び出し時に記述される必要はありません。
-これは、名前付け表記では、パラメータ群の任意の組み合わせを省略することができるので、特殊なケースでは有用です。
+どちらの表記でも、関数定義時にデフォルト値を与えられていれるパラメータについては、呼び出し時に記述される必要はありません。
+しかしこれは、名前付け表記で特に有用です。
+なぜなら、パラメータ群の任意の組み合わせを省略できるからです。
 一方、位置表記のパラメータは右から左へ省略していくことしかできません。
    </para>
 
@@ -3873,7 +3874,7 @@ SELECT CASE WHEN min(employees) > 0
     The following examples will illustrate the usage of all three
     notations, using the following function definition:
 -->
-下記は3つの表記方法を使った関数定義の例です。
+本節の例では、次の関数定義を使って、3通りすべての表記方法について説明します。
 <programlisting>
 CREATE FUNCTION concat_lower_or_upper(a text, b text, uppercase boolean DEFAULT false)
 RETURNS text
@@ -3972,7 +3973,7 @@ SELECT concat_lower_or_upper('Hello', 'World');
      <literal>=></literal> to separate it from the argument expression.
      For example:
 -->
-名前付け表記では、各引数の名前は<literal>=></literal>を使用し引数の表現と分けて指定されます。例を挙げます。
+名前付け表記では、各引数の名前は<literal>=></literal>を使用し引数の式と分けて指定されます。例を挙げます。
 <screen>
 SELECT concat_lower_or_upper(a => 'Hello', b => 'World');
  concat_lower_or_upper 
@@ -3986,7 +3987,9 @@ SELECT concat_lower_or_upper(a => 'Hello', b => 'World');
      using named notation is that the arguments may be specified in any
      order, for example:
 -->
-繰り返しになりますが、<literal>uppercase</literal>引数が省略されていますので、暗黙的に<literal>false</literal>に設定されます。名前付け表記の使用の利点の１つとして、引数を任意の順序で指定できる点があります。以下に例を示します。
+この場合も、<literal>uppercase</literal>引数が省略されていますので、暗黙的に<literal>false</literal>に設定されます。
+名前付け表記の使用の利点の１つとして、引数を任意の順序で指定できる点があります。
+以下に例を示します。
 <screen>
 SELECT concat_lower_or_upper(a => 'Hello', b => 'World', uppercase => true);
  concat_lower_or_upper 
@@ -4038,7 +4041,9 @@ SELECT concat_lower_or_upper(a := 'Hello', uppercase := true, b := 'World');
     already mentioned, named arguments cannot precede positional arguments.
     For example:
 -->
-混在表記は名前付け表記と位置表記を組み合わせたものです。しかし既に述べたように、名前付けされた引数は位置づけされたパラメータの前に記述することはできません。例を挙げます。
+混在表記は名前付け表記と位置表記を組み合わせたものです。
+しかし既に述べたように、名前付けされた引数は位置づけされたパラメータより前に記述することはできません。
+例を挙げます。
 <screen>
 SELECT concat_lower_or_upper('Hello', 'World', uppercase => true);
  concat_lower_or_upper 


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) 節の冒頭、および２番目のパラグラフは原文に忠実でなかったので全面的に翻訳を見直しました。
(2) "The following examples"で始まる文が原文の意味を取り違えていたので訳し直しました。「本節の例」とするのは、ちょっと訳しすぎですが、実際に指しているのは直後の関数定義より後の4.3.1-3で使われる例のことで、「以下の例」は誤解を招くし、「以降の例」もちょっと不自然な感じなので。
(3) "expression"は「表現」ではなく「式」としました。
(4) "Again"は、前言を繰り返しているのではなく、前と同じことが起きていることを指すので、訳し方を変更し、また句点で改行を入れました。
(5) 「パラメータの前」は意味が曖昧なので「パラメータより前」とし、また句点で改行を入れました。
