### PR TITLE
datatype.sgml (8.5.1 日付/時刻の入力) の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -2588,7 +2588,7 @@ MINUTE TO SECOND
      <literal>YMD</> to select year-month-day interpretation.
 -->
 日付と時刻の入力は、ISO 8601、<acronym>SQL</acronym>互換、伝統的な<productname>POSTGRES</productname>、その他を含むほとんどの適正とみなされる書式を受け付けます。
-日付の入力における日-月-年の順序のようないずれとも解釈されるいくつかの書式については、それらのフィールドを好きな順序に指定できるようになっています。
+一部の書式では日付の入力における日-月-年の順序が曖昧ですが、これらのフィールドの期待される順序を指定する方式が提供されています。
 <xref linkend="guc-datestyle">パラメータを<literal>MDY</>に設定すれば、月日年という順で解釈され、<literal>DMY</>に設定すれば日月年という順で、<literal>YMD</>に設定すれば年月日という順で解釈されます。
     </para>
 
@@ -2602,8 +2602,8 @@ MINUTE TO SECOND
      recognized text fields including months, days of the week, and
      time zones.
 -->
-<productname>PostgreSQL</productname>は日付/時刻の運用において標準<acronym>SQL</acronym>の要求よりも柔軟です。
-日付/時刻の入力における正確な構文解析規則と、月および週、そして時間帯を含む使用可能なテキストフィールドに関しては<xref linkend="datetime-appendix">を参照してください。
+<productname>PostgreSQL</productname>は日付/時刻入力の取扱いにおいて標準<acronym>SQL</acronym>の要求よりも柔軟です。
+日付/時刻の入力における厳密な構文解析規則と、月および週、そして時間帯を含む使用可能なテキストフィールドに関しては<xref linkend="datetime-appendix">を参照してください。
     </para>
 
     <para>
@@ -2614,9 +2614,9 @@ MINUTE TO SECOND
      information.
      <acronym>SQL</acronym> requires the following syntax
 -->
-テキスト文字列のように、日付や時刻リテラルは単一引用符で囲む必要があることを思い出してください。
+日付や時刻リテラルの入力では、テキスト文字列のように、単一引用符で囲む必要があることを思い出してください。
 詳細は<xref linkend="sql-syntax-constants-generic">を参照してください。
-<acronym>SQL</acronym>では下記の構文が必要です。
+<acronym>SQL</acronym>では下記の構文が要求されます。
 <synopsis>
 <replaceable>type</replaceable> [ (<replaceable>p</replaceable>) ] '<replaceable>value</replaceable>'
 </synopsis>
@@ -2632,7 +2632,7 @@ MINUTE TO SECOND
 ここで、<replaceable>p</replaceable>は秒フィールドの小数点以下の桁数を与えるオプションの精度の指定です。
 精度は<type>time</type>、<type>timestamp</type>および<type>interval</type>型に対して設定できます。
 値の許容範囲は既に説明しています。
-定数指定において精度指定がない場合は、デフォルトのリテラル値の精度になります。
+定数指定において精度指定がない場合は、リテラル値の精度がデフォルトとして使われます。
     </para>
 
     <sect3>
@@ -2717,21 +2717,21 @@ MINUTE TO SECOND
 <!--
          <entry>January 8 in any mode</entry>
 -->
-     <entry>すべてのモードで1月8日になります。</entry>
+         <entry>すべてのモードで1月8日になります。</entry>
         </row>
         <row>
          <entry>Jan-08-1999</entry>
 <!--
          <entry>January 8 in any mode</entry>
 -->
-     <entry>すべてのモードで1月8日になります。</entry>
+         <entry>すべてのモードで1月8日になります。</entry>
         </row>
         <row>
          <entry>08-Jan-1999</entry>
 <!--
          <entry>January 8 in any mode</entry>
 -->
-     <entry>すべてのモードで1月8日になります。</entry>
+         <entry>すべてのモードで1月8日になります。</entry>
         </row>
         <row>
          <entry>99-Jan-08</entry>
@@ -2745,49 +2745,49 @@ MINUTE TO SECOND
 <!--
          <entry>January 8, except error in <literal>YMD</> mode</entry>
 -->
-     <entry>1月8日。ただし<literal>YMD</>モードではエラー。</entry>
+         <entry>1月8日。ただし<literal>YMD</>モードではエラー。</entry>
         </row>
         <row>
          <entry>Jan-08-99</entry>
 <!--
          <entry>January 8, except error in <literal>YMD</> mode</entry>
 -->
