### PR TITLE
queries.sgml(7.6 LIMITとOFFSET)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/queries.sgml
+++ b/doc/src/sgml/queries.sgml
@@ -2678,7 +2678,7 @@ SELECT <replaceable>select_list</replaceable>
    <literal>LIMIT ALL</> is the same as omitting the <literal>LIMIT</>
    clause.
 -->
-限度(limit)数を指定すると、指定した行数より多くの行が返されることはありません（しかし、問い合わせの結果によって、指定より少ないことはあります）。
+限度(limit)数を指定すると、指定した行数より多くの行が返されることはありません（しかし、問い合わせの結果が指定した行数より少なければ、それより少なくなります）。
 <literal>LIMIT ALL</>は、<literal>LIMIT</>句を省略した場合と同じです。
   </para>
 
@@ -2692,7 +2692,7 @@ SELECT <replaceable>select_list</replaceable>
    skipped before starting to count the <literal>LIMIT</> rows that
    are returned.
 -->
-<literal>OFFSET</>は、返す行の開始位置を飛ばす行数を指定します。
+<literal>OFFSET</>は、行を返し始める前に飛ばす行数を指定します。
 <literal>OFFSET 0</>は、<literal>OFFSET</>句を省略した場合と同じで、<literal>LIMIT NULL</>は<literal>LIMIT</>句を省略した場合と同じです。
 <literal>OFFSET</>および<literal>LIMIT</>の両者が指定された場合、<literal>OFFSET</>分の行を飛ばしてから、返される<literal>LIMIT</>行を数え始めます。
   </para>
@@ -2707,8 +2707,8 @@ SELECT <replaceable>select_list</replaceable>
    ordering is unknown, unless you specified <literal>ORDER BY</>.
 -->
 <literal>LIMIT</>を使用する時は、結果の行を一意な順序に制御する<literal>ORDER BY</>句を使用することが重要です。
-<literal>ORDER BY</>を使わなければ、予測できない問い合わせの行の部分集合を得ることになるでしょう。
-10番目から20番目の行を問い合わせることもあるでしょうが、10番目から20番目というのは、どのような並び順を用いるのでしょうか？
+<literal>ORDER BY</>を使わなければ、問い合わせの行について予測不能な部分集合を得ることになるでしょう。
+10番目から20番目の行を問い合わせることもあるでしょうが、どういう並び順での10番目から20番目の行でしょうか？
 <literal>ORDER BY</>を指定しなければ、並び順はわかりません。
   </para>
 
@@ -2727,8 +2727,8 @@ SELECT <replaceable>select_list</replaceable>
    <literal>ORDER BY</> is used to constrain the order.
 -->
 問い合わせオプティマイザは、問い合わせ計画を生成する時に<literal>LIMIT</>を考慮します。
-したがって、<literal>LIMIT</>と<literal>OFFSET</>に指定した値によって、（行の順序が異なる）異なった計画が得られます。
-このように、1つの問い合わせ結果から異なる部分集合を選び出すために、異なる<literal>LIMIT</>/<literal>OFFSET</>の値を使用すると、<literal>ORDER BY</>で結果の順序を制御しない限りは、<emphasis>矛盾した結果が生じるでしょう</emphasis>。
+そのため、<literal>LIMIT</>と<literal>OFFSET</>に指定した値によって、異なった計画（得られる行の順序も異なります）が得られる可能性が高いです。
+従って、1つの問い合わせ結果から異なる部分集合を選び出すために、異なる<literal>LIMIT</>/<literal>OFFSET</>の値を使用すると、<literal>ORDER BY</>で結果の順序を制御しなければ、<emphasis>一貫しない結果が生じるでしょう</emphasis>。
 これは不具合ではありません。
 <literal>ORDER BY</>を使って順序を制御しない限り、SQLは必ずしも特定の順序で問い合わせの結果を渡さないという特性の必然的な結果です。
   </para>


### PR DESCRIPTION
(1) "if the query itself yields less rows"の"yields less rows"の部分を明示的に訳出しました。
(2) "before beginning to return rows"の訳を原文に忠実にしました。
(3) "unpredictable"の掛かり先が誤解されるような訳文になっていたので訂正しました。
(4) "in what ordering?"の訳を原文に忠実にしました。
(5) "very likely"を明示的に訳出し、また"(yielding different row orders)"の主語が"different plans"であることが明快にわかるような訳文にしました。
(6) "inconsistent"の訳語として「矛盾した」は違和感が強かったので「一貫しない」としました。