### PR TITLE
ddl.sgml (5.4節 システム列)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -1457,7 +1457,7 @@ TABLE ... CONSTRAINT ... EXCLUDE</></link>を参照して下さい。
       linkend="datatype-oid"> for more information about the type.
 -->
 行のオブジェクト識別子（オブジェクトID）です。
-この列は<literal>WITH OIDS</literal>を付けてテーブルが作成された場合、あるいはその時に<xref linkend="guc-default-with-oids">設定変数が設定されていた場合にのみ存在します。
+この列は<literal>WITH OIDS</literal>を付けてテーブルが作成された場合、あるいはテーブル作成時に<xref linkend="guc-default-with-oids">設定変数が設定されていた場合にのみ存在します。
 この列の型は<literal>oid</literal>（列名と同じ）です。この型についての詳細は<xref linkend="datatype-oid">を参照してください。
      </para>
     </listitem>

--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -1457,7 +1457,7 @@ TABLE ... CONSTRAINT ... EXCLUDE</></link>を参照して下さい。
       linkend="datatype-oid"> for more information about the type.
 -->
 行のオブジェクト識別子（オブジェクトID）です。
-この列は<literal>WITH OIDS</literal>を付けた場合と、その時に<xref linkend="guc-default-with-oids">が設定されていた場合に作成されます。
+この列は<literal>WITH OIDS</literal>を付けてテーブルが作成された場合、あるいはその時に<xref linkend="guc-default-with-oids">設定変数が設定されていた場合にのみ存在します。
 この列の型は<literal>oid</literal>（列名と同じ）です。この型についての詳細は<xref linkend="datatype-oid">を参照してください。
      </para>
     </listitem>
@@ -1483,7 +1483,7 @@ TABLE ... CONSTRAINT ... EXCLUDE</></link>を参照して下さい。
 この行を含むテーブルのOIDです。
 この列は特に、継承階層からの選択問い合わせでは便利です（<xref linkend="ddl-inherit">を参照してください）。
 この列がないと、どのテーブルからその行が来たのかわかりにくいからです。
-<structfield>tableoid</structfield>はテーブル名を得るために<classname>pg_class</classname>の<structfield>oid</structfield>列に結合することができます。
+<structfield>tableoid</structfield>を<classname>pg_class</classname>の<structfield>oid</structfield>列に結合することでテーブル名を得ることができます。
      </para>
     </listitem>
    </varlistentry>
@@ -1503,8 +1503,8 @@ TABLE ... CONSTRAINT ... EXCLUDE</></link>を参照して下さい。
       logical row.)
 -->
 この行バージョンの挿入トランザクションの識別情報（トランザクションID）です。
-（行のバージョンとは、行の個別の状態です。
-行が更新される度に、同一の論理的な行に対する新しいバージョンの行が作成されます。）
+（行バージョンとは、行の個別の状態です。
+行が更新される度に、同一の論理的な行に対する新しい行バージョンが作成されます。）
      </para>
     </listitem>
    </varlistentry>
@@ -1542,8 +1542,8 @@ TABLE ... CONSTRAINT ... EXCLUDE</></link>を参照して下さい。
       deletion was rolled back.
 -->
 削除トランザクションの識別情報（トランザクションID）です。
-削除されていない行ではゼロです。
-可視のバージョンの行でこの列が非ゼロの場合があります。
+削除されていない行バージョンではゼロです。
+可視の行バージョンでこの列が非ゼロの場合があります。
 これは通常、削除トランザクションがまだコミットされていないこと、または、削除の試行がロールバックされたことを意味しています。
      </para>
     </listitem>
@@ -1584,7 +1584,7 @@ TABLE ... CONSTRAINT ... EXCLUDE</></link>を参照して下さい。
       number, should be used to identify logical rows.
 -->
 テーブル内における、行バージョンの物理的位置を表します。
-<structfield>ctid</structfield>は行バージョンを素早く見つけるために使うことができますが、行の<structfield>ctid</structfield>は更新されたり、<command>VACUUM FULL</>により移動させられたりすると変わります。
+<structfield>ctid</structfield>は行バージョンを素早く見つけるために使うことができますが、行の<structfield>ctid</structfield>は<command>VACUUM FULL</>により更新あるいは移動させられると変わります。
 したがって、<structfield>ctid</structfield>は長期の行識別子としては使えません。
 論理行を識別するためには、OID、あるいはさらに良いのはユーザ定義の通番数を使うべきです。
      </para>
@@ -1622,7 +1622,7 @@ OIDは32ビット数であり、クラスタ全体で1つのカウンタです�
        table size had better be much less than that, or performance
        might suffer.)
 -->
-一意性制約は、OIDが行を同定するために使用されるようなテーブルのOID列に作成されなくてはいけません。
+OIDを行の特定のために使用するテーブルについては、OID列に一意性制約を作成するべきです。
 このような一意性制約（もしくは一意インデックス）が存在する場合は、システムは既存の行に一致するようなOIDを生成しません。
 （もちろん、これはテーブルの行数が2<superscript>32</>（40億）より少ない場合に可能となります。性能を考慮すると、実際には行数はそれよりずっと少ない方がよいでしょう。）
       </para>


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) oid列が作成される場合の説明について、訳文を原文に忠実なものにしました。
(2) tableoidからテーブル名を取得する方法の説明について、自然な日本語になるよう、to不定詞を目的ではなく結果の意味にして訳しました。
(3) "row version"の訳し方がバラバラだったので「行バージョン」に統一しました(が、これが適切かどうか、今一つ、自信はありません）。
(4) ctidの値が変わる場合について、"by VACUUM FULL"の掛かり先の解釈が間違っているように思えたので、修正しました。
(5) "should"を"must"と同じに訳していた文について、訂正すると同時に、自然な日本語になるよう訳を見直しました。