-     <entry>1月8日。ただし<literal>YMD</>モードではエラー。</entry>
+         <entry>1月8日。ただし<literal>YMD</>モードではエラー。</entry>
         </row>
         <row>
          <entry>19990108</entry>
 <!--
          <entry>ISO 8601; January 8, 1999 in any mode</entry>
 -->
-     <entry>ISO 8601。すべてのモードで1月8日になります。</entry>
+         <entry>ISO 8601。すべてのモードで1月8日になります。</entry>
         </row>
         <row>
          <entry>990108</entry>
 <!--
          <entry>ISO 8601; January 8, 1999 in any mode</entry>
 -->
-     <entry>ISO 8601。すべてのモードで1月8日になります。</entry>
+         <entry>ISO 8601。すべてのモードで1月8日になります。</entry>
         </row>
         <row>
          <entry>1999.008</entry>
 <!--
          <entry>year and day of year</entry>
 -->
-     <entry>年とその日までの累計</entry>
+         <entry>年と年間通算日</entry>
         </row>
         <row>
          <entry>J2451187</entry>
 <!--
          <entry>Julian date</entry>
 -->
-     <entry>ユリウス日</entry>
+         <entry>ユリウス日</entry>
         </row>
         <row>
          <entry>January 8, 99 BC</entry>
 <!--
          <entry>year 99 BC</entry>
 -->
-     <entry>西暦紀元前99年</entry>
+         <entry>西暦紀元前99年</entry>
         </row>
        </tbody>
       </tgroup>
@@ -2840,8 +2840,8 @@ MINUTE TO SECOND
 これらの型への有効な入力は、時刻、その後にオプションで時間帯からなります。
 （<xref linkend="datatype-datetime-time-table">と<xref linkend="datatype-timezone-table">を参照してください。）
 <type>time without time zone</type>への入力に時間帯が指定された場合、時間帯は警告なく無視されます。
-また、<literal>America/New_York</literal>など夏時間規則を含む時間帯名を使用していない限り、日付を指定することはできますが、これは無視されます。
-この場合、標準か夏時間かどちらを適用するかを決定できるように、日付の指定が必要です。
+また、日付を指定することもできますが、<literal>America/New_York</literal>のような夏時間規則を含む時間帯名を使用しているのでなければ、それは無視されます。
+夏時間規則のある時間帯名の場合は、標準と夏時間のどちらを適用するかを決定できるように、日付の指定が必要です。
 適切な時間帯オフセットは<type>time with time zone</type>型の値に記録されています。
      </para>
 
@@ -2962,7 +2962,7 @@ MINUTE TO SECOND
 <!--
           <entry>POSIX-style time zone specification</entry>
 -->
-          <entry>POSIX書式の time zone 仕様</entry>
+          <entry>POSIX書式の時間帯指定</entry>
          </row>
          <row>
           <entry><literal>-8:00</literal></entry>
@@ -3098,7 +3098,7 @@ January 8 04:05:06 1999 PST
       That is, the resulting value is derived from the date/time
       fields in the input value, and is not adjusted for time zone.
 -->
-標準<acronym>SQL</acronym>では、<type>timestamp without time zone</type>のリテラルと<type>timestamp with time zone</type>のリテラルを、<quote>+</quote>もしくは<quote>-</quote>記号と時刻の後の時間帯補正を付けて区別します。
+標準<acronym>SQL</acronym>では、<type>timestamp without time zone</type>のリテラルと<type>timestamp with time zone</type>のリテラルを、時刻の後の<quote>+</quote>もしくは<quote>-</quote>記号と時間帯補正の有無により区別します。
 そのため、標準に従うと、
 
 <programlisting>TIMESTAMP '2004-10-19 10:23:54'</programlisting>
@@ -3108,8 +3108,8 @@ January 8 04:05:06 1999 PST
 <programlisting>TIMESTAMP '2004-10-19 10:23:54+02'</programlisting>
 
 は<type>timestamp with time zone</type>になります。
