### PR TITLE
CREATE TABLESPACEの説明を改善(Issues #603)

### DIFF
--- a/doc/src/sgml/ref/create_tablespace.sgml
+++ b/doc/src/sgml/ref/create_tablespace.sgml
@@ -56,7 +56,7 @@ CREATE TABLESPACE <replaceable class="parameter">tablespace_name</replaceable>
    the file system where the data files containing database objects
    (such as tables and indexes) can reside.
 -->
-テーブル空間を使用すると、データベースオブジェクト（テーブルやインデックスなど）が入ったデータファイルを格納する、ファイルシステム上の別の場所をスーパーユーザができます。
+スーパーユーザはテーブル空間を使用することで、データベースオブジェクト（テーブルやインデックスなど）が入ったデータファイルを格納できる、ファイルシステム上の別の場所を定義できます。
   </para>
 
   <para>


### PR DESCRIPTION
#603 
"define"と"can"の訳抜けを訂正し、さらに日本語としてわかりやすくなるように、訳文の構造を変更しました。