### PR TITLE
improve translation of release-old.sgml

### DIFF
--- a/doc/src/sgml/release-old.sgml
+++ b/doc/src/sgml/release-old.sgml
@@ -8688,7 +8688,7 @@ Bug fixes:
 <!--
 <title><productname>Postgres95</productname> Release 0.03</title>
 -->
-<title><productname>Postgres95</productname> リリース0.03</title>
+<title><productname>Postgres95</productname>リリース0.03</title>
 
    <note>
 <!--
@@ -8819,7 +8819,7 @@ New documentation:
 <!--
 <title><productname>Postgres95</productname> Release 0.02</title>
 -->
-<title><productname>Postgres95</productname> リリース0.02</title>
+<title><productname>Postgres95</productname>リリース0.02</title>
 
    <note>
 <!--

--- a/doc/src/sgml/release-old.sgml
+++ b/doc/src/sgml/release-old.sgml
@@ -1532,7 +1532,7 @@ month-related formats</para></listitem>
 <!--
     A dump/restore is not required for those running 7.3.X.
 -->
-7.3.Xからの移行の場合は ダンプ/リストアは必要ありません。
+7.3.Xからの移行の場合はダンプ/リストアは必要ありません。
    </para>
   </sect2>
 
@@ -1606,7 +1606,7 @@ datestyles</para></listitem>
 <!--
     A dump/restore is not required for those running 7.3.X.
 -->
-7.3.Xからの移行の場合は ダンプ/リストアは必要ありません。
+7.3.Xからの移行の場合はダンプ/リストアは必要ありません。
    </para>
   </sect2>
 
@@ -1700,7 +1700,7 @@ concern since there is no reason for non-developers to use this script anyway.
 <!--
     A dump/restore is not required for those running 7.3.X.
 -->
-7.3.X からの移行の場合は ダンプ/リストアは必要ありません。
+7.3.Xからの移行の場合はダンプ/リストアは必要ありません。
    </para>
   </sect2>
 
@@ -1766,7 +1766,7 @@ since <productname>PostgreSQL</productname> 7.1.
     A dump/restore is <emphasis>not</emphasis> required for those
     running 7.3.*.
 -->
-7.3.* からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+7.3.*からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
    </para>
 
   </sect2>
@@ -1849,7 +1849,7 @@ operations on bytea columns (Joe)</para></listitem>
     A dump/restore is <emphasis>not</emphasis> required for those
     running 7.3.*.
 -->
-7.3.X からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+7.3.*からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
    </para>
   </sect2>
 
@@ -1911,14 +1911,14 @@ operations on bytea columns (Joe)</para></listitem>
 <!--
    <title>Migration to Version 7.3.4</title>
 -->
-   <title>バージョン7.3.4への移行方法</title>
+   <title>バージョン7.3.4への移行</title>
 
    <para>
 <!--
     A dump/restore is <emphasis>not</emphasis> required for those
     running 7.3.*.
 -->
-7.3.X からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+7.3.*からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
    </para>
   </sect2>
 
@@ -1968,14 +1968,14 @@ operations on bytea columns (Joe)</para></listitem>
 <!--
   <title>Migration to Version 7.3.3</title>
 -->
-  <title>バージョン7.3.3への移行方法</title>
+  <title>バージョン7.3.3への移行</title>
 
   <para>
 <!--
    A dump/restore is <emphasis>not</emphasis> required for those
    running version 7.3.*.
 -->
-7.3.X からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+7.3.*からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
   </para>
  </sect2>
 
@@ -2097,14 +2097,14 @@ operations on bytea columns (Joe)</para></listitem>
 <!--
   <title>Migration to Version 7.3.2</title>
 -->
-  <title>バージョン7.3.2への移行方法</title>
+  <title>バージョン7.3.2への移行</title>
 
   <para>
 <!--
    A dump/restore is <emphasis>not</emphasis> required for those
    running version 7.3.*.
 -->
-7.3.X からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+7.3.*からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
   </para>
  </sect2>
 
@@ -2176,7 +2176,7 @@ operations on bytea columns (Joe)</para></listitem>
 <!--
   <title>Migration to Version 7.3.1</title>
 -->
-  <title>バージョン7.3.1への移行方法</title>
+  <title>バージョン7.3.1への移行</title>
 
   <para>
 <!--
@@ -2186,7 +2186,7 @@ operations on bytea columns (Joe)</para></listitem>
    has a new major version number for this release, which might require
    recompilation of client code in certain cases.
 -->
-7.3 からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+7.3からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
 しかし、<productname>PostgreSQL</productname>の主なインタフェースライブラリであるのメジャーバージョン番号がこのリリースから変更されましたので、libpqを使用したクライアントコードを再リンクする必要があります。
   </para>
  </sect2>
@@ -2429,7 +2429,7 @@ operations on bytea columns (Joe)</para></listitem>
 <!--
   <title>Migration to Version 7.3</title>
 -->
-  <title>バージョン 7.3 への移行</title>
+  <title>バージョン7.3への移行</title>
 
   <para>
 <!--
@@ -2456,7 +2456,7 @@ operations on bytea columns (Joe)</para></listitem>
 <!--
      Pre-6.3 clients are no longer supported.
 -->
-6.3 よりも前のバージョンのクライアントはサポートされません。
+6.3よりも前のバージョンのクライアントはサポートされません。
     </para>
    </listitem>
 
@@ -3166,7 +3166,7 @@ month-related formats</para></listitem>
 <!--
     A dump/restore is not required for those running 7.2.X.
 -->
-7.2.Xからの移行の場合は ダンプ/リストアは必要ありません。
+7.2.Xからの移行の場合はダンプ/リストアは必要ありません。
    </para>
   </sect2>
 
@@ -3232,7 +3232,7 @@ datestyles</para></listitem>
 <!--
     A dump/restore is not required for those running 7.2.X.
 -->
-7.2.Xからの移行の場合は ダンプ/リストアは必要ありません。
+7.2.Xからの移行の場合はダンプ/リストアは必要ありません。
    </para>
   </sect2>
 
@@ -3385,21 +3385,21 @@ since <productname>PostgreSQL</productname> 7.1.
   This release contains a variety of fixes for version 7.2.3,
   including fixes to prevent possible data loss.
 -->
-このリリースはバージョン 7.2.3 の不具合を改修したものです。 データ損失の可能性を防止するための改修も含まれています。
+このリリースはバージョン7.2.3の不具合を改修したものです。データ損失の可能性を防止するための改修も含まれています。
  </para>
 
  <sect2>
 <!--
   <title>Migration to Version 7.2.4</title>
 -->
-  <title>バージョン 7.2.4 への移行方法</title>
+  <title>バージョン7.2.4への移行</title>
 
   <para>
 <!--
    A dump/restore is <emphasis>not</emphasis> required for those
    running version 7.2.*.
 -->
-7.2.X からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+7.2.*からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
   </para>
  </sect2>
 
@@ -3442,21 +3442,21 @@ since <productname>PostgreSQL</productname> 7.1.
   This release contains a variety of fixes for version 7.2.2,
   including fixes to prevent possible data loss.
 -->
-このリリースはバージョン 7.2.2 の不具合を改修したものです。 データ損失の可能性を防止するための改修も含まれています。
+このリリースはバージョン7.2.2の不具合を改修したものです。データ損失の可能性を防止するための改修も含まれています。
  </para>
 
  <sect2>
 <!--
   <title>Migration to Version 7.2.3</title>
 -->
-  <title>バージョン 7.2.3 への移行方法</title>
+  <title>バージョン7.2.3への移行</title>
 
   <para>
 <!--
    A dump/restore is <emphasis>not</emphasis> required for those
    running version 7.2.*.
 -->
-7.2.X からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+7.2.*からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
   </para>
  </sect2>
 