-<productname>PostgreSQL</productname>は、その型が決まる前に文字列リテラルの内容を検証しません。
-そのため上のように<type>timestamp without time zone</type>を扱います。
+<productname>PostgreSQL</productname>では、その型を決める前に文字列リテラルの内容を検証しません。
+そのため上の例はいずれも<type>timestamp without time zone</type>として扱います。
 リテラルが確実に<type>timestamp with time zone</type>として扱われるようにするには、例えば、<programlisting>TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54+02'</programlisting>のように正しい明示的な型を指定してください。
 <type>timestamp without time zone</type>と決定済みのリテラルでは、<productname>PostgreSQL</productname>は警告なく時間帯情報をすべて無視します。
 つまり、結果の値は明示された入力値の日付/時刻フィールドから持ち込まれますが、時間帯の調整はなされません。
@@ -3141,7 +3141,7 @@ January 8 04:05:06 1999 PST
       <varname>timezone</> or use the <literal>AT TIME ZONE</> construct
       (see <xref linkend="functions-datetime-zoneconvert">).
 -->
-<type>timestamp with time zone</type>値が出力されると、この値はUTCから現行の<varname>timezone</>に変換され、その時間帯のローカル時間として表示されます。
+<type>timestamp with time zone</type>の値が出力されると、この値はUTCから現行の<varname>timezone</>に変換され、その時間帯のローカル時間として表示されます。
 他の時間帯での時間を表示するには、<varname>timezone</>を変更するか、あるいは<literal>AT TIME ZONE</>構文（<xref linkend="functions-datetime-zoneconvert"> を参照）を使用します。
      </para>
 
@@ -3153,7 +3153,7 @@ January 8 04:05:06 1999 PST
       as <varname>timezone</> local time.  A different time zone can
       be specified for the conversion using <literal>AT TIME ZONE</>.
 -->
-<type>timestamp without time zone</type>と<type>timestamp with time zone</type>間の変換では、通常<type>timestamp without time zone</type>値は<varname>timezone</>ローカル時間としてみなされる、または、指定されるものと想定されます。
+<type>timestamp without time zone</type>と<type>timestamp with time zone</type>の間の変換では、通常<type>timestamp without time zone</type>の値は<varname>timezone</>のローカル時間としてみなされる、または、指定されるものと想定されます。
 <literal>AT TIME ZONE</>を使用する変換では、異なる時間帯を指定できます。
      </para>
     </sect3>
@@ -3162,7 +3162,7 @@ January 8 04:05:06 1999 PST
 <!--
      <title>Special Values</title>
 -->
-<title>特殊な値</title>
+<title>特別な値</title>
 
      <indexterm>
 <!--
@@ -3197,7 +3197,7 @@ January 8 04:05:06 1999 PST
 -->
 <productname>PostgreSQL</productname>では利便性のために、<xref linkend="datatype-datetime-special-table">に示されているような特別な日付/時刻入力値をサポートしています。
 <literal>infinity</literal>と<literal>-infinity</literal>の値は、特別にシステム内部で表現され、変更されずに表示されます。
-他のものは、単に簡略化された表記で、読み込まれる際には通常の日付/時刻値に変換されます。
+他のものは、単に簡略化された表記で、読み込まれるときに通常の日付/時刻値に変換されます。
 （特に<literal>now</>とその関連文字列は読み込まれるとすぐにその時点の値に変換されます。）
 これらの値はすべて、SQLコマンドで定数として使う場合は、単一引用符でくくらなければなりません。
      </para>
@@ -3206,7 +3206,7 @@ January 8 04:05:06 1999 PST
 <!--
        <title>Special Date/Time Inputs</title>
 -->
-       <title>特殊な日付/時刻定数</title>
+       <title>特別な日付/時刻定数</title>
        <tgroup cols="3">
         <thead>
          <row>
@@ -3243,7 +3243,7 @@ January 8 04:05:06 1999 PST
 <!--
           <entry>earlier than all other time stamps</entry>
 -->
-      <entry>他のすべてのタイムスタンプより過去</entry>
+          <entry>他のすべてのタイムスタンプより過去</entry>
          </row>
          <row>
           <entry><literal>now</literal></entry>
@@ -3251,7 +3251,7 @@ January 8 04:05:06 1999 PST
 <!--
           <entry>current transaction's start time</entry>
 -->
-      <entry>現トランザクションの開始時刻</entry>
+          <entry>現トランザクションの開始時刻</entry>
          </row>
          <row>
           <entry><literal>today</literal></entry>
@@ -3259,7 +3259,7 @@ January 8 04:05:06 1999 PST
 <!--
           <entry>midnight today</entry>
 -->
-      <entry>今日の始まり</entry>
+          <entry>今日の午前０時</entry>
          </row>
          <row>
           <entry><literal>tomorrow</literal></entry>
