### PR TITLE
queries.sgml(7.5 行の並べ替え)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/queries.sgml
+++ b/doc/src/sgml/queries.sgml
@@ -2544,7 +2544,7 @@ SELECT a, b FROM table1 ORDER BY a + b, c;
    <literal>&lt;</literal> operator.  Similarly, descending order is
    determined with the <literal>&gt;</literal> operator.
 -->
-複数の式が指定された場合、前の式の値が等しい行を並べ替える際に後の値が使用されます。
+複数の式が指定された場合、前の式の値が等しい行を並べ替える際に後の式の値が使用されます。
 列指定の後にオプションで<literal>ASC</>もしくは<literal>DESC</>を付与することで、並べ替えの方向を昇順、降順にするかを設定することができます。
 <literal>ASC</>順がデフォルトです。
 昇順では、小さな値を先に出力します。

--- a/doc/src/sgml/queries.sgml
+++ b/doc/src/sgml/queries.sgml
@@ -2045,7 +2045,7 @@ GROUP BY GROUPING SETS (
     ordering of rows that its <literal>ORDER BY</> sees as equivalent.)
 -->
 複数のウィンドウ関数が使用された場合、そのウィンドウ定義にある構文的に同等である<literal>PARTITION BY</>および<literal>ORDER BY</>句を持つすべてのウィンドウ関数は、データ全体に渡って単一の実行手順により評価されることが保証されています。
-したがって、<literal>ORDER BY</>が一意的に順序付けを決定しなくても同一の並べ替え順序付けを見ることができます。
+したがって、<literal>ORDER BY</>が一意に順序付けを決定しなくても同一の並べ替え順序付けを見ることができます。
 しかし、異なる<literal>PARTITION BY</>または<literal>ORDER BY</>仕様を持つ関数の評価については保証されません。
 （このような場合、並べ替え手順がウィンドウ関数評価の諸手順間で一般的に必要となり、<literal>ORDER BY</>が等価と判断する行の順序付けを保存するような並べ替えは保証されません。）
    </para>

--- a/doc/src/sgml/queries.sgml
+++ b/doc/src/sgml/queries.sgml
@@ -53,7 +53,7 @@ SQLでは、<xref linkend="sql-select">コマンドを、問い合わせを指�
    table expression, and the sort specification.  <literal>WITH</>
    queries are treated last since they are an advanced feature.
 -->
-以降の節では、選択リスト、テーブル式、並び替えの仕様について詳細に説明します。
+以降の節では、選択リスト、テーブル式、並べ替えの仕様について詳細に説明します。
 <literal>WITH</>問い合わせは、より進んだ機能のため最後で扱います。
   </para>
 
@@ -2045,9 +2045,9 @@ GROUP BY GROUPING SETS (
     ordering of rows that its <literal>ORDER BY</> sees as equivalent.)
 -->
 複数のウィンドウ関数が使用された場合、そのウィンドウ定義にある構文的に同等である<literal>PARTITION BY</>および<literal>ORDER BY</>句を持つすべてのウィンドウ関数は、データ全体に渡って単一の実行手順により評価されることが保証されています。
-したがって、<literal>ORDER BY</>が一意的に順序付けを決定しなくても同一の並び替え順序付けを見ることができます。
+したがって、<literal>ORDER BY</>が一意的に順序付けを決定しなくても同一の並べ替え順序付けを見ることができます。
 しかし、異なる<literal>PARTITION BY</>または<literal>ORDER BY</>仕様を持つ関数の評価については保証されません。
-（このような場合、並び替え手順がウィンドウ関数評価の諸手順間で一般的に必要となり、<literal>ORDER BY</>が等価と判断する行の順序付けを保存するような並び替えは保証されません。）
+（このような場合、並べ替え手順がウィンドウ関数評価の諸手順間で一般的に必要となり、<literal>ORDER BY</>が等価と判断する行の順序付けを保存するような並べ替えは保証されません。）
    </para>
 
    <para>
