### PR TITLE
func.sgml(9.18 配列関数と演算子)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -15789,8 +15789,8 @@ SELECT NULLIF(value, '(none)') ...
    number of dimensions or subscript ranges were different.)
 -->
 配列比較では、配列要素ごとに、要素のデータ型のデフォルトのB-tree比較関数を使用して、その内容が比較されます。
-多次元配列では、行番号を優先して取り出します（最後の添え字が最も最初になります）。
-2つの配列で内容が同じで要素数が異なる場合、どの次元で最初に違いがあったかによってソート順が変わります。
+多次元配列では、行番号を優先して取り出します（最後の添え字が最も速く変わる順序で比較します）。
+2つの配列の内容が同じで次元数が異なる場合、どの次元で最初に違いがあったかによってソート順が決まります。
 （これは8.2より前の<productname>PostgreSQL</>では異なります。古いバージョンでは、次数や添え字範囲が異なっていたとしても、内容が同じであれば、2つの配列は同じものとしていました。）
   </para>
 
@@ -15927,7 +15927,7 @@ SELECT NULLIF(value, '(none)') ...
 <!--
         <entry>returns the number of dimensions of the array</entry>
 -->
-        <entry>その配列の次数を返す</entry>
+        <entry>配列の次元数を返す</entry>
         <entry><literal>array_ndims(ARRAY[[1,2,3], [4,5,6]])</literal></entry>
         <entry><literal>2</literal></entry>
        </row>
@@ -15941,7 +15941,7 @@ SELECT NULLIF(value, '(none)') ...
 <!--
         <entry>returns a text representation of array's dimensions</entry>
 -->
-        <entry>配列の次数をテキスト表現で返す</entry>
+        <entry>配列の次元をテキスト表現で返す</entry>
         <entry><literal>array_dims(ARRAY[[1,2,3], [4,5,6]])</literal></entry>
         <entry><literal>[1:2][1:3]</literal></entry>
        </row>
@@ -15957,7 +15957,7 @@ SELECT NULLIF(value, '(none)') ...
         <entry>returns an array initialized with supplied value and
          dimensions, optionally with lower bounds other than 1</entry>
 -->
-         <entry>提供された値と次数で初期化された配列を返す。１以外の下限を持たせることもできます</entry>
+         <entry>提供された値と次元で初期化された配列を返す。オプションで１以外の添字の下限を指定する。</entry>
         <entry><literal>array_fill(7, ARRAY[3], ARRAY[2])</literal></entry>
         <entry><literal>[2:4]={7,7,7}</literal></entry>
        </row>
@@ -15971,7 +15971,7 @@ SELECT NULLIF(value, '(none)') ...
 <!--
         <entry>returns the length of the requested array dimension</entry>
 -->
-        <entry>入力された配列次元の長さを返す</entry>
+        <entry>指定次数での配列の長さを返す</entry>
         <entry><literal>array_length(array[1,2,3], 1)</literal></entry>
         <entry><literal>3</literal></entry>
        </row>
@@ -15985,7 +15985,7 @@ SELECT NULLIF(value, '(none)') ...
 <!--
         <entry>returns lower bound of the requested array dimension</entry>
 -->
-        <entry>配列次元の下限を返す</entry>
+        <entry>指定次数での配列の添字の下限を返す</entry>
         <entry><literal>array_lower('[0:2]={1,2,3}'::int[], 1)</literal></entry>
         <entry><literal>0</literal></entry>
        </row>
@@ -16046,7 +16046,7 @@ SELECT NULLIF(value, '(none)') ...
         <entry>remove all elements equal to the given value from the array
          (array must be one-dimensional)</entry>
 -->
-        <entry>配列から与えられた値と等しい全ての要素を削除（配列は一次元）</entry>
+        <entry>配列から指定の値と等しい要素をすべて削除（配列は一次元であること）</entry>
         <entry><literal>array_remove(ARRAY[1,2,3,2], 2)</literal></entry>
         <entry><literal>{1,3}</literal></entry>
        </row>
@@ -16060,7 +16060,7 @@ SELECT NULLIF(value, '(none)') ...
 <!--
         <entry>replace each array element equal to the given value with a new value</entry>
 -->
-        <entry>新規値で与えられた値と等しいそれぞれの要素を置換</entry>
+        <entry>指定の値と等しい各要素を新しい値で置換</entry>
         <entry><literal>array_replace(ARRAY[1,2,5,4], 5, 3)</literal></entry>
         <entry><literal>{1,2,3,4}</literal></entry>
        </row>
