### PR TITLE
sect1の目次にrefentryの一覧が出るようにする #586

### DIFF
--- a/doc/src/sgml/stylesheet-custom.xsl
+++ b/doc/src/sgml/stylesheet-custom.xsl
@@ -161,4 +161,27 @@
   </xsl:if>
 
 </xsl:template>
+
+<xsl:template name="section.toc">
+  <xsl:param name="toc-context" select="."/>
+  <xsl:param name="toc.title.p" select="true()"/>
+
+  <xsl:call-template name="make.toc">
+    <xsl:with-param name="toc-context" select="$toc-context"/>
+    <xsl:with-param name="toc.title.p" select="$toc.title.p"/>
+    <xsl:with-param name="nodes"
+                    select="refentry
+                           |bridgehead[$bridgehead.in.toc != 0]"/>
+
+  </xsl:call-template>
+</xsl:template>
+
+<xsl:template match="sect1" mode="toc">
+  <xsl:param name="toc-context" select="."/>
+  <xsl:call-template name="subtoc">
+    <xsl:with-param name="toc-context" select="$toc-context"/>
+    <xsl:with-param name="nodes" select="sect2|refentry                                 |bridgehead[$bridgehead.in.toc != 0]"/>
+  </xsl:call-template>
+</xsl:template>
+
 </xsl:stylesheet>

--- a/doc/src/sgml/stylesheet.xsl
+++ b/doc/src/sgml/stylesheet.xsl
@@ -19,6 +19,7 @@
 <!-- <xsl:param name="chunker.output.indent" select="'yes'"/> -->
 <xsl:param name="chunk.quietly" select="1"></xsl:param>
 <xsl:param name="toc.max.depth">2</xsl:param>
+<xsl:param name="generate.section.toc.level">1</xsl:param>
 
 <xsl:param name="website.stylesheet" select="0"/>
 


### PR DESCRIPTION
xslthtmlの変更に伴いセクション内の目次の出力が変わっていたため修正。

修正前 https://pgsql-jp.github.io/jpug-doc/9.5.2/html/spi-interface.html
修正後 https://pgsql-jp.github.io/jpug-doc/9.5.3/html/spi-interface.html

変わってしまっていたのはsect1/refentryという構成の場合。