@@ -2059,9 +2059,9 @@ GROUP BY GROUPING SETS (
     top-level <literal>ORDER BY</> clause if you want to be sure the
     results are sorted in a particular way.
 -->
-現時点では、ウィンドウ関数は常に事前に並び替えられたデータを必要とするので、問い合わせ出力はウィンドウ関数の<literal>PARTITION BY</>/<literal>ORDER BY</>句のどれか１つに従って順序付けされます。
+現時点では、ウィンドウ関数は常に事前に並べ替えられたデータを必要とするので、問い合わせ出力はウィンドウ関数の<literal>PARTITION BY</>/<literal>ORDER BY</>句のどれか１つに従って順序付けされます。
 とはいえ、これに依存することは薦められません。
-確実に結果が特定の方法で並び替えられるようにしたいのであれば、明示的な最上階層の<literal>ORDER BY</>を使用します。
+確実に結果が特定の方法で並べ替えられるようにしたいのであれば、明示的な最上階層の<literal>ORDER BY</>を使用します。
    </para>
   </sect2>
  </sect1>
@@ -2334,8 +2334,8 @@ SELECT DISTINCT ON (<replaceable>expression</replaceable> <optional>, <replaceab
 -->
 ここで<replaceable>expression</replaceable>は、すべての行で評価される任意の評価式です。
 すべての式が等しくなる行の集合は、重複しているとみなされ、集合の最初の行だけが出力内に保持されます。
-<literal>DISTINCT</>フィルタに掛けられる行の順序の一意性を保証できるよう十分な数の列で問い合わせを並べ替えしない限り、出力される集合の<quote>最初の行</quote>は予想不可能であることに注意してください。
-（<literal>DISTINCT ON</>処理は、<literal>ORDER BY</>による並び替えの後に行われます。）
+<literal>DISTINCT</>フィルタに掛けられる行の順序の一意性を保証できるよう十分な数の列で問い合わせを並べ替えない限り、出力される集合の<quote>最初の行</quote>は予想不可能であることに注意してください。
+（<literal>DISTINCT ON</>処理は、<literal>ORDER BY</>による並べ替えの後に行われます。）
    </para>
 
    <para>
@@ -2483,13 +2483,13 @@ SELECT DISTINCT ON (<replaceable>expression</replaceable> <optional>, <replaceab
 <!--
   <title>Sorting Rows</title>
 -->
-  <title>行の並び替え</title>
+  <title>行の並べ替え</title>
 
   <indexterm zone="queries-order">
 <!--
    <primary>sorting</primary>
 -->
-   <primary>並び替え</primary>
+   <primary>並べ替え</primary>
   </indexterm>
 
   <indexterm zone="queries-order">
@@ -2510,7 +2510,7 @@ SELECT DISTINCT ON (<replaceable>expression</replaceable> <optional>, <replaceab
 並べ替えが選ばれなかった場合、行は無規則な順序で返されます。
 そのような場合、実際の順序は、スキャンや結合計画の種類や、ディスク上に格納されている順序に依存します。
 しかし、当てにしてはいけません。
-明示的に並び替え手続きを選択した場合にのみ、特定の出力順序は保証されます。
+明示的に並べ替え手続きを選択した場合にのみ、特定の出力順序は保証されます。
   </para>
 
   <para>
@@ -2528,7 +2528,7 @@ SELECT <replaceable>select_list</replaceable>
    The sort expression(s) can be any expression that would be valid in the
    query's select list.  An example is:
 -->
-並び替え式(複数可)は問い合わせの選択リスト内で有効な任意の式を取ることができます。
+並べ替え式(複数可)は問い合わせの選択リスト内で使用可能な任意の式を取ることができます。
 以下に例を示します。
 <programlisting>
 SELECT a, b FROM table1 ORDER BY a + b, c;
@@ -2544,8 +2544,8 @@ SELECT a, b FROM table1 ORDER BY a + b, c;
    <literal>&lt;</literal> operator.  Similarly, descending order is
    determined with the <literal>&gt;</literal> operator.
 -->
-複数の式が指定された場合、前の値と同じ値を持つ行を並び替えする際に後の値が使用されます。
-列指定の後に省略可能な<literal>ASC</>もしくは<literal>DESC</>を付与することで、並び替えの方向を昇順、降順にするかを設定することができます。
+複数の式が指定された場合、前の式の値が等しい行を並べ替える際に後の値が使用されます。
+列指定の後にオプションで<literal>ASC</>もしくは<literal>DESC</>を付与することで、並べ替えの方向を昇順、降順にするかを設定することができます。
 <literal>ASC</>順がデフォルトです。
 昇順では、小さな値を先に出力します。
 ここでの<quote>小さい</quote>とは、<literal>&lt;</literal>演算子によって決定されます。
@@ -2561,8 +2561,8 @@ SELECT a, b FROM table1 ORDER BY a + b, c;
       but a user-defined data type's designer could choose to do something
       different.
 -->
-実際、<productname>PostgreSQL</>は、<literal>ASC</>と<literal>DESC</>の並び替え順を決定するために、式のデータ型用の<firstterm>デフォルトのB-tree演算子クラス</>を使用します。
-慣習的に、データ型は<literal>&lt;</literal>と<literal>&gt;</literal>演算子をこの並び替え順になるように設定されます。
+実際、<productname>PostgreSQL</>は、<literal>ASC</>と<literal>DESC</>の並べ替え順を決定するために、式のデータ型用の<firstterm>デフォルトのB-tree演算子クラス</>を使用します。
+慣習的に、データ型は<literal>&lt;</literal>と<literal>&gt;</literal>演算子をこの並べ替え順になるように設定されます。
 しかし、ユーザ定義データ型の設計者は異なるものを選択することができます。
      </para>
     </footnote>
@@ -2576,8 +2576,8 @@ SELECT a, b FROM table1 ORDER BY a + b, c;
    non-null value; that is, <literal>NULLS FIRST</> is the default for
    <literal>DESC</> order, and <literal>NULLS LAST</> otherwise.
 -->
-<literal>NULLS FIRST</>および<literal>NULLS LAST</>オプションを使用して、その並び替え順においてNULL値を非NULL値の前にするか後にするかを決定することができます。
-デフォルトでは、NULL値はあたかもすべての非NULL値よりも大きいとみなして並び替えます。
+<literal>NULLS FIRST</>および<literal>NULLS LAST</>オプションを使用して、その並べ替え順においてNULL値を非NULL値の前にするか後にするかを決定することができます。
+デフォルトでは、NULL値はあたかもすべての非NULL値よりも大きいとみなして並べ替えます。
 と言うことは、<literal>NULLS FIRST</>は<literal>DESC</>順序付けのデフォルトで、そうでなければ<literal>NULLS LAST</>です。
   </para>
 
@@ -2588,7 +2588,7 @@ SELECT a, b FROM table1 ORDER BY a + b, c;
    <literal>ORDER BY x ASC, y DESC</>, which is not the same as
    <literal>ORDER BY x DESC, y DESC</>.
 -->
-この順序づけオプションは、並び替えされる列を個別に指定したとみなされることに注意してください。
+この順序づけオプションは、並べ替えで使用される各列に個別に適用されることに注意してください。
 例えば、<literal>ORDER BY x, y DESC</>は、<literal>ORDER BY x DESC, y DESC</>と同じではなく、<literal>ORDER BY x ASC, y DESC</>を意味します。
   </para>
 
@@ -2607,7 +2607,7 @@ SELECT a, max(b) FROM table1 GROUP BY a ORDER BY 1;
    column name has to stand alone, that is, it cannot be used in an expression
    &mdash; for example, this is <emphasis>not</> correct:
 -->
-両方とも最初の出力列で並び替えされます。
+両方とも最初の出力列で並べ替えられます。
 出力列名は単体でなければなりません。つまり式としては使用できないことに注意してください。
 例えば以下は<emphasis>間違い</>です。
 <programlisting>
@@ -2638,7 +2638,7 @@ SELECT a + b AS sum, c FROM table1 ORDER BY sum + c;          -- 間違い
    output column names or numbers, not by expressions.
 -->
 <literal>ORDER BY</>を、<literal>UNION</>、<literal>INTERSECT</>、<literal>EXCEPT</>組み合わせの結果に適用することができます。
-しかしこの場合、出力列の名前または番号でのみ並び替えすることができ、式では並び替えすることができません。
+しかしこの場合、出力列の名前または番号でのみ並べ替えることができ、式では並べ替えることができません。
   </para>
  </sect1>
 
@@ -3240,7 +3240,7 @@ SELECT n FROM t LIMIT 100;
 これが動作するのは、<productname>PostgreSQL</productname>の実装が、実際に親問い合わせで取り出されるのと同じ数の<literal>WITH</>問い合わせの行のみを評価するからです。
 この秘訣を実稼動環境で使用することは勧められません。
 他のシステムでは異なった動作をする可能性があるからです。
-同時に、もし外部問い合わせを再帰的問い合わせの結果を並び替えしたり、またはそれらを他のテーブルと結合するような書き方をした場合、動作しません。
+同時に、もし外部問い合わせを再帰的問い合わせの結果を並べ替えたり、またはそれらを他のテーブルと結合するような書き方をした場合、動作しません。
 このような場合、外部問い合わせは通常、<literal>WITH</>問い合わせの出力をとにかくすべて取り込もうとするからです。
   </para>
 


### PR DESCRIPTION
(1) 「並び替え」を全面的に「並べ替え」に書き換えました。なお「並び替えする」については「並べ替える」としました。
(2) "would be valid in select list"の訳がわかりにくかったので修正しました。なお、元の訳が「選択リスト内で有効な」としていたのは、原文に忠実なように見えますが、仮定法の"would"が無視されており、正確には「選択リスト内で(もし使用されたなら)有効な」ということなので、「選択リスト内で使用可能な」と変更しました。
(3) 「前の値と同じ値を持つ行」は意味が理解できないので訳文を修正しました。
(4) "consider"の解釈が間違っていたので、文全体の訳を見直しました。直訳すると「個別に考慮される」ですが、わかりやすくなるよう「適用される」としました。