### PR TITLE
datatype.sgml(8.5節 日付/時刻データ型)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -3311,7 +3311,7 @@ January 8 04:05:06 1999 PST
 <!--
     <title>Date/Time Output</title>
 -->
-<title>日付/時刻出力</title>
+    <title>日付/時刻の出力</title>
 
     <indexterm>
      <primary>date</primary>
@@ -3351,7 +3351,7 @@ January 8 04:05:06 1999 PST
      <productname>POSTGRES</> style outputs date-only values in
      <acronym>ISO</acronym> format.
 -->
-日付/時刻型の出力書式は、ISO 8601、<acronym>SQL</acronym>（Ingres）、伝統的な<productname>POSTGRES</>（Unix <application>date</>書式）またはGermanの４つのいずれかに設定されます。
+日付/時刻型の出力書式は、ISO 8601、<acronym>SQL</acronym>（Ingres）、伝統的な<productname>POSTGRES</>（Unix <application>date</>書式）またはGermanの４つのいずれかに設定できます。
 デフォルトは<acronym>ISO</acronym>書式です。
 （標準<acronym>SQL</acronym>ではISO 8601書式の使用が定められています。
 <quote>SQL</quote>という出力書式名は歴史的な事故です。）
@@ -3368,7 +3368,7 @@ http://www.postgresql.org/message-id/2598E90D3D534989905115C5C1172679@maumau
 <!--
       <title>Date/Time Output Styles</title>
 -->
-<title>日付/時刻出力形式</title>
+      <title>日付/時刻の出力形式</title>
       <tgroup cols="3">
        <thead>
         <row>
@@ -3377,7 +3377,7 @@ http://www.postgresql.org/message-id/2598E90D3D534989905115C5C1172679@maumau
          <entry>Description</entry>
          <entry>Example</entry>
 -->
-     <entry>様式仕様</entry>
+     <entry>様式指定</entry>
      <entry>説明</entry>
      <entry>例</entry>
         </row>
@@ -3396,7 +3396,7 @@ http://www.postgresql.org/message-id/2598E90D3D534989905115C5C1172679@maumau
 <!--
          <entry>traditional style</entry>
 -->
-     <entry>伝統的な様式</entry>
+         <entry>伝統的な様式</entry>
          <entry><literal>12/17/1997 07:37:16.00 PST</literal></entry>
         </row>
         <row>
@@ -3404,7 +3404,7 @@ http://www.postgresql.org/message-id/2598E90D3D534989905115C5C1172679@maumau
 <!--
          <entry>original style</entry>
 -->
-     <entry>特有の様式</entry>
+         <entry>独自の様式</entry>
          <entry><literal>Wed Dec 17 07:37:16 1997 PST</literal></entry>
         </row>
         <row>
@@ -3412,7 +3412,7 @@ http://www.postgresql.org/message-id/2598E90D3D534989905115C5C1172679@maumau
 <!--
          <entry>regional style</entry>
 -->
-     <entry>地域限定様式</entry>
+         <entry>地域限定様式</entry>
          <entry><literal>17.12.1997 07:37:16.00 PST</literal></entry>
         </row>
        </tbody>
@@ -3428,9 +3428,9 @@ http://www.postgresql.org/message-id/2598E90D3D534989905115C5C1172679@maumau
       above.  This is for readability and for consistency with RFC 3339 as
       well as some other database systems.
 -->
-ISO 8601の仕様では大文字の<literal>T</>は日付と時間を分割します。
+ISO 8601の仕様では日付と時刻を区切るために大文字の<literal>T</>を使用します。
 <productname>PostgreSQL</>は入力ではこの書式を受け付けますが、上記のように出力では<literal>T</>ではなく空白を使用します。
-これは読みやすさと他のデータベースシステムと同様のRFC3339に準拠し整合性を保つためです。
+これは読みやすさのため、そしてRFC3339や他のデータベースシステムとの整合性を保つためです。
      </para>
     </note>
 
@@ -3544,7 +3544,7 @@ ISO 8601の仕様では大文字の<literal>T</>は日付と時間を分割し�
     is that the latest known rules for a given time zone will
     continue to be observed indefinitely far into the future.
 -->