@@ -16075,7 +16075,7 @@ SELECT NULLIF(value, '(none)') ...
         <entry>concatenates array elements using supplied delimiter and
          optional null string</entry>
 -->
-        <entry>配列の要素を提供された区切り文字、および省略可能なNULL文字を使用して連結</entry>
+        <entry>配列の要素を提供された区切り文字、およびオプションで指定するNULL文字列を使用して連結</entry>
         <entry><literal>array_to_string(ARRAY[1, 2, 3, NULL, 5], ',', '*')</literal></entry>
         <entry><literal>1,2,3,*,5</literal></entry>
        </row>
@@ -16089,7 +16089,7 @@ SELECT NULLIF(value, '(none)') ...
 <!--
         <entry>returns upper bound of the requested array dimension</entry>
 -->
-        <entry>入力された配列の次元の上限を返す</entry>
+        <entry>指定次数での配列の添字の上限を返す</entry>
         <entry><literal>array_upper(ARRAY[1,8,3,7], 1)</literal></entry>
         <entry><literal>4</literal></entry>
        </row>
@@ -16118,7 +16118,7 @@ SELECT NULLIF(value, '(none)') ...
         <entry>splits string into array elements using supplied delimiter and
          optional null string</entry>
 -->
-        <entry>提供された区切り文字、および省略可能なNULL文字を使用して、文字列を配列の要素に分割</entry>
+        <entry>提供された区切り文字、およびオプションで指定するNULL文字列を使用して、文字列を配列の要素に分割</entry>
         <entry><literal>string_to_array('xx~^~yy~^~zz', '~^~', 'yy')</literal></entry>
         <entry><literal>{xx,NULL,zz}</literal></entry>
        </row>
@@ -16149,7 +16149,7 @@ SELECT NULLIF(value, '(none)') ...
          of rows.  This is only allowed in the FROM clause; see
          <xref linkend="queries-tablefunctions"></entry>
 -->
-        <entry>(型が異なっているかもしれない)複数の配列の行の集合への展開。これはFROM句の中でのみ許されている。<xref linkend="queries-tablefunctions">を参照</entry>
+        <entry>複数の配列(型が異なっているかもしれない)を行の集合に展開。これはFROM句の中でのみ使用可能。<xref linkend="queries-tablefunctions">を参照</entry>
         <entry><literal>unnest(ARRAY[1,2],ARRAY['foo','bar','baz'])</literal></entry>
         <entry><literallayout class="monospaced">1    foo
 2    bar
@@ -16193,8 +16193,9 @@ NULL baz</literallayout>(3 rows)</entry>
     input string is returned as a one-element array.  Otherwise the input
     string is split at each occurrence of the delimiter string.
 -->
-<function>string_to_array</function>では、もし区切り文字がNULLの場合、入力された文字列の各々の文字が分割され要素となった配列を返します。
-区切り文字が空白文字の場合、入力された文字列全体が一つの要素となる配列を返します。そうでなければ、入力された文字列が区切り文字で分割されます。
+<function>string_to_array</function>では、区切り文字がNULLの場合、入力された文字列の各々の文字が別々の要素となった配列を返します。
+区切り文字が空文字列の場合、入力された文字列全体が一つの要素となる配列を返します。
+それ以外の場合、入力された文字列が区切り文字列のある箇所で分割されます。
    </para>
 
    <para>
@@ -16206,8 +16207,8 @@ NULL baz</literallayout>(3 rows)</entry>
     is omitted or NULL, any null elements in the array are simply skipped
     and not represented in the output string.
 -->
-<function>string_to_array</function>では、NULL文字パラメータが省略、もしくはNULLの指定がされた場合、入力された部分文字列がNULLに変換されることはありません。
-<function>array_to_string</function>では、NULL文字パラメータが省略、もしくはNULLの指定がされた場合、すべてのNULL文字の処理がスキップされて出力文字列に現れることはありません。
+<function>string_to_array</function>では、NULL文字列パラメータが省略、もしくはNULLの指定がされた場合、入力文字列中の部分文字列がNULLに置換されることはありません。
+<function>array_to_string</function>では、NULL文字列パラメータが省略、もしくはNULLの指定がされた場合、配列中のNULL要素はスキップされ、出力文字列に現れません。
    </para>
 
    <note>
@@ -16221,8 +16222,8 @@ NULL baz</literallayout>(3 rows)</entry>
      than returning NULL as before.
 -->
 <function>string_to_array</>は、<productname>PostgreSQL</>9.1から、前のバージョンとは2つの異なる振る舞いするようになりました。
