### PR TITLE
fix translation of 'subdirectory'

### DIFF
--- a/doc/src/sgml/extend.sgml
+++ b/doc/src/sgml/extend.sgml
@@ -1540,7 +1540,7 @@ include $(PGXS)
         <varname>EXTENSION</varname> is set,
         or <literal>contrib</literal> if not)
 -->
-DATAおよびDOCSファイルのインストール先となるはずの<literal><replaceable>prefix</>/share</literal>副ディレクトリです。
+DATAおよびDOCSファイルのインストール先となるはずの<literal><replaceable>prefix</>/share</literal>サブディレクトリです。
 （設定がない場合、デフォルトは<varname>EXTENSION</varname>が設定されている場合は<literal>extension</literal>に、設定されていない場合は<literal>contrib</literal>になります。）
        </para>
       </listitem>
@@ -1798,10 +1798,10 @@ make VPATH=/path/to/extension/source/tree install
 -->
 <varname>REGRESS</>変数に列挙されたスクリプトは、<literal>make install</>を実行した後で<literal>make installcheck</literal>によって呼び出すことができる、作成したモジュールのリグレッション試験で使用されます。
 これが動作するためには、<productname>PostgreSQL</productname>サーバが実行していなければなりません。
-<varname>REGRESS</>変数に列挙されたスクリプトは、拡張のディレクトリ内の<literal>sql/</literal>という名前の副ディレクトリ内に存在しなければなりません。
+<varname>REGRESS</>変数に列挙されたスクリプトは、拡張のディレクトリ内の<literal>sql/</literal>という名前のサブディレクトリ内に存在しなければなりません。
 これらのファイルは<literal>.sql</literal>という拡張子を持たなければなりません。
 この拡張子はメークファイル内の<varname>REGRESS</varname>リストには含まれません。
-また試験ごとに<literal>expected/</literal>という名前の副ディレクトリ内に想定出力を内容として含む、同じステムに<literal>.out</literal>拡張子を付けた名前のファイルがなければなりません。
+また試験ごとに<literal>expected/</literal>という名前のサブディレクトリ内に想定出力を内容として含む、同じステムに<literal>.out</literal>拡張子を付けた名前のファイルがなければなりません。
 <literal>make installcheck</literal>は<application>psql</>を用いて各試験スクリプトを実行し、結果出力が想定ファイルに一致するかどうか比較します。
 何らかの差異は<command>diff -c</command>書式で<literal>regression.diffs</literal>に書き出されます。
 想定ファイルがない試験を実行しようとすると<quote>問題</quote>として報告されます。

--- a/doc/src/sgml/ref/pg_xlogdump.sgml
+++ b/doc/src/sgml/ref/pg_xlogdump.sgml
@@ -164,7 +164,7 @@ PostgreSQL documentation
         directory.
 -->
 ログセグメントファイルを見つけ出すディレクトリです。
-デフォルトでは現在のディレクトリ内の<literal>pg_xlog</literal>副ディレクトリから検索されます。
+デフォルトでは現在のディレクトリ内の<literal>pg_xlog</literal>サブディレクトリから検索されます。
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
subdirectoryの訳を「サブディレクトリ」に統一しました。