### PR TITLE
func.sgml (9.26.7 データベースオブジェクト管理関数) の翻訳改善

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -24137,7 +24137,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
 <!--
         Total disk space used by indexes attached to the specified table
 -->
-       指定されテーブルに付与されたインデックスで使用される総ディスク容量。
+指定されテーブルに付与されたインデックスで使用される総ディスク容量。
        </entry>
       </row>
       <row>
@@ -24151,7 +24151,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
         <literal>'fsm'</literal>, <literal>'vm'</>, or <literal>'init'</>)
         of the specified table or index
 -->
-       指定されたテーブルまたはインデックスの指定されたフォーク（<literal>'main'</literal>、<literal>'fsm'</literal>、<literal>'vm'</>または<literal>'init'</>）で使用されるディスク容量
+指定されたテーブルまたはインデックスの指定されたフォーク（<literal>'main'</literal>、<literal>'fsm'</literal>、<literal>'vm'</>または<literal>'init'</>）で使用されるディスク容量
        </entry>
       </row>
       <row>
@@ -24163,7 +24163,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
 <!--
         Shorthand for <literal>pg_relation_size(..., 'main')</literal>
 -->
-        <literal>pg_relation_size(..., 'main')</literal>の省略表現
+<literal>pg_relation_size(..., 'main')</literal>の省略表現
        </entry>
       </row>
       <row>
@@ -24176,7 +24176,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
          Converts a size in bytes expressed as a 64-bit integer into a
          human-readable format with size units
 -->
-         64ビット整数で表現されたバイト単位のサイズを可読性が高いサイズ単位の書式に変換
+64ビット整数で表現されたサイズ（バイト数）を、サイズの単位をつけた可読性が高い書式に変換
        </entry>
       </row>
       <row>
@@ -24189,7 +24189,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
          Converts a size in bytes expressed as a numeric value into a
          human-readable format with size units
 -->
-         numeric値で表現されたバイト単位のサイズを可読性が高いサイズ単位の書式に変換
+numeric値で表現されたバイト単位のサイズを可読性が高いサイズ単位の書式に変換
        </entry>
       </row>
       <row>
@@ -24202,7 +24202,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
         Disk space used by the specified table, excluding indexes
         (but including TOAST, free space map, and visibility map)
 -->
-       指定されたテーブルで使用される容量の内、すべてのインデックスを除外した(しかしTOAST、空き領域マップ、可視性マップを含む)ディスク総容量。
+指定されたテーブルで使用されるディスク容量、インデックスは除外する（しかしTOAST、空き領域マップ、可視性マップは含む）
        </entry>
       </row>
       <row>
@@ -24235,7 +24235,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
         Total disk space used by the specified table,
         including all indexes and <acronym>TOAST</> data
 -->
-       指定されたテーブルで使用される、すべてのインデックスと<acronym>TOAST</>データを含むディスク総容量
+指定されたテーブルで使用される、すべてのインデックスと<acronym>TOAST</>データを含むディスク総容量
        </entry>
       </row>
      </tbody>
@@ -24247,7 +24247,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
     <function>pg_column_size</> shows the space used to store any individual
     data value.
 -->
-    <function>pg_column_size</>はどんな個別のデータ値を格納するのにも使用される領域を示します。
+    <function>pg_column_size</>は任意の個別のデータ値を格納するのに使用されている領域を示します。
    </para>
 
    <para>
@@ -24269,7 +24269,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
     (TOAST space, free space map, and visibility map are included.)
 -->
 <function>pg_table_size</>は、テーブルのOIDまたは名前を受け付け、インデックスを除いたテーブルのみで使用されるディスク容量を返します。
-(TOAST領域、空き領域マップ、可視性マップを含みます。)
+(TOAST領域、空き領域マップ、可視性マップは含みます。)
    </para>
 
    <para>
@@ -24292,7 +24292,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
     unless it is the default tablespace for the current database.
 -->
 <function>pg_database_size</>と<function>pg_tablespace_size</>はデータベースまたはテーブル空間の名前またはOIDを受付け、そこで使用される総容量を返します。
-<function>pg_database_size</function>を使うためには、(デフォルトで付与されている)指定されたデータベースに<literal>CONNECT</>権限を持っていなければなりません。
+<function>pg_database_size</function>を使うためには、指定されたデータベースに<literal>CONNECT</>権限(デフォルトで付与されている)を持っていなければなりません。
 <function>pg_tablespace_size</>を使うためには、それが現在のデータベースのデフォルトテーブル空間でない限り、指定されたテーブル空間に<literal>CREATE</>権限を持っていなければなりません。
    </para>
 
@@ -24345,7 +24345,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
        <literal>'init'</literal> returns the size of the initialization
        fork, if any, associated with the relation.
 -->
