### PR TITLE
datatype.sgml (8.5 日付/時刻データ型)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -2311,8 +2311,8 @@ SELECT E'\\xDEADBEEF';
     linkend="datetime-units-history"> for more information).
 -->
 <productname>PostgreSQL</productname>では、<xref linkend="datatype-datetime-table">に示されている<acronym>SQL</acronym>の日付と時刻データ型のすべてがサポートされています。
-これらのデータ型で利用できる演算子については<xref linkend="functions-datetime">で説明します。
-グレゴリオ暦が導入される前の年であっても（<xref linkend="datetime-units-history">参照）、日付はグレゴリオ暦にしたがって計算されます。
+これらのデータ型で利用できる演算については<xref linkend="functions-datetime">で説明します。
+グレゴリオ暦が導入されるより前の年であっても（<xref linkend="datetime-units-history">参照）、日付はグレゴリオ暦にしたがって計算されます。
    </para>
 
     <table id="datatype-datetime-table">
@@ -2353,7 +2353,7 @@ SELECT E'\\xDEADBEEF';
 <!--
         <entry>1 microsecond / 14 digits</entry>
 -->
-<entry>1μ秒、14桁</entry>
+<entry>1マイクロ秒、14桁</entry>
        </row>
        <row>
         <entry><type>timestamp [ (<replaceable>p</replaceable>) ] with time zone</type></entry>
@@ -2368,7 +2368,7 @@ SELECT E'\\xDEADBEEF';
 <!--
         <entry>1 microsecond / 14 digits</entry>
 -->
-<entry>1μ秒、14桁</entry>
+<entry>1マイクロ秒、14桁</entry>
        </row>
        <row>
         <entry><type>date</type></entry>
@@ -2398,7 +2398,7 @@ SELECT E'\\xDEADBEEF';
 <!--
         <entry>1 microsecond / 14 digits</entry>
 -->
-<entry>1μ秒、14桁</entry>
+<entry>1マイクロ秒、14桁</entry>
        </row>
        <row>
         <entry><type>time [ (<replaceable>p</replaceable>) ] with time zone</type></entry>
@@ -2413,7 +2413,7 @@ SELECT E'\\xDEADBEEF';
 <!--
         <entry>1 microsecond / 14 digits</entry>
 -->
-<entry>1μ秒、14桁</entry>
+<entry>1マイクロ秒、14桁</entry>
        </row>
        <row>
         <entry><type>interval [ <replaceable>fields</replaceable> ] [ (<replaceable>p</replaceable>) ]</type></entry>
@@ -2428,7 +2428,7 @@ SELECT E'\\xDEADBEEF';
         <entry>時間間隔</entry>
         <entry>-178000000年</entry>
         <entry>178000000年</entry>
-        <entry>1μ秒、14桁</entry>
+        <entry>1マイクロ秒、14桁</entry>
        </row>
       </tbody>
      </tgroup>
@@ -2446,7 +2446,7 @@ SELECT E'\\xDEADBEEF';
 -->
 標準SQLでは、単なる<type>timestamp</type>という記述は<type>timestamp without time zone</type>と同じであることを要求します。
 <productname>PostgreSQL</productname>はこれに準じます。
-<type>timestamp with time zone</type>は<type>timestamptz</type>と省略することが許容されています。これは<productname>PostgreSQL</productname>独自の拡張です。
+<type>timestamp with time zone</type>は<type>timestamptz</type>と省略することができますが、これは<productname>PostgreSQL</productname>の拡張です。
     </para>
    </note>
 
@@ -2460,8 +2460,8 @@ SELECT E'\\xDEADBEEF';
     <replaceable>p</replaceable> is from 0 to 6 for the
     <type>timestamp</type> and <type>interval</type> types.
 -->
-<type>time</type>、<type>timestamp</type>および<type>interval</type>は秒フィールドに保有されている小数点以下の桁数を指定するオプションの精度値である<replaceable>p</replaceable>を受け付けます。
-デフォルトでは、明示的な精度に対する限界はありません。
+<type>time</type>、<type>timestamp</type>および<type>interval</type>は秒フィールドに保有されている小数点以下の桁数を指定する精度値<replaceable>p</replaceable>をオプションで受け付けます。
+デフォルトでは、精度についての明示的な限界はありません。
 <replaceable>p</replaceable>の許容範囲は<type>timestamp</type>型と<type>interval</type>型の場合は0から6です。
    </para>
 
@@ -2482,11 +2482,11 @@ SELECT E'\\xDEADBEEF';
     range of <type>timestamp</type> values to be represented than
     shown above: from 4713 BC up to 5874897 AD.
     -->
-<type>timestamp</>の値が8バイト整数（現在のデフォルト）で格納されていれば、すべての値についてμ秒精度が有効です。
+<type>timestamp</>の値が8バイト整数（現在のデフォルト）で格納されていれば、すべての値についてマイクロ秒精度が有効です。
 <type>timestamp</>の値が倍精度浮動小数点数（将来のサポートが保証されないコンパイル時のオプション）で格納されていると、有効な精度は6より小さいかもしれません。
 <type>timestamp</>の値は2000-01-01深夜を基準にした経過秒数として格納されます。
-<type>timestamp</type>の値が浮動小数点数として格納されていれば、2000-01-01から数年の範囲でμ秒精度が得られますが、それより離脱すると精度は劣化します。
-浮動小数点datetimesを使用すると上で示した範囲より広い<type>timestamp</type>の値（4713 BCから5874897 ADまで）が認められます。
+<type>timestamp</type>の値が浮動小数点数として格納されていれば、2000-01-01から数年の範囲でマイクロ秒精度が得られますが、それより離脱すると精度は劣化します。
+浮動小数点の日付時刻を使用すると、上で示した範囲より広い<type>timestamp</type>の値（4713 BCから5874897 ADまで）を利用できます。
    </para>
 
    <para>


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) 「μ秒」はすべて「マイクロ秒」に表記を変更しました(他のファイルは、調査した限り、すべて「マイクロ秒」でした)。
(2) "operations"が「演算子」となっていたので、「演算」に訂正しました。
(3) 「導入される前の年」は、その1年だけと解される可能性があるので、「導入される『より』前の年」としました。
(4) 「許容される」はかなり仰々しい感じがするので、単に「できる」としました。
(5) "PostgreSQL extension"を「PostgreSQL独自の拡張」と訳していましたが、「独自の」は訳し過ぎなので削除しました(他のファイルでも同じ表現がありそうですが)。
(6) 「オプションの精度値であるp」は意味がわかりにくかったので、修正しました。
(7) "explicit"の掛かり先がおかしかったので修正しました。
(8) "datetimes"を翻訳し、また"allow"の訳語を改善しました。