### PR TITLE
queries.sgml(7.3 選択リスト)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/queries.sgml
+++ b/doc/src/sgml/queries.sgml
@@ -2091,8 +2091,8 @@ GROUP BY GROUPING SETS (
    list determines which <emphasis>columns</emphasis> of the
    intermediate table are actually output.
 -->
-前節で示したように、<command>SELECT</command>コマンド中のテーブル式は、テーブルの結合やビュー、行の抽出、グループ化などにより中間の仮想テーブルを作ります。
-このテーブルは最終的に<firstterm>選択リスト</firstterm>に渡されます。
+前節で示したように、<command>SELECT</command>コマンド中のテーブル式は、テーブルやビューの結合、行の抽出、グループ化などにより中間の仮想テーブルを作ります。
+このテーブルは最終的に<firstterm>選択リスト</firstterm>による処理に渡されます。
 選択リストは、中間のテーブルのどの<emphasis>列</emphasis>を実際に出力するかを決めます。
   </para>
 
@@ -2194,7 +2194,7 @@ SELECT tbl1.*, tbl2.a FROM ...
     processing, such as for use in an <literal>ORDER BY</> clause
     or for display by the client application.  For example:
 -->
-選択リスト中の項目は、<literal>ORDER BY</>句の中での参照、もしくはクライアントアプリケーションによる表示に使うように、それに続く処理のために名前を割り当てることができます。
+選択リスト中の項目は、<literal>ORDER BY</>句の中での参照、もしくはクライアントアプリケーションによる表示での使用など、それに続く処理のために名前を割り当てることができます。
 例を示します。
 <programlisting>
 SELECT a AS value, b + c AS sum FROM ...
@@ -2209,7 +2209,7 @@ SELECT a AS value, b + c AS sum FROM ...
     calls, this is the name of the function.  For complex expressions,
     the system will generate a generic name.
 -->
-もし<literal>AS</>を使った列名の指定がなかった場合、システムはデフォルトの列名を割り当てます。
+<literal>AS</>を使った出力列名の指定がない場合、システムはデフォルトの列名を割り当てます。
 単純な列参照では参照された列名となります。
 関数呼び出しでは関数名となります。
 複雑な表現についてはシステムが汎用の名前を生成します。
@@ -2254,7 +2254,7 @@ SELECT a "value", b + c AS sum FROM ...
      to rename the same column twice, but the name assigned in
      the select list is the one that will be passed on.
 -->
-ここでの出力列の名前は、<literal>FROM</>句（<xref linkend="queries-table-aliases">を参照）で示したものとは異なります。
+ここでの出力列の名前の指定は、<literal>FROM</>句での名前の指定（<xref linkend="queries-table-aliases">を参照）とは異なります。
 同じ列の名前を2度変更することができますが、渡されるのは選択リストの中で割り当てられたものです。
     </para>
    </note>
@@ -2290,7 +2290,7 @@ SELECT DISTINCT <replaceable>select_list</replaceable> ...
     (Instead of <literal>DISTINCT</> the key word <literal>ALL</literal>
     can be used to specify the default behavior of retaining all rows.)
 -->
-（<literal>DISTINCT</>の代わりに<literal>ALL</literal>キーワードを指定すると、すべての行がデフォルトで保持されます。）
+（<literal>DISTINCT</>の代わりに<literal>ALL</literal>キーワードを使用して、すべての行が保持されるというデフォルトの動作を指定することができます。）
    </para>
 
    <indexterm>
@@ -2308,8 +2308,8 @@ SELECT DISTINCT <replaceable>select_list</replaceable> ...
     least one column value.  Null values are considered equal in this
     comparison.
 -->
-少なくとも1つの列の値が異なる場合、それら2行は別個とみなされます。
-NULL値は、この比較において等しいとみなされます。
+少なくとも1つの列の値が異なる場合、もちろん、それら2行は異なるとみなされます。
+NULL値同士は、この比較において等しいとみなされます。
    </para>
 
    <para>
@@ -2332,9 +2332,9 @@ SELECT DISTINCT ON (<replaceable>expression</replaceable> <optional>, <replaceab
     (<literal>DISTINCT ON</> processing occurs after <literal>ORDER
     BY</> sorting.)
 -->
-<replaceable>expression</replaceable>は、すべての行で評価される任意の評価式です。
-すべての式が等しくなる行の集合は、重複しているとみなされ、集合の最初の行だけが出力されます。
-<literal>DISTINCT</>フィルタに掛けられる行の順序の一意性を保証できるよう問い合わせが列を並び替えしない限り、出力される集合の<quote>最初の行</quote>は予想不可能であることに注意してください。
+ここで<replaceable>expression</replaceable>は、すべての行で評価される任意の評価式です。
+すべての式が等しくなる行の集合は、重複しているとみなされ、集合の最初の行だけが出力内に保持されます。
+<literal>DISTINCT</>フィルタに掛けられる行の順序の一意性を保証できるよう十分な数の列で問い合わせを並べ替えしない限り、出力される集合の<quote>最初の行</quote>は予想不可能であることに注意してください。
 （<literal>DISTINCT ON</>処理は、<literal>ORDER BY</>による並び替えの後に行われます。）
    </para>
 


### PR DESCRIPTION
主な修正点は以下の通りです。
(1) "combining tables, views, eliminating rows..."で"combining"は"tables"のみに掛かっているという解釈になっていましたが、"tables (and/or) views"に掛かっていると見なして訳を変更しました。
(2) 「表示に使うように」は普通に読むと例示ではなく目的に解釈されそうなので、例示であることを明確にするため「表示での使用など」としました。
(3) "that done in the FROM clause"の解釈がおかしかったので、修正しました。
(4) "can be used to specify the default behavior"の解釈が間違っていたので修正しました。
(5) "sorted on enough columns"の解釈が間違っていたので修正しました。
その他、いくつか原文のみに存在する語句を明示的に訳出しました。