@@ -3267,7 +3267,7 @@ January 8 04:05:06 1999 PST
 <!--
           <entry>midnight tomorrow</entry>
 -->
-      <entry>明日の始まり</entry>
+          <entry>明日の午前０時</entry>
          </row>
          <row>
           <entry><literal>yesterday</literal></entry>
@@ -3275,7 +3275,7 @@ January 8 04:05:06 1999 PST
 <!--
           <entry>midnight yesterday</entry>
 -->
-      <entry>昨日の始まり</entry>
+          <entry>昨日の午前０時</entry>
          </row>
          <row>
           <entry><literal>allballs</literal></entry>
@@ -3298,7 +3298,7 @@ January 8 04:05:06 1999 PST
       linkend="functions-datetime-current">.)  Note that these are
       SQL functions and are <emphasis>not</> recognized in data input strings.
 -->
-<acronym>SQL</acronym>互換の関数である、<literal>CURRENT_DATE</literal>、<literal>CURRENT_TIME</literal>、<literal>CURRENT_TIMESTAMP</literal>、<literal>LOCALTIME</literal>、<literal>LOCALTIMESTAMP</literal>も、対応するデータ型の日付または時間の値として使用できます。
+<acronym>SQL</acronym>互換の関数である、<literal>CURRENT_DATE</literal>、<literal>CURRENT_TIME</literal>、<literal>CURRENT_TIMESTAMP</literal>、<literal>LOCALTIME</literal>、<literal>LOCALTIMESTAMP</literal>も、対応するデータ型の現在の日付または時間の値を取得するために使用できます。
 後の4つでは、オプションとして秒以下の精度指定が可能です。
 （<xref linkend="functions-datetime-current"> を参照してください。）
 これらはSQL関数であり、データ入力文字列として認識<emphasis>されない</>ことに注意してください。

--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -2588,7 +2588,7 @@ MINUTE TO SECOND
      <literal>YMD</> to select year-month-day interpretation.
 -->
 日付と時刻の入力は、ISO 8601、<acronym>SQL</acronym>互換、伝統的な<productname>POSTGRES</productname>、その他を含むほとんどの適正とみなされる書式を受け付けます。
-一部の書式では日付の入力における日-月-年の順序が曖昧ですが、これらのフィールドの期待される順序を指定する方式が提供されています。
+日付の入力における日-月-年の順序のようないずれとも解釈されるいくつかの書式については、それらのフィールドを好きな順序に指定できるようになっています。
 <xref linkend="guc-datestyle">パラメータを<literal>MDY</>に設定すれば、月日年という順で解釈され、<literal>DMY</>に設定すれば日月年という順で、<literal>YMD</>に設定すれば年月日という順で解釈されます。
     </para>
 
@@ -2602,8 +2602,8 @@ MINUTE TO SECOND
      recognized text fields including months, days of the week, and
      time zones.
 -->
-<productname>PostgreSQL</productname>は日付/時刻入力の取扱いにおいて標準<acronym>SQL</acronym>の要求よりも柔軟です。
-日付/時刻の入力における厳密な構文解析規則と、月および週、そして時間帯を含む使用可能なテキストフィールドに関しては<xref linkend="datetime-appendix">を参照してください。
+<productname>PostgreSQL</productname>は日付/時刻の運用において標準<acronym>SQL</acronym>の要求よりも柔軟です。
+日付/時刻の入力における正確な構文解析規則と、月および週、そして時間帯を含む使用可能なテキストフィールドに関しては<xref linkend="datetime-appendix">を参照してください。
     </para>
 
     <para>
@@ -2614,9 +2614,9 @@ MINUTE TO SECOND
      information.
      <acronym>SQL</acronym> requires the following syntax
 -->
-日付や時刻リテラルの入力では、テキスト文字列のように、単一引用符で囲む必要があることを思い出してください。
+テキスト文字列のように、日付や時刻リテラルは単一引用符で囲む必要があることを思い出してください。
 詳細は<xref linkend="sql-syntax-constants-generic">を参照してください。
-<acronym>SQL</acronym>では下記の構文が要求されます。
+<acronym>SQL</acronym>では下記の構文が必要です。
 <synopsis>
 <replaceable>type</replaceable> [ (<replaceable>p</replaceable>) ] '<replaceable>value</replaceable>'
 </synopsis>
