### PR TITLE
datatype.sgml(8.6-8.10)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -5307,7 +5307,7 @@ IPv6ではアドレス長は128ビットですので、128ビットが一意な�
      that has bits set to the right of the specified netmask.
 -->
 <type>cidr</type>データ型はIPv4、IPv6ネットワーク仕様を保持します。
-入出力書式はクラス分けのないインターネットドメインルーティング協定に従います。
+入出力書式はCIDR表記（クラスレスアドレッシング）に従います。
 ネットワークを指定する時の書式は<replaceable class="parameter">address/y</>で、<replaceable class="parameter">address</>がIPv4もしくはIPv6アドレスで表したネットワーク、<replaceable class="parameter">y</>はネットマスクのビット数です。
 <replaceable class="parameter">y</>が省略された場合には、従来のクラス付きアドレス番号指定システムに従って計算されますが、入力時に書き込まれたオクテットすべてが含まれるように大きさは確保されます。
 指定したネットマスクの右側にビットをセットしたネットワークアドレスを指定するとエラーになります。

--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -4411,7 +4411,7 @@ P <optional> <replaceable>years</>-<replaceable>months</>-<replaceable>days</> <
 <!--
     <title>Using the <type>boolean</type> Type</title>
 -->
-<title><type>boolean</type>型を使って</title>
+<title><type>boolean</type>型の使用</title>
 
 <programlisting>
 CREATE TABLE test1 (a boolean, b text);
@@ -4617,7 +4617,7 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
 -->
 列挙型の値はディスク上では4バイトを占めます。
 列挙型の値のテキストラベルの長さは、<productname>PostgreSQL</productname>に組み込まれた<symbol>NAMEDATALEN</symbol>設定により制限されます。
-標準の構築では、これは最大63バイトを意味します。
+標準のビルドでは、これは最大63バイトを意味します。
     </para>
 
     <para>
@@ -4675,10 +4675,10 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry>Description</entry>
         <entry>Representation</entry>
 -->
-    <entry>型名</entry>
-    <entry>格納サイズ</entry>
-    <entry>説明</entry>
-    <entry>表現</entry>
+        <entry>型名</entry>
+        <entry>格納サイズ</entry>
+        <entry>説明</entry>
+        <entry>表現</entry>
        </row>
       </thead>
       <tbody>
@@ -4688,8 +4688,8 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry>16 bytes</entry>
         <entry>Point on a plane</entry>
 -->
-    <entry>16バイト</entry>
-    <entry>平面における座標点</entry>
+        <entry>16バイト</entry>
+        <entry>平面における座標点</entry>
         <entry>(x,y)</entry>
        </row>
        <row>
@@ -4698,8 +4698,8 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry>32 bytes</entry>
         <entry>Infinite line</entry>
 -->
-    <entry>32バイト</entry>
-    <entry>無限の直線</entry>
+        <entry>32バイト</entry>
+        <entry>無限の直線</entry>
         <entry>{A,B,C}</entry>
        </row>
        <row>
@@ -4708,8 +4708,8 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry>32 bytes</entry>
         <entry>Finite line segment</entry>
 -->
-    <entry>32バイト</entry>
-    <entry>有限の線分</entry>
+        <entry>32バイト</entry>
+        <entry>有限の線分</entry>
         <entry>((x1,y1),(x2,y2))</entry>
        </row>
        <row>
@@ -4718,8 +4718,8 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry>32 bytes</entry>
         <entry>Rectangular box</entry>
 -->
-    <entry>32バイト</entry>
-    <entry>矩形</entry>
+        <entry>32バイト</entry>
+        <entry>矩形</entry>
         <entry>((x1,y1),(x2,y2))</entry>
        </row>
        <row>
@@ -4728,8 +4728,8 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry>16+16n bytes</entry>
         <entry>Closed path (similar to polygon)</entry>
 -->
-    <entry>16+16nバイト</entry>
-    <entry>閉経路（多角形に類似）</entry>
+        <entry>16+16nバイト</entry>
+        <entry>閉経路（多角形に類似）</entry>
         <entry>((x1,y1),...)</entry>
        </row>
        <row>
@@ -4738,8 +4738,8 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry>16+16n bytes</entry>
         <entry>Open path</entry>
 -->
-    <entry>16+16nバイト</entry>
-    <entry>開経路</entry>
+        <entry>16+16nバイト</entry>
+        <entry>開経路</entry>
         <entry>[(x1,y1),...]</entry>
        </row>
        <row>