@@ -3496,21 +3496,21 @@ since <productname>PostgreSQL</productname> 7.1.
 <!--
   This release contains a variety of fixes for version 7.2.1.
 -->
-このリリースはバージョン 7.2.1 の不具合を改修したものです。
+このリリースはバージョン7.2.1の不具合を改修したものです。
  </para>
 
  <sect2>
 <!--
   <title>Migration to Version 7.2.2</title>
 -->
-  <title>バージョン 7.2.2 への移行方法</title>
+  <title>バージョン7.2.2への移行</title>
 
   <para>
 <!--
    A dump/restore is <emphasis>not</emphasis> required for those
    running version 7.2.*.
 -->
-7.2.X からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+7.2.*からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
   </para>
  </sect2>
 
@@ -3557,21 +3557,21 @@ since <productname>PostgreSQL</productname> 7.1.
 <!--
   This release contains a variety of fixes for version 7.2.
 -->
-このリリースはバージョン 7.2 の不具合を改修したものです。
+このリリースはバージョン7.2の不具合を改修したものです。
  </para>
 
  <sect2>
 <!--
   <title>Migration to Version 7.2.1</title>
 -->
-  <title>バージョン 7.2.1 への移行方法</title>
+  <title>バージョン7.2.1への移行</title>
 
   <para>
 <!--
    A dump/restore is <emphasis>not</emphasis> required for those
    running version 7.2.
 -->
-7.2 からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+7.2からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
   </para>
  </sect2>
 
@@ -3758,14 +3758,14 @@ OID は省略できるようになりました。ユーザは OID の使用が�
 <!--
   <title>Migration to Version 7.2</title>
 -->
-  <title>バージョン 7.2 への移行</title>
+  <title>バージョン7.2への移行</title>
 
   <para>
 <!--
    A dump/restore using <command>pg_dump</command> is required for
    those wishing to migrate data from any previous release.
 -->
-以前のリリースからデータを移行する場合、<command>pg_dump</command> によるダンプ/リストアが必要です。
+以前のリリースからデータを移行する場合、<command>pg_dump</command>によるダンプ/リストアが必要です。
   </para>
 
   <para>
@@ -4310,14 +4310,14 @@ OID は省略できるようになりました。ユーザは OID の使用が�
 <!--
    <title>Migration to Version 7.1.3</title>
 -->
-   <title>7.1.3 への移行方法</title>
+   <title>7.1.3への移行</title>
 
    <para>
 <!--
     A dump/restore is <emphasis>not</emphasis> required for those running
     7.1.X.
 -->
-7.1.X からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+7.1.Xからの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
    </para>
   </sect2>
 
@@ -4363,7 +4363,7 @@ Cygwin build (Jason Tishler)
 <!--
    This has one fix from 7.1.1.
 -->
-このリリースは 7.1.1 の不具合を改修したものです。
+このリリースは7.1.1の不具合を改修したものです。
   </para>
 
 
@@ -4371,14 +4371,14 @@ Cygwin build (Jason Tishler)
 <!--
    <title>Migration to Version 7.1.2</title>
 -->
-   <title>バージョン 7.1.2 への移行方法</title>
+   <title>バージョン7.1.2への移行</title>
 
    <para>
 <!--
     A dump/restore is <emphasis>not</emphasis> required for those running
     7.1.X.
 -->
-7.1.X からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+7.1.Xからの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
    </para>
   </sect2>
 
@@ -4419,7 +4419,7 @@ pg_dump cleanups
 <!--
    This has a variety of fixes from 7.1.
 -->
-このリリースは 7.1 の不具合を改修したものです。
+このリリースは7.1の不具合を改修したものです。
   </para>
 
 
@@ -4427,14 +4427,14 @@ pg_dump cleanups
 <!--
    <title>Migration to Version 7.1.1</title>
 -->
-   <title>バージョン 7.1.1 への移行方法</title>
+   <title>バージョン7.1.1への移行</title>
 
    <para>
 <!--
     A dump/restore is <emphasis>not</emphasis> required for those running
     7.1.
 -->
-7.1.X からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+7.1からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
    </para>
   </sect2>
 
@@ -4612,14 +4612,14 @@ FROM での副問い合わせもサポートされるようになりました。
 <!--
    <title>Migration to Version 7.1</title>
 -->
-   <title>バージョン 7.1 への移行</title>
+   <title>バージョン7.1への移行</title>
 
    <para>
 <!--
        A dump/restore using pg_dump is required for those wishing to migrate
        data from any previous release.
 -->
-以前のリリースからデータを移行する場合、pg_dump によるダンプ/リストアが必要です。
+以前のリリースからデータを移行する場合、pg_dumpによるダンプ/リストアが必要です。
    </para>
   </sect2>
 
@@ -4840,7 +4840,7 @@ New FreeBSD tools ipc_check, start-scripts/freebsd
 <!--
    This has a variety of fixes from 7.0.2.
 -->
-このリリースは 7.0.2 の不具合を改修したものです。
+このリリースは7.0.2の不具合を改修したものです。
   </para>
 
 
@@ -4848,14 +4848,14 @@ New FreeBSD tools ipc_check, start-scripts/freebsd
 <!--
    <title>Migration to Version 7.0.3</title>
 -->
-   <title>バージョン 7.0.3 への移行方法</title>
+   <title>バージョン7.0.3への移行</title>
 
    <para>
 <!--
     A dump/restore is <emphasis>not</emphasis> required for those running
     7.0.*.
 -->
-7.0.* からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+7.0.*からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
    </para>
   </sect2>
 
@@ -4939,14 +4939,14 @@ Fix for crash of backend, on abort (Tom)
 <!--
    <title>Migration to Version 7.0.2</title>
 -->
-   <title>バージョン 7.0.2 への移行方法</title>
+   <title>バージョン7.0.2への移行</title>
 
    <para>
 <!--
     A dump/restore is <emphasis>not</emphasis> required for those running
     7.*.
 -->
-7.* からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+7.*からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
    </para>
   </sect2>
 
@@ -4993,14 +4993,14 @@ tarballに文書を追加した。
 <!--
    <title>Migration to Version 7.0.1</title>
 -->
-   <title>バージョン 7.0.1 への移行方法</title>
+   <title>バージョン7.0.1への移行</title>
 
    <para>
 <!--
     A dump/restore is <emphasis>not</emphasis> required for those running
     7.0.
 -->
-7.0 からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+7.0からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
    </para>
   </sect2>
 
@@ -5162,7 +5162,7 @@ PARTIAL MATCH 外部キー以外の外部キーが実装されました。
 <!--
    <title>Migration to Version 7.0</title>
 -->
-   <title>バージョン 7.0 への移行</title>
+   <title>バージョン7.0への移行</title>
 
    <para>
 <!--
@@ -5174,7 +5174,9 @@ PARTIAL MATCH 外部キー以外の外部キーが実装されました。
     release; however, a full dump/reload installation is always the
     most robust method for upgrades.
 -->
-以前のリリースからデータを移行する場合、<application>pg_dump</application> によるダンプ/リストアが必要です。6.5.* からのアップグレードの場合、<application>pg_upgrade</application> を使用してこのリリースにアップグレードすることもできます。 しかし、完全なインストレーションのダンプをリストアする方法が、常に堅牢なアップグレードの方法です。
+以前のリリースからデータを移行する場合、<application>pg_dump</application> によるダンプ/リストアが必要です。
+6.5.*からのアップグレードの場合、<application>pg_upgrade</application> を使用してこのリリースにアップグレードすることもできます。
+しかし、完全なインストレーションのダンプをリストアする方法が、常に堅牢なアップグレードの方法です。
    </para>
 
    <para>
