### PR TITLE
func.sgml (9.26.6, 9.26.8)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -23616,7 +23616,8 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
     Many of these functions have equivalent commands in the replication
     protocol; see <xref linkend="protocol-replication">.
 -->
-ここの関数の多くには、レプリケーションプロトコルに等価なコマンドがあります。<xref linkend="protocol-replication">を参照してください。
+これらの関数の多くには、レプリケーションプロトコルに等価なコマンドがあります。
+<xref linkend="protocol-replication">を参照してください。
    </para>
 
    <para>
@@ -23711,7 +23712,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
         effect as the replication protocol command
         <literal>CREATE_REPLICATION_SLOT ... LOGICAL</literal>.
 -->
-<parameter>slot_name</parameter>という名前の新しい論理(デコード)レプリケーションスロットを作成します。
+出力プラグイン<parameter>plugin</parameter>を使用して、<parameter>slot_name</parameter>という名前の新しい論理(デコード)レプリケーションスロットを作成します。
 この関数を呼び出すのはレプリケーションプロトコルコマンド<literal>CREATE_REPLICATION_SLOT ... LOGICAL</literal>と同じ効果があります。
        </entry>
       </row>
@@ -23925,7 +23926,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
 <!--
         Has a replication origin been configured in the current session?
 -->
-現在のセッションで、レプリケーション起点が設定されたか
+現在のセッションで、レプリケーション起点が設定されたかどうかを返します。
        </entry>
       </row>
 
@@ -24514,14 +24515,14 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
     <xref linkend="functions-admin-index-table"> shows the functions
     available for index maintenance tasks.
 -->
-<xref linkend="functions-admin-index-table">にインデックスの補修タスクに使用できる関数を示します。
+<xref linkend="functions-admin-index-table">にインデックスの保守タスクに使用できる関数を示します。
    </para>
 
    <table id="functions-admin-index-table">
 <!--
     <title>Index Maintenance Functions</title>
 -->
-    <title>インデックス補修関数</title>
+    <title>インデックス保守関数</title>
     <tgroup cols="3">
      <thead>
 <!--

--- a/doc/src/sgml/func0.sgml
+++ b/doc/src/sgml/func0.sgml
@@ -1,11 +1,11 @@
 <!-- 警告：このファイルは直接編集しないでください！