@@ -4748,8 +4748,8 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry>40+16n bytes</entry>
         <entry>Polygon (similar to closed path)</entry>
 -->
-    <entry>40+16nバイト</entry>
-    <entry>多角形（閉経路に類似）</entry>
+        <entry>40+16nバイト</entry>
+        <entry>多角形（閉経路に類似）</entry>
         <entry>((x1,y1),...)</entry>
        </row>
        <row>
@@ -4759,9 +4759,9 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry>Circle</entry>
         <entry>&lt;(x,y),r&gt; (center point and radius)</entry>
 -->
-    <entry>24バイト</entry>
-    <entry>円</entry>
-    <entry>&lt;(x,y),r&gt;（中心と半径）</entry>
+        <entry>24バイト</entry>
+        <entry>円</entry>
+        <entry>&lt;(x,y),r&gt;（中心と半径）</entry>
        </row>
       </tbody>
      </tgroup>
@@ -4861,10 +4861,7 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
      <literal>(<replaceable>x2</replaceable>,<replaceable>y2</replaceable>)</literal>
      are two different points on the line.
 -->
-     <literal>(<replaceable>x1</replaceable>,<replaceable>y1</replaceable>)</literal>
-と
-     <literal>(<replaceable>x2</replaceable>,<replaceable>y2</replaceable>)</literal>
-はその直線上の2つの異なる点です。
+ここで<literal>(<replaceable>x1</replaceable>,<replaceable>y1</replaceable>)</literal>と<literal>(<replaceable>x2</replaceable>,<replaceable>y2</replaceable>)</literal>はその直線上の2つの異なる点です。
     </para>
    </sect2>
 
@@ -4979,7 +4976,7 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
      upper right and lower left corners, in that order.
      -->
 任意の対角頂点を入力として指定することができます。
-しかし頂点は右上の頂点を最初に、左下の頂点をその後に格納するよう必要に応じて並べられます。
+しかし頂点は右上の頂点を最初に、左下の頂点をその後に格納するよう必要に応じて並べ替えられます。
     </para>
    </sect2>
 
@@ -5257,10 +5254,9 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
      <type>cidr</type> type rather than <type>inet</type>.
 -->
 <type>inet</type>型はIPv4もしくはIPv6ホストアドレスとオプションでそのサブネットを１つのフィールドに保持します。
-サブネットはホストアドレスのうち何ビットがネットワークアドレス（<quote>ネットマスク</quote>）を表すかを指定することで表現されます。
-もしネットマスクが32の場合、IPv4では単一ホストを意味し、サブネットを示しません。
-IPv6ではアドレス長は128ビットです。
-そのため128ビットが一意なホストアドレスを指定します。
+サブネットはホストアドレス内のネットワークアドレスのビット数（<quote>ネットマスク</quote>）により表現されます。
+ネットマスクが32でアドレスがIPv4の場合、その値はサブネットを示さず、単一ホストを表します。
+IPv6ではアドレス長は128ビットですので、128ビットが一意なホストアドレスを指定します。
 ネットワークのみを使用したい場合は<type>inet</type>ではなく<type>cidr</type>型を利用してください。
     </para>
 
@@ -5280,9 +5276,9 @@ IPv6ではアドレス長は128ビットです。
       <replaceable class="parameter">/y</replaceable>
       portion is suppressed if the netmask specifies a single host.
 -->
-このデータ型に対する入力書式は、IPv4、IPv6両方とも<replaceable class="parameter">address/y</replaceable>です。
-<replaceable class="parameter">y</replaceable>がネットマスクのビット数です。
-もし<replaceable class="parameter">/y</replaceable>部分がない場合、ネットマスクはIPv4では32、IPv6では128となり、つまり、その値は単一ホストを表現します。
+このデータ型に対する入力書式は<replaceable class="parameter">address/y</replaceable>です。
+ここで、<replaceable class="parameter">address</replaceable>はIPv4またはIPv6のアドレス、<replaceable class="parameter">y</replaceable>はネットマスクのビット数です。
+<replaceable class="parameter">/y</replaceable>部分がない場合、ネットマスクはIPv4では32、IPv6では128となり、つまり、その値は単一ホストを表現します。
 ネットマスクが単一ホストを表す場合、その表示時、<replaceable class="parameter">/y</replaceable>の部分は抑制されます。
     </para>
    </sect2>
@@ -5312,9 +5308,8 @@ IPv6ではアドレス長は128ビットです。
 -->
 <type>cidr</type>データ型はIPv4、IPv6ネットワーク仕様を保持します。
 入出力書式はクラス分けのないインターネットドメインルーティング協定に従います。