@@ -2632,7 +2632,7 @@ MINUTE TO SECOND
 ここで、<replaceable>p</replaceable>は秒フィールドの小数点以下の桁数を与えるオプションの精度の指定です。
 精度は<type>time</type>、<type>timestamp</type>および<type>interval</type>型に対して設定できます。
 値の許容範囲は既に説明しています。
-定数指定において精度指定がない場合は、リテラル値の精度がデフォルトとして使われます。
+定数指定において精度指定がない場合は、デフォルトのリテラル値の精度になります。
     </para>
 
     <sect3>
@@ -2717,21 +2717,21 @@ MINUTE TO SECOND
 <!--
          <entry>January 8 in any mode</entry>
 -->
-         <entry>すべてのモードで1月8日になります。</entry>
+     <entry>すべてのモードで1月8日になります。</entry>
         </row>
         <row>
          <entry>Jan-08-1999</entry>
 <!--
          <entry>January 8 in any mode</entry>
 -->
-         <entry>すべてのモードで1月8日になります。</entry>
+     <entry>すべてのモードで1月8日になります。</entry>
         </row>
         <row>
          <entry>08-Jan-1999</entry>
 <!--
          <entry>January 8 in any mode</entry>
 -->
-         <entry>すべてのモードで1月8日になります。</entry>
+     <entry>すべてのモードで1月8日になります。</entry>
         </row>
         <row>
          <entry>99-Jan-08</entry>
@@ -2745,49 +2745,49 @@ MINUTE TO SECOND
 <!--
          <entry>January 8, except error in <literal>YMD</> mode</entry>
 -->
-         <entry>1月8日。ただし<literal>YMD</>モードではエラー。</entry>
+     <entry>1月8日。ただし<literal>YMD</>モードではエラー。</entry>
         </row>
         <row>
          <entry>Jan-08-99</entry>
 <!--
          <entry>January 8, except error in <literal>YMD</> mode</entry>
 -->
-         <entry>1月8日。ただし<literal>YMD</>モードではエラー。</entry>
+     <entry>1月8日。ただし<literal>YMD</>モードではエラー。</entry>
         </row>
         <row>
          <entry>19990108</entry>
 <!--
          <entry>ISO 8601; January 8, 1999 in any mode</entry>
 -->
-         <entry>ISO 8601。すべてのモードで1月8日になります。</entry>
+     <entry>ISO 8601。すべてのモードで1月8日になります。</entry>
         </row>
         <row>
          <entry>990108</entry>
 <!--
          <entry>ISO 8601; January 8, 1999 in any mode</entry>
 -->
-         <entry>ISO 8601。すべてのモードで1月8日になります。</entry>
+     <entry>ISO 8601。すべてのモードで1月8日になります。</entry>
         </row>
         <row>
          <entry>1999.008</entry>
 <!--
          <entry>year and day of year</entry>
 -->
-         <entry>年と年間通算日</entry>
+     <entry>年とその日までの累計</entry>
         </row>
         <row>
          <entry>J2451187</entry>
 <!--
          <entry>Julian date</entry>
 -->
-         <entry>ユリウス日</entry>
+     <entry>ユリウス日</entry>
         </row>
         <row>
          <entry>January 8, 99 BC</entry>
 <!--
          <entry>year 99 BC</entry>
 -->
-         <entry>西暦紀元前99年</entry>
+     <entry>西暦紀元前99年</entry>
         </row>
        </tbody>
       </tgroup>
@@ -2840,8 +2840,8 @@ MINUTE TO SECOND
 これらの型への有効な入力は、時刻、その後にオプションで時間帯からなります。
 （<xref linkend="datatype-datetime-time-table">と<xref linkend="datatype-timezone-table">を参照してください。）
 <type>time without time zone</type>への入力に時間帯が指定された場合、時間帯は警告なく無視されます。
-また、日付を指定することもできますが、<literal>America/New_York</literal>のような夏時間規則を含む時間帯名を使用しているのでなければ、それは無視されます。
-夏時間規則のある時間帯名の場合は、標準と夏時間のどちらを適用するかを決定できるように、日付の指定が必要です。
+また、<literal>America/New_York</literal>など夏時間規則を含む時間帯名を使用していない限り、日付を指定することはできますが、これは無視されます。
+この場合、標準か夏時間かどちらを適用するかを決定できるように、日付の指定が必要です。
 適切な時間帯オフセットは<type>time with time zone</type>型の値に記録されています。
      </para>
 
