### PR TITLE
datatype.sgml (8.11 テキスト検索に関する型)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -5708,8 +5708,8 @@ SELECT * FROM test;
      duplicate-elimination are done automatically during input, as shown in
      this example:
 -->
-<type>tsvector</type>の値は重複がない<firstterm>字句単位</>のソート済みリストです。
-また、これらの単語は同じ単語の変種を吸収するために<firstterm>正規化</>が行われます（詳細は<xref linkend="textsearch">を参照）。
+<type>tsvector</type>の値は重複がない<firstterm>語彙素</>のソート済みリストです。
+語彙素とは同じ単語の変種をまとめるために<firstterm>正規化</>された単語です（詳細は<xref linkend="textsearch">を参照）。
 以下の例に示すようにソートと重複除去は入力の際に自動的になされます。
 
 <programlisting>
@@ -5723,7 +5723,7 @@ SELECT 'a fat cat sat on a mat and ate a fat rat'::tsvector;
      To represent
      lexemes containing whitespace or punctuation, surround them with quotes:
 -->
-空白文字または句読点を含む字句単位を表現するには、引用符でくくってください。
+空白文字または句読点を含む語彙素を表現するには、引用符でくくってください。
 
 <programlisting>
 SELECT $$the lexeme '    ' contains spaces$$::tsvector;
@@ -5737,7 +5737,7 @@ SELECT $$the lexeme '    ' contains spaces$$::tsvector;
      to avoid the confusion of having to double quote marks within the
      literals.)  Embedded quotes and backslashes must be doubled:
 -->
-（この例と次の例では、リテラル内の二重引用符記号が含まれることによる混乱を防ぐためにドル引用符付け文字列を使用します。）
+（この例と次の例では、リテラル内で引用符記号を二重にしなければならないことによる混乱を防ぐためにドル引用符付け文字列を使用します。）
 引用符およびバックスラッシュが埋め込まれている場合は、以下のように二重にしなければなりません。
 
 <programlisting>
@@ -5751,7 +5751,7 @@ SELECT $$the lexeme 'Joe''s' contains a quote$$::tsvector;
      Optionally, integer <firstterm>positions</>
      can be attached to lexemes:
 -->
-オプションとして、字句要素に整数の<firstterm>位置</>を付けることもできます。
+オプションとして、語彙素に整数の<firstterm>位置</>を付けることもできます。
 
 <programlisting>
 SELECT 'a:1 fat:2 cat:3 sat:4 on:5 a:6 mat:7 and:8 ate:9 a:10 fat:11 rat:12'::tsvector;
@@ -5770,7 +5770,7 @@ SELECT 'a:1 fat:2 cat:3 sat:4 on:5 a:6 mat:7 and:8 ate:9 a:10 fat:11 rat:12'::ts
 位置は通常、元の単語の文書中の位置を示します。
 位置情報を<firstterm>近接順序</firstterm>に使用することができます。
 位置の値は1から16383までで、これより大きな値は警告なく16383に設定されます。
-同一字句要素に対する重複する位置項目は破棄されます。
+同一語彙素に対する重複する位置項目は破棄されます。
     </para>
 
     <para>
@@ -5780,9 +5780,9 @@ SELECT 'a:1 fat:2 cat:3 sat:4 on:5 a:6 mat:7 and:8 ate:9 a:10 fat:11 rat:12'::ts
      <literal>B</literal>, <literal>C</literal>, or <literal>D</literal>.
      <literal>D</literal> is the default and hence is not shown on output:
 -->
-位置を持つ字句単位はさらに<firstterm>重み</>付きのラベルを付与することができます。
+位置を持つ語彙素はさらに<firstterm>重み</>付きのラベルを付与することができます。
 ラベルは<literal>A</literal>、<literal>B</literal>、<literal>C</literal>、<literal>D</literal>を取ることができます。
-<literal>D</literal>はデフォルトですので、以下の結果には現れません。
+<literal>D</literal>はデフォルトですので、以下のように出力には現れません。
 
 <programlisting>
 SELECT 'a:1A fat:2B,4C cat:5D'::tsvector;
@@ -5809,7 +5809,7 @@ SELECT 'a:1A fat:2B,4C cat:5D'::tsvector;
      for the application.  For example,
 -->
 <type>tsvector</type>型自体は正規化を行わないことを理解することは重要です。
-与えられる単語はアプリケーションで適切に正規化されていると仮定しています。
+与えられる単語はアプリケーションのために適切に正規化されていると仮定しています。
 以下に例を示します。
 
 <programlisting>
@@ -5827,7 +5827,7 @@ select 'The Fat Rats'::tsvector;
      for searching:
 -->
 ほとんどの英文テキスト検索アプリケーションでは、上の単語は正規化されていないとみなされますが、<type>tsvector</type>は気にしません。