-ネットワークを指定する時の書式は<replaceable class="parameter">address/y</>で、<replaceable class="parameter">address</>がIPv4もしくはIPv6アドレスで表したネットワークです。
-<replaceable class="parameter">y</>はネットマスクのビット数です。
-もし<replaceable class="parameter">y</>が省略された場合には、入力時に書き込まれたオクテットすべてが含まれるように大きさが確保されること以外は、従来のクラス付きアドレス番号指定システムに従って計算されます。
+ネットワークを指定する時の書式は<replaceable class="parameter">address/y</>で、<replaceable class="parameter">address</>がIPv4もしくはIPv6アドレスで表したネットワーク、<replaceable class="parameter">y</>はネットマスクのビット数です。
+<replaceable class="parameter">y</>が省略された場合には、従来のクラス付きアドレス番号指定システムに従って計算されますが、入力時に書き込まれたオクテットすべてが含まれるように大きさは確保されます。
 指定したネットマスクの右側にビットをセットしたネットワークアドレスを指定するとエラーになります。
     </para>
 
@@ -5556,7 +5551,7 @@ PostgreSQLではビット反転に関する準備をしていません。
     <replaceable>n</replaceable> is a positive integer.
 -->
 ビット列とは1と0のビットが連続したものです。
-ビットマスクを格納したり顕在化するために使用されます。
+ビットマスクを格納したり可視化するために使用されます。
 SQLのビット型には2つあります。
 <type>bit(<replaceable>n</replaceable>)</type>と<type>bit varying(<replaceable>n</replaceable>)</type>です。
 ここで<replaceable>n</replaceable>は正の整数です。
@@ -5573,7 +5568,7 @@ SQLのビット型には2つあります。
     <literal>bit(1)</literal>, while <type>bit varying</type> without a length
     specification means unlimited length.
 -->
-<type>bit</type>型のデータは厳密に<replaceable>n</replaceable>で表される長さに一致しなければなりません。
+<type>bit</type>型のデータは<replaceable>n</replaceable>で表される長さに正確に一致しなければなりません。
 この長さより長いか短いビット列を格納しようとするとエラーになります。
 <type>bit varying</type>型のデータは最大<replaceable>n</replaceable>までの可変長です。
 最大長を越えるビット列は受け付けません。
@@ -5605,15 +5600,14 @@ SQLのビット型には2つあります。
     linkend="functions-bitstring">.
 -->
 ビット列定数に関する構文についての情報は<xref linkend="sql-syntax-bit-strings">を参照してください。
-ビット論理演算子とビット列操作関数が用意されています。
-<xref linkend="functions-bitstring">を参照してください。
+ビット論理演算子とビット列操作関数が利用可能ですが、<xref linkend="functions-bitstring">を参照してください。
    </para>
 
    <example>
 <!--
     <title>Using the Bit String Types</title>
 -->
-<title>ビット列データ型を使って</title>
+<title>ビット列データ型の使用</title>
 
 <programlisting>
 CREATE TABLE test (a BIT(3), b BIT VARYING(5));
@@ -5641,7 +5635,7 @@ SELECT * FROM test;
     in <xref linkend="datatype-character"> for character strings).
 -->
 ビット列の値は8ビット毎に1バイト、さらにビット列長に応じた5または8バイトのオーバーヘッドが必要です。
-（しかし、文字列に関する<xref linkend="datatype-character">の説明と同様、長い値は圧縮または行外に移動する可能性があります。）
+（しかし、文字列に関する<xref linkend="datatype-character">で説明したように、長い値は圧縮または行外に移動する可能性があります。）
    </para>
   </sect1>
 


### PR DESCRIPTION
多くは軽微な修正です。
(1) 使用例のタイトルで「～を使って」は違和感があったので「～の使用」に変更しました(2箇所)。
(2) "build"の訳語で「構築」は意味が曖昧(別の意味に取られる)ので、より意味が限定的だと思われる「ビルド」に変更しました。
(3) entryタグのインデントを慣例に従って原文に合わせました。
(4) "(be) reordered"の訳を「並べられる」から「並べ替えられる」に変更しました。
(5) サブネットの説明、アドレスの入力形式の説明を、なるべく原文に忠実になるように訳し直しました。
(6) "visualize"の訳語として「顕在化」は違和感が強かったので「可視化」としました(もっと良い訳語がありそう)。
(7) セミコロンで訳文を2つに分けることで、文と文のつながりがわかりにくくなっていた箇所について、1文に統合しました。
(8) "as explained"の訳語がおかしかったので、訂正しました。