### PR TITLE
queries.sgml (主に7.2.1.1項 結合テーブル)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/queries.sgml
+++ b/doc/src/sgml/queries.sgml
@@ -117,7 +117,7 @@ SELECT 3 * 4;
   This is more useful if the expressions in the select list return
   varying results.  For example, you could call a function this way:
 -->
-選択リストの式が様々な結果を返す場合、これはさらに有用です。
+選択リストの式が返す結果が変化する場合、これはさらに有用です。
 例えば、関数を次のように呼び出すことができます。
 <programlisting>
 SELECT random();
@@ -198,9 +198,9 @@ FROM <replaceable>table_reference</replaceable> <optional>, <replaceable>table_r
     and <literal>HAVING</> clauses and is finally the result of the
     overall table expression.
 -->
-テーブル参照は、テーブル名（スキーマで修飾することもできます）、副問い合わせによる派生テーブル、<literal>結合</>の組み立て、またはこれらの複雑な組み合わせからなります。
-<literal>FROM</>句に複数のテーブル参照がある場合、クロス結合されます（その行のデカルト積が形成されます。下記を参照）。
-<literal>FROM</>リストは<literal>WHERE</>句、<literal>GROUP BY</>句、および<literal>HAVING</>句で変換対象となる中間的な仮想テーブルになり、最終的にはテーブル式全体の結果となります。
+テーブル参照は、テーブル名（スキーマで修飾することもできます）、あるいは、副問い合わせ、<literal>JOIN</>による結合、これらの複雑な組み合わせなどの派生テーブルとすることができます。
+<literal>FROM</>句に複数のテーブル参照がある場合、クロス結合されます（テーブルの行のデカルト積が形成されます。下記を参照）。
+<literal>FROM</>リストの結果は<literal>WHERE</>句、<literal>GROUP BY</>句、および<literal>HAVING</>句での変換対象となる中間的な仮想テーブルになり、最終的にはテーブル式全体の結果となります。
    </para>
 
    <indexterm>
@@ -333,7 +333,7 @@ FROM <replaceable>table_reference</replaceable> <optional>, <replaceable>table_r
         <literal>FROM <replaceable>T1</replaceable>,
         <replaceable>T2</replaceable></literal>.
 -->
-<literal>FROM <replaceable>T1</replaceable> CROSS JOIN <replaceable>T2</replaceable></literal> は <literal>FROM <replaceable>T1</replaceable> INNER JOIN <replaceable>T2</replaceable> ON TRUE</literal> と同じです(後述)。
+<literal>FROM <replaceable>T1</replaceable> CROSS JOIN <replaceable>T2</replaceable></literal> は <literal>FROM <replaceable>T1</replaceable> INNER JOIN <replaceable>T2</replaceable> ON TRUE</literal> と同じです（下記を参照）。
 また <literal>FROM <replaceable>T1</replaceable>, <replaceable>T2</replaceable></literal> とも同じです。
         <note>
         <para>
@@ -352,15 +352,18 @@ FROM <replaceable>table_reference</replaceable> <optional>, <replaceable>table_r
          reference <replaceable>T1</replaceable> in the first case but not
          the second.
 -->
-正確には２つより多いテーブルが現れた場合、この後者の等価性は保たれてはいません。なぜなら、<literal>JOIN</>はカンマより強固に結合するためです。例えば
+３つ以上のテーブルが現れた場合、この後者の等価性は厳密には保たれてはいません。
+なぜなら、<literal>JOIN</>はカンマより強固に結合するためです。
+例えば
 <literal>FROM <replaceable>T1</replaceable> CROSS JOIN
 <replaceable>T2</replaceable> INNER JOIN <replaceable>T3</replaceable>
-ON <replaceable>条件</replaceable></literal>
+ON <replaceable>condition</replaceable></literal>
 は
 <literal>FROM <replaceable>T1</replaceable>,
 <replaceable>T2</replaceable> INNER JOIN <replaceable>T3</replaceable>