@@ -5606,14 +5608,14 @@ New multibyte encodings
 <!--
    <title>Migration to Version 6.5.3</title>
 -->
-   <title>バージョン 6.5.3 への移行方法</title>
+   <title>バージョン6.5.3への移行</title>
 
    <para>
 <!--
     A dump/restore is <emphasis>not</emphasis> required for those running
     6.5.*.
 -->
-6.5.* からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+6.5.*からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
    </para>
   </sect2>
   <sect2>
@@ -5660,14 +5662,14 @@ Fix dumping rules on inherited tables
 <!--
    <title>Migration to Version 6.5.2</title>
 -->
-   <title>バージョン 6.5.2 への移行方法</title>
+   <title>バージョン6.5.2への移行</title>
 
    <para>
 <!--
     A dump/restore is <emphasis>not</emphasis> required for those running
     6.5.*.
 -->
-6.5.* からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+6.5.*からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
    </para>
   </sect2>
 
@@ -5734,14 +5736,14 @@ Updated version of pgaccess 0.98
 <!--
    <title>Migration to Version 6.5.1</title>
 -->
-   <title>バージョン 6.5.1 への移行方法</title>
+   <title>バージョン6.5.1への移行</title>
 
    <para>
 <!--
     A dump/restore is <emphasis>not</emphasis> required for those running
     6.5.
 -->
-6.5 からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+6.5からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
    </para>
   </sect2>
 
@@ -6015,7 +6017,7 @@ CASE、INTERSECT、EXCEPT 文をサポートするようになりました。新
 <!--
    <title>Migration to Version 6.5</title>
 -->
-   <title>バージョン 6.5 への移行</title>
+   <title>バージョン6.5への移行</title>
 
    <para>
 <!--
@@ -6026,7 +6028,8 @@ CASE、INTERSECT、EXCEPT 文をサポートするようになりました。新
     be used to upgrade to this release because the on-disk structure
     of the tables has changed compared to previous releases.
 -->
-以前のリリースの<productname>PostgreSQL</productname> からデータを移行する場合、<application>pg_dump</application> によるダンプ/リストアが必要です。<application> pg_upgrade</application> を使用してこのリリースにアップグレードすることは<emphasis>できません</emphasis>。
+以前のリリースの<productname>PostgreSQL</productname>からデータを移行する場合、<application>pg_dump</application>によるダンプ/リストアが必要です。
+<application>pg_upgrade</application>を使用してこのリリースにアップグレードすることは<emphasis>できません</emphasis>。
    </para>
 
    <para>
@@ -6057,7 +6060,8 @@ CASE、INTERSECT、EXCEPT 文をサポートするようになりました。新
      updated by concurrent transactions before the current transaction does
      a commit or rollback.
 -->
-6.5 における読み込み操作はデータをロックしませんので、トランザクション隔離レベルに関係なく、あるトランザクションで読み込まれたデータは、他の操作によって変更されることがあります。言い替えると、<command>SELECT</command> で読み込まれた行は、返された(つまり、文またはトランザクションの始まりから少し後の)時点に存在した行を意味し、現在のトランザクションがコミット、またはロールバックするまでの間、同時に実行されるトランザクションによる更新や削除から保護される行であることは意味しません。
+6.5における読み込み操作はデータをロックしませんので、トランザクション隔離レベルに関係なく、あるトランザクションで読み込まれたデータは、他の操作によって変更されることがあります。
+言い替えると、<command>SELECT</command> で読み込まれた行は、返された(つまり、文またはトランザクションの始まりから少し後の)時点に存在した行を意味し、現在のトランザクションがコミット、またはロールバックするまでの間、同時に実行されるトランザクションによる更新や削除から保護される行であることは意味しません。
     </para>
 
     <para>
@@ -6068,7 +6072,8 @@ CASE、INTERSECT、EXCEPT 文をサポートするようになりました。新
      taken into account when porting applications from previous releases of
      <productname>PostgreSQL</productname> and other environments.
 -->
-行が実際に存在することを確実にする、または、同時に行われる更新から保護するためには、<command>SELECT FOR UPDATE</command> または、適切な<command>LOCK TABLE</command> 文を使用しなければなりません。これは、<productname>PostgreSQL</productname> の以前のリリース、もしくは、他の環境からアプリケーションを移植する場合には考慮しなければなりません。
+行が実際に存在することを確実にする、または、同時に行われる更新から保護するためには、<command>SELECT FOR UPDATE</command>または、適切な<command>LOCK TABLE</command>文を使用しなければなりません。
+これは、<productname>PostgreSQL</productname>の以前のリリース、もしくは、他の環境からアプリケーションを移植する場合には考慮しなければなりません。
     </para>
 
     <para>
@@ -6081,7 +6086,9 @@ CASE、INTERSECT、EXCEPT 文をサポートするようになりました。新
      use <command>LOCK parent_table IN SHARE MODE</command> command if a
      transaction is going to update/insert a foreign key.
 -->
-<filename>contrib/refint.*</filename> トリガを参照整合性のために使用している場合は、上のことに注意して下さい。今のところ更に技術を追加しなければなりません。1 つの方法は、トランザクションが主キーを更新、削除する時に<command>LOCK parent_table IN SHARE ROW EXCLUSIVE MODE</command> コマンドを使用し、トランザクションが外部キーを更新、挿入する時に、<command>LOCK parent_table IN SHARE MODE</command> コマンドを使用することです。
+<filename>contrib/refint.*</filename> トリガを参照整合性のために使用している場合は、上のことに注意して下さい。
+今のところ更に技術を追加しなければなりません。
+1つの方法は、トランザクションが主キーを更新、削除する時に<command>LOCK parent_table IN SHARE ROW EXCLUSIVE MODE</command>コマンドを使用し、トランザクションが外部キーを更新、挿入する時に、<command>LOCK parent_table IN SHARE MODE</command>コマンドを使用することです。
 
      <note>
       <para>
@@ -6303,7 +6310,7 @@ New install commands for plpgsql(Jan)
 The 6.4.1 release was improperly packaged.  This also has one additional
 bug fix.
 -->
-リリース6.4.1 は正しくパッケージ化されていませんでした。また、不具合を1つ改修しています。
+リリース6.4.1は正しくパッケージ化されていませんでした。また、不具合を1つ改修しています。
 </para>
 
 
@@ -6311,14 +6318,14 @@ bug fix.
 <!--
 <title>Migration to Version 6.4.2</title>
 -->
-<title>バージョン 6.4.2 への移行方法</title>
+<title>バージョン6.4.2への移行</title>
 
 <para>
 <!--
 A dump/restore is <emphasis>not</emphasis> required for those running
 6.4.*.
 -->
-6.4.* からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+6.4.*からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
 </para>
 </sect2>
 <sect2>
@@ -6357,7 +6364,8 @@ Fix for datetime constant problem on some platforms(Thomas)
 This is basically a cleanup release for 6.4.  We have fixed a variety of
 problems reported by 6.4 users.
 -->
-このリリースは基本的には 6.4 を整理したものです。6.4 のユーザから報告があった不具合を改修しています。
+このリリースは基本的には6.4を整理したものです。
+6.4のユーザから報告があった不具合を改修しています。
 </para>
 
 
@@ -6365,14 +6373,14 @@ problems reported by 6.4 users.
 <!--
 <title>Migration to Version 6.4.1</title>
 -->
-<title>バージョン 6.4.1 への移行方法</title>
+<title>バージョン6.4.1への移行</title>
 
 <para>
 <!--
 A dump/restore is <emphasis>not</emphasis> required for those running
 6.4.
 -->
-6.4 からの移行の場合は ダンプ/リストアは必要<emphasis>ありません</emphasis>。
+6.4からの移行の場合はダンプ/リストアは必要<emphasis>ありません</emphasis>。
 </para>
 </sect2>
 <sect2>
