### PR TITLE
queries.sgml(7.4 問い合わせの結合)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/queries.sgml
+++ b/doc/src/sgml/queries.sgml
@@ -2437,7 +2437,7 @@ SELECT DISTINCT ON (<replaceable>expression</replaceable> <optional>, <replaceab
    Furthermore, it eliminates duplicate rows from its result, in the same
    way as <literal>DISTINCT</>, unless <literal>UNION ALL</> is used.
 -->
-<literal>UNION</>は、<replaceable>query2</replaceable>の結果を<replaceable>query1</replaceable>の結果に付加します（しかし、実際に行が返された順序である保証はありません）。
+<literal>UNION</>は、<replaceable>query2</replaceable>の結果を<replaceable>query1</replaceable>の結果に付加します（しかし、この順序で実際に行が返される保証はありません）。
 さらに、<literal>UNION ALL</>を指定しないと、<literal>DISTINCT</>と同様に、結果から重複している行を削除します。
   </para>
 
@@ -2473,7 +2473,7 @@ SELECT DISTINCT ON (<replaceable>expression</replaceable> <optional>, <replaceab
    the corresponding columns have compatible data types, as
    described in <xref linkend="typeconv-union-case">.
 -->
-2つの問い合わせの和、積、差を算出するために、そこの2つの問い合わせは<quote>和両立</quote>でなければいけません。
+2つの問い合わせの和、積、差を算出するために、そこの2つの問い合わせは<quote>union互換</quote>でなければいけません。
 つまり、その問い合わせが同じ数の列を返し、対応する列は互換性のあるデータ型（<xref linkend="typeconv-union-case">を参照）でなければなりません。
   </para>
  </sect1>


### PR DESCRIPTION
(1) "this is the order in which the rows are actually returned"について、「実際に行が返された順序である」という訳文では、「UNIONを構成する各SELECT文が返した順序「と解釈してしまうが、正しくは「UNIONされたSELECT文全体が返す順序」である。「返された」を「返される」と修正するだけでも十分だが、"there is no guarantee that"と組み合わせて意味が明確になるように「この順序で返される保証はない」とした。
(2) "union compatible"の訳語の「和両立」は全く意味が理解できないので「union互換」とした。本節では"union"を「和」と訳しているが、この段落はunion, intersect, exceptに共通の話をしているので、unionのまま残した方が良いと判断。