@@ -2962,7 +2962,7 @@ MINUTE TO SECOND
 <!--
           <entry>POSIX-style time zone specification</entry>
 -->
-          <entry>POSIX書式の時間帯指定</entry>
+          <entry>POSIX書式の time zone 仕様</entry>
          </row>
          <row>
           <entry><literal>-8:00</literal></entry>
@@ -3098,7 +3098,7 @@ January 8 04:05:06 1999 PST
       That is, the resulting value is derived from the date/time
       fields in the input value, and is not adjusted for time zone.
 -->
-標準<acronym>SQL</acronym>では、<type>timestamp without time zone</type>のリテラルと<type>timestamp with time zone</type>のリテラルを、時刻の後の<quote>+</quote>もしくは<quote>-</quote>記号と時間帯補正の有無により区別します。
+標準<acronym>SQL</acronym>では、<type>timestamp without time zone</type>のリテラルと<type>timestamp with time zone</type>のリテラルを、<quote>+</quote>もしくは<quote>-</quote>記号と時刻の後の時間帯補正を付けて区別します。
 そのため、標準に従うと、
 
 <programlisting>TIMESTAMP '2004-10-19 10:23:54'</programlisting>
@@ -3108,8 +3108,8 @@ January 8 04:05:06 1999 PST
 <programlisting>TIMESTAMP '2004-10-19 10:23:54+02'</programlisting>
 
 は<type>timestamp with time zone</type>になります。
-<productname>PostgreSQL</productname>では、その型を決める前に文字列リテラルの内容を検証しません。
-そのため上の例はいずれも<type>timestamp without time zone</type>として扱います。
+<productname>PostgreSQL</productname>は、その型が決まる前に文字列リテラルの内容を検証しません。
+そのため上のように<type>timestamp without time zone</type>を扱います。
 リテラルが確実に<type>timestamp with time zone</type>として扱われるようにするには、例えば、<programlisting>TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54+02'</programlisting>のように正しい明示的な型を指定してください。
 <type>timestamp without time zone</type>と決定済みのリテラルでは、<productname>PostgreSQL</productname>は警告なく時間帯情報をすべて無視します。
 つまり、結果の値は明示された入力値の日付/時刻フィールドから持ち込まれますが、時間帯の調整はなされません。
@@ -3141,7 +3141,7 @@ January 8 04:05:06 1999 PST
       <varname>timezone</> or use the <literal>AT TIME ZONE</> construct
       (see <xref linkend="functions-datetime-zoneconvert">).
 -->
-<type>timestamp with time zone</type>の値が出力されると、この値はUTCから現行の<varname>timezone</>に変換され、その時間帯のローカル時間として表示されます。
+<type>timestamp with time zone</type>値が出力されると、この値はUTCから現行の<varname>timezone</>に変換され、その時間帯のローカル時間として表示されます。
 他の時間帯での時間を表示するには、<varname>timezone</>を変更するか、あるいは<literal>AT TIME ZONE</>構文（<xref linkend="functions-datetime-zoneconvert"> を参照）を使用します。
      </para>
 
@@ -3153,7 +3153,7 @@ January 8 04:05:06 1999 PST
       as <varname>timezone</> local time.  A different time zone can
       be specified for the conversion using <literal>AT TIME ZONE</>.
 -->
-<type>timestamp without time zone</type>と<type>timestamp with time zone</type>の間の変換では、通常<type>timestamp without time zone</type>の値は<varname>timezone</>のローカル時間としてみなされる、または、指定されるものと想定されます。
+<type>timestamp without time zone</type>と<type>timestamp with time zone</type>間の変換では、通常<type>timestamp without time zone</type>値は<varname>timezone</>ローカル時間としてみなされる、または、指定されるものと想定されます。
 <literal>AT TIME ZONE</>を使用する変換では、異なる時間帯を指定できます。
      </para>
     </sect3>
@@ -3162,7 +3162,7 @@ January 8 04:05:06 1999 PST
 <!--
      <title>Special Values</title>
 -->
-<title>特別な値</title>
+<title>特殊な値</title>
 
      <indexterm>
 <!--
@@ -3197,7 +3197,7 @@ January 8 04:05:06 1999 PST
 -->
 <productname>PostgreSQL</productname>では利便性のために、<xref linkend="datatype-datetime-special-table">に示されているような特別な日付/時刻入力値をサポートしています。
 <literal>infinity</literal>と<literal>-infinity</literal>の値は、特別にシステム内部で表現され、変更されずに表示されます。
