### PR TITLE
DROP CONVERSIONの概要の修正(Issues #607)

### DIFF
--- a/doc/src/sgml/ref/drop_conversion.sgml
+++ b/doc/src/sgml/ref/drop_conversion.sgml
@@ -19,7 +19,7 @@
 <!--
   <refpurpose>remove a conversion</refpurpose>
 -->
-  <refpurpose>変換を削除する</refpurpose>
+  <refpurpose>符号化方式変換を削除する</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -39,8 +39,14 @@ DROP CONVERSION [ IF EXISTS ] <replaceable>name</replaceable> [ CASCADE | RESTRI
    <command>DROP CONVERSION</command> removes a previously defined conversion.
    To be able to drop a conversion, you must own the conversion.
 -->
-<command>DROP CONVERSION</command>を使用すると、以前に定義した変換を削除できます。
+<command>DROP CONVERSION</command>を使用すると、以前に定義した符号化方式変換（以下、単に「変換」と記します）を削除できます。
 変換を削除するには、その変換を所有していなければなりません。
+<!--
+訳注：9.5で導入されたTRANSFORMを「変換」と訳すことにしたため、
+それと区別するため"conversion"を「符号化方式変換」としました。
+なお、CREATE TRANSFORMの説明の原文では"encoding conversion"と
+記述されています。
+-->
   </para>
  </refsect1>
 


### PR DESCRIPTION
#607 
DROP CONVERSIONとDROP TRANSFORMの概要がいずれも「変換の削除」となっていたので、CREATE CONVERSIONの説明に合わせて、DROP CONVERSIONを「符号化方式変換の削除」としました。
説明の中でも繰り返し、「変換」が出てくるので、ちょっとやり過ぎかも知れませんが、最初の「変換」についてだけ、「符号化方式変換」とし、さらに訳注をSGMLコメントとして入れました。