- 1. func.sgmlを編集したら、split.shを起動します。
- 2. するとfunc[0-4].sgmlが生成されます。
- 3. func.sgmlとともにfunc[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
- 4. レビューはfunc[0-4].sgmlに対して行います。
- 5. 指摘された点があればfunc.sgmlに反映し、1に戻ります。
- 6. func.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
- -->
+1. func.sgmlを編集したら、split.shを起動します。
+2. するとfunc[0-4].sgmlが生成されます。
+3. func.sgmlとともにfunc[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
+4. レビューはfunc[0-4].sgmlに対して行います。
+5. 指摘された点があればfunc.sgmlに反映し、1に戻ります。
+6. func.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
+-->
 <!-- doc/src/sgml/func.sgml -->
 
  <chapter id="functions">

--- a/doc/src/sgml/func1.sgml
+++ b/doc/src/sgml/func1.sgml
@@ -1,11 +1,11 @@
 <!-- 警告：このファイルは直接編集しないでください！
- 1. func.sgmlを編集したら、split.shを起動します。
- 2. するとfunc[0-4].sgmlが生成されます。
- 3. func.sgmlとともにfunc[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
- 4. レビューはfunc[0-4].sgmlに対して行います。
- 5. 指摘された点があればfunc.sgmlに反映し、1に戻ります。
- 6. func.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
- -->
+1. func.sgmlを編集したら、split.shを起動します。
+2. するとfunc[0-4].sgmlが生成されます。
+3. func.sgmlとともにfunc[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
+4. レビューはfunc[0-4].sgmlに対して行います。
+5. 指摘された点があればfunc.sgmlに反映し、1に戻ります。
+6. func.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
+-->
 <!-- split-func1-start -->
 
   <sect1 id="functions-logical">

--- a/doc/src/sgml/func2.sgml
+++ b/doc/src/sgml/func2.sgml
@@ -1,11 +1,11 @@
 <!-- 警告：このファイルは直接編集しないでください！
- 1. func.sgmlを編集したら、split.shを起動します。
- 2. するとfunc[0-4].sgmlが生成されます。
- 3. func.sgmlとともにfunc[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
- 4. レビューはfunc[0-4].sgmlに対して行います。
- 5. 指摘された点があればfunc.sgmlに反映し、1に戻ります。
- 6. func.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
- -->
+1. func.sgmlを編集したら、split.shを起動します。
+2. するとfunc[0-4].sgmlが生成されます。
+3. func.sgmlとともにfunc[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
+4. レビューはfunc[0-4].sgmlに対して行います。
+5. 指摘された点があればfunc.sgmlに反映し、1に戻ります。
+6. func.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
+-->
 <!-- split-func2-start -->
 
   <sect1 id="functions-formatting">

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -1,11 +1,11 @@
 <!-- 警告：このファイルは直接編集しないでください！
- 1. func.sgmlを編集したら、split.shを起動します。
- 2. するとfunc[0-4].sgmlが生成されます。
- 3. func.sgmlとともにfunc[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
- 4. レビューはfunc[0-4].sgmlに対して行います。
- 5. 指摘された点があればfunc.sgmlに反映し、1に戻ります。
- 6. func.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
- -->
+1. func.sgmlを編集したら、split.shを起動します。
+2. するとfunc[0-4].sgmlが生成されます。
+3. func.sgmlとともにfunc[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
+4. レビューはfunc[0-4].sgmlに対して行います。
+5. 指摘された点があればfunc.sgmlに反映し、1に戻ります。
+6. func.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
+-->
 <!-- split-func3-start -->
 
  <sect1 id="functions-json">

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -1,11 +1,11 @@
 <!-- 警告：このファイルは直接編集しないでください！
- 1. func.sgmlを編集したら、split.shを起動します。
- 2. するとfunc[0-4].sgmlが生成されます。
- 3. func.sgmlとともにfunc[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
- 4. レビューはfunc[0-4].sgmlに対して行います。
- 5. 指摘された点があればfunc.sgmlに反映し、1に戻ります。
- 6. func.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
- -->
+1. func.sgmlを編集したら、split.shを起動します。
+2. するとfunc[0-4].sgmlが生成されます。
+3. func.sgmlとともにfunc[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
+4. レビューはfunc[0-4].sgmlに対して行います。
+5. 指摘された点があればfunc.sgmlに反映し、1に戻ります。
+6. func.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
+-->
 <!-- split-func4-start -->
 
  <sect1 id="functions-subquery">
@@ -4860,7 +4860,8 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
     Many of these functions have equivalent commands in the replication
     protocol; see <xref linkend="protocol-replication">.
 -->
-ここの関数の多くには、レプリケーションプロトコルに等価なコマンドがあります。<xref linkend="protocol-replication">を参照してください。
+これらの関数の多くには、レプリケーションプロトコルに等価なコマンドがあります。
+<xref linkend="protocol-replication">を参照してください。
    </para>
 
    <para>
@@ -4955,7 +4956,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
         effect as the replication protocol command
         <literal>CREATE_REPLICATION_SLOT ... LOGICAL</literal>.
 -->
-<parameter>slot_name</parameter>という名前の新しい論理(デコード)レプリケーションスロットを作成します。
+出力プラグイン<parameter>plugin</parameter>を使用して、<parameter>slot_name</parameter>という名前の新しい論理(デコード)レプリケーションスロットを作成します。
 この関数を呼び出すのはレプリケーションプロトコルコマンド<literal>CREATE_REPLICATION_SLOT ... LOGICAL</literal>と同じ効果があります。
        </entry>
       </row>
@@ -5169,7 +5170,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
 <!--
         Has a replication origin been configured in the current session?
 -->
-現在のセッションで、レプリケーション起点が設定されたか
+現在のセッションで、レプリケーション起点が設定されたかどうかを返します。
        </entry>
       </row>
 
@@ -5758,14 +5759,14 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
     <xref linkend="functions-admin-index-table"> shows the functions
     available for index maintenance tasks.
 -->
-<xref linkend="functions-admin-index-table">にインデックスの補修タスクに使用できる関数を示します。
+<xref linkend="functions-admin-index-table">にインデックスの保守タスクに使用できる関数を示します。
    </para>
 
    <table id="functions-admin-index-table">
 <!--
     <title>Index Maintenance Functions</title>
 -->
-    <title>インデックス補修関数</title>
+    <title>インデックス保守関数</title>
     <tgroup cols="3">
      <thead>
 <!--


### PR DESCRIPTION
変更があるのはfunc4.sgmlだけですが、split.shの変更に伴い、func[0-4].sgmlの冒頭の注意書きのインデントが変わってしまったようです。このPRでマージすれば、次回以降はdiffにならなくなるので、このままとします。
それ以外の変更点は以下の通りです。
(1) "these functions"がなぜか「ここの関数」となっていたので「これらの関数」に修正しました。
(2) "using the output plugin"が訳抜けしていたので、訳しました。
(3) pg_replication_origin_session_is_setup関数の説明は原文に忠実なのですが、表の中でこの関数の説明だけ他と文体が違うので、「かどうかを返します」を補いました。
(4) 9.5.0の時に指摘された「補修」が残っている部分があったので、「保守」に訂正しました。