-1つ目は、入力した文字列長が0の場合、NULLを返すのではなく空の(要素が0の)配列を返すようになりました。
-2つ目は区切り文字がNULLの場合、以前はNULLを返していましたが9.1からは入力文字列を個別の文字列で分割するようになりました。
+1つ目は、入力した文字列長が0の場合、NULLを返すのではなく空の(要素数が0の)配列を返すようになりました。
+2つ目は区切り文字列がNULLの場合、以前はNULLを返していましたが9.1からは入力文字列を個別の文字に分割するようになりました。
     </para>
    </note>
 
@@ -16231,7 +16232,7 @@ NULL baz</literallayout>(3 rows)</entry>
     See also <xref linkend="functions-aggregate"> about the aggregate
     function <function>array_agg</function> for use with arrays.
 -->
-配列を伴った集約関数の使用方法は、<xref linkend="functions-aggregate">も参照してください。
+配列を使用する集約関数<function>array_agg</function>について、<xref linkend="functions-aggregate">も参照してください。
    </para>
   </sect1>
 

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -16193,8 +16193,8 @@ NULL baz</literallayout>(3 rows)</entry>
     input string is returned as a one-element array.  Otherwise the input
     string is split at each occurrence of the delimiter string.
 -->
-<function>string_to_array</function>では、区切り文字がNULLの場合、入力された文字列の各々の文字が別々の要素となった配列を返します。
-区切り文字が空文字列の場合、入力された文字列全体が一つの要素となる配列を返します。
+<function>string_to_array</function>では、区切り文字列がNULLの場合、入力された文字列の各々の文字が別々の要素となった配列を返します。
+区切り文字列が空文字列の場合、入力された文字列全体が一つの要素となる配列を返します。
 それ以外の場合、入力された文字列が区切り文字列のある箇所で分割されます。
    </para>
 

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -1973,8 +1973,8 @@ SELECT NULLIF(value, '(none)') ...
    number of dimensions or subscript ranges were different.)
 -->
 配列比較では、配列要素ごとに、要素のデータ型のデフォルトのB-tree比較関数を使用して、その内容が比較されます。
-多次元配列では、行番号を優先して取り出します（最後の添え字が最も最初になります）。
-2つの配列で内容が同じで要素数が異なる場合、どの次元で最初に違いがあったかによってソート順が変わります。
+多次元配列では、行番号を優先して取り出します（最後の添え字が最も速く変わる順序で比較します）。
+2つの配列の内容が同じで次元数が異なる場合、どの次元で最初に違いがあったかによってソート順が決まります。
 （これは8.2より前の<productname>PostgreSQL</>では異なります。古いバージョンでは、次数や添え字範囲が異なっていたとしても、内容が同じであれば、2つの配列は同じものとしていました。）
   </para>
 
@@ -2111,7 +2111,7 @@ SELECT NULLIF(value, '(none)') ...
 <!--
         <entry>returns the number of dimensions of the array</entry>
 -->
-        <entry>その配列の次数を返す</entry>
+        <entry>配列の次元数を返す</entry>
         <entry><literal>array_ndims(ARRAY[[1,2,3], [4,5,6]])</literal></entry>
         <entry><literal>2</literal></entry>
        </row>
@@ -2125,7 +2125,7 @@ SELECT NULLIF(value, '(none)') ...
 <!--
         <entry>returns a text representation of array's dimensions</entry>
 -->
-        <entry>配列の次数をテキスト表現で返す</entry>
+        <entry>配列の次元をテキスト表現で返す</entry>
         <entry><literal>array_dims(ARRAY[[1,2,3], [4,5,6]])</literal></entry>
         <entry><literal>[1:2][1:3]</literal></entry>
        </row>
@@ -2141,7 +2141,7 @@ SELECT NULLIF(value, '(none)') ...
         <entry>returns an array initialized with supplied value and
          dimensions, optionally with lower bounds other than 1</entry>
 -->
-         <entry>提供された値と次数で初期化された配列を返す。１以外の下限を持たせることもできます</entry>
+         <entry>提供された値と次元で初期化された配列を返す。オプションで１以外の添字の下限を指定する。</entry>
         <entry><literal>array_fill(7, ARRAY[3], ARRAY[2])</literal></entry>
         <entry><literal>[2:4]={7,7,7}</literal></entry>
        </row>