-時間帯および時間帯の取り決めは地球の幾何学的要素のみでなく政治的判断に影響されます。
+時間帯および時間帯の取り決めは地球の幾何学的要素のみでなく政治的決定に影響されます。
 世界にまたがる時間帯は1900年代に標準化されたようですが、特に夏時間規則の点で、勝手に変更する傾向が続いています。
 <productname>PostgreSQL</productname>は歴史的な時間帯ルールについての情報に、広く使われているIANA時間帯データベースを使用します。
 将来の時間は、ある与えられた時間帯に対する最新の既知のルールが、将来長きに渡りそのまま遵守が継続されるということを前提としています。
@@ -3557,7 +3557,7 @@ ISO 8601の仕様では大文字の<literal>T</>は日付と時間を分割し�
      However, the <acronym>SQL</acronym> standard has an odd mix of date and
      time types and capabilities. Two obvious problems are:
 -->
-<productname>PostgreSQL</productname>は汎用的に使用できるように標準<acronym>SQL</acronym>への互換性に対し最大限の努力をしています。
+<productname>PostgreSQL</productname>は典型的な使用法については標準<acronym>SQL</acronym>への互換性に対し最大限の努力をしています。
 しかし、標準<acronym>SQL</acronym>には、日付と時刻のデータ型と機能に関する混乱が見受けられます。
 2つの明らかな問題点を以下に示します。
 
@@ -3665,7 +3665,7 @@ ISO 8601の仕様では大文字の<literal>T</>は日付と時間を分割し�
 こうした指定は、単に特定のUTCからのオフセットを定義します。
 一方、完全な時間帯名称では夏時間遷移規則群も組み込まれます。
 認識可能な省略形は<literal>pg_timezone_abbrevs</>ビューに列挙されています（<xref linkend="view-pg-timezone-abbrevs">を参照してください）。
-時間帯省略形に対して<xref linkend="guc-timezone">設定パラメータおよび<xref linkend="guc-log-timezone">設定パラメータを設定することはできませんが、日付時刻型の入力値や<literal>AT TIME ZONE</>演算子に省略形を使用することができます。
+<xref linkend="guc-timezone">設定パラメータおよび<xref linkend="guc-log-timezone">設定パラメータを時間帯省略形に設定することはできませんが、日付時刻型の入力値や<literal>AT TIME ZONE</>演算子に省略形を使用することができます。
        </para>
       </listitem>
       <listitem>
@@ -3695,12 +3695,12 @@ ISO 8601の仕様では大文字の<literal>T</>は日付と時間を分割し�
 -->
 時間帯名やその省略形に加え、<productname>PostgreSQL</productname>は、<replaceable>STD</><replaceable>offset</>や<replaceable>STD</><replaceable>offset</><replaceable>DST</>という形式のPOSIX様式の時間帯指定を受付けます。
 ここで、<replaceable>STD</>は時間帯省略形、<replaceable>offset</>はUTCから西に数えた時間単位のオフセットです。
-また、<replaceable>DST</>は省略可能で夏時間時間帯の省略形で、指定オフセットから1時間進むことを意味します。
-例えば、<literal>EST5EDT</>が認識済みの時間帯名でない場合でも、受付けられ、合衆国東海岸時間と同じものとして動作します。
-この文法では、文字列による時間帯の短縮を指定したり文字列の周りを山括弧で囲むことができるようになります(<literal>&lt;&gt;</>)。
-夏時間時間帯名があると、IANA時間帯データベースの<filename>posixrules</>項目で使用される夏時間変換規則と同じ規則に従って使用されるものと前提されます。
+また、オプションで夏時間時間帯の省略形の<replaceable>DST</>を指定すると、指定オフセットから1時間進むものとみなされます。
+例えば、<literal>EST5EDT</>が認識済みの時間帯名でないとしても、受付けられ、合衆国東海岸時間と同じものとして動作します。
+この構文では、時間帯の短縮は文字列、あるいは任意の文字列を山括弧(<literal>&lt;&gt;</>)で括ったもので指定できます。
+夏時間帯の省略名があると、IANA時間帯データベースの<filename>posixrules</>項目で使用される夏時間変換規則と同じ規則に従って使用されるものとみなされます。
 標準的な<productname>PostgreSQL</productname>インストレーションでは、<filename>posixrules</>は<literal>US/Eastern</>と同じです。