@@ -6783,8 +6791,8 @@ new Makefile.shlib for shared library configuration(Tom)
 This is a bug-fix release for 6.3.x.
 Refer to the release notes for version 6.3 for a more complete summary of new features.
 -->
-このリリースは 6.3.x の不具合を改修したものです。
- 新機能の完全な要約については バージョン 6.3 のリリースノートを参照して下さい。
+このリリースは6.3.xの不具合を改修したものです。
+新機能の完全な要約についてはバージョン6.3のリリースノートを参照して下さい。
 </para>
 <para>
 <!--
@@ -6799,7 +6807,7 @@ Summary:
 Repairs automatic configuration support for some platforms, including Linux,
 from breakage inadvertently introduced in version 6.3.1.
 -->
-Linux を含むいくつかのプラットフォームの自動設定サポートにおいて、バージョン 6.3.1 で間違って導入された障害を修復しました。
+Linux を含むいくつかのプラットフォームの自動設定サポートにおいて、バージョン6.3.1で間違って導入された障害を修復しました。
 </para>
 </listitem>
 
@@ -6821,7 +6829,7 @@ A dump/restore is NOT required for those running 6.3 or 6.3.1.  A
 This last step should be performed while the postmaster is not running.
 You should re-link any custom applications that use <productname>PostgreSQL</productname> libraries.
 -->
-6.3 や 6.3.1 からはダンプ/リストアは必要ありません。
+6.3や6.3.1からはダンプ/リストアは必要ありません。
 <literal> make distclean</>、<literal>make</>、<literal>make install</> だけが必要です。
 この最後の段階は、postmaster が稼働していない時に行わなければなりません。
 <productname>PostgreSQL</productname> ライブラリを使用している独自のアプリケーションは、再リンクしなければなりません。
@@ -6831,7 +6839,7 @@ You should re-link any custom applications that use <productname>PostgreSQL</pro
 For upgrades from pre-6.3 installations,
 refer to the installation and migration instructions for version 6.3.
 -->
-6.3 以前のインストレーションからのアップグレードの場合は、バージョン 6.3 用のインストール・移行手順を参照して下さい。
+6.3以前のインストレーションからのアップグレードの場合は、バージョン6.3用のインストール・移行手順を参照して下さい。
 </para>
 
   <sect2>
@@ -6909,7 +6917,7 @@ Repair byte ordering for mixed-endian clients and servers.
 <!--
 Minor updates to allowed SQL syntax.
 -->
-使用できる SQL 構文の若干の更新。
+使用できるSQL構文の若干の更新。
 </para>
 </listitem>
 
@@ -6931,7 +6939,7 @@ A dump/restore is NOT required for those running 6.3.  A
 This last step should be performed while the postmaster is not running.
 You should re-link any custom applications that use <productname>PostgreSQL</productname> libraries.
 -->
-6.3 からはダンプ/リストアは必要ありません。
+6.3からはダンプ/リストアは必要ありません。
 <literal>make distclean</>、<literal>make</>、<literal>make install</> だけが必要です。
 この最後の段階は、postmaster が稼働していない時に行わなければなりません。
 <productname>PostgreSQL</productname> ライブラリを使用している独自のアプリケーションは、再リンクしなければなりません。
@@ -6941,7 +6949,7 @@ You should re-link any custom applications that use <productname>PostgreSQL</pro
 For upgrades from pre-6.3 installations,
 refer to the installation and migration instructions for version 6.3.
 -->
-6.3 以前のインストレーションからのアップグレードの場合は、バージョン 6.3 用のインストール・移行手順を参照して下さい。
+6.3以前のインストレーションからのアップグレードの場合は、バージョン6.3用のインストール・移行手順を参照して下さい。
 </para>
 
   <sect2>
@@ -7033,7 +7041,8 @@ Better identify tcl and tk libs and includes(Bruce)
       so you might need to start <application>postmaster</application> with the
       <option>-i</option> flag.
 -->
-クライアント/サーバ接続用のソケットインタフェース。現在、これがデフォルトとなりましたので、<application>postmaster</application> 起動時に<option>-i</option> フラグが必要になる可能性があります。
+クライアント/サーバ接続用のソケットインタフェース。
+現在、これがデフォルトとなりましたので、<application>postmaster</application> 起動時に<option>-i</option> フラグが必要になる可能性があります。
      </para>
     </listitem>
 
@@ -7073,7 +7082,9 @@ Bruce Momjian による、このリリースを紹介する以下のノートが
    only the big items that cannot be described in one sentence.  A review
    of the detailed changes list is still needed.
 -->
-いくつか言及すべき、6.3 の一般的な問題点があります。一行では書き表せない程度の項目です。詳細な変更点リストの再検査がまだ必要です。
+いくつか言及すべき、6.3の一般的な問題点があります。
+一行では書き表せない程度の項目です。
+詳細な変更点リストの再検査がまだ必要です。
   </para>
   <para>
 <!--
@@ -7100,7 +7111,7 @@ Vadim は副セレクトを使用した大きな SQL マップを残し、また
    postmaster -i option, and of course edit <filename>pg_hba.conf</filename>.  Also, for this
    reason, the format of <filename>pg_hba.conf</filename> has changed.
 -->
-次に、6.3 はデフォルトで、 TCP/IPではなく Unix ドメインソケットを使用するようになりました。
+次に、6.3はデフォルトで、TCP/IPではなくUnixドメインソケットを使用するようになりました。
 他のマシンからの接続を可能にするには、postmaster の新規の -i オプションを使用し、もちろん、<filename>pg_hba.conf</filename>ファイルを編集しなければなりません。
 また、このため、<filename>pg_hba.conf</filename>の書式が変更されました。
   </para>
@@ -7188,7 +7199,7 @@ pg_user は pg_shadow のビューとなり、PUBLIC より SELECT 可能です�
 <!--
    <title>Migration to Version 6.3</title>
 -->
-   <title>バージョン 6.3 への移行</title>
+   <title>バージョン6.3への移行</title>
 
    <para>
 <!--
@@ -7438,14 +7449,15 @@ Refer to the 6.2 release notes for instructions.
 <!--
 <title>Migration from version 6.2 to version 6.2.1</title>
 -->
-<title>バージョン 6.2 からバージョン 6.2.1 への移行</title>
+<title>バージョン6.2からバージョン6.2.1への移行</title>
 
 <para>
 <!--
 This is a minor bug-fix release. A dump/reload is not required from version 6.2,
 but is required from any release prior to 6.2.
 -->
-これは小さな不具合を改修したリリースです。バージョン 6.2 からの場合は、ダンプ/リロードは必要ありませんが、それ以前のリリースでは必要です。
+これは小さな不具合を改修したリリースです。
+バージョン6.2からの場合は、ダンプ/リロードは必要ありませんが、それ以前のリリースでは必要です。
 </para>
 <para>
 <!--
@@ -7453,7 +7465,8 @@ In upgrading from version 6.2, if you choose to dump/reload you will find that
 avg(money) is now calculated correctly. All other bug fixes take effect
 upon updating the executables.
 -->
-バージョン 6.2 からのアップグレードで、ダンプ/リロードを行った場合、avg(money) の計算が正確になったことが判るでしょう。この他全ての不具合の改修は、実行形式ファイルを更新した時点で効果が得られます。
+バージョン6.2からのアップグレードで、ダンプ/リロードを行った場合、avg(money) の計算が正確になったことが判るでしょう。
+この他全ての不具合の改修は、実行形式ファイルを更新した時点で効果が得られます。
 </para>
 <para>
 <!--
@@ -7525,21 +7538,21 @@ previous releases of <productname>PostgreSQL</productname>.
 <!--
 <title>Migration from version 6.1 to version 6.2</title>
 -->
