### PR TITLE
config.sgmlの訳がおかしいのを修正しました。

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -8664,8 +8664,9 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
         <literal>ERROR</> or lower, the statement that timed out will also be
         logged.  A value of zero (the default) turns this off.
        -->
-       指定されたミリ秒を越えてコマンドがクライアントからサーバに届いたどんなコマンドの実行も停止します。
-もし、<varname>log_min_error_statement</>が<literal>ERROR</>もしくはそれ以下に設定されると、タイムアウトする文は同時にログに書き込まれます。値がゼロ（デフォルト）の場合、これを無効にします。
+       コマンドがクライアントからサーバに届いた時から数えて、実行時間が指定されたミリ秒を越えた文を停止します。
+<varname>log_min_error_statement</>が<literal>ERROR</>もしくはそれ以下に設定された場合は、タイムアウトした文はログにも書き込まれます。
+値がゼロ（デフォルト）の場合、これを無効にします。
        </para>
 
        <para>

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -8664,8 +8664,8 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
         <literal>ERROR</> or lower, the statement that timed out will also be
         logged.  A value of zero (the default) turns this off.
        -->
-       コマンドがクライアントからサーバに届いた時から数えて、実行時間が指定されたミリ秒を越えた文を停止します。
-<varname>log_min_error_statement</>が<literal>ERROR</>もしくはそれ以下に設定された場合は、タイムアウトした文はログにも書き込まれます。
+コマンドがクライアントからサーバに届いた時から数えて、実行時間が指定されたミリ秒を越えた文を停止します。
+<varname>log_min_error_statement</>が<literal>ERROR</>もしくはそれ以下に設定されている場合は、タイムアウトした文はログに書き込まれます。
 値がゼロ（デフォルト）の場合、これを無効にします。
        </para>
 


### PR DESCRIPTION
statement_timeoutの訳が日本語的におかしいのを修正、また句読点で文を分けました。