-このためPOSIX書式の時間帯指定はUSA夏時間規則に従います。
+このためPOSIX書式の時間帯指定は米国の夏時間規則に従います。
 必要に応じて<filename>posixrules</>ファイルを置き換えることで、この動作を調整することができます。
        </para>
       </listitem>
@@ -3718,9 +3718,11 @@ ISO 8601の仕様では大文字の<literal>T</>は日付と時間を分割し�
      noon Eastern Standard Time (UTC-5), regardless of whether daylight
      savings was nominally in effect on that date.
 -->
-一言で言うと、これは省略形と正式名称間の差異です。
-省略形はUTCから固定したオフセットを表わすのに対して、ほとんどの省略なしの名称はローカルの夏時間規定を意味するので、UTCオフセットには２つの可能性があります。
-例えば<literal>2014-06-04 12:00 America/New_York</>はニューヨークの正午と個別に東部夏時間(UTC-4)を示します。つまり<literal>2014-06-04 12:00 EDT</>と同時刻を示します。しかし、<literal>2014-06-04 12:00 EST</>は東部標準時間(UTC-5)を示し、夏時間かどうかに関わらず、実質標準的な時間です。
+一言で言うと、これは省略形と正式名称との差異です。
+省略形はUTCから固定したオフセットを表わすのに対して、多くの正式名称はローカルの夏時間規定を暗示するので、2つのUTCオフセットがあるかもしれません。
+例えば<literal>2014-06-04 12:00 America/New_York</>はニューヨークの正午を示しますが、これはこの日について言えば東部夏時間(UTC-4)です。
+つまり<literal>2014-06-04 12:00 EDT</>はこれと同時刻を示します。
+しかし、<literal>2014-06-04 12:00 EST</>は、その日に夏時間が使用されていたかどうかに関わらず、東部標準時間(UTC-5)での正午を示します。
     </para>
 
     <para>
@@ -3733,10 +3735,10 @@ ISO 8601の仕様では大文字の<literal>T</>は日付と時間を分割し�
      meant) on the specified date; but, as with the <literal>EST</> example
      above, this is not necessarily the same as local civil time on that date.
 -->
-管轄によって同じ略号を使っていることがさらに問題を複雑にしています。
-例えばモスクワでは<literal>MSK</>はここ数年ではUTC+3を意味しますが、他ではUTC+4を意味します。
-<application>PostgreSQL</>ではそのような固有の日付の略号(ほぼ最新の)のを実装しています。
-しかし、<literal>EST</>の例にあるように、必ずしも常用時間を示しているわけではありません。
+問題を更に複雑にしているのは、一部の管轄は同じ略号を使って、年によって異なるUTCオフセットを表していることです。
+例えばモスクワでは<literal>MSK</>はある年ではUTC+3を意味しますが、別の年ではUTC+4を意味します。
+<application>PostgreSQL</>ではそのような略号について、指定の日に何を意味していたか（あるいは最も最近にどういう意味だったか）に従って解釈します。
+しかし、<literal>EST</>の例にあるように、必ずしもその日付における地方常用時を示しているとは限りません。
     </para>
 
     <para>
@@ -3753,7 +3755,8 @@ ISO 8601の仕様では大文字の<literal>T</>は日付と時間を分割し�
      of Greenwich.
 -->
 時間帯省略形の正当性を検査しないため、POSIX書式時間帯機能ではおかしな入力を警告なく受け付けてしまう可能性があることに注意すべきです。
-例えば、システムの動作はより独特なUTCの省略形を使用し続けた状態で、<literal>SET TIMEZONE TO FOOBAR0</>でも動作します。
+例えば、<literal>SET TIMEZONE TO FOOBAR0</>でも動作します。
+このとき、システムは事実上、UTCについての奇妙な省略形を使用する状態になります。
 他にも、POSIX時間帯名称では正のオフセットがグリニッジの<emphasis>西</>側で使用されるという問題には注意しなければなりません。
 <productname>PostgreSQL</productname>は、他ではすべてISO-8601規約にしたがい、正の時間帯オフセットはグリニッジの<emphasis>東</>としています。
     </para>
