### PR TITLE
datatype.sgml (8.2 通貨型、8.3 文字型)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -1419,7 +1419,7 @@ SELECT '12.34'::float8::numeric::money;
     However, this is not recommended.  Floating point numbers should not be
     used to handle money due to the potential for rounding errors.
 -->
-しかしこれは推奨されません。浮動小数点数値は丸めの可能性がありますので貨幣を扱うために使用すべきではありません。
+しかしこれは推奨されません。浮動小数点数値は丸め誤差の可能性がありますので貨幣を扱うために使用すべきではありません。
    </para>
 
    <para>
@@ -1429,7 +1429,7 @@ SELECT '12.34'::float8::numeric::money;
     precision, and must also be done in two stages:
 -->
 <type>money</type>型の値は精度を落とすことなく<type>numeric</type>にキャストすることができます。
-他の型への変換では精度を落とす可能性がありますので、２段階で行う必要があります。
+他の型への変換では精度を落とす可能性があり、また２段階で行う必要があります。
 <programlisting>
 SELECT '52093.89'::money::numeric::float8;
 </programlisting>
@@ -1563,8 +1563,8 @@ SELECT '52093.89'::money::numeric::float8;
 <type>character varying(<replaceable>n</>)</type>と<type>character(<replaceable>n</>)</type>です。
 ここで<replaceable>n</>は正の整数です。
 これらのデータ型は2つとも<replaceable>n</>文字長（バイト数ではなく）までの文字列を保存できます。
-超過している文字がすべて空白の場合を除いて、上限を越えた文字列をこの型の列に保存しようとするとエラーになります。
-すべて空白の場合は長さの限界で切り捨てられます。
+上限を越えた文字列をこれらの型の列に保存しようとするとエラーになります。
+ただし、上限を超えた部分にある文字がすべて空白の場合はエラーにはならず、文字列の最大長にまで切り詰められます。
 （この一風変わった例外は標準<acronym>SQL</acronym>で要求されています。）
 もし宣言された上限よりも文字列が短い時は<type>character</type>の値は空白で埋められ、<type>character varying</type>の値は単にその短い文字列で保存されます。
    </para>
@@ -1632,7 +1632,7 @@ SELECT '52093.89'::money::numeric::float8;
 <type>character</type>型の値は、指定長<replaceable>n</>になるまで物理的に空白で埋められ、そのまま格納、表示されます。
 しかし、最後の空白は、重要ではないものとして扱われ、2つの<type>character</type>型の値を比べる際には無視されます。
 空白が重要な照合順序では、この挙動は予期しない結果を返す可能性があります。例えば、<command>SELECT 'a '::CHAR(2) collate "C" &lt; E'a\n'::CHAR(2)</command>は<literal>C</>ロケールでスペースが改行よりも大きいにも関わらず真を返します。
-また、<type>character</type>値を他の文字列型に変換する際には除去されます。
+<type>character</type>値を他の文字列型に変換する際は、文字列の終わりの空白は除去されます。
 <type>character varying</type>型と<type>text</type>型の値の中や、パターンマッチを行なう際、すなわち<literal>LIKE</>や正規表現では、最後の空白は意味的に重要なもの<emphasis>です</>ので、注意してください。
    </para>
 
@@ -1655,14 +1655,14 @@ SELECT '52093.89'::money::numeric::float8;
     specifier, rather than making up an arbitrary length limit.)
 -->
 短い文字列（126バイトまで）の保存には、実際の文字列に１バイト加えたサイズが必要です。
-<type>character</type>では空白埋め込み分が加わります。
+<type>character</type>では空白埋め込み分もこれに含まれます。
 より長い文字列では１バイトではなく４バイトのオーバーヘッドになります。
 長い文字列はシステムにより自動的に圧縮されますので、ディスク上の物理的必要容量サイズはより小さくなるかもしれません。
 また、非常に長い値はより短い列の値への高速アクセスに干渉しないように、バックグラウンドテーブルに格納されます。
 いずれの場合にあっても保存できる最長の文字列は約1ギガバイトです。
 （データ型宣言に使われる<replaceable>n</>に許される最大値はこれより小さいものです。
 マルチバイト文字符号化方式においては文字数とバイト数はまったく異なっているため、この値の変更は便利ではありません。
-特定の上限を設けずに長い文字列を保存したい場合は、任意の上限を設けるよりも長さの指定がない<type>text</type>もしくは<type>character varying</type>を使用してください。）
+特定の上限を設けずに長い文字列を保存したい場合は、適当な上限を設けるよりも、<type>text</type>もしくは長さの指定がない<type>character varying</type>を使用してください。）
    </para>
 
    <tip>
@@ -1706,7 +1706,7 @@ SELECT '52093.89'::money::numeric::float8;
 <!--
     <title>Using the Character Types</title>
 -->
-<title>文字データ型を使って</title>
+<title>文字データ型の使用</title>
 
 <programlisting>
 CREATE TABLE test1 (a character(4));


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) "rounding errors"を「丸め」と訳していたのを「丸め誤差」に変更
(2) 「Aの可能性がありますので、Bを行う必要があります」だと、「Bをすれば、Aの可能性を防げる」ことを示唆するが、原文はそんなことは言っていないので、単に「～可能性があり、また～必要があります」に訂正
(3) 長過ぎる文字列を代入するときの例外の説明がわかりにくかったので、訳文の分け方を変更して、さらに訳を一部修正
(4) "trailing spaces"が訳文に出ていなかったので、明示的に訳した
(5) "include"を「加わります」としていたが、誤解を招く可能性もあるので、「含まれます」に変更
(6) "without a length specifier"の掛かり先の解釈が間違っていたので訂正