-<title>バージョン 6.1 からバージョン 6.2 への移行</title>
+<title>バージョン6.1からバージョン6.2への移行</title>
 
 <para>
 <!--
 This migration requires a complete dump of the 6.1 database and a
 restore of the database in 6.2.
 -->
-この移行の場合、6.1 データベースの完全なダンプと、6.2 のデータベースへのリストアが必要です。
+この移行の場合、6.1データベースの完全なダンプと、6.2のデータベースへのリストアが必要です。
 </para>
 <para>
 <!--
 Note that the <command>pg_dump</command> and <command>pg_dumpall</command> utility from 6.2 should be used
 to dump the 6.1 database.
 -->
-6.1 のデータベースをダンプするには、6.2 の<command>pg_dump</command> や<command>pg_dumpall</command> ユーティリティを使用しなければならないことに注意して下さい。
+6.1のデータベースをダンプするには、6.2の<command>pg_dump</command>や<command>pg_dumpall</command>ユーティリティを使用しなければならないことに注意して下さい。
 </para>
 </sect2>
 
@@ -7547,14 +7560,15 @@ to dump the 6.1 database.
 <!--
 <title>Migration from version 1.<replaceable>x</> to version 6.2</title>
 -->
-<title>バージョン 1.<replaceable>x</> からバージョン 6.2 への移行</title>
+<title>バージョン1.<replaceable>x</>からバージョン6.2への移行</title>
 
 <para>
 <!--
 Those migrating from earlier 1.* releases should first upgrade to 1.09
 because the COPY output format was improved from the 1.02 release.
 -->
-1.* の初期リリースからの移行の場合は、まず、1.09 へアップグレードしなければなりません。 COPY の出力書式がリリース1.02 から改良されたからです。
+1.*の初期リリースからの移行の場合は、まず、1.09へアップグレードしなければなりません。
+COPY の出力書式がリリース1.02から改良されたからです。
 </para>
 </sect2>
 
@@ -7697,7 +7711,7 @@ SPI and Trigger programming guides (Vadim &amp; D'Arcy)
 <!--
 <title>Migration from version 6.1 to version 6.1.1</title>
 -->
-<title>バージョン 6.1 からバージョン 6.1.1 への移行</title>
+<title>バージョン6.1からバージョン6.1.1への移行</title>
 
 <para>
 <!--
@@ -7705,7 +7719,9 @@ This is a minor bug-fix release. A dump/reload is not required from version 6.1,
 but is required from any release prior to 6.1.
 Refer to the release notes for 6.1 for more details.
 -->
-これは小さな不具合を改修したリリースです。バージョン 6.1 からの移行の場合はダンプ/リロードは不要ですが、それ以前のリリースからの場合は全てダンプ/リロードは必要です。より詳細は 6.1 のリリースノートを参照して下さい。
+これは小さな不具合を改修したリリースです。
+バージョン6.1からの移行の場合はダンプ/リロードは不要ですが、それ以前のリリースからの場合は全てダンプ/リロードは必要です。
+より詳細は6.1のリリースノートを参照して下さい。
 </para>
 </sect2>
 
@@ -7758,7 +7774,7 @@ pg_dumpall now returns proper status, portability fix(Bruce)
  The regression tests have been adapted and extensively modified for the
  6.1 release of <productname>PostgreSQL</productname>.
 -->
-<productname>PostgreSQL</productname> 6.1 リリースでは、リグレッションテストが追加され、また、多くの変更がなされました。
+<productname>PostgreSQL</productname> 6.1リリースでは、リグレッションテストが追加され、また、多くの変更がなされました。
 </para>
 
 <para>
@@ -7769,7 +7785,7 @@ pg_dumpall now returns proper status, portability fix(Bruce)
  The polygon output in misc.out has only been spot-checked for correctness
  relative to the original regression output.
 -->
-新しい 3 個のデータ型(<type>datetime</type>、<type>timespan</type>、<type>circle</type>) が<productname>PostgreSQL</productname> 固有の型セットとして追加されました。
+新しい3個のデータ型(<type>datetime</type>、<type>timespan</type>、<type>circle</type>) が<productname>PostgreSQL</productname> 固有の型セットとして追加されました。
 point、boxe、path、polygon の出力書式において、これら型の間で一貫性を持たせました。
 misc.out における polygon 出力は元のリグレッション出力からの相対値の正確さをチェックする部分的なものになりました。
 </para>
@@ -7787,7 +7803,10 @@ optimizer which uses <firstterm>genetic</firstterm>
  intervals) and tests involving those types are explicitly bracketed with
  <command>set geqo to 'off'</command> and <command>reset geqo</command>.
 -->
-<productname>PostgreSQL</productname> 6.1 では、<firstterm>遺伝的</firstterm>アルゴリズムを使用した、新しい、もう一つのオプティマイザを導入しました。問い合わせに複数の条件や複数のテーブルが含まれる(オプティマイザが評価の順番を選択することになる)場合、このアルゴリズムは問い合わせ結果の順番において不規則な動作をもたらします。多くのリグレッションテストがその結果を明示的に順序付けするように変更されましたので、オプティマイザの選択の影響はありません。ごく一部の (例えば、pointや time intervalなどの)生来順番を持たないデータ型用のリグレッションテストやこれらの型を使用するテスト、明示的に<command>set geqo to 'off'</command> と<command>reset geqo</command>の間で行われます。
+<productname>PostgreSQL</productname> 6.1では、<firstterm>遺伝的</firstterm>アルゴリズムを使用した、新しい、もう一つのオプティマイザを導入しました。
+問い合わせに複数の条件や複数のテーブルが含まれる(オプティマイザが評価の順番を選択することになる)場合、このアルゴリズムは問い合わせ結果の順番において不規則な動作をもたらします。
+多くのリグレッションテストがその結果を明示的に順序付けするように変更されましたので、オプティマイザの選択の影響はありません。
+ごく一部の(例えば、pointや time intervalなどの)生来順番を持たないデータ型用のリグレッションテストやこれらの型を使用するテストは、明示的に<command>set geqo to 'off'</command> と<command>reset geqo</command>の間で行われます。
 </para>
 
 <para>
