### PR TITLE
queries.sgml (7.2.2 WHERE句)の誤訳訂正

### DIFF
--- a/doc/src/sgml/queries.sgml
+++ b/doc/src/sgml/queries.sgml
@@ -1437,7 +1437,7 @@ FROM a NATURAL JOIN b WHERE b.val &gt; 5
      in the final result.
 -->
 どれを使うかは、主にスタイルの問題です。
-<literal>FROM</>句で<literal>JOIN</>構文を使用すると、SQL標準であってもおそらく他のSQLデータベース管理システムに移植できません。
+<literal>FROM</>句の<literal>JOIN</>構文はSQL標準であるにも関わらず、おそらく他のSQLデータベース管理システムへの移植性では劣るでしょう。
 外部結合については、<literal>FROM</>句以外に選択の余地はありません。
 外部結合の<literal>ON</>句または<literal>USING</>句は、<literal>WHERE</>条件とは等しく<emphasis>ありません</>。
 なぜなら、最終結果での行を除去すると同様に、（一致しない入力行に対する）行の追加となるからです。


### PR DESCRIPTION
"not as portable"の解釈が間違っていたので修正しました。