-ON <replaceable>条件</replaceable></literal>
-と同じではありません。なぜなら最初のケースでは<replaceable>条件</replaceable>が<replaceable>T1</replaceable>を参照できますが、2番目はできません。
+ON <replaceable>condition</replaceable></literal>
+と同じではありません。
+なぜなら最初のケースでは<replaceable>condition</replaceable>が<replaceable>T1</replaceable>を参照できますが、2番目ではできないからです。
         </para>
         </note>
        </para>
@@ -371,7 +374,7 @@ ON <replaceable>条件</replaceable></literal>
 <!--
       <term>Qualified joins
 -->
-      <term>修飾付き結合
+      <term>限定的な結合
       <indexterm>
 <!--
        <primary>join</primary>
@@ -425,7 +428,7 @@ ON <replaceable>条件</replaceable></literal>
 <!--
         The possible types of qualified join are:
 -->
-修飾付き結合には次のものがあります。
+限定的な結合には次のものがあります。
 
        <variablelist>
         <varlistentry>
@@ -440,7 +443,7 @@ ON <replaceable>条件</replaceable></literal>
            For each row R1 of T1, the joined table has a row for each
            row in T2 that satisfies the join condition with R1.
 -->
-T1の行R1に対して、T2において行R1との結合条件を満たしている行が、結合されたテーブルに含まれます。
+T1の各行R1に対して、T2において行R1との結合条件を満たしている各行が、結合されたテーブルに含まれます。
           </para>
          </listitem>
         </varlistentry>
@@ -555,7 +558,7 @@ T1の行R1に対して、T2において行R1との結合条件を満たしてい
         from <replaceable>T1</> and <replaceable>T2</> match if the
         <literal>ON</> expression evaluates to true.
 -->
-<literal>ON</>句は最も一般的な結合条件であり、<literal>WHERE</>句で使われるものと同じ論理値評価式となります。
+<literal>ON</>句は最も汎用的な結合条件であり、<literal>WHERE</>句で使われるものと同じ論理値評価式となります。
 <literal>ON</>式の評価が真となる場合、<replaceable>T1</>および<replaceable>T2</>の対応する行が一致します。
        </para>
 
@@ -572,10 +575,9 @@ T1の行R1に対して、T2において行R1との結合条件を満たしてい
         = <replaceable>T2</>.a AND <replaceable>T1</>.b
         = <replaceable>T2</>.b</literal>.
 -->
-<literal>USING</>句は省略形です。
-両側に同じ名前の結合する列（複数可）がある特定の状況で利用することが出来ます。
-それは、結合テーブルが共通で持つカンマで区切られた列名のリストから、それぞれの列の組み合わせの等価性を結合条件として生成します。
-例えば, <replaceable>T1</>と<replaceable>T2</>を<literal>USING (a, b)</>と共に使用した場合は、<literal>ON <replaceable>T1</>.a = <replaceable>T2</>.a AND <replaceable>T1</>.b = <replaceable>T2</>.b</literal>という結合条件を生成します。
+<literal>USING</>句は、結合の両側で結合列に同じ名前を使っているという特別な状況の利点を活かすことができる省略形です。
+それは、結合テーブルが共通で持つ列名をカンマで区切ったリストから、それぞれの列の組み合わせの等価性を結合条件として生成します。
+例えば, <replaceable>T1</>と<replaceable>T2</>を<literal>USING (a, b)</>を使用して結合する場合は、<literal>ON <replaceable>T1</>.a = <replaceable>T2</>.a AND <replaceable>T1</>.b = <replaceable>T2</>.b</literal>という結合条件を生成します。
        </para>
 
        <para>
@@ -590,7 +592,8 @@ T1の行R1に対して、T2において行R1との結合条件を満たしてい
         followed by any remaining columns from <replaceable>T2</>.
 -->
 さらに、<literal>JOIN USING</>の出力は、冗長列を抑制します。マッチした列は両方が同じ値を待つので両方を出力する必要がありません。
