### PR TITLE
advanced.sgml: "capital"の訳語を「州都」に変更

### DIFF
--- a/doc/src/sgml/advanced.sgml
+++ b/doc/src/sgml/advanced.sgml
@@ -829,8 +829,8 @@ SELECT sum(salary) OVER w, avg(salary) OVER w
     implicitly when you list all cities.  If you're really clever you
     might invent some scheme like this:
 -->
-2つのテーブル<classname>cities</classname>（都市）テーブルと<classname>capitals</classname>（行政府所在地）テーブルを作ってみましょう。
-行政府所在地は本来同時に都市でもありますので、全ての都市をリストする時は何もしなくても行政府所在地も表示する何らかの方法が必要です。
+2つのテーブル<classname>cities</classname>（都市）テーブルと<classname>capitals</classname>（州都）テーブルを作ってみましょう。
+州都は本来同時に都市でもありますので、全ての都市をリストする時は何もしなくても州都も表示する何らかの方法が必要です。
 賢い人なら次のような案を工夫するかもしれません。
 
 <programlisting>
@@ -897,7 +897,7 @@ CREATE TABLE capitals (
 -->
 この例では、<classname>capitals</classname>テーブルの行は<firstterm>親</firstterm>の<classname>cities</classname>テーブルから全ての列、すなわち<structfield>name</structfield>（都市名）、<structfield>population</structfield>（人口）そして<structfield>altitude</structfield>（標高）を<firstterm>継承</firstterm>します。
 <structfield>name</structfield>列のデータ型は、可変長文字列のために<productname>PostgreSQL</productname>が初めから備えている<type>text</type>型です。
-州の行政府所在地のテーブルは、これに加えて州を示す<structfield>state</>列を持ちます。
+州都のテーブルは、これに加えて州を示す<structfield>state</>列を持ちます。
 <productname>PostgreSQL</productname>では、テーブルは関連付けられたテーブルがあればそれぞれから属性を継承することができます。
    </para>
 
@@ -907,7 +907,7 @@ CREATE TABLE capitals (
     including  state capitals, that are located at an altitude
     over 500 feet:
 -->
-以下の問い合わせの例は、行政府所在地も含めて、標高500フィート以上に位置する全ての都市を求めるものです。
+以下の問い合わせの例は、州都も含めて、標高500フィート以上に位置する全ての都市を求めるものです。
 
 <programlisting>
 SELECT name, altitude
@@ -936,7 +936,7 @@ SELECT name, altitude
     all  the cities that are not state capitals and
     are situated at an altitude over 500 feet:
 -->
-その一方、行政府所在地ではない標高500フィート以上に位置する都市を見つけ出したい時は次のような問い合わせになります。
+その一方、州都ではない標高500フィート以上に位置する都市を見つけ出したい時は次のような問い合わせになります。
 
 <programlisting>
 SELECT name, altitude


### PR DESCRIPTION
advanced.sgmlとddl.sgmlでチュートリアルのcapitalsテーブルを参照していますが、advancedでは「行政府所在地」、ddlでは「州都」と訳していました。
「州都」の方が一般的だと思っているので、そちらに統一します。