### PR TITLE
Doc ja 9 5

### DIFF
--- a/doc/src/sgml/release-9.1.sgml
+++ b/doc/src/sgml/release-9.1.sgml
@@ -2948,7 +2948,7 @@ Sparc V8 マシンでのコンパイル失敗を修正しました。
 <!--
   <title>Release 9.1.15</title>
 -->
-  <title>リリース9.1.14</title>
+  <title>リリース9.1.15</title>
 
   <note>
 <!--


### PR DESCRIPTION
藤井です。

9.1のリリースノートで、一部タイトルのバージョン番号が
間違っていました。修正を取り込んでいただければと思います。