-<literal>'init'</literal>を指定すると、もしあれば、リレーションに関連した初期化フォークを返します。
+<literal>'init'</literal>を指定すると、もしあれば、リレーションに関連した初期化フォークの容量を返します。
       </para>
      </listitem>
     </itemizedlist>
@@ -24382,7 +24382,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
     If an OID that does not represent an existing object is passed as
     argument to one of the above functions, NULL is returned.
 -->
-上記の関数に対し、既存オブジェクトに該当するOIDがないものが渡された場合はNULLが返されます。
+上記の関数に対し、既存オブジェクトに該当するものがないOIDが渡された場合はNULLが返されます。
    </para>
 
    <para>
@@ -24470,7 +24470,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
     be used to get the correct value.  The function returns NULL if passed
     a relation that does not have storage, such as a view.
 -->
-<function>pg_relation_filenode</>は、テーブル、インデックス、シーケンス、もしくはTOASTテーブルのOIDまたは名前を受け付け、現在それに充てられている<quote>ファイルノード</>を返します。
+<function>pg_relation_filenode</>は、テーブル、インデックス、シーケンス、もしくはTOASTテーブルのOIDまたは名前を受け付け、現在それに充てられている<quote>ファイルノード</>番号を返します。
 ファイルノードは、リレーションに使用しているファイル名の基礎部分です(詳しくは<xref linkend="storage-file-layout">を参照して下さい)。
 ほとんどのテーブルについては、結果が<structname>pg_class</>.<structfield>relfilenode</>と同じになります。ただし、いくつかのシステムカタログでは<structfield>relfilenode</>が0になるため、これらのシステムカタログの正しいファイルノードを取得するには、この関数を使用しなければいけません。
 この関数は、ビューの様にストレージに格納されないリレーションが指定された場合はNULLを返します。

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -24189,7 +24189,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
          Converts a size in bytes expressed as a numeric value into a
          human-readable format with size units
 -->
-numeric値で表現されたバイト単位のサイズを可読性が高いサイズ単位の書式に変換
+numeric値で表現されたサイズ（バイト数）を、サイズの単位をつけた可読性が高い書式に変換
        </entry>
       </row>
       <row>

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -5433,7 +5433,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
          Converts a size in bytes expressed as a numeric value into a
          human-readable format with size units
 -->
-numeric値で表現されたバイト単位のサイズを可読性が高いサイズ単位の書式に変換
+numeric値で表現されたサイズ（バイト数）を、サイズの単位をつけた可読性が高い書式に変換
        </entry>
       </row>
       <row>

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -5381,7 +5381,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
 <!--
         Total disk space used by indexes attached to the specified table
 -->
-       指定されテーブルに付与されたインデックスで使用される総ディスク容量。
+指定されテーブルに付与されたインデックスで使用される総ディスク容量。
        </entry>
       </row>
       <row>
@@ -5395,7 +5395,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
         <literal>'fsm'</literal>, <literal>'vm'</>, or <literal>'init'</>)
         of the specified table or index
 -->
-       指定されたテーブルまたはインデックスの指定されたフォーク（<literal>'main'</literal>、<literal>'fsm'</literal>、<literal>'vm'</>または<literal>'init'</>）で使用されるディスク容量
+指定されたテーブルまたはインデックスの指定されたフォーク（<literal>'main'</literal>、<literal>'fsm'</literal>、<literal>'vm'</>または<literal>'init'</>）で使用されるディスク容量
        </entry>
       </row>
       <row>
@@ -5407,7 +5407,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
 <!--
         Shorthand for <literal>pg_relation_size(..., 'main')</literal>
 -->
-        <literal>pg_relation_size(..., 'main')</literal>の省略表現
+<literal>pg_relation_size(..., 'main')</literal>の省略表現
        </entry>
       </row>
       <row>
@@ -5420,7 +5420,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
          Converts a size in bytes expressed as a 64-bit integer into a
          human-readable format with size units
 -->
-         64ビット整数で表現されたバイト単位のサイズを可読性が高いサイズ単位の書式に変換
+64ビット整数で表現されたサイズ（バイト数）を、サイズの単位をつけた可読性が高い書式に変換
        </entry>
       </row>
       <row>
@@ -5433,7 +5433,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
          Converts a size in bytes expressed as a numeric value into a
          human-readable format with size units
 -->
-         numeric値で表現されたバイト単位のサイズを可読性が高いサイズ単位の書式に変換
+numeric値で表現されたバイト単位のサイズを可読性が高いサイズ単位の書式に変換
        </entry>
       </row>
       <row>
@@ -5446,7 +5446,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
         Disk space used by the specified table, excluding indexes
         (but including TOAST, free space map, and visibility map)
 -->
-       指定されたテーブルで使用される容量の内、すべてのインデックスを除外した(しかしTOAST、空き領域マップ、可視性マップを含む)ディスク総容量。
+指定されたテーブルで使用されるディスク容量、インデックスは除外する（しかしTOAST、空き領域マップ、可視性マップは含む）
        </entry>
       </row>
       <row>
