### PR TITLE
ddl.sgml (5.6 権限)の翻訳改善

### DIFF
--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -2234,7 +2234,7 @@ ALTER TABLE products RENAME TO items;
 -->
 権限にはいくつかの種類があります。
 すなわち<literal>SELECT</>、 <literal>INSERT</>、<literal>UPDATE</>、<literal>DELETE</>、<literal>TRUNCATE</>、<literal>REFERENCES</>、<literal>TRIGGER</>、<literal>CREATE</>、<literal>CONNECT</>、<literal>TEMPORARY</>、 <literal>EXECUTE</>、<literal>USAGE</>です。
-特定のオブジェクトに適用する権限は、オブジェクトの型（テーブル、関数など）により変わります。
+特定のオブジェクトに適用可能な権限は、オブジェクトの型（テーブル、関数など）により変わります。
 <productname>PostgreSQL</productname>がサポートする様々な権限の詳細については<xref linkend="sql-grant">リファレンスページを参照してください。
 以降の節および章でもこれらの権限の使用方法についての説明があります。
   </para>
@@ -2323,7 +2323,7 @@ REVOKE ALL ON accounts FROM PUBLIC;
    privilege.  For details see the <xref linkend="sql-grant"> and
    <xref linkend="sql-revoke"> reference pages.
 -->
-普通はオブジェクトの所有者（またはスーパーユーザ）は、オブジェクトにおける権限の付与や剥奪ができます。
+普通はオブジェクトの所有者（またはスーパーユーザ）だけが、オブジェクトにおける権限の付与や剥奪ができます。
 しかし<quote>with grant option</>を付けることで、権限を与えられたユーザが、所有者と同様に他のユーザに権限を付与することが可能になります。
 もし後になってグラントオプションが剥奪されると、剥奪されたユーザから（直接もしくは権限付与の連鎖により）権限を与えられていたユーザはすべて、その権限が剥奪されます。
 詳細は、<xref linkend="sql-grant">と<xref linkend="sql-revoke">を参照してください。


### PR DESCRIPTION
(1) applicableを原文に忠実に「適用可能な」としました。
(2) "only"が訳文に出ていませんでしたが、重要な意味を持っているので、明示的に訳しました。