### PR TITLE
ref/create_opclass.sgmlの9.5.2の変更部分の翻訳

### DIFF
--- a/doc/src/sgml/ref/create_opclass.sgml
+++ b/doc/src/sgml/ref/create_opclass.sgml
@@ -251,7 +251,7 @@ CREATE OPERATOR CLASS <replaceable class="parameter">name</replaceable> [ DEFAUL
       <literal>FUNCTION</> clauses, except for the case of a B-tree sort
       support function that is meant to support cross-data-type comparisons.
 -->
-<literal>FUNCTION</>句では、関数の入力データ型（B-Tree比較関数およびハッシュ関数用）またはクラスのデータ型（B-treeソートサポート関数とGiST、SP-GiST、GIN演算子クラスのすべての関数用）と異なる場合、関数がサポートする予定の演算対象データ型です。
+<literal>FUNCTION</>句では、関数の入力データ型（B-Tree比較関数およびハッシュ関数用）またはクラスのデータ型（B-treeソートサポート関数とGiST、SP-GiST、GIN、BRIN演算子クラスのすべての関数用）と異なる場合、関数がサポートする予定の演算対象データ型です。
 これらのデフォルトは常に正確です。
 このため、しかしデータ型を跨がる比較をサポートする予定のB-treeソートサポート関数は除き、<literal>FUNCTION</>句で<replaceable class="parameter">op_type</replaceable>を指定する必要はありません。
      </para>
@@ -331,7 +331,7 @@ CREATE OPERATOR CLASS <replaceable class="parameter">name</replaceable> [ DEFAUL
 -->
 インデックスに実際に格納されるデータ型です。
 通常、このデータ型は列のデータ型と同じです。
-しかし、異なるデータ型を許可するインデックスメソッドも存在します（現時点ではGiSTとGIN）。
+しかし、異なるデータ型を許可するインデックスメソッドも存在します（現時点ではGiST、GIN、BRIN）。
 インデックスメソッドが異なるデータ型の使用を許可していなければ、<literal>STORAGE</>句を指定してはいけません。
      </para>
     </listitem>


### PR DESCRIPTION
翻訳とは言えない変更のみです。