-<literal>JOIN ON</> は <replaceable>T1</> からすべての列と続く <replaceable>T2</> からすべての列を生成します。<literal>JOIN USING</>は列のペアリスト(リスト順)毎に１つの列を出力します。そして、<replaceable>T1</> の残りの列を出力し、<replaceable>T2</>の残りの列を出力します。
+<literal>JOIN ON</> は <replaceable>T1</> からのすべての列と、それに続く <replaceable>T2</> からのすべての列を生成します。
+<literal>JOIN USING</>は指定された列のペアのそれぞれについて１つの出力（結合リストでの指定順）、続いて<replaceable>T1</>の残りの列、その後に<replaceable>T2</>の残りの列を出力します。
        </para>
 
        <para>
@@ -617,8 +620,7 @@ T1の行R1に対して、T2において行R1との結合条件を満たしてい
         column names, <literal>NATURAL</literal> behaves like
         <literal>CROSS JOIN</literal>.
 -->
-最後に、<literal>NATURAL</>は<literal>USING</>の略記形式です。
-２つの入力テーブルの両方に含まれているすべての列名で構成される<literal>USING</>リストを形成します。
+最後に、<literal>NATURAL</>は<literal>USING</>の略記形式で、２つの入力テーブルの両方に含まれているすべての列名で構成される<literal>USING</>リストを形成します。
 <literal>USING</>と同様、これらの列は出力テーブルに一度だけ現れます。
 共通する列が存在しない場合、<literal>NATURAL</literal>は<literal>CROSS JOIN</literal>と同様に動作します。
        </para>
@@ -634,7 +636,8 @@ T1の行R1に対して、T2において行R1との結合条件を満たしてい
          column as well.
 -->
 <literal>USING</literal>は、リストされている列のみ結合するのでリレーションの列の変更から適度に安全です。
-<literal>NATURAL</>は、かなり危険です。新しい列だけでなく、いずれかのリレーションのスキーマ変更も新しく列名が一致するような結合の組み合わせの原因となるためです。
+<literal>NATURAL</>は、<literal>USING</literal>よりもかなり危険です。
+いずれかのリレーションのスキーマ変更により新しくマッチする列名が作られると、結合にその新しい列も使われるようになってしまうからです。
         </para>
        </note>
       </listitem>
@@ -779,6 +782,7 @@ T1の行R1に対して、T2において行R1との結合条件を満たしてい
      joins.
 -->
 この理由は<literal>ON</>句の中の制約は結合の<emphasis>前</>に処理され、一方<literal>WHERE</>句の中の制約は結合の<emphasis>後</>に処理されることによります。
+これは内部結合には影響がありませんが、外部結合には大きな影響があります。
     </para>
    </sect3>
 

--- a/doc/src/sgml/queries.sgml
+++ b/doc/src/sgml/queries.sgml
@@ -576,7 +576,7 @@ T1の各行R1に対して、T2において行R1との結合条件を満たして
         = <replaceable>T2</>.b</literal>.
 -->
 <literal>USING</>句は、結合の両側で結合列に同じ名前を使っているという特別な状況の利点を活かすことができる省略形です。
-それは、結合テーブルが共通で持つ列名をカンマで区切ったリストから、それぞれの列の組み合わせの等価性を結合条件として生成します。
+それは、結合テーブルが共通で持つ列名をカンマで区切ったリストから、それぞれの列のの等価性を結合条件として生成します。
 例えば, <replaceable>T1</>と<replaceable>T2</>を<literal>USING (a, b)</>を使用して結合する場合は、<literal>ON <replaceable>T1</>.a = <replaceable>T2</>.a AND <replaceable>T1</>.b = <replaceable>T2</>.b</literal>という結合条件を生成します。
        </para>
 


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) "varying"を"various"と誤読していたと思われるので修正
(2) "such as"の掛かり先の解釈が間違っていたので修正
(3) replaceableタグの内側は訳さない
(4) "qualified join"を「修飾付き結合」と訳していたが、これは"cross join"と対比して使っているので、schema-qualifiedから訳語を借りて「修飾付き」とするのは誤り。とりあえず「限定的な」としたが、もっと良い訳語はないか？
(5) "considerably more risky"を単に「かなり危険」と訳していたが、絶対的に危険なのではなく、比較対象に比べると危険度が高いという話なので、原文では省略されている"than..."を訳文では補った。
(6) "That does not matter..."の文が訳抜けしていたので翻訳
(7) その他、原文に忠実でないと思われる訳文や訳語について変更