@@ -3766,8 +3769,8 @@ ISO 8601の仕様では大文字の<literal>T</>は日付と時間を分割し�
      not others.)
 -->
 すべての場合において、時間帯名や略号は大文字小文字の区別なく認識されます。
-（これは<productname>PostgreSQL</productname>のバージョン8.2以前からの変更です。
-以前はすべてではありませんが、ある文脈では大文字小文字が区別されました。） 
+（これは<productname>PostgreSQL</productname>の8.2より前のバージョンからの変更です。
+以前は、文脈によって大文字小文字が区別される場合と、されない場合がありました。） 
     </para>
 
     <para>
@@ -3800,8 +3803,8 @@ ISO 8601の仕様では大文字の<literal>T</>は日付と時間を分割し�
         sets the time zone for the session.  This is an alternative spelling
         of <command>SET TIMEZONE TO</> with a more SQL-spec-compatible syntax.
 -->
-<command>SET TIME ZONE</command> <acronym>SQL</acronym>コマンドはセッションの時間帯を設定します。
-これはSQL仕様互換の文法により従っている<command>SET TIMEZONE TO</>の別名です。
+<acronym>SQL</acronym>コマンド<command>SET TIME ZONE</command>はセッションの時間帯を設定します。
+これは<command>SET TIMEZONE TO</>の別名ですが、SQL仕様の構文へのより高い互換性があります。
        </para>
       </listitem>
 
@@ -3824,7 +3827,7 @@ ISO 8601の仕様では大文字の<literal>T</>は日付と時間を分割し�
    <!--
     <title>Interval Input</title>
     -->
-    <title>時間間隔入力</title>
+    <title>時間間隔の入力</title>
 
     <indexterm>
     <!--
@@ -3864,7 +3867,7 @@ ISO 8601の仕様では大文字の<literal>T</>は日付と時間を分割し�
 <replaceable>direction</>（方向）は<literal>ago</literal>もしくは空です。
 アットマーク（<literal>@</>）はオプションで、付けても付けなくても構いません。
 異なる単位における時間量は適切に符号を考慮して暗黙的に足されます。
-<literal>ago</literal>はすべてのフィールドを反転させます。
+<literal>ago</literal>はすべてのフィールドの正負を逆にします。
 この構文はまた、<xref linkend="guc-intervalstyle">が<literal>postgres_verbose</>に設定されている場合に時間間隔の出力でも使用されます。
     </para>
 
@@ -3883,8 +3886,8 @@ ISO 8601の仕様では大文字の<literal>T</>は日付と時間を分割し�
 例えば、<literal>'1 12:59:10'</>は<literal>'1 day 12 hours 59 min 10 sec'</>（1日と12時間59分10秒）と解釈されます。
 また年と月の組み合わせはダッシュを使って指定することができます。
 例えば、<literal>'200-10'</>は<literal>'200 years 10 months'</>（200年と10か月）と解釈されます。
-（実際これらの簡略形は標準SQLで許されたもののみです。
-そして<varname>IntervalStyle</>が<literal>sql_standard</literal>に設定されている場合に出力でも使用されます。）
+（実際のところ、標準SQLで許されている簡略形はこれらだけです。
+そして<varname>IntervalStyle</>が<literal>sql_standard</literal>に設定されている場合には、これらが出力で使用されます。）
     </para>
 
     <para>
@@ -3909,11 +3912,9 @@ P <replaceable>quantity</> <replaceable>unit</> <optional> <replaceable>quantity
       <literal>M</> depends on whether it is before or after
       <literal>T</>.
       -->
-文字列は<literal>P</>で始まらなければならず、また、一日における時間をもたらす<literal>T</>を含めることができます。
+文字列は<literal>P</>で始まらなければならず、また、日と時間を区切る<literal>T</>を含めることができます。
 利用可能な単位の省略形を<xref linkend="datatype-interval-iso8601-units">に示します。
-単位は省略しても構いません。
-また任意の順番で指定できます。
-しかし、1日より小さな単位は<literal>T</>の後に書かなければなりません。
+単位は省略しても構いませんし、任意の順番で指定できますが、1日より小さな単位は<literal>T</>の後に書かなければなりません。
 特に<literal>M</>の意味は<literal>T</>の前にあるか後にあるかに依存します。
      </para>
 
