### PR TITLE
ref/pg_ctl.sgmlの9.5.2変更部分の翻訳

### DIFF
--- a/doc/src/sgml/ref/pg_ctl-ref.sgml
+++ b/doc/src/sgml/ref/pg_ctl-ref.sgml
@@ -486,7 +486,7 @@ Windowsではデフォルトで、サーバの標準出力と標準エラーは�
         seconds.
 -->
 起動または停止の完了まで待機する最大の秒数。
-デフォルトは環境変数<envar>PGCTLTIMEOUT</>の値で、それが設定されなければ60秒です。
+デフォルトは環境変数<envar>PGCTLTIMEOUT</>の値で、それが設定されていなければ60秒です。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/ref/pg_ctl-ref.sgml
+++ b/doc/src/sgml/ref/pg_ctl-ref.sgml
@@ -486,7 +486,7 @@ Windowsではデフォルトで、サーバの標準出力と標準エラーは�
         seconds.
 -->
 起動または停止の完了まで待機する最大の秒数。
-★翻訳が必要
+デフォルトは環境変数<envar>PGCTLTIMEOUT</>の値で、それが設定されなければ60秒です。
        </para>
       </listitem>
      </varlistentry>
@@ -662,8 +662,12 @@ Windowsのサービスとして実行する際に、イベントログへの出�
 
     <listitem>
      <para>
+<!--
       Default limit on the number of seconds to wait when waiting for startup
       or shutdown to complete.  If not set, the default is 60 seconds.
+-->
+起動または終了が完了するまでに待機する秒数のデフォルトの最大値です。
+設定されていない場合のデフォルトは60秒です。
      </para>
     </listitem>
    </varlistentry>
@@ -676,7 +680,7 @@ Windowsのサービスとして実行する際に、イベントログへの出�
 <!--
       Default data directory location.
 -->
-      デフォルトのデータディレクトリの場所です。
+デフォルトのデータディレクトリの場所です。
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
ついでに、翻訳がインデントされていた部分を1箇所だけ修正しました。