### PR TITLE
ddl.sgml (5.5節 テーブルの変更)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -1804,7 +1804,7 @@ OIDは複数のテーブルをまたがって一意であると仮定しては�
 <!--
     To add a column, use a command like:
 -->
-列を追加するには、次のようにコマンドを使用します。
+列を追加するには、次のようなコマンドを使用します。
 <programlisting>
 ALTER TABLE products ADD COLUMN description text;
 </programlisting>
@@ -1833,7 +1833,7 @@ ALTER TABLE products ADD COLUMN description text CHECK (description &lt;&gt; '')
     correctly.
 -->
 実際には<command>CREATE TABLE</>内の列の記述に使用されている全てのオプションが、ここで使用できます。
-ただしデフォルト値は与えられている制約を満足するものでなくてはならないことに注意してください。満足しない場合は<literal>ADD</>が失敗します。一方で、新規の列に正しく値を入れた後で制約を追加することができます（後述）。
+ただしデフォルト値は与えられている制約を満足するものでなくてはならないことに注意してください。満足しない場合は<literal>ADD</>が失敗します。一方で、新規の列に正しく値を入れた後で制約を追加することができます（下記参照）。
    </para>
 
   <tip>
@@ -1874,7 +1874,7 @@ ALTER TABLE products ADD COLUMN description text CHECK (description &lt;&gt; '')
 <!--
     To remove a column, use a command like:
 -->
-列を削除するには、次のようにコマンドを使用します。
+列を削除するには、次のようなコマンドを使用します。
 <programlisting>
 ALTER TABLE products DROP COLUMN description;
 </programlisting>
@@ -1887,9 +1887,9 @@ ALTER TABLE products DROP COLUMN description;
     the column by adding <literal>CASCADE</>:
 -->
 列内にある、どんなデータであれ消去します。
-また列を含むテーブルの制約も消去されます。
-しかし、もし列が他のテーブルの外部キー制約として参照されている場合は、<productname>PostgreSQL</productname>は暗黙のうちに制約を消去しません。
-<literal>CASCADE</>を追加することにより列に依存する全てを消去することができます。
+またその列に関連するテーブルの制約も消去されます。
+しかし、その列が他のテーブルの外部キー制約として参照されている場合は、<productname>PostgreSQL</productname>は暗黙のうちに制約を消去したりはしません。
+<literal>CASCADE</>を追加することにより列に依存する全てを消去することを許可できます。
 <programlisting>
 ALTER TABLE products DROP COLUMN description CASCADE;
 </programlisting>
@@ -1930,7 +1930,7 @@ ALTER TABLE products ADD FOREIGN KEY (product_group_id) REFERENCES product_group
     To add a not-null constraint, which cannot be written as a table
     constraint, use this syntax:
 -->
-テーブル制約として記述できない非NULL制約を追加するには、次の構文を使用します。
+非NULL制約はテーブル制約として記述できないので、追加するには次の構文を使用します。
 <programlisting>
 ALTER TABLE products ALTER COLUMN product_no SET NOT NULL;
 </programlisting>
@@ -1972,10 +1972,10 @@ ALTER TABLE products ALTER COLUMN product_no SET NOT NULL;
 -->
 制約を削除するには、その制約名を知る必要があります。
 自分で名前を付けた場合は簡単です。
-しかし、自分で名前を付けていない場合はシステム生成の名前が割り当てられているので、それを探さなくてはなりません。
+しかし、自分で名前を付けていない場合はシステム生成の名前が割り当てられているので、それを調べなくてはなりません。
 それには<application>psql</application>の<literal>\d <replaceable>tablename</replaceable></literal>コマンドを使用すると便利です。
 他のインタフェースにもテーブルの詳細を調べる方法があるかもしれません。
-コマンドは以下の通りです。
+制約名がわかったら、次のコマンドで制約を削除できます。
 <programlisting>
 ALTER TABLE products DROP CONSTRAINT some_name;
 </programlisting>
@@ -1994,7 +1994,8 @@ ALTER TABLE products DROP CONSTRAINT some_name;
     is that a foreign key constraint depends on a unique or primary key
     constraint on the referenced column(s).
 -->
-列の削除に関して、何かが依存している制約を削除する場合には<literal>CASCADE</>を付ける必要があります。例として、参照されている列に付いている一意または主キー制約に依存している外部キー制約を削除する場合です。
+列の削除の場合と同じく、何か他のものが依存している制約を削除する場合には<literal>CASCADE</>を付ける必要があります。
+例えば、外部キー制約は、参照されている列の一意または主キー制約に依存しています。
    </para>
 
    <para>
@@ -2002,7 +2003,7 @@ ALTER TABLE products DROP CONSTRAINT some_name;
     This works the same for all constraint types except not-null
     constraints. To drop a not null constraint use:
 -->
-これは、非NULL制約以外の全ての制約型に適用できます。
+上記は、非NULL制約以外の全ての制約型に適用できます。
 非NULL制約を削除するには、次のようにします。
 <programlisting>
 ALTER TABLE products ALTER COLUMN product_no DROP NOT NULL;


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) 「次のようにコマンドを使用」はちょっと違和感があった(原文に忠実でもない)ので「次のよう『な』コマンドを使用」としました。
(2) "see below"は、その直下の記述を参照しているので、「後述」ではなく「下記参照」としました。
(3) "constraints involving the column"のinvolveは「～を巻き込む」という意味なので「列を含む制約」ではなく「列に関連する制約」としました。
(4) 「テーブル制約として記述できない非NULL制約」だと、「テーブル制約として記述できる非NULL制約」もあるような感じがするので、訳し方を変えました。
(5) "Then the command is:"を「コマンドは以下の通りです」とするのは"Then"が訳されていないことを除けば原文に忠実だったのですが、その直前に制約名を調べる「コマンド」の話をしていて、文脈上は大きな誤解を招く表現になっていました。"Then"は「(制約名がわかったので)次は」、"the command"は「(制約を削除する)コマンド」という意味なので、思い切って意訳しました。
(6) "As with"の解釈が間違っていたので、訳を修正しました。
(7) "This"の指すものが「これ」では不明確だったので、「上記」としました。