### PR TITLE
ddl.sgml (5.8 スキーマ)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -2944,7 +2944,7 @@ SELECT * FROM information WHERE group_id = 2 FOR UPDATE;
    only the data in a single database, the one specified in the connection
    request.
 -->
-<productname>PostgreSQL</productname>データベースクラスタには、複数の名前付きデータベースが含まれます。
+<productname>PostgreSQL</productname>データベースクラスタには、1つ以上の名前付きデータベースが含まれます。
 ユーザおよびユーザのグループはクラスタ全体で共有されますが、他のデータは複数のデータベース間で共有されません。
 サーバに接続しているクライアントは、単一のデータベース、つまり接続要求で指定したデータベース内のデータにしかアクセスできません。
   </para>
@@ -2976,9 +2976,9 @@ SELECT * FROM information WHERE group_id = 2 FOR UPDATE;
    of the schemas in the database he is connected to, if he has
    privileges to do so.
 -->
-データベースには、複数の名前付き<firstterm>スキーマ</>が含まれ、スキーマにはテーブルが含まれます。
+データベースには、1つ以上の名前付き<firstterm>スキーマ</>が含まれ、スキーマにはテーブルが含まれます。
 スキーマには、データ型、関数および演算子などの他の名前付きオブジェクトも含まれます。
-同じオブジェクト名を異なるスキーマで使用しても矛盾は起こりません。
+同じオブジェクト名を異なるスキーマで使用しても競合は起こりません。
 例えば、<literal>schema1</>と<literal>myschema</>の両方のスキーマに<literal>mytable</>というテーブルが含まれていても構いません。
 スキーマはデータベースとは異なり厳格に分離されていないので、ユーザは、権限さえ持っていれば接続しているデータベース内のどのスキーマのオブジェクトにでもアクセスすることができます。
   </para>
@@ -3091,7 +3091,8 @@ CREATE SCHEMA myschema;
     to other kinds of named objects, such as types and functions.)
 -->
 この方法は、後の章で説明するテーブル変更コマンドやデータアクセスコマンドなど、テーブル名を必要とする場合すべてに使用できます。
-（簡単に、テーブルについてのみ述べます。しかし型や関数といった名前付きのオブジェクトの全種類について同様の考え方が適用できます。）
+（話を簡単にするため、テーブルについてのみ述べます。
+しかし型や関数といった名前付きのオブジェクトの他の種類について同様の考え方が適用できます。）
    </para>
 
    <para>
@@ -3107,7 +3108,7 @@ CREATE SCHEMA myschema;
     forma</> compliance with the SQL standard.  If you write a database name,
     it must be the same as the database you are connected to.
 -->
-を使用することもできますが、現在ではこの構文は<foreignphrase>形式上</>標準SQLに準拠するためにのみ存在しています。
+を使用することもできますが、現在ではこの構文は標準SQLに<foreignphrase>形式的に</>準拠するためにのみ存在しています。
 記述されるデータベース名は、接続しているデータベースと同じ名前でなければなりません。
    </para>
 
@@ -3144,7 +3145,7 @@ DROP SCHEMA myschema;
 <!--
     To drop a schema including all contained objects, use:
 -->
-オブジェクトを含むスキーマを削除する場合には次のようにします。
+スキーマ内の全オブジェクトも含めてスキーマを削除する場合には次のようにします。
 <programlisting>
 DROP SCHEMA myschema CASCADE;
 </programlisting>
@@ -3337,7 +3338,7 @@ SHOW search_path;
     Therefore, in the default configuration, any unqualified access
     again can only refer to the public schema.
 -->
-検索パス内で最初に存在するスキーマが、新規オブジェクトが作成されるデフォルトの場所になります。
+実存するスキーマのうち、検索パス内で最初に現れるスキーマが、新規オブジェクトが作成されるデフォルトの場所になります。
 これが、デフォルトでオブジェクトがpublicスキーマに作成される理由です。
 オブジェクトがスキーマ修飾なしで別の文脈で参照される場合（テーブル変更、データ変更、あるいは問い合わせコマンドなど）、一致するオブジェクトが見つかるまで検索パス内で探索されます。
 そのためデフォルト構成では、非修飾のアクセスはpublicスキーマしか参照できません。
@@ -3391,7 +3392,7 @@ publicスキーマはデフォルトで存在するということ以外に特�
     See also <xref linkend="functions-info"> for other ways to manipulate
     the schema search path.
 -->
-スキーマ検索パスに操作する他の方法については<xref linkend="functions-info">を参照してください。
+スキーマ検索パスを操作する他の方法については<xref linkend="functions-info">を参照してください。
    </para>
 
    <para>
@@ -3465,7 +3466,7 @@ SELECT 3 OPERATOR(pg_catalog.+) 4;
     <literal>public</literal> schema.  If you do
     not want to allow that, you can revoke that privilege:
 -->
-他のユーザのスキーマ内でオブジェクトを作成することも可能です。
+他のユーザのスキーマ内でオブジェクトを作成できるようにすることも可能です。
 それには、スキーマ上で<literal>CREATE</literal>権限が付与されていなければなりません。
 デフォルトでは、<literal>public</literal> スキーマに関しては全てのユーザが<literal>CREATE</literal>と<literal>USAGE</literal>権限を持っていることに注意してください。
 つまり、全てのユーザは、そのユーザが接続できる任意のデータベース上の<literal>public</literal>スキーマにオブジェクトを作成できるということです。
@@ -3567,8 +3568,8 @@ REVOKE CREATE ON SCHEMA public FROM PUBLIC;
 -->
 スキーマを作成しない場合は、全てのユーザが暗黙にpublicスキーマにアクセスします。
 これはスキーマがまったく使用できない状況と同じです。
-この構成は主に、データベースで作業するのが1人または2、3人しかいない場合に推奨されます。
-またこの構成では、スキーマを認識しない状況からの移行を容易に行えます。
+この構成は主に、データベースで作業するのが1人のユーザまたは数人の協働ユーザだけの場合に推奨されます。
+またこの構成では、スキーマを認識しない環境からの移行を容易に行えます。
       </para>
      </listitem>
 
@@ -3636,7 +3637,7 @@ REVOKE CREATE ON SCHEMA public FROM PUBLIC;
     This is how <productname>PostgreSQL</productname> will effectively
     behave if you create a per-user schema for every user.
 -->
-標準SQLでは、1つのスキーマ内の異なるユーザが所有するオブジェクトという概念は存在しません。
+標準SQLでは、1つのスキーマ内のオブジェクトを異なるユーザが所有するという概念は存在しません。
 それどころか、実装によっては所有者と異なる名前のスキーマを作成することが許可されていない場合もあります。
 実際、標準で規定されている基本スキーマサポートのみを実装しているデータベースシステムでは、スキーマという概念とユーザという概念はほとんど同じなのです。
 そのため、修飾名とは<literal><replaceable>username</>.<replaceable>tablename</></literal>のことであると思っているユーザはたくさんいます。


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) "one or more"を「複数」と訳している箇所があったので、訂正しました。
(2) "conflict"の訳語を、「矛盾」から「競合」に変更しました。
(3) "For brevity"の訳し方がおかしかったので、修正しました。
(4) "other kinds"が「全種類」となっていたので訂正しました。
(5) 「形式上」の掛かり先がわかりにくかったので、移動した上で「形式的に」と修正しました。
(6) "first schema in the search path that exists"の訳文の意味が、日本語だけだと誤解されかねないものだったので、語を補ってわかりやすくしました。
その他、原文の意図が正しく伝わらない可能性があるように思えた訳文について、なるべく原文に忠実になるように訳を修正しました。