@@ -7797,7 +7816,8 @@ optimizer which uses <firstterm>genetic</firstterm>
  tests were generated. The current <filename>./expected/*.out</filename> files reflect this
  new interpretation, which might not be correct!
 -->
-配列指示子(大括弧に囲まれた原子値)の解釈が、元となるリグレッションテストが生成された後に数回変更されたようです。現在の<filename>./expected/*.out</filename> はこの新しい解釈を反映していますが、間違っているかもしれません。
+配列指示子(大括弧に囲まれた原子値)の解釈が、元となるリグレッションテストが生成された後に数回変更されたようです。
+現在の<filename>./expected/*.out</filename> はこの新しい解釈を反映していますが、間違っているかもしれません。
 </para>
 
 <para>
@@ -7806,7 +7826,8 @@ optimizer which uses <firstterm>genetic</firstterm>
  to differences in implementations of <function>pow()</function> and <function>exp()</function> and the signaling
  mechanisms used for overflow and underflow conditions.
 -->
-float8 リグレッションテストは少なくともいくつかのプラットフォームで失敗します。これは、<function>pow()</function> と<function>exp()</function> の実装やオーバーフロー、アンダーフロー検出に使用される通知機構の違いが原因です。
+float8リグレッションテストは少なくともいくつかのプラットフォームで失敗します。
+これは、<function>pow()</function>と<function>exp()</function>の実装やオーバーフロー、アンダーフロー検出に使用される通知機構の違いが原因です。
 </para>
 
 <para>
@@ -7817,28 +7838,29 @@ float8 リグレッションテストは少なくともいくつかのプラッ�
  <quote>random</> does not seem to produce random results on my test
  machine (Linux/<application>gcc</>/i686).
 -->
-random テストの結果は<quote>不規則</>なものです。また、リグレッションテストの評価は単なる diff コマンドを使用しますので、<quote>random</quote> テストは<quote>失敗</quote>します。 しかし、私の試験用マシン(Linux/<application>gcc</>/i686)では<quote>random</> は不規則な結果を生成しないようです。
+randomテストの結果は<quote>不規則</>なものであり、リグレッションテストの評価は単なるdiffコマンドを使用しますので、<quote>random</quote>テストは<quote>失敗</quote>するでしょう。
+しかし、私の試験用マシン(Linux/<application>gcc</>/i686)では<quote>random</>は不規則な結果を生成しないようです。
 </para>
 
 <sect2>
 <!--
 <title>Migration to Version 6.1</title>
 -->
-<title>バージョン 6.1 への移行</title>
+<title>バージョン6.1への移行</title>
 
 <para>
 <!--
 This migration requires a complete dump of the 6.0 database and a
 restore of the database in 6.1.
 -->
-この移行の場合、6.0 データベースの完全なダンプと、6.1 のデータベースへのリストアが必要です。
+この移行の場合、6.0データベースの完全なダンプと、6.1のデータベースへのリストアが必要です。
 </para>
 <para>
 <!--
 Those migrating from earlier 1.* releases should first upgrade to 1.09
 because the COPY output format was improved from the 1.02 release.
 -->
-1.* の初期リリースからの移行の場合は、まず、1.09 へアップグレードしなければなりません。 COPY の出力書式がリリース1.02 から改良されたからです。
+1.*の初期リリースからの移行の場合は、まず、1.09へアップグレードしなければなりません。COPYの出力書式がリリース1.02から改良されたからです。
 </para>
 </sect2>
 
@@ -7968,21 +7990,21 @@ DG/UX, Ultrix, IRIX, AIX portability fixes
 A dump/restore is required for those wishing to migrate data from
 previous releases of <productname>PostgreSQL</productname>.
 -->
-以前のリリースの<productname>PostgreSQL</productname> からデータを移行する場合はダンプ/リストアが必要です。
+以前のリリースの<productname>PostgreSQL</productname>からデータを移行する場合はダンプ/リストアが必要です。
 </para>
 
 <sect2>
 <!--
 <title>Migration from version 1.09 to version 6.0</title>
 -->
-<title>バージョン 1.09 からバージョン 6.0 への移行</title>
+<title>バージョン1.09からバージョン6.0への移行</title>
 
 <para>
 <!--
 This migration requires a complete dump of the 1.09 database and a
 restore of the database in 6.0.
 -->
-この移行の場合、1.09 データベースの完全なダンプと、6.0 のデータベースへのリストアが必要です。
+この移行の場合、1.09データベースの完全なダンプと、6.0のデータベースへのリストアが必要です。
 </para>
 </sect2>
 
@@ -7990,14 +8012,14 @@ restore of the database in 6.0.
 <!--
 <title>Migration from pre-1.09 to version 6.0</title>
 -->
-<title>1.09より前のバージョンからバージョン 6.0 への移行</title>
+<title>1.09より前のバージョンからバージョン6.0への移行</title>
 
 <para>
 <!--
 Those migrating from earlier 1.* releases should first upgrade to 1.09
 because the COPY output format was improved from the 1.02 release.
 -->
-1.* の初期リリースからの移行の場合は、まず、1.09 へアップグレードしなければなりません。 COPY の出力書式がリリース1.02 から改良されたからです。
+1.*の初期リリースからの移行の場合は、まず、1.09へアップグレードしなければなりません。COPYの出力書式がリリース1.02から改良されたからです。
 </para>
 </sect2>
 
@@ -8137,7 +8159,8 @@ Sorry, we didn't keep track of changes from 1.02 to 1.09.  Some of
 the changes listed in 6.0 were actually included in the 1.02.1 to 1.09
 releases.
 -->
-すいません。 1.02から 1.09 での変更履歴は残っていません。6.0 にて示した変更点の中には、実際には 1.02.1から 1.09リリースでの変更も含まれています。
+すいません。1.02から1.09での変更履歴は残っていません。
+6.0にて示した変更点の中には、実際には1.02.1から1.09リリースでの変更も含まれています。
 </para>
 </sect1>
 
@@ -8159,14 +8182,15 @@ releases.
 <!--
 <title>Migration from version 1.02 to version 1.02.1</title>
 -->
-<title>バージョン 1.02 からバージョン 1.02.1 への移行</title>
+<title>バージョン1.02からバージョン1.02.1への移行</title>
 
 <para>
 <!--
 Here is a new migration file for 1.02.1.  It includes the 'copy' change
 and a script to convert old <acronym>ASCII</acronym> files.
 -->
-1.02.1 用の新しい移行ファイルがあります。 このファイルには 'copy' の変更や古い<acronym>ASCII</acronym> ファイルの変換スクリプトがあります。
+1.02.1用の新しい移行ファイルがあります。
+このファイルには'copy'の変更や古い<acronym>ASCII</acronym>ファイルの変換スクリプトがあります。
 </para>
 <note>
 <para>
@@ -8174,14 +8198,14 @@ and a script to convert old <acronym>ASCII</acronym> files.
 The following notes are for the benefit of users who want to migrate
 databases from <productname>Postgres95</> 1.01 and 1.02 to <productname>Postgres95</> 1.02.1.
 -->
-以下の注意は、<productname>Postgres95</> 1.01 および 1.02 から<productname>Postgres95</> 1.02.1 への移行を行うユーザ向けのものです。
+以下の注意は、<productname>Postgres95</> 1.01および1.02から<productname>Postgres95</> 1.02.1への移行を行うユーザ向けのものです。
 </para>
 <para>
 <!--
 If you are starting afresh with <productname>Postgres95</> 1.02.1 and do not need
 to migrate old databases, you do not need to read any further.
 -->
-新規に<productname>Postgres95</> 1.02.1 を使用し始める場合は古いデータベースを移行する必要はありませんので、これ以上読み続ける必要はありません。
+新規に<productname>Postgres95</> 1.02.1を使用し始める場合は古いデータベースを移行する必要はありませんので、これ以上読み続ける必要はありません。
 </para>
 </note>
 
@@ -8190,7 +8214,7 @@ to migrate old databases, you do not need to read any further.
 In order to upgrade older <productname>Postgres95</> version 1.01 or 1.02 databases to
 version 1.02.1, the following steps are required:
 -->
-古い<productname>Postgres95</> バージョン 1.01 または 1.02 データベースからバージョン 1.02.1 へアップグレードするためには、以下の手順が必要です。
+古い<productname>Postgres95</>バージョン1.01または1.02データベースからバージョン1.02.1へアップグレードするためには、以下の手順が必要です。
 </para>
 <procedure>
 <step>
@@ -8198,7 +8222,7 @@ version 1.02.1, the following steps are required:
 <!--
 Start up a new 1.02.1 postmaster
 -->
-新しい 1.02.1 の postmaster を起動します。
+新しい1.02.1のpostmasterを起動します。
 </para>
 </step>
 <step>
@@ -8211,7 +8235,10 @@ Add the new built-in functions and operators of 1.02.1 to 1.01 or 1.02
   1.01 or 1.02 database is named <literal>testdb</literal> and you have cut the commands
   from the end of this file and saved them in <filename>addfunc.sql</filename>:
 -->
-1.02.1 の新しい組み込み関数と演算子を 1.01 または 1.02 データベースに追加します。これは所有する 1.01 または 1.02 データベースに対して、新しい 1.02.1 サーバを実行させ、このファイルの最後にある問い合わせを実行することで行われます。<command>psql</> を使用して簡単に実施できます。1.01 または 1.02 データベースの名前が<literal>testdb</literal> であり、また、このファイルの最後の部分を<filename>addfunc.sql</filename> に保存したとすると、以下のようになります。
+1.02.1の新しい組み込み関数と演算子を1.01または1.02のデータベースに追加します。
+これは所有する1.01または1.02のデータベースに対して、新しい1.02.1のサーバを実行させ、このファイルの最後にある問い合わせを実行することで行われます。
+これは<command>psql</>を使用して簡単に実施できます。
+1.01または1.02のデータベースの名前が<literal>testdb</literal>であり、また、このファイルの最後の部分を<filename>addfunc.sql</filename>に保存したとすると、以下のようになります。
 <programlisting>
 % psql testdb -f addfunc.sql
 </programlisting>
@@ -8221,7 +8248,8 @@ Those upgrading 1.02 databases will get a warning when executing the
 last two statements in the file because they are already present in 1.02.  This is
 not a cause for concern.
 -->
-1.02 では既に存在するため、1.02 データベースのアップグレードでは、ファイルの最後の2文の実行の際に警告が表示されます。気にする必要はありません。
+1.02では既に存在するため、1.02のデータベースのアップグレードでは、ファイルの最後の2文の実行の際に警告が表示されます。
+気にする必要はありません。
 </para>
 </step>
 </procedure>
@@ -8242,7 +8270,10 @@ database.  The old format used '.' as end-of-data, while '\.' is now the
 end-of-data marker.  Also, empty strings are now loaded in as '' rather
 than NULL. See the copy manual page for full details.
 -->
-以前のバージョンで生成した、pg_dump や テキストモードの<literal>copy tablename to stdout</literal> をリロードする場合、データベースにロードする前に、その ASCII ファイルに対して以下の<command>sed</command> を実行する必要があります。古い書式では '.' をデータ終端として使用していますが、'\.' がデータ終端を示すようになりました。また、空文字列は NULL ではなく '' としてロードされるようになりました。完全な詳細については copy マニュアルページを参照して下さい。
+以前のバージョンで生成した、pg_dumpやテキストモードの<literal>copy tablename to stdout</literal>をリロードする場合、データベースにロードする前に、その ASCII ファイルに対して以下の<command>sed</command>を実行する必要があります。
+古い書式では '.'をデータ終端として使用していますが、'\.'がデータ終端を示すようになりました。
+また、空文字列はNULLではなく''としてロードされるようになりました。
+完全な詳細についてはcopyマニュアルページを参照して下さい。
 
 <programlisting>
 sed 's/^\.$/\\./g' &lt;in_file &gt;out_file
@@ -8253,7 +8284,7 @@ sed 's/^\.$/\\./g' &lt;in_file &gt;out_file
 If you are loading an older binary copy or non-<systemitem>stdout</> copy, there is no
 end-of-data character, and hence no conversion necessary.
 -->
-古いバイナリ copy や<systemitem>標準出力</>以外の copy からロードする場合は、データ終端文字はありませんので、変換する必要はありません。
+古いバイナリcopyや<systemitem>標準出力</>以外のcopyからロードする場合は、データ終端文字はありませんので、変換する必要はありません。
 
 <programlisting>
 -- following lines added by agc to reflect the case-insensitive
@@ -8351,28 +8382,28 @@ Contributors (apologies to any missed)
 <!--
 <title>Migration from version 1.0 to version 1.01</title>
 -->
-<title>バージョン 1.0 からバージョン 1.01 への移行</title>
+<title>バージョン1.0からバージョン1.01への移行</title>
 
 <para>
 <!--
 The following notes are for the benefit of users who want to migrate
 databases from <productname>Postgres95</> 1.0 to <productname>Postgres95</> 1.01.
 -->
-以下の注意は、<productname>Postgres95</> 1.0 から<productname>Postgres95</> 1.01 への移行を行うユーザ向けのものです。
+以下の注意は、<productname>Postgres95</> 1.0から<productname>Postgres95</> 1.01への移行を行うユーザ向けのものです。
 </para>
 <para>
 <!--
 If you are starting afresh with <productname>Postgres95</> 1.01 and do not need
 to migrate old databases, you do not need to read any further.
 -->
-新規に<productname>Postgres95</> 1.02.1 を使用し始める場合は古いデータベースを移行する必要はありませんので、これ以上読み続ける必要はありません。
+新規に<productname>Postgres95</> 1.01を使用し始める場合は古いデータベースを移行する必要はありませんので、これ以上読み続ける必要はありません。
 </para>
 <para>
 <!--
 In order to <productname>Postgres95</> version 1.01 with databases created with
 <productname>Postgres95</> version 1.0, the following steps are required:
 -->
-<productname>Postgres95</> バージョン 1.0 で作成したデータベースを<productname>Postgres95</> バージョン 1.01 で使用するためには、以下の手順が必要です。
+<productname>Postgres95</>バージョン1.0で作成したデータベースを<productname>Postgres95</>バージョン1.01で使用するためには、以下の手順が必要です。
 </para>
 <procedure>
 <step>
@@ -8381,7 +8412,7 @@ In order to <productname>Postgres95</> version 1.01 with databases created with
 Set the definition of <symbol>NAMEDATALEN</symbol> in <filename>src/Makefile.global</filename> to 16
    and <symbol>OIDNAMELEN</symbol> to 20.
 -->
-<filename>src/Makefile.global</filename> 内の<symbol>NAMEDATALEN</symbol>の定義を 16 に、<symbol>OIDNAMELEN</symbol>の定義を 20 に設定します。
+<filename>src/Makefile.global</filename>内の<symbol>NAMEDATALEN</symbol>の定義を16に、<symbol>OIDNAMELEN</symbol>の定義を20に設定します。
 </para>
 </step>
 <step>
@@ -8423,7 +8454,7 @@ HBA = 1
    you do not take steps A or B above, the out-of-the-box 1.01 will
    not allow you to connect to 1.0 databases.
 -->
-ホストベース認証方式はデフォルトで有効であり、上の A または B の手順を行わなかった場合、1.01 ボックス以外から 1.0 データベースへ接続することはできなくなることに注意して下さい。
+ホストベース認証方式はデフォルトで有効であり、上のAまたはBの手順を行わなかった場合、箱から出してすぐの1.01から1.0のデータベースへ接続できなくなることに注意して下さい。
 </para>
 </step>
 </substeps>
@@ -8434,7 +8465,7 @@ HBA = 1
 <!--
 Compile and install 1.01, but DO NOT do the <command>initdb</command> step.
 -->
-1.01 をコンパイルし、インストールします。 しかし、<command>initdb</command>を実行してはいけません。
+1.01をコンパイルし、インストールします。しかし、<command>initdb</command>を実行してはいけません。
 </para>
 </step>
 <step>
@@ -8443,7 +8474,7 @@ Compile and install 1.01, but DO NOT do the <command>initdb</command> step.
 Before doing anything else, terminate your 1.0 postmaster, and
    backup your existing <envar>$PGDATA</envar> directory.
 -->
-これ以上作業する前に、1.0 のpostmaster を終了させ、既存の<envar>$PGDATA</envar>ディレクトリをバックアップします。
+これ以上作業する前に、1.0のpostmasterを終了し、既存の<envar>$PGDATA</envar>ディレクトリをバックアップします。
 </para>
 </step>
 <step>
@@ -8452,7 +8483,7 @@ Before doing anything else, terminate your 1.0 postmaster, and
 Set your <envar>PGDATA</envar> environment variable to your 1.0 databases, but set up
    path up so that 1.01 binaries are being used.
 -->
-<envar>PGDATA</envar>環境変数を 1.0 データベースに設定し、パスを 1.01のバイナリが使用されるように設定します。
+<envar>PGDATA</envar>環境変数を1.0のデータベースに設定しますが、パスは1.01のバイナリが使用されるように設定します。
 </para>
 </step>
 <step>
@@ -8460,7 +8491,7 @@ Set your <envar>PGDATA</envar> environment variable to your 1.0 databases, but s
 <!--
 Modify the file <filename><envar>$PGDATA</envar>/PG_VERSION</filename> from 5.0 to 5.1
 -->
-<filename><envar>$PGDATA</envar>/PG_VERSION</filename>ファイルを 5.0から5.1へ変更します。
+<filename><envar>$PGDATA</envar>/PG_VERSION</filename>ファイルを5.0から5.1へ変更します。
 </para>
 </step>
 <step>
@@ -8468,7 +8499,7 @@ Modify the file <filename><envar>$PGDATA</envar>/PG_VERSION</filename> from 5.0 
 <!--
 Start up a new 1.01 postmaster
 -->
-新しい 1.01 postmaster を起動します。
+新しい1.01のpostmasterを起動します。
 </para>
 </step>
 <step>
@@ -8480,7 +8511,10 @@ Add the new built-in functions and operators of 1.01 to 1.0
    in the file 1.0_to_1.01.sql.   This can be done easily through <command>psql</command>.
    If your 1.0 database is name <literal>testdb</literal>:
 -->
-1.01 の新しい組み込み関数と演算子を 1.0 データベースに追加します。これは所有する 1.0 データベースに対して、新しい 1.01 サーバを実行させ、添付の問い合わせを 1.0_to_1.01.sql に保存して実行して下さい。<command>psql</command>を使用して簡単に実施できます。1.0 データベースの名前が<literal>testdb</literal>の場合は以下のようになります。
+1.01の新しい組み込み関数と演算子を1.0のデータベースに追加します。
+これは所有する1.0のデータベースに対して、新しい1.01のサーバを実行し、添付の問い合わせを1.0_to_1.01.sqlに保存することでできます。
+これは<command>psql</command>を使用して簡単に実施できます。
+1.0のデータベースの名前が<literal>testdb</literal>の場合は以下のようになります。
 
 <programlisting>
 % psql testdb -f 1.0_to_1.01.sql
@@ -8489,7 +8523,7 @@ Add the new built-in functions and operators of 1.01 to 1.0
 <!--
 and then execute the following commands (cut and paste from here):
 -->
-(以下を切り出して使用して下さい。)
+そして以下のコマンドを実行します(ここから切り出して貼付けてください)。
 
 <programlisting>
 -- add builtin functions that are new to 1.01
@@ -8845,7 +8879,7 @@ The following bugs have been fixed in postgres95-beta-0.02:
 <!--
 <title><productname>Postgres95</productname> Release 0.01</title>
 -->
-<title><productname>Postgres95</productname> リリース0.01</title>
+<title><productname>Postgres95</productname>リリース0.01</title>
 
    <note>
 <!--
@@ -8887,7 +8921,7 @@ Initial release.
     Timing under Linux 2.0.27 seems to have a roughly 5% variation from run
     to run, presumably due to the scheduling vagaries of multitasking systems.
 -->
-Linux 2.0.27 での時間計測は実行する度におおよそ 5% の変動があるようです。
+Linux 2.0.27での時間計測は実行する度におおよそ5%の変動があるようです。
 おそらく、マルチタスクシステムにおけるスケジューリングの気まぐれのためでしょう。
    </para>
 
@@ -8895,7 +8929,7 @@ Linux 2.0.27 での時間計測は実行する度におおよそ 5% の変動が
 <!--
     <title>Version 6.5</title>
 -->
-    <title>バージョン 6.5</title>
+    <title>バージョン6.5</title>
 
     <para>
 <!--
@@ -8905,7 +8939,7 @@ Linux 2.0.27 での時間計測は実行する度におおよそ 5% の変動が
      releases.
 -->
 以前のリリースと同様、新しいリグレッションテストが追加されていますので、リリース間での時間は直接比較できません。
-一般的には、6.5 は以前のリリースより高速です。
+一般的には、6.5は以前のリリースより高速です。
     </para>
 
     <para>
@@ -8936,7 +8970,7 @@ Time   System
      For the <systemitem class="osname">Linux</systemitem> system above, using <acronym>UW-SCSI</acronym> disks rather than (older) <acronym>IDE</acronym>
      disks leads to a 50% improvement in speed on the regression test.
 -->
-上で使用した<systemitem class="osname">Linux</systemitem>システムでは、(古い)<acronym>IDE</acronym>ディスクではなく<acronym>UW-SCSI</acronym>ディスクを使用すると、リグレッションテストの速度が 50% 速くなりました。
+上で使用した<systemitem class="osname">Linux</systemitem>システムでは、(古い)<acronym>IDE</acronym>ディスクではなく<acronym>UW-SCSI</acronym>ディスクを使用すると、リグレッションテストの速度が50%速くなりました。
     </para>
    </sect2>
 
@@ -8944,7 +8978,7 @@ Time   System
 <!--
 <title>Version 6.4beta</title>
 -->
-<title>バージョン 6.4beta</title>
+<title>バージョン6.4beta</title>
 
 <para>
 <!--
@@ -8953,7 +8987,7 @@ since some additional regression tests have been included.
 In general, however, 6.4 should be slightly faster than the previous release (thanks, Bruce!).
 -->
 このリリースでの時間は、新しいリグレッションテストが追加されていますので、以前のリリースの時間と直接比較できません。
-しかし、一般的には 6.4 は以前のリリースよりかなり高速になっているはずです。(ありがとう。Bruce!)
+しかし、一般的には6.4は以前のリリースよりかなり高速になっているはずです。(ありがとう。Bruce!)
 </para>
 <para>
 <literallayout class="monospaced">
@@ -8977,8 +9011,8 @@ since some additional regression tests have been included and some obsolete test
 time travel have been removed.
 In general, however, 6.3 is substantially faster than previous releases (thanks, Bruce!).
 -->
-このリリースでの時間は、新しいリグレッションテストが追加され、また、time travel が削除されたことなどいくつかのテストが削除されましたので、以前のリリースの時間と直接比較できません。
-しかし、一般的には 6.3 は以前のリリースよりかなり高速になっているはずです。(ありがとう。Bruce!)
+このリリースでの時間は、新しいリグレッションテストが追加され、また、time travelが削除されたことなどいくつかのテストが削除されましたので、以前のリリースの時間と直接比較できません。
+しかし、一般的には6.3は以前のリリースよりかなり高速になっているはずです。(ありがとう。Bruce!)
 </para>
 <para>
 <programlisting>
@@ -8993,7 +9027,7 @@ In general, however, 6.3 is substantially faster than previous releases (thanks,
 <!--
 <title>Version 6.1</title>
 -->
-<title>バージョン 6.1</title>
+<title>バージョン6.1</title>
 
 <para>
 <programlisting>


### PR DESCRIPTION
斉藤さんのメール（[jpug-doc: 5110] 「リリースx.x.x」のスペースの有無）に刺激を受けて https://pgsql-jp.github.io/jpug-doc/9.5.2/html/release.html を眺めたら、また別のところが気になってしまったので、直しています。

すべてrelease-oldの修正なので、あまり力を入れるべき所ではないとは思うのですが。

- 移行方法 → 移行に統一　（←これが目次で見える）
- バージョンx.y.zの前後の空白も削除（ただし、削除した結果、バージョン情報と前後の半角文字がくっついてしまうような場合には削除しない）
- 逆に言うと、削除した結果、半角文字と全角文字がくっつく程度なら積極的に空白を削除。
- 原則一文一行に
- out-of-the-boxの訳が明らかにおかしいので修正