### PR TITLE
ref/create_rule.sgmlの翻訳改善

### DIFF
--- a/doc/src/sgml/ref/create_rule.sgml
+++ b/doc/src/sgml/ref/create_rule.sgml
@@ -305,8 +305,8 @@ CREATE [ OR REPLACE ] RULE <replaceable class="parameter">name</replaceable> AS 
    to refer to the existing row being updated or deleted.
 -->
 <replaceable class="parameter">condition</replaceable>と<replaceable class="parameter">command</replaceable>の内部では、対象とするテーブルの値を参照するために、特別なテーブル名<literal>NEW</literal>と<literal>OLD</literal>を使用できます。
-<literal>NEW</literal>は、<literal>ON INSERT</literal>と<literal>ON UPDATE</literal>ルールで有効です。挿入または更新される新しい行を参照します。
-<literal>OLD</literal>は、<literal>ON UPDATE</literal>と<literal>ON DELETE</literal>ルールで有効です。更新または削除される既存の行を参照します。
+<literal>NEW</literal>は、<literal>ON INSERT</literal>と<literal>ON UPDATE</literal>ルールで有効で、挿入または更新される新しい行を参照します。
+<literal>OLD</literal>は、<literal>ON UPDATE</literal>と<literal>ON DELETE</literal>ルールで有効で、更新または削除される既存の行を参照します。
   </para>
  </refsect1>
 


### PR DESCRIPTION
不用意に文を２つに分けていたため、後の文の主語が不明確になっていました。
文を１つにつなげることで、意味を明確にしました。