### PR TITLE
storage.sgmlの訳語を揃えました。

### DIFF
--- a/doc/src/sgml/storage.sgml
+++ b/doc/src/sgml/storage.sgml
@@ -185,7 +185,7 @@ Item
  <entry>Subdirectory containing permanent files for the statistics
   subsystem</entry>
 -->
- <entry>統計サブシステムのための永続ファイルを保有するサブディレクトリ</entry>
+ <entry>統計サブシステム用の永続ファイルを保有するサブディレクトリ</entry>
 </row>
 
 <row>
@@ -194,7 +194,7 @@ Item
  <entry>Subdirectory containing temporary files for the statistics
   subsystem</entry>
   -->
- <entry>統計用サブシステム用の一時ファイルを保有するサブディレクトリ</entry>
+ <entry>統計サブシステム用の一時ファイルを保有するサブディレクトリ</entry>
 </row>
 
 <row>


### PR DESCRIPTION
"for the statistics subsystem"の訳語が、「統計サブシステムのための」と
「統計用サブシステム用の」となっていて統一感がなかったので、簡潔性を重
視して「統計サブシステム用の」としました。