-検索が適切に行われるように単語を正規化するために、生の文書テキストは通常<function>to_tsvector</>経由で渡されます。
+検索用に単語を適切に正規化するために、生の文書テキストは通常<function>to_tsvector</>経由で渡されます。
 
 <programlisting>
 SELECT to_tsvector('english', 'The Fat Rats');
@@ -5839,7 +5839,7 @@ SELECT to_tsvector('english', 'The Fat Rats');
 <!--
      Again, see <xref linkend="textsearch"> for more detail.
 -->
-繰り返しますが、詳細は<xref linkend="textsearch">を参照してください。
+これについても、詳細は<xref linkend="textsearch">を参照してください。
     </para>
 
    </sect2>
@@ -5862,7 +5862,7 @@ SELECT to_tsvector('english', 'The Fat Rats');
      <literal>!</> (NOT).  Parentheses can be used to enforce grouping
      of the operators:
 -->
-<type>tsquery</type>の値には検索される字句単位が格納され、それらは<literal>&amp;</literal> (論理積)、<literal>|</literal> (論理和)、<literal>!</>(否定)論理演算子を遵守することで組み合わせられます。
+<type>tsquery</type>の値には検索される語彙素が格納され、それらは<literal>&amp;</literal> (論理積)、<literal>|</literal> (論理和)、<literal>!</>(否定)論理演算子を遵守することで組み合わせられます。
 括弧を使用して演算子を強制的にグループ化することができます。
 
 <programlisting>
@@ -5896,8 +5896,8 @@ SELECT 'fat &amp; rat &amp; ! cat'::tsquery;
      one or more weight letters, which restricts them to match only
      <type>tsvector</> lexemes with matching weights:
 -->
-省略することもできますが、<type>tsquery</type>内の字句単位に1つ以上の重み文字をもったラベルを付けることができます。
-これにより、こうした一致に関する重みの1つを持つ<type>tsvector</>字句要素のみに一致するように制限させることができます。
+省略することもできますが、<type>tsquery</type>内の語彙素に1つ以上の重み文字をもったラベルを付けることができます。
+こうすると、同じ重みを持つ<type>tsvector</>語彙素のみに一致するように制限することになります。
 
 <programlisting>
 SELECT 'fat:ab &amp; cat'::tsquery;
@@ -5912,7 +5912,7 @@ SELECT 'fat:ab &amp; cat'::tsquery;
      Also, lexemes in a <type>tsquery</type> can be labeled with <literal>*</>
      to specify prefix matching:
      -->
-同時に、<type>tsquery</type>内の字句単位は、前方一致を指定するため<literal>*</>でラベルを付けることができます。
+同時に、<type>tsquery</type>内の語彙素は、前方一致を指定するため<literal>*</>でラベルを付けることができます。
 <programlisting>
 SELECT 'super:*'::tsquery;
   tsquery  
@@ -5958,7 +5958,7 @@ SELECT to_tsquery('postgres:*');
      to the <type>tsquery</> type.  The <function>to_tsquery</>
      function is convenient for performing such normalization:
 -->
-字句単位の引用符規則は前に説明した<type>tsvector</>における字句単位と同じです。
+語彙素の引用符規則は前に説明した<type>tsvector</>における語彙素と同じです。
 また、<type>tsvector</>同様、必要な単語の正規化は<type>tsquery</>型に変換する前に行う必要があります。
 こうした正規化の実行には<function>to_tsquery</>関数が簡便です。
 


### PR DESCRIPTION
(1) "lexeme"の訳語が「字句単位(要素)」となっていたのを「語彙素」に変更しました。
そもそも「語彙素」が一般的な訳語のようですし、
https://ja.wikipedia.org/wiki/%E8%AA%9E%E5%BD%99%E7%B4%A0
この節と、12章は密接に関連していて訳語を合わせるべきですが、12章では「語彙素」としていて、かつ出現数も圧倒的に多いです。
他に、func.sgml、unaccent.sgml、release-9.4.sgmlでも「語彙素」でした。catalogs.sgmlにも2箇所"lexeme"があり、こちらは「字句」としていますが、これは別にPRを作りたいと思います。全体がそういう状態なので、MLでの議論やIssuesへの登録は不要と判断しました。
(2) "which are words"の解釈が間違っていたので訳し直しました。
(3) "having to double quote marks"の解釈が間違っていたので訳し直しました。
(4) "is not shown on output:"の解釈がちょっと違っていたので、修正しました。
(5) "for the application"の解釈がちょっと違っていたので、修正しました。
(6) "to normalize the words appropriately for searching"の解釈が間違っていたので、修正しました。
(7) "Again"の訳語を直しました。
(8) "which restricts..."の訳がおかしかったので、修正しました。