### PR TITLE
logicaldecoding.sgmlの9.5.2対応です。

### DIFF
--- a/doc/src/sgml/logicaldecoding.sgml
+++ b/doc/src/sgml/logicaldecoding.sgml
@@ -190,8 +190,8 @@ postgres=# SELECT pg_drop_replication_slot('regression_slot');
     distribution.  This requires that client authentication is set up to allow
     replication connections
     (see <xref linkend="streaming-replication-authentication">) and
-    that <varname>max_wal_senders</varname> is set sufficiently high to allow ★変更あり
-    an additional connection.★変更あり
+    that <varname>max_wal_senders</varname> is set sufficiently high to allow
+    an additional connection.
 -->
 以下はPostgreSQLに付属するプログラム<xref linkend="app-pgrecvlogical">を用いてロジカルデコーディングを
 ストリーミングレプリケーションのプロトコルによって制御する例です。


### PR DESCRIPTION
9.5.1からの変更は、原文のtypo修正だけなので、日本語には変更はありません。