-他のものは、単に簡略化された表記で、読み込まれるときに通常の日付/時刻値に変換されます。
+他のものは、単に簡略化された表記で、読み込まれる際には通常の日付/時刻値に変換されます。
 （特に<literal>now</>とその関連文字列は読み込まれるとすぐにその時点の値に変換されます。）
 これらの値はすべて、SQLコマンドで定数として使う場合は、単一引用符でくくらなければなりません。
      </para>
@@ -3206,7 +3206,7 @@ January 8 04:05:06 1999 PST
 <!--
        <title>Special Date/Time Inputs</title>
 -->
-       <title>特別な日付/時刻定数</title>
+       <title>特殊な日付/時刻定数</title>
        <tgroup cols="3">
         <thead>
          <row>
@@ -3243,7 +3243,7 @@ January 8 04:05:06 1999 PST
 <!--
           <entry>earlier than all other time stamps</entry>
 -->
-          <entry>他のすべてのタイムスタンプより過去</entry>
+      <entry>他のすべてのタイムスタンプより過去</entry>
          </row>
          <row>
           <entry><literal>now</literal></entry>
@@ -3251,7 +3251,7 @@ January 8 04:05:06 1999 PST
 <!--
           <entry>current transaction's start time</entry>
 -->
-          <entry>現トランザクションの開始時刻</entry>
+      <entry>現トランザクションの開始時刻</entry>
          </row>
          <row>
           <entry><literal>today</literal></entry>
@@ -3259,7 +3259,7 @@ January 8 04:05:06 1999 PST
 <!--
           <entry>midnight today</entry>
 -->
-          <entry>今日の午前０時</entry>
+      <entry>今日の始まり</entry>
          </row>
          <row>
           <entry><literal>tomorrow</literal></entry>
@@ -3267,7 +3267,7 @@ January 8 04:05:06 1999 PST
 <!--
           <entry>midnight tomorrow</entry>
 -->
-          <entry>明日の午前０時</entry>
+      <entry>明日の始まり</entry>
          </row>
          <row>
           <entry><literal>yesterday</literal></entry>
@@ -3275,7 +3275,7 @@ January 8 04:05:06 1999 PST
 <!--
           <entry>midnight yesterday</entry>
 -->
-          <entry>昨日の午前０時</entry>
+      <entry>昨日の始まり</entry>
          </row>
          <row>
           <entry><literal>allballs</literal></entry>
@@ -3298,7 +3298,7 @@ January 8 04:05:06 1999 PST
       linkend="functions-datetime-current">.)  Note that these are
       SQL functions and are <emphasis>not</> recognized in data input strings.
 -->
-<acronym>SQL</acronym>互換の関数である、<literal>CURRENT_DATE</literal>、<literal>CURRENT_TIME</literal>、<literal>CURRENT_TIMESTAMP</literal>、<literal>LOCALTIME</literal>、<literal>LOCALTIMESTAMP</literal>も、対応するデータ型の現在の日付または時間の値を取得するために使用できます。
+<acronym>SQL</acronym>互換の関数である、<literal>CURRENT_DATE</literal>、<literal>CURRENT_TIME</literal>、<literal>CURRENT_TIMESTAMP</literal>、<literal>LOCALTIME</literal>、<literal>LOCALTIMESTAMP</literal>も、対応するデータ型の日付または時間の値として使用できます。
 後の4つでは、オプションとして秒以下の精度指定が可能です。
 （<xref linkend="functions-datetime-current"> を参照してください。）
 これらはSQL関数であり、データ入力文字列として認識<emphasis>されない</>ことに注意してください。


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) ”For some formats"の解釈が間違っていたので、訳し直しました。
(2) "handling", "exact"の訳語に違和感があったので、修正しました。また"input"を明示的に訳出しました。
(3) 「テキスト文字列のように」の掛かり先がわかりにくかったので、語順を変更しました。
(4) "It defaults to..."の解釈がおかしかったので、訳し直しました。
(5) "date of year"の訳語を「年間通算日」に変更しました。
(6) "except when"の解釈が間違っていたので、訳し直しました。また、"In this case"を素直に「この場合」と訳すと、どういう場合を指しているのかまったく理解不能なので、具体的に意訳しました。
(7) specialの訳語を「特殊」から「特別」に変更しました。
(8) midnightの訳語を「午前０時」としました。