### PR TITLE
queries.sgml(7.7 VALUESリスト)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/queries.sgml
+++ b/doc/src/sgml/queries.sgml
@@ -2778,7 +2778,7 @@ VALUES ( <replaceable class="PARAMETER">expression</replaceable> [, ...] ) [, ..
 括弧で括られた式のリストがそれぞれ、テーブルの行を生成します。
 リストは同一の要素数（つまり、テーブルの列数）を持たなければなりません。
 また、各リストで対応する項目のデータ型に互換性がなければなりません。
-最終的に実際各列に割り当てられるデータ型は、<literal>UNION</>と同様の規則に従って決定されます。
+最終的に各列に割り当てられる実際のデータ型は、<literal>UNION</>と同様の規則に従って決定されます。
 （<xref linkend="typeconv-union-case">を参照してください。）
   </para>
 
@@ -2796,7 +2796,7 @@ VALUES (1, 'one'), (2, 'two'), (3, 'three');
    equivalent to:
 -->
 これは、2列3行のテーブルを返します。
-実質以下と同じです。
+実質的に、以下と同じです。
 <programlisting>
 SELECT 1 AS column1, 'one' AS column2
 UNION ALL
@@ -2814,7 +2814,7 @@ SELECT 3, 'three';
    list, like this:
 -->
 デフォルトでは、<productname>PostgreSQL</productname>は<literal>VALUES</>テーブルの各列に<literal>column1</>、<literal>column2</>といった名前をつけます。
-標準SQLでは列名は規定されていませんので、他のデータベースシステムでは他の名前を付与しています。
+標準SQLではこれらの列名は規定されていませんので、データベースシステムの種類によって異なる名前を付与しています。
 そのため、通常はテーブル別名リストを使用して、以下のようにデフォルトの名前を上書きする方がよいでしょう。
 <programlisting>
 => SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three')) AS t (num,letter);
@@ -2833,7 +2833,7 @@ SELECT 3, 'three';
    Syntactically, <literal>VALUES</> followed by expression lists is
    treated as equivalent to:
 -->
-文法的には、式リストに続く<literal>VALUES</>は、以下と同様に扱われます。
+文法的には、<literal>VALUES</>の後に式のリストがあるものは、以下と同様に扱われます。
 <synopsis>
 SELECT <replaceable>select_list</replaceable> FROM <replaceable>table_expression</replaceable>
 </synopsis>
@@ -2845,8 +2845,8 @@ SELECT <replaceable>select_list</replaceable> FROM <replaceable>table_expression
    is most commonly used as the data source in an <command>INSERT</> command,
    and next most commonly as a subquery.
 -->
-そして、<literal>SELECT</>が記述できるところであれば、記述することができます。
-例えば、<literal>UNION</>の一部として使用することもできますし、<replaceable>sort_specification</replaceable> (<literal>ORDER BY</>、<literal>LIMIT</>、<literal>OFFSET</>)に付けることもできます。
+そして、<literal>SELECT</>が記述できるところであれば、どこにでも記述することができます。
+例えば、<literal>UNION</>の一部として使用することもできますし、<replaceable>sort_specification</replaceable> (<literal>ORDER BY</>、<literal>LIMIT</>、<literal>OFFSET</>)を付けることもできます。
 <literal>VALUES</>は<command>INSERT</>コマンドの元データとしてもっとも頻繁に使用されます。
 次に使用頻度が高いのは副問い合わせとしての使用です。
   </para>


### PR DESCRIPTION
(1) "actual data type"の"actual"の掛かり先が明確になるようにしました。
(2) 「実質以下と同じ」は誤読される可能性が高いので、修正しました。
(3) "the column names"の"the"を明示的に訳出しました（そうしないと誤読される可能性が高い）。
(4) "different"を「他の」と訳すのはおかしいので、修正しました。
(5) "VALUES followed by expression lists"の訳が間違っていた（順序が逆だった）ので訂正しました。
(6) "anywhere"を明示的に訳出しました。
(7) "attach ～ to it"の訳が間違っていた（主客が逆だった）ので訂正しました。