@@ -5479,7 +5479,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
         Total disk space used by the specified table,
         including all indexes and <acronym>TOAST</> data
 -->
-       指定されたテーブルで使用される、すべてのインデックスと<acronym>TOAST</>データを含むディスク総容量
+指定されたテーブルで使用される、すべてのインデックスと<acronym>TOAST</>データを含むディスク総容量
        </entry>
       </row>
      </tbody>
@@ -5491,7 +5491,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
     <function>pg_column_size</> shows the space used to store any individual
     data value.
 -->
-    <function>pg_column_size</>はどんな個別のデータ値を格納するのにも使用される領域を示します。
+    <function>pg_column_size</>は任意の個別のデータ値を格納するのに使用されている領域を示します。
    </para>
 
    <para>
@@ -5513,7 +5513,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
     (TOAST space, free space map, and visibility map are included.)
 -->
 <function>pg_table_size</>は、テーブルのOIDまたは名前を受け付け、インデックスを除いたテーブルのみで使用されるディスク容量を返します。
-(TOAST領域、空き領域マップ、可視性マップを含みます。)
+(TOAST領域、空き領域マップ、可視性マップは含みます。)
    </para>
 
    <para>
@@ -5536,7 +5536,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
     unless it is the default tablespace for the current database.
 -->
 <function>pg_database_size</>と<function>pg_tablespace_size</>はデータベースまたはテーブル空間の名前またはOIDを受付け、そこで使用される総容量を返します。
-<function>pg_database_size</function>を使うためには、(デフォルトで付与されている)指定されたデータベースに<literal>CONNECT</>権限を持っていなければなりません。
+<function>pg_database_size</function>を使うためには、指定されたデータベースに<literal>CONNECT</>権限(デフォルトで付与されている)を持っていなければなりません。
 <function>pg_tablespace_size</>を使うためには、それが現在のデータベースのデフォルトテーブル空間でない限り、指定されたテーブル空間に<literal>CREATE</>権限を持っていなければなりません。
    </para>
 
@@ -5589,7 +5589,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
        <literal>'init'</literal> returns the size of the initialization
        fork, if any, associated with the relation.
 -->
-<literal>'init'</literal>を指定すると、もしあれば、リレーションに関連した初期化フォークを返します。
+<literal>'init'</literal>を指定すると、もしあれば、リレーションに関連した初期化フォークの容量を返します。
       </para>
      </listitem>
     </itemizedlist>
@@ -5626,7 +5626,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
     If an OID that does not represent an existing object is passed as
     argument to one of the above functions, NULL is returned.
 -->
-上記の関数に対し、既存オブジェクトに該当するOIDがないものが渡された場合はNULLが返されます。
+上記の関数に対し、既存オブジェクトに該当するものがないOIDが渡された場合はNULLが返されます。
    </para>
 
    <para>
@@ -5714,7 +5714,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
     be used to get the correct value.  The function returns NULL if passed
     a relation that does not have storage, such as a view.
 -->
-<function>pg_relation_filenode</>は、テーブル、インデックス、シーケンス、もしくはTOASTテーブルのOIDまたは名前を受け付け、現在それに充てられている<quote>ファイルノード</>を返します。
+<function>pg_relation_filenode</>は、テーブル、インデックス、シーケンス、もしくはTOASTテーブルのOIDまたは名前を受け付け、現在それに充てられている<quote>ファイルノード</>番号を返します。
 ファイルノードは、リレーションに使用しているファイル名の基礎部分です(詳しくは<xref linkend="storage-file-layout">を参照して下さい)。
 ほとんどのテーブルについては、結果が<structname>pg_class</>.<structfield>relfilenode</>と同じになります。ただし、いくつかのシステムカタログでは<structfield>relfilenode</>が0になるため、これらのシステムカタログの正しいファイルノードを取得するには、この関数を使用しなければいけません。
 この関数は、ビューの様にストレージに格納されないリレーションが指定された場合はNULLを返します。


### PR DESCRIPTION
差分のレビューにはfunc4.sgmlを参照してください。
主な修正点は以下の通りです。
(1) 訳文がインデントされていたものを行頭から開始するようにしました。
(2) "with size units"を「サイズ単位」としていたのは意味が理解できないので、訳を修正しました。「kBやMBなどのサイズをつけて表現する」という意味なのですが、直前に「バイト単位」という語句もあり、ちょっと苦心しました。
(3) pg_table_sizeの説明を、なるべく原文に忠実になるように修正しました。
(4) "any"の訳し方がおかしかったので、訂正しました。
(5) 「（デフォルトで付与されている）」のカッコ書きの位置に違和感があったので移動しました。
(6) "size", "number"の訳抜けがあったので修正しました。