@@ -2155,7 +2155,7 @@ SELECT NULLIF(value, '(none)') ...
 <!--
         <entry>returns the length of the requested array dimension</entry>
 -->
-        <entry>入力された配列次元の長さを返す</entry>
+        <entry>指定次数での配列の長さを返す</entry>
         <entry><literal>array_length(array[1,2,3], 1)</literal></entry>
         <entry><literal>3</literal></entry>
        </row>
@@ -2169,7 +2169,7 @@ SELECT NULLIF(value, '(none)') ...
 <!--
         <entry>returns lower bound of the requested array dimension</entry>
 -->
-        <entry>配列次元の下限を返す</entry>
+        <entry>指定次数での配列の添字の下限を返す</entry>
         <entry><literal>array_lower('[0:2]={1,2,3}'::int[], 1)</literal></entry>
         <entry><literal>0</literal></entry>
        </row>
@@ -2230,7 +2230,7 @@ SELECT NULLIF(value, '(none)') ...
         <entry>remove all elements equal to the given value from the array
          (array must be one-dimensional)</entry>
 -->
-        <entry>配列から与えられた値と等しい全ての要素を削除（配列は一次元）</entry>
+        <entry>配列から指定の値と等しい要素をすべて削除（配列は一次元であること）</entry>
         <entry><literal>array_remove(ARRAY[1,2,3,2], 2)</literal></entry>
         <entry><literal>{1,3}</literal></entry>
        </row>
@@ -2244,7 +2244,7 @@ SELECT NULLIF(value, '(none)') ...
 <!--
         <entry>replace each array element equal to the given value with a new value</entry>
 -->
-        <entry>新規値で与えられた値と等しいそれぞれの要素を置換</entry>
+        <entry>指定の値と等しい各要素を新しい値で置換</entry>
         <entry><literal>array_replace(ARRAY[1,2,5,4], 5, 3)</literal></entry>
         <entry><literal>{1,2,3,4}</literal></entry>
        </row>
@@ -2259,7 +2259,7 @@ SELECT NULLIF(value, '(none)') ...
         <entry>concatenates array elements using supplied delimiter and
          optional null string</entry>
 -->
-        <entry>配列の要素を提供された区切り文字、および省略可能なNULL文字を使用して連結</entry>
+        <entry>配列の要素を提供された区切り文字、およびオプションで指定するNULL文字列を使用して連結</entry>
         <entry><literal>array_to_string(ARRAY[1, 2, 3, NULL, 5], ',', '*')</literal></entry>
         <entry><literal>1,2,3,*,5</literal></entry>
        </row>
@@ -2273,7 +2273,7 @@ SELECT NULLIF(value, '(none)') ...
 <!--
         <entry>returns upper bound of the requested array dimension</entry>
 -->
-        <entry>入力された配列の次元の上限を返す</entry>
+        <entry>指定次数での配列の添字の上限を返す</entry>
         <entry><literal>array_upper(ARRAY[1,8,3,7], 1)</literal></entry>
         <entry><literal>4</literal></entry>
        </row>
@@ -2302,7 +2302,7 @@ SELECT NULLIF(value, '(none)') ...
         <entry>splits string into array elements using supplied delimiter and
          optional null string</entry>
 -->
-        <entry>提供された区切り文字、および省略可能なNULL文字を使用して、文字列を配列の要素に分割</entry>
+        <entry>提供された区切り文字、およびオプションで指定するNULL文字列を使用して、文字列を配列の要素に分割</entry>
         <entry><literal>string_to_array('xx~^~yy~^~zz', '~^~', 'yy')</literal></entry>
         <entry><literal>{xx,NULL,zz}</literal></entry>
        </row>
@@ -2333,7 +2333,7 @@ SELECT NULLIF(value, '(none)') ...
          of rows.  This is only allowed in the FROM clause; see
          <xref linkend="queries-tablefunctions"></entry>
 -->
-        <entry>(型が異なっているかもしれない)複数の配列の行の集合への展開。これはFROM句の中でのみ許されている。<xref linkend="queries-tablefunctions">を参照</entry>
+        <entry>複数の配列(型が異なっているかもしれない)を行の集合に展開。これはFROM句の中でのみ使用可能。<xref linkend="queries-tablefunctions">を参照</entry>
         <entry><literal>unnest(ARRAY[1,2],ARRAY['foo','bar','baz'])</literal></entry>
         <entry><literallayout class="monospaced">1    foo
 2    bar