@@ -4161,7 +4162,7 @@ P <optional> <replaceable>years</>-<replaceable>months</>-<replaceable>days</> <
    <!--
     <title>Interval Output</title>
     -->
-    <title>時間間隔出力</title>
+    <title>時間間隔の出力</title>
 
     <indexterm>
     <!--
@@ -4200,7 +4201,7 @@ P <optional> <replaceable>years</>-<replaceable>months</>-<replaceable>days</> <
      with explicit signs added to disambiguate mixed-sign intervals.
      -->
 <literal>sql_standard</>形式は、時間間隔値が標準制約（構成要素に正負が混在していない年数と月数のみ、または日数と時間のみ）を満足する場合、時間間隔リテラル文字列に対し標準SQLに準拠する出力を作成します。
-そうでなければ、出力は、正負混在した時間間隔のあいまいさを無くす明示的な符号が付加され、日数-時間数リテラル文字列を伴った標準年数-月数リテラル文字列のようになります。
+それ以外の場合、出力は、標準的な年数-月数のリテラル文字列の後に日数-時間のリテラル文字列が続いたものになり、正負混在した時間間隔のあいまいさを無くすために明示的な符号が付加されます。
     </para>
 
     <para>
@@ -4209,7 +4210,7 @@ P <optional> <replaceable>years</>-<replaceable>months</>-<replaceable>days</> <
      <productname>PostgreSQL</> releases prior to 8.4 when the
      <xref linkend="guc-datestyle"> parameter was set to <literal>ISO</>.
      -->
-<literal>postgres</>書式の出力は、<xref linkend="guc-datestyle">パラメータが<literal>ISO</>に設定されたとき、8.4以前のリリースと一致します。
+<literal>postgres</>書式の出力は、<xref linkend="guc-datestyle">パラメータが<literal>ISO</>に設定されたとき、8.4より前のリリースと一致します。
     </para>
 
     <para>
@@ -4218,7 +4219,7 @@ P <optional> <replaceable>years</>-<replaceable>months</>-<replaceable>days</> <
      <productname>PostgreSQL</> releases prior to 8.4 when the
      <varname>DateStyle</> parameter was set to non-<literal>ISO</> output.
      -->
-<literal>postgres_verbose</>書式の出力は、<xref linkend="guc-datestyle">パラメータが<literal>ISO</>に設定されたとき、8.4以前のリリースと一致します。
+<literal>postgres_verbose</>書式の出力は、<xref linkend="guc-datestyle">パラメータが<literal>ISO</>以外に設定されたとき、8.4より前のリリースと一致します。
     </para>
 
     <para>
@@ -4227,7 +4228,7 @@ P <optional> <replaceable>years</>-<replaceable>months</>-<replaceable>days</> <
      with designators</> described in section 4.4.3.2 of the
      ISO 8601 standard.
      -->
-<literal>iso_8601</>書式の出力はISO 8601 標準の4.4.3.2セクションに記述の<quote>format with designators（指名付き書式）</>に一致します。
+<literal>iso_8601</>書式の出力はISO 8601 標準の4.4.3.2節に記述の<quote>format with designators（指名付き書式）</>に一致します。
     </para>
 
      <table id="interval-style-output-table">


### PR DESCRIPTION
8.5.2-8.5.5を見直しました。
変更箇所が多いので、一部の説明だけで、個別の変更箇所の説明は省略します。不明点などあれば、遠慮なく、コメントをください。
(1) 節のタイトルに「の」を補いました。8.5.1節のタイトルが「時刻/日付『の』入力」なので、それに体裁を合わせるのも1つの理由です。またインデントを原文に合わせて調整しました。
(2) オリジナルの3721-3行目および3756行目の変更は、改行の挿入をしたため、変更部分がハイライトされていませんが、翻訳を大幅に見直しているので、注意してレビューしてください。
(3) オリジナルの3914-6行目は、別々の文にすると意味が理解できないので、1つの文につなげましたが、接続詞を補っただけで、訳自体は変更していません。