@@ -2377,8 +2377,9 @@ NULL baz</literallayout>(3 rows)</entry>
     input string is returned as a one-element array.  Otherwise the input
     string is split at each occurrence of the delimiter string.
 -->
-<function>string_to_array</function>では、もし区切り文字がNULLの場合、入力された文字列の各々の文字が分割され要素となった配列を返します。
-区切り文字が空白文字の場合、入力された文字列全体が一つの要素となる配列を返します。そうでなければ、入力された文字列が区切り文字で分割されます。
+<function>string_to_array</function>では、区切り文字がNULLの場合、入力された文字列の各々の文字が別々の要素となった配列を返します。
+区切り文字が空文字列の場合、入力された文字列全体が一つの要素となる配列を返します。
+それ以外の場合、入力された文字列が区切り文字列のある箇所で分割されます。
    </para>
 
    <para>
@@ -2390,8 +2391,8 @@ NULL baz</literallayout>(3 rows)</entry>
     is omitted or NULL, any null elements in the array are simply skipped
     and not represented in the output string.
 -->
-<function>string_to_array</function>では、NULL文字パラメータが省略、もしくはNULLの指定がされた場合、入力された部分文字列がNULLに変換されることはありません。
-<function>array_to_string</function>では、NULL文字パラメータが省略、もしくはNULLの指定がされた場合、すべてのNULL文字の処理がスキップされて出力文字列に現れることはありません。
+<function>string_to_array</function>では、NULL文字列パラメータが省略、もしくはNULLの指定がされた場合、入力文字列中の部分文字列がNULLに置換されることはありません。
+<function>array_to_string</function>では、NULL文字列パラメータが省略、もしくはNULLの指定がされた場合、配列中のNULL要素はスキップされ、出力文字列に現れません。
    </para>
 
    <note>
@@ -2405,8 +2406,8 @@ NULL baz</literallayout>(3 rows)</entry>
      than returning NULL as before.
 -->
 <function>string_to_array</>は、<productname>PostgreSQL</>9.1から、前のバージョンとは2つの異なる振る舞いするようになりました。
-1つ目は、入力した文字列長が0の場合、NULLを返すのではなく空の(要素が0の)配列を返すようになりました。
-2つ目は区切り文字がNULLの場合、以前はNULLを返していましたが9.1からは入力文字列を個別の文字列で分割するようになりました。
+1つ目は、入力した文字列長が0の場合、NULLを返すのではなく空の(要素数が0の)配列を返すようになりました。
+2つ目は区切り文字列がNULLの場合、以前はNULLを返していましたが9.1からは入力文字列を個別の文字に分割するようになりました。
     </para>
    </note>
 
@@ -2415,7 +2416,7 @@ NULL baz</literallayout>(3 rows)</entry>
     See also <xref linkend="functions-aggregate"> about the aggregate
     function <function>array_agg</function> for use with arrays.
 -->
-配列を伴った集約関数の使用方法は、<xref linkend="functions-aggregate">も参照してください。
+配列を使用する集約関数<function>array_agg</function>について、<xref linkend="functions-aggregate">も参照してください。
    </para>
   </sect1>
 

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -2377,8 +2377,8 @@ NULL baz</literallayout>(3 rows)</entry>
     input string is returned as a one-element array.  Otherwise the input
     string is split at each occurrence of the delimiter string.
 -->
-<function>string_to_array</function>では、区切り文字がNULLの場合、入力された文字列の各々の文字が別々の要素となった配列を返します。
-区切り文字が空文字列の場合、入力された文字列全体が一つの要素となる配列を返します。
+<function>string_to_array</function>では、区切り文字列がNULLの場合、入力された文字列の各々の文字が別々の要素となった配列を返します。
+区切り文字列が空文字列の場合、入力された文字列全体が一つの要素となる配列を返します。
 それ以外の場合、入力された文字列が区切り文字列のある箇所で分割されます。
    </para>
 


### PR DESCRIPTION
レビューにはfunc3.sgmlを使用してください。
元の訳では"dimension(s)"の訳語が「次元」「次数」でかなり揺れており、修正でも迷ったところはありますが、"number of dimensions"は「次元数」、"(requested) dimension"は「次数」、"dimensions"は「次元」と訳してみました。
配列の"upper(lower) bounds"について「上限」「下限」が使われていましたが、わかりにくいと思ったので、原文に"subscript"という語がなくても、それを補って「添字の上限(下限)」と訳してみました。
"string"が「文字」と訳されていた部分が多かったので、気づいたものはすべて「文字列」に訂正しました。