### PR TITLE
update release-9.[1-4] for 9.5.3

### DIFF
--- a/doc/src/sgml/release-9.1.sgml
+++ b/doc/src/sgml/release-9.1.sgml
@@ -2,52 +2,83 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-1-22">
+<!--
   <title>Release 9.1.22</title>
+-->
+  <title>リリース9.1.22</title>
 
   <note>
+<!--
   <title>Release Date</title>
+-->
+  <title>リリース日</title>
   <simpara>2016-05-12</simpara>
   </note>
 
   <para>
+<!--
    This release contains a variety of fixes from 9.1.21.
    For information about new features in the 9.1 major release, see
    <xref linkend="release-9-1">.
+-->
+このリリースは9.1.21に対し、各種不具合を修正したものです。
+9.1メジャーリリースにおける新機能については、<xref linkend="release-9-1">を参照してください。
   </para>
 
   <para>
+<!--
    The <productname>PostgreSQL</> community will stop releasing updates
    for the 9.1.X release series in September 2016.
    Users are encouraged to update to a newer release branch soon.
+-->
+<productname>PostgreSQL</>コミュニティは2016年の9月に9.1.Xリリースシリーズの更新リリースを終了する予定です。
+早めに新しいリリースのブランチに更新することを推奨します。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.1.22</title>
+-->
+   <title>バージョン9.1.22への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.1.X.
+-->
+9.1.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if you are upgrading from a version earlier than 9.1.16,
     see <xref linkend="release-9-1-16">.
+-->
+また、9.1.16よりも前のリリースからアップグレードする場合は、<xref linkend="release-9-1-16">を参照して下さい。
    </para>
 
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Clear the OpenSSL error queue before OpenSSL calls, rather than
       assuming it's clear already; and make sure we leave it clear
       afterwards (Peter Geoghegan, Dave Vitek, Peter Eisentraut)
+-->
+OpenSSLを呼び出す前にそのエラーキューを、既に消去されているとみなすのではなく、消去します。また、必ず後に消去しておくようにします。
+(Peter Geoghegan, Dave Vitek, Peter Eisentraut)
      </para>
 
      <para>
+<!--
       This change prevents problems when there are multiple connections
       using OpenSSL within a single process and not all the code involved
       follows the same rules for when to clear the error queue.
@@ -56,108 +87,167 @@
       SSL connections using the PHP, Python, or Ruby wrappers for OpenSSL.
       It's possible for similar problems to arise within the server as well,
       if an extension module establishes an outgoing SSL connection.
+-->
+この変更は、一つのプロセスの中でOpenSSLを使った複数の接続があって、含まれるコードの全てがエラーキューを消去するとき同一規則に従っていない場合の問題を防ぎます。
+特に、クライアントアプリケーションがPHPやPython、RubyのOpenSSLラッパーを使ったSSL接続と同時に、<application>libpq</>でSSL接続を使っているときに、障害が報告されました。
+拡張モジュールが外にむけたSSL接続をするのであれば、同様にサーバでも似た問題が起こる可能性があります。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <quote>failed to build any <replaceable>N</>-way joins</quote>
       planner error with a full join enclosed in the right-hand side of a
       left join (Tom Lane)
+-->
+左外部結合の右手側に入っている完全外部結合でのプランナのエラー<quote>failed to build any <replaceable>N</>-way joins (N個立ての結合の構築にいずれも失敗しました)</quote>を修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible misbehavior of <literal>TH</>, <literal>th</>,
       and <literal>Y,YYY</> format codes in <function>to_timestamp()</>
       (Tom Lane)
+-->
+<function>to_timestamp()</>の書式コード<literal>TH</>、<literal>th</>、<literal>Y,YYY</>の誤った振る舞いを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       These could advance off the end of the input string, causing subsequent
       format codes to read garbage.
+-->
+これにより、入力文字列の末尾を超えて進み、次の書式コードでゴミが読まれるおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix dumping of rules and views in which the <replaceable>array</>
       argument of a <literal><replaceable>value</> <replaceable>operator</>
       ANY (<replaceable>array</>)</literal> construct is a sub-SELECT
       (Tom Lane)
+-->
+<literal><replaceable>value</> <replaceable>operator</> ANY (<replaceable>array</>)</literal>という構造の<replaceable>array</>引数が副問い合わせである場合のルールとビューのダンプを修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Make <application>pg_regress</> use a startup timeout from the
       <envar>PGCTLTIMEOUT</> environment variable, if that's set (Tom Lane)
+-->
+<envar>PGCTLTIMEOUT</>環境変数が設定されているなら、<application>pg_regress</>がその値による起動タイムアウトを適用するようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This is for consistency with a behavior recently added
       to <application>pg_ctl</>; it eases automated testing on slow machines.
+-->
+これは、最近<application>pg_ctl</>に追加された振る舞いとの一貫性のためで、
+遅いマシンでの自動テストを容易にします。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_upgrade</> to correctly restore extension
       membership for operator families containing only one operator class
       (Tom Lane)
+-->
+一つの演算子クラスだけを含む演算子族の拡張への所属を正しくリストアできるように<application>pg_upgrade</>を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       In such a case, the operator family was restored into the new database,
       but it was no longer marked as part of the extension.  This had no
       immediate ill effects, but would cause later <application>pg_dump</>
       runs to emit output that would cause (harmless) errors on restore.
+-->
+このような場合、演算子族は新しいデータベースにリストアされますが、もはや拡張の一部として記されませんでした。
+これは直ちには悪影響はありませんが、後に<application>pg_dump</>がリストア時に（無害な）エラーを引き起こす出力を吐き出す原因となりました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Rename internal function <function>strtoi()</>
       to <function>strtoint()</> to avoid conflict with a NetBSD library
       function (Thomas Munro)
+-->
+NetBSDのライブラリ関数との衝突を避けるため、内部関数<function>strtoi()</>の名前を<function>strtoint()</>に変えました。
+(Thomas Munro)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix reporting of errors from <function>bind()</>
       and <function>listen()</> system calls on Windows (Tom Lane)
+-->
+Windowsにおけるシステムコール<function>bind()</>と<function>listen()</>からのエラー報告を修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Reduce verbosity of compiler output when building with Microsoft Visual
       Studio (Christian Ullrich)
+-->
+Microsoft Visual Studioでビルドするときのコンパイラ出力の冗長さを減らしました。
+(Christian Ullrich)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid possibly-unsafe use of Windows' <function>FormatMessage()</>
       function (Christian Ullrich)
+-->
+Windowsの<function>FormatMessage()</>関数の安全でない可能性のある使用を回避しました。
+(Christian Ullrich)
      </para>
 
      <para>
+<!--
       Use the <literal>FORMAT_MESSAGE_IGNORE_INSERTS</> flag where
       appropriate.  No live bug is known to exist here, but it seems like a
       good idea to be careful.
+-->
+適切に<literal>FORMAT_MESSAGE_IGNORE_INSERTS</>フラグを使用します。
+これに関連した既知の未修整バグはありませんが、注意深くすることは良い考えと思われます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Update time zone data files to <application>tzdata</> release 2016d
       for DST law changes in Russia and Venezuela.  There are new zone
       names <literal>Europe/Kirov</> and <literal>Asia/Tomsk</> to reflect
       the fact that these regions now have different time zone histories from
       adjacent regions.
+-->
+タイムゾーンデータファイルを<application>tzdata</> release 2016dに更新しました。
+ロシア、ベネズエラの夏時間法の変更、当該地域は今では隣接した地域とは異なるタイムゾーンの歴史を持っているという事実を反映させた新しい地域名<literal>Europe/Kirov</>、<literal>Asia/Tomsk</>が含まれます。
      </para>
     </listitem>
 
@@ -194,7 +284,7 @@
 <!--
    <title>Migration to Version 9.1.21</title>
 -->
-   <title>バージョン 9.1.21への移行</title>
+   <title>バージョン9.1.21への移行</title>
 
    <para>
 <!--
@@ -214,7 +304,10 @@
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
@@ -509,7 +602,7 @@ Perl本体からもはや提供されなくなったため、MSVCビルドで<li
 <!--
    <title>Migration to Version 9.1.20</title>
 -->
-   <title>バージョン 9.1.20への移行</title>
+   <title>バージョン9.1.20への移行</title>
 
    <para>
 <!--
@@ -1217,7 +1310,6 @@ Windowsにおいて<application>pg_upgrade</>のファイルコピーをする�
       Install our <filename>missing</> script where PGXS builds can find it
       (Jim Nasby)
 -->
-
 PGXSビルドで見つけられる場所に<filename>missing</>スクリプトを設置するようにしました。 
 (Jim Nasby)
      </para>
@@ -1302,15 +1394,14 @@ MSVCビルドにてインストールされるヘッダファイル群に<filena
    <xref linkend="release-9-1">.
 -->
 このリリースは9.1.18に対し、各種不具合を修正したものです。
-9.1メジャーリリースにおける新機能については、<xref linkend="release-9-1">
-を参照してください。
+9.1メジャーリリースにおける新機能については、<xref linkend="release-9-1">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.1.19</title>
 -->
-<title>バージョン 9.1.19への移行</title>
+   <title>バージョン9.1.19への移行</title>
 
    <para>
 <!--
@@ -1433,7 +1524,7 @@ SPIクエリ結果に多数のタプルを挿入するときの O(N^2) の振る
       Back-patch 9.3-era addition of per-resource-owner lock caches
       (Jeff Janes)
 -->
-9.3時代に加わったリソース所有者ごとのロックキャッシュを後方適用しました。
+9.3時代に加わったリソース所有者ごとのロックキャッシュをより前のバージョンに適用しました。
 (Jeff Janes)
      </para>
 
@@ -2101,7 +2192,6 @@ Perlでは5.8.0以降からこの機能に依存しています。
       Avoid use of inline functions when compiling with
       32-bit <application>xlc</>, due to compiler bugs (Noah Misch)
 -->
-
 コンパイラバグのため、32bit <application>xlc</>でインライン関数展開を使わないようにしました。
 (Noah Misch)
      </para>
@@ -2179,15 +2269,14 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
    <xref linkend="release-9-1">.
 -->
 このリリースは9.1.17に対し、各種不具合を修正したものです。
-9.1メジャーリリースにおける新機能については、<xref linkend="release-9-1">
-を参照してください。
+9.1メジャーリリースにおける新機能については、<xref linkend="release-9-1">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.1.18</title>
 -->
-<title>バージョン 9.1.18への移行</title>
+   <title>バージョン9.1.18への移行</title>
 
    <para>
 <!--
@@ -2286,15 +2375,14 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
    <xref linkend="release-9-1">.
 -->
 このリリースは9.1.16に対し、各種不具合を修正したものです。
-9.1メジャーリリースにおける新機能については、<xref linkend="release-9-1">
-を参照してください。
+9.1メジャーリリースにおける新機能については、<xref linkend="release-9-1">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.1.17</title>
 -->
-<title>バージョン 9.1.17への移行</title>
+   <title>バージョン9.1.17への移行</title>
 
    <para>
 <!--
@@ -2392,7 +2480,7 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
 長い間、<application>libpq</>はTLS v1のみのプロトコルが利用できるようにコーディングされていました。
 今ではTLSの新しいバージョンは一般的になったため、最新の一般的にサポートされているTLSバージョンでサーバと調停することを許可しました。
 (<productname>PostgreSQL</>サーバーはすでに調停するこは可能であったため、サーバサイドの変更は必要ありませんでした。)
-これは9.4.0ですでにリリースされている変更のバックパッチです。
+これは9.4.0ですでにリリースされている変更の、より前のバージョンへのパッチです。
      </para>
     </listitem>
 
@@ -2422,15 +2510,14 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
    <xref linkend="release-9-1">.
 -->
 このリリースは9.1.15に対し、各種不具合を修正したものです。
-9.1メジャーリリースにおける新機能については、<xref linkend="release-9-1">
-を参照してください。
+9.1メジャーリリースにおける新機能については、<xref linkend="release-9-1">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.1.16</title>
 -->
-<title>バージョン 9.1.16への移行</title>
+   <title>バージョン9.1.16への移行</title>
 
    <para>
 <!--
@@ -2462,7 +2549,7 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
 <!--
    <title>Changes</title>
 -->
-<title>変更点</title>
+   <title>変更点</title>
 
    <itemizedlist>
 
@@ -3245,7 +3332,7 @@ Sparc V8 マシンでのコンパイル失敗を修正しました。
 <!--
    <title>Migration to Version 9.1.15</title>
 -->
-<title>バージョン 9.1.15への移行</title>
+   <title>バージョン9.1.15への移行</title>
 
    <para>
 <!--
@@ -3720,7 +3807,7 @@ EvalPlanQual処理で解放済みメモリを使用してしまう問題を修�
       deemed a back-patchable bug fix rather than a feature addition.
 -->
 以前のコーディングでは辞書のサイズを超えた場合、クラッシュする可能性がありました。
-このため機能追加ではなくバグフィックスとしてバックパッチしました。
+このため、これは機能追加というより、より前のバージョンにパッチとして適用されたバグフィックスと考えられます。
      </para>
     </listitem>
 
@@ -4492,7 +4579,7 @@ SRET(アジア/スレドネコリムスク)、XJT(アジア/ウルムチ)、西�
 <!--
    <title>Migration to Version 9.1.14</title>
 -->
-<title>バージョン 9.1.14への移行</title>
+   <title>バージョン9.1.14への移行</title>
 
    <para>
 <!--
@@ -4511,7 +4598,6 @@ SRET(アジア/スレドネコリムスク)、XJT(アジア/ウルムチ)、西�
 下記に示すはじめの変更点を確認し、使用しているインストレーションが影響を受けるか、その場合どのような処置を施すべきか判断してください。
    </para>
 
-
    <para>
 <!--
     Also, if you are upgrading from a version earlier than 9.1.11,
@@ -4519,7 +4605,6 @@ SRET(アジア/スレドネコリムスク)、XJT(アジア/ウルムチ)、西�
 -->
 また、9.1.11よりも前のリリースからアップグレードする場合は、<xref linkend="release-9-1-11">を参照して下さい。
    </para>
-
 
   </sect2>
 
@@ -4538,7 +4623,6 @@ SRET(アジア/スレドネコリムスク)、XJT(アジア/ウルムチ)、西�
       indexes on <type>bit</> columns (Heikki Linnakangas)
 -->
 <filename>contrib/btree_gist</>拡張モジュールにおける<type>bit</>カラムのインデックスの初期化パディングバイトを修正しました。(Heikki Linnakangas)
-
      </para>
 
      <para>
@@ -4719,7 +4803,6 @@ Appendプラン出力の行全体を参照することによって、<quote>reco
       (Etsuro Fujita)
 -->
 <xref linkend="guc-default-with-oids">がtrueの場合でも、外部テーブルがOID付で作成される事を防止しました。(Etsuro Fujita)
-
      </para>
     </listitem>
 
@@ -5321,7 +5404,6 @@ GINメタページのアクティブな部分は標準的なディスクセク�
 <!--
    <title>Migration to Version 9.1.12</title>
 -->
-
    <title>バージョン9.1.12への移行</title>
 
    <para>
@@ -5438,7 +5520,6 @@ PLバリデータ関数の主な役割は<command>CREATE FUNCTION</>の中で黙
       Prevent buffer overrun with long datetime strings (Noah Misch)
 -->
 長い日付時刻文字列によるバッファオーバーランを防止しました。(Noah Misch)
-
      </para>
 
      <para>
@@ -6293,7 +6374,6 @@ WAL再生中に<filename>pg_multixact</>のデータを切り詰めるように�
       Linnakangas)
 -->
 GINインデックスがツリーページを削除する際の競合条件を修正しました。(Heikki Linnakangas)
-
      </para>
 
      <para>
@@ -6546,7 +6626,6 @@ Windowsエラーコード変換のログ取得時に発生する可能性があ�
 -->
 9.1.Xからの移行ではダンプ/リストアは不要です。
    </para>
-
 
    <para>
 <!--
@@ -8850,9 +8929,6 @@ Windowsでのプロセス起動時のクラッシュや、ホットスタンバ�
 -->
 接頭辞、つまり<replaceable>word</><literal>:*</>のパターンを含むテキスト検索の問い合わせについて、選択性の推定を改善しました。(Tom Lane)
      </para>
-
-     <para>
-     </para>
     </listitem>
 
     <listitem>
@@ -9632,7 +9708,6 @@ PL/PythonにおいてPostgreSQL符号化方式とPython符号化方式との間�
 -->
 時間帯データファイルを<application>tzdata</>リリース2012eに更新しました。
 モロッコおよびトケラウにおける夏時間の変更が含まれます。
-
      </para>
     </listitem>
 
@@ -10768,7 +10843,6 @@ SSIトランザクションの整理における境界問題を修正しまし�
 -->
 ロックが<quote>transaction zero</>によって保持されていると記録されることが時々ありました。
 少なくともスレーブサーバでアサーションエラーが発生することが分かっていますが、もっと深刻な問題が起こる可能性があります。
-
      </para>
     </listitem>
 
@@ -11267,7 +11341,6 @@ ARMにおいて可能ならばスピンロックに<function>__sync_lock_test_an
 -->
 この関数は、以前の廃止予定でARMv6以降では使用できなくなった<literal>SWPB</>命令の使用を置き換えるものです。
 最近のARMボードでも古いコードは明白な方法で失敗することはありませんが、単に同時アクセスのインターロックを行わず、マルチプロセス操作において奇妙な失敗をもたらすと報告されています。
-
      </para>
     </listitem>
 
@@ -12433,7 +12506,6 @@ GiSTインデックススキャン終了時のメモリリークを修正しま�
    <itemizedlist>
 
     <!-- This list duplicates items below, but without authors or details-->
-
 
     <listitem>
      <para>
@@ -14791,7 +14863,6 @@ SELECT * FROM places ORDER BY location <-> point '(101,456)' LIMIT 10;
        sorting.  Also, <command>ANALYZE</> won't try to use inappropriate
        statistics-gathering methods for columns of such composite types.
 -->
-
 これは、ソート処理なく問い合わせを実現できる場合、実行時に潜在する<quote>could not identify a comparison function</>失敗を防止します。
 また<command>ANALYZE</>は、こうした複合型の列に対する不適切な統計情報収集メソッドの使用を試みません。
       </para>

--- a/doc/src/sgml/release-9.2.sgml
+++ b/doc/src/sgml/release-9.2.sgml
@@ -2,46 +2,73 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-2-17">
+<!--
   <title>Release 9.2.17</title>
+-->
+  <title>リリース9.2.17</title>
 
   <note>
+<!--
   <title>Release Date</title>
+-->
+  <title>リリース日</title>
   <simpara>2016-05-12</simpara>
   </note>
 
   <para>
+<!--
    This release contains a variety of fixes from 9.2.16.
    For information about new features in the 9.2 major release, see
    <xref linkend="release-9-2">.
+-->
+このリリースは9.2.16に対し、各種不具合を修正したものです。
+9.2メジャーリリースにおける新機能については、<xref linkend="release-9-2">を参照してください。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.2.17</title>
+-->
+   <title>バージョン9.2.17への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.2.X.
+-->
+9.2.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if you are upgrading from a version earlier than 9.2.11,
     see <xref linkend="release-9-2-11">.
+-->
+また、9.2.11よりも前のリリースからアップグレードする場合は、<xref linkend="release-9-2-11">を参照して下さい。
    </para>
 
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Clear the OpenSSL error queue before OpenSSL calls, rather than
       assuming it's clear already; and make sure we leave it clear
       afterwards (Peter Geoghegan, Dave Vitek, Peter Eisentraut)
+-->
+OpenSSLを呼び出す前にそのエラーキューを、既に消去されているとみなすのではなく、消去します。また、必ず後に消去しておくようにします。
+(Peter Geoghegan, Dave Vitek, Peter Eisentraut)
      </para>
 
      <para>
+<!--
       This change prevents problems when there are multiple connections
       using OpenSSL within a single process and not all the code involved
       follows the same rules for when to clear the error queue.
@@ -50,24 +77,37 @@
       SSL connections using the PHP, Python, or Ruby wrappers for OpenSSL.
       It's possible for similar problems to arise within the server as well,
       if an extension module establishes an outgoing SSL connection.
+-->
+この変更は、一つのプロセスの中でOpenSSLを使った複数の接続があって、含まれるコードの全てがエラーキューを消去するとき同一規則に従っていない場合の問題を防ぎます。
+特に、クライアントアプリケーションがPHPやPython、RubyのOpenSSLラッパーを使ったSSL接続と同時に、<application>libpq</>でSSL接続を使っているときに、障害が報告されました。
+拡張モジュールが外にむけたSSL接続をするのであれば、同様にサーバでも似た問題が起こる可能性があります。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <quote>failed to build any <replaceable>N</>-way joins</quote>
       planner error with a full join enclosed in the right-hand side of a
       left join (Tom Lane)
+-->
+左外部結合の右手側に入っている完全外部結合でのプランナのエラー<quote>failed to build any <replaceable>N</>-way joins (N個立ての結合の構築にいずれも失敗しました)</quote>を修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect handling of equivalence-class tests in multilevel
       nestloop plans (Tom Lane)
+-->
+複数階層の入れ子ループプランにおける等価クラス検査の誤った扱いを修正しました。
+ (Tom Lane)
      </para>
 
      <para>
+<!--
       Given a three-or-more-way equivalence class of variables, such
       as <literal>X.X = Y.Y = Z.Z</>, it was possible for the planner to omit
       some of the tests needed to enforce that all the variables are actually
@@ -75,120 +115,187 @@
       the <literal>WHERE</> clauses.  For various reasons, erroneous plans
       were seldom selected in practice, so that this bug has gone undetected
       for a long time.
+-->
+<literal>X.X = Y.Y = Z.Z</>のような、3つ以上からなる変数の等価クラスが与えられると、プランナが全ての変数が実際に等しいようにするために必要な検査の一部を怠る可能性があり、出力される行が<literal>WHERE</>句を満たさない結合をもたらしました。
+さまざまな理由のため、誤ったプランは実際には滅多に選択されません。
+そのため、このバグは長い間気づかれずにきました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible misbehavior of <literal>TH</>, <literal>th</>,
       and <literal>Y,YYY</> format codes in <function>to_timestamp()</>
       (Tom Lane)
+-->
+<function>to_timestamp()</>の書式コード<literal>TH</>、<literal>th</>、<literal>Y,YYY</>の誤った振る舞いを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       These could advance off the end of the input string, causing subsequent
       format codes to read garbage.
+-->
+これにより、入力文字列の末尾を超えて進み、次の書式コードでゴミが読まれるおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix dumping of rules and views in which the <replaceable>array</>
       argument of a <literal><replaceable>value</> <replaceable>operator</>
       ANY (<replaceable>array</>)</literal> construct is a sub-SELECT
       (Tom Lane)
+-->
+<literal><replaceable>value</> <replaceable>operator</> ANY (<replaceable>array</>)</literal>という構造の<replaceable>array</>引数が副問い合わせである場合のルールとビューのダンプを修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Make <application>pg_regress</> use a startup timeout from the
       <envar>PGCTLTIMEOUT</> environment variable, if that's set (Tom Lane)
+-->
+<envar>PGCTLTIMEOUT</>環境変数が設定されているなら、<application>pg_regress</>がその値による起動タイムアウトを適用するようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This is for consistency with a behavior recently added
       to <application>pg_ctl</>; it eases automated testing on slow machines.
+-->
+これは、最近<application>pg_ctl</>に追加された振る舞いとの一貫性のためで、
+遅いマシンでの自動テストを容易にします。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_upgrade</> to correctly restore extension
       membership for operator families containing only one operator class
       (Tom Lane)
+-->
+一つの演算子クラスだけを含む演算子族の拡張への所属を正しくリストアできるように<application>pg_upgrade</>を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       In such a case, the operator family was restored into the new database,
       but it was no longer marked as part of the extension.  This had no
       immediate ill effects, but would cause later <application>pg_dump</>
       runs to emit output that would cause (harmless) errors on restore.
+-->
+このような場合、演算子族は新しいデータベースにリストアされますが、もはや拡張の一部として記されませんでした。
+これは直ちには悪影響はありませんが、後に<application>pg_dump</>がリストア時に（無害な）エラーを引き起こす出力を吐き出す原因となりました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Back-port 9.4-era memory-barrier code changes into 9.2 and 9.3 (Tom Lane)
+-->
+9.4のメモリバリアコードの変更を9.2と9.3にバックポートしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       These changes were not originally needed in pre-9.4 branches, but we
       recently back-patched a fix that expected the barrier code to work
       properly.  Only IA64 (when using icc), HPPA, and Alpha platforms are
       affected.
+-->
+この変更は本来9.4より前のブランチでは必要ありませんでしたが、バリアコードが正しく動くようにする修正を最近、より前のバージョンにパッチとして適用しました。
+(iccを使用した時の)IA64、HPPA、Alphaプラットフォームのみに影響します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Reduce the number of SysV semaphores used by a build configured with
-      <option>--disable-spinlocks</> (Tom Lane)
+      <option>&#045;&#045;disable-spinlocks</> (Tom Lane)
+-->
+<option>--disable-spinlocks</>と設定されたビルドで、使用されるSysVセマフォの数を減らしました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Rename internal function <function>strtoi()</>
       to <function>strtoint()</> to avoid conflict with a NetBSD library
       function (Thomas Munro)
+-->
+NetBSDのライブラリ関数との衝突を避けるため、内部関数<function>strtoi()</>の名前を<function>strtoint()</>に変えました。
+(Thomas Munro)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix reporting of errors from <function>bind()</>
       and <function>listen()</> system calls on Windows (Tom Lane)
+-->
+Windowsにおけるシステムコール<function>bind()</>と<function>listen()</>からのエラー報告を修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Reduce verbosity of compiler output when building with Microsoft Visual
       Studio (Christian Ullrich)
+-->
+Microsoft Visual Studioでビルドするときのコンパイラ出力の冗長さを減らしました。
+(Christian Ullrich)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid possibly-unsafe use of Windows' <function>FormatMessage()</>
       function (Christian Ullrich)
+-->
+Windowsの<function>FormatMessage()</>関数の安全でない可能性のある使用を回避しました。
+(Christian Ullrich)
      </para>
 
      <para>
+<!--
       Use the <literal>FORMAT_MESSAGE_IGNORE_INSERTS</> flag where
       appropriate.  No live bug is known to exist here, but it seems like a
       good idea to be careful.
+-->
+適切に<literal>FORMAT_MESSAGE_IGNORE_INSERTS</>フラグを使用します。
+これに関連した既知の未修整バグはありませんが、注意深くすることは良い考えと思われます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Update time zone data files to <application>tzdata</> release 2016d
       for DST law changes in Russia and Venezuela.  There are new zone
       names <literal>Europe/Kirov</> and <literal>Asia/Tomsk</> to reflect
       the fact that these regions now have different time zone histories from
       adjacent regions.
+-->
+タイムゾーンデータファイルを<application>tzdata</> release 2016dに更新しました。
+ロシア、ベネズエラの夏時間法の変更、当該地域は今では隣接した地域とは異なるタイムゾーンの歴史を持っているという事実を反映させた新しい地域名<literal>Europe/Kirov</>、<literal>Asia/Tomsk</>が含まれます。
      </para>
     </listitem>
 
@@ -225,7 +332,7 @@
 <!--
    <title>Migration to Version 9.2.16</title>
 -->
-   <title>バージョン 9.2.16への移行</title>
+   <title>バージョン9.2.16への移行</title>
 
    <para>
 <!--
@@ -245,7 +352,10 @@
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
@@ -332,7 +442,6 @@
       Avoid use of <function>sscanf()</> to parse <literal>ispell</>
       dictionary files (Artur Zakirov)
 -->
-
 <literal>ispell</>辞書ファイルを解析するのに<function>sscanf()</>を使わないようにしました。
 (Artur Zakirov)
      </para>
@@ -541,7 +650,7 @@ Perl本体からもはや提供されなくなったため、MSVCビルドで<li
 <!--
    <title>Migration to Version 9.2.15</title>
 -->
-   <title>バージョン 9.2.15への移行</title>
+   <title>バージョン9.2.15への移行</title>
 
    <para>
 <!--
@@ -1296,7 +1405,6 @@ Python 3.5で通るように<application>PL/Python</>のリグレッションテ
       Install our <filename>missing</> script where PGXS builds can find it
       (Jim Nasby)
 -->
-
 PGXSビルドで見つけられる場所に<filename>missing</>スクリプトを設置するようにしました。 
 (Jim Nasby)
      </para>
@@ -1381,15 +1489,14 @@ MSVCビルドにてインストールされるヘッダファイル群に<filena
    <xref linkend="release-9-2">.
 -->
 このリリースは9.2.13に対し、各種不具合を修正したものです。
-9.2メジャーリリースにおける新機能については、<xref linkend="release-9-2">
-を参照してください。
+9.2メジャーリリースにおける新機能については、<xref linkend="release-9-2">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.2.14</title>
 -->
-   <title>バージョン 9.2.14への移行</title>
+   <title>バージョン9.2.14への移行</title>
 
    <para>
 <!--
@@ -1518,7 +1625,7 @@ Branch: REL9_1_STABLE [9b1b9446f] 2015-08-27 12:22:10 -0400
       Back-patch 9.3-era addition of per-resource-owner lock caches
       (Jeff Janes)
 -->
-9.3時代に加わったリソース所有者ごとのロックキャッシュを後方適用しました。
+9.3時代に加わったリソース所有者ごとのロックキャッシュをより前のバージョンに適用しました。
 (Jeff Janes)
      </para>
 
@@ -1729,7 +1836,6 @@ SSL再ネゴシエーションの使用は理論的には良い考えですが�
 -->
 小さい<varname>work_mem</>設定でタプルストアを使用するときに、<quote>unexpected out-of-memory situation during sort</>エラーになるのを修正しました。
 (Tom Lane)
-
      </para>
     </listitem>
 
@@ -1915,7 +2021,6 @@ GINインデックスで全ゼロページを再利用可能にしました。
 -->
 SP-GiSTインデックスで全ゼロページの扱いを修正しました。
 (Heikki Linnakangas)
-
      </para>
 
      <para>
@@ -2196,7 +2301,6 @@ Branch: REL9_2_STABLE [e90a629e1] 2015-09-22 14:58:38 -0700
       common.
 -->
 <application>gcc</>が一般的になりつつあるネイティブアセンブラを使う構成である場合に、<application>gcc</>でのビルドができませんでした。
-
      </para>
     </listitem>
 
@@ -2235,7 +2339,6 @@ Perlでは5.8.0以降からこの機能に依存しています。
       Avoid use of inline functions when compiling with
       32-bit <application>xlc</>, due to compiler bugs (Noah Misch)
 -->
-
 コンパイラバグのため、32bit <application>xlc</>でインライン関数展開を使わないようにしました。
 (Noah Misch)
      </para>
@@ -2313,15 +2416,14 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
    <xref linkend="release-9-2">.
 -->
 このリリースは9.2.12に対し、各種不具合を修正したものです。
-9.2メジャーリリースにおける新機能については、<xref linkend="release-9-2">
-を参照してください。
+9.2メジャーリリースにおける新機能については、<xref linkend="release-9-2">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.2.13</title>
 -->
-   <title>バージョン 9.2.13への移行</title>
+   <title>バージョン9.2.13への移行</title>
 
    <para>
 <!--
@@ -2420,15 +2522,14 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
    <xref linkend="release-9-2">.
 -->
 このリリースは9.2.11に対し、各種不具合を修正したものです。
-9.2メジャーリリースにおける新機能については、<xref linkend="release-9-2">
-を参照してください。
+9.2メジャーリリースにおける新機能については、<xref linkend="release-9-2">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.2.12</title>
 -->
-<title>バージョン 9.2.12への移行</title>
+   <title>バージョン9.2.12への移行</title>
 
    <para>
 <!--
@@ -2451,7 +2552,7 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
 <!--
    <title>Changes</title>
 -->
-<title>変更点</title>
+   <title>変更点</title>
 
    <itemizedlist>
 
@@ -2538,7 +2639,7 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
 長い間、<application>libpq</>はTLS v1のみのプロトコルが利用できるようにコーディングされていました。
 今ではTLSの新しいバージョンは一般的になったため、最新の一般的にサポートされているTLSバージョンでサーバと調停することを許可しました。
 (<productname>PostgreSQL</>サーバーはすでに調停するこは可能であったため、サーバサイドの変更は必要ありませんでした。)
-これは9.4.0ですでにリリースされている変更のバックパッチです。
+これは9.4.0ですでにリリースされている変更の、より前のバージョンへのパッチです。
      </para>
     </listitem>
 
@@ -2568,15 +2669,14 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
    <xref linkend="release-9-2">.
 -->
 このリリースは9.2.10に対し、各種不具合を修正したものです。
-9.2メジャーリリースにおける新機能については、<xref linkend="release-9-2">
-を参照してください。
+9.2メジャーリリースにおける新機能については、<xref linkend="release-9-2">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.2.11</title>
 -->
-<title>バージョン 9.2.11への移行</title>
+   <title>バージョン9.2.11への移行</title>
 
    <para>
 <!--
@@ -3473,7 +3573,7 @@ Sparc V8 マシンでのコンパイル失敗を修正しました。
 <!--
    <title>Migration to Version 9.2.10</title>
 -->
-<title>バージョン 9.2.10への移行</title>
+   <title>バージョン9.2.10への移行</title>
 
    <para>
 <!--
@@ -4022,7 +4122,7 @@ JSONへのドメインの変換を以前の動作に戻しました。
       deemed a back-patchable bug fix rather than a feature addition.
 -->
 以前のコーディングでは辞書のサイズを超えた場合、クラッシュする可能性がありました。
-このため機能追加ではなくバグフィックスとしてバックパッチしました。
+このため、これは機能追加というより、より前のバージョンにパッチとして適用されたバグフィックスと考えられます。
      </para>
     </listitem>
 
@@ -4883,7 +4983,7 @@ SRET(アジア/スレドネコリムスク)、XJT(アジア/ウルムチ)、西�
 <!--
    <title>Migration to Version 9.2.9</title>
 -->
-<title>バージョン 9.2.9への移行</title>
+   <title>バージョン9.2.9への移行</title>
 
    <para>
 <!--
@@ -4910,7 +5010,6 @@ SRET(アジア/スレドネコリムスク)、XJT(アジア/ウルムチ)、西�
 また、9.2.6よりも前のリリースからアップグレードする場合は、<xref linkend="release-9-2-6">を参照して下さい。
    </para>
 
-
   </sect2>
 
   <sect2>
@@ -4928,7 +5027,6 @@ SRET(アジア/スレドネコリムスク)、XJT(アジア/ウルムチ)、西�
       indexes on <type>bit</> columns (Heikki Linnakangas)
 -->
 <filename>contrib/btree_gist</>拡張モジュールにおける<type>bit</>カラムのインデックスの初期化パディングバイトを修正しました。(Heikki Linnakangas)
-
      </para>
 
      <para>
@@ -5175,7 +5273,6 @@ Appendプラン出力の行全体を参照することによって、<quote>reco
       (Etsuro Fujita)
 -->
 <xref linkend="guc-default-with-oids">がtrueの場合でも、外部テーブルがOID付で作成される事を防止しました。(Etsuro Fujita)
-
      </para>
     </listitem>
 
@@ -6001,7 +6098,6 @@ PLバリデータ関数の主な役割は<command>CREATE FUNCTION</>の中で黙
       Prevent buffer overrun with long datetime strings (Noah Misch)
 -->
 長い日付時刻文字列によるバッファオーバーランを防止しました。(Noah Misch)
-
      </para>
 
      <para>
@@ -6808,8 +6904,8 @@ Cygwin環境で廃止予定の<literal>dllwrap</>ツールの使用を止めま�
     issues.  See the first two changelog entries below to find out whether
     your installation has been affected and what steps you can take if so.
 -->
-しかしながら、本リリースは多くのデータ破損が発生する可能性がある問題を修正しています。下記に示すはじめの2つの変更点を確認し、使用しているインストレーションが影響を受けるか、その場合どのような処
-置を施すべきか判断してください。
+しかしながら、本リリースは多くのデータ破損が発生する可能性がある問題を修正しています。
+下記に示すはじめの2つの変更点を確認し、使用しているインストレーションが影響を受けるか、その場合どのような処置を施すべきか判断してください。
    </para>
 
    <para>
@@ -6818,7 +6914,6 @@ Cygwin環境で廃止予定の<literal>dllwrap</>ツールの使用を止めま�
     see <xref linkend="release-9-2-4">.
 -->
 また、9.2.4以前のリリースからアップグレードする場合は、<xref linkend="release-9-2-4">を参照して下さい。
-
    </para>
 
   </sect2>
@@ -7265,7 +7360,6 @@ Windowsエラーコード変換のログ取得時に発生する可能性があ�
 時間帯データファイルを<application>tzdata</>リリース2013hに更新しました。
 アルゼンチン、ブラジル、ヨルダン、リビア、リヒテンシュタイン、モロッコ、およびパレスチナでの夏時間の変更が含まれます。
 インドネシアで使用されている新しい時間帯の略号、WIB, WIT, WITAが追加されました。
-
      </para>
     </listitem>
 
@@ -7344,7 +7438,6 @@ Windowsエラーコード変換のログ取得時に発生する可能性があ�
       when using a single-byte server encoding.
 -->
 シングルバイトのサーバエンコーディングを使用している場合のみ、<productname>PostgreSQL</>が非ASCII文字の大文字変換を行います。
-
      </para>
     </listitem>
 
@@ -10422,9 +10515,6 @@ btreeおよびGINインデックスが破損する可能性は低いです。
 -->
 接頭辞、つまり<replaceable>word</><literal>:*</>のパターンを含むテキスト検索の問い合わせについて、選択性の推定を改善しました。(Tom Lane)
      </para>
-
-     <para>
-     </para>
     </listitem>
 
     <listitem>
@@ -11159,7 +11249,6 @@ WALファイルが書き込まれた時に、その更新をアーカイブす�
         to <structfield>pid</>, to match other system tables (Magnus Hagander)
 -->
 <link linkend="monitoring-stats-views-table"><structname>pg_stat_activity</></link><structfield>.procpid</>の名前を<structfield>pid</>に変更し、他のシステムテーブルと同じようにしました。(Magnus Hagander)
-
        </para>
       </listitem>
 
@@ -12347,13 +12436,10 @@ Windowsで<filename>postgresql.conf</filename>の行番号が報告されるよ�
 <!--
         Cancel the running query if the client gets disconnected
         (Florian Pflug)
-
 -->
 クライアントが切断されたら、実行中の問い合わせを取り消すようにしました。(Florian Pflug)
        </para>
-      </listitem>
 
-      <listitem>
        <para>
 <!--
         If the backend detects loss of client connection during a query, it

--- a/doc/src/sgml/release-9.3.sgml
+++ b/doc/src/sgml/release-9.3.sgml
@@ -2,46 +2,73 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-3-13">
+<!--
   <title>Release 9.3.13</title>
+-->
+  <title>リリース9.3.13</title>
 
   <note>
+<!--
   <title>Release Date</title>
+-->
+  <title>リリース日</title>
   <simpara>2016-05-12</simpara>
   </note>
 
   <para>
+<!--
    This release contains a variety of fixes from 9.3.12.
    For information about new features in the 9.3 major release, see
    <xref linkend="release-9-3">.
+-->
+このリリースは9.3.12に対し、各種不具合を修正したものです。
+9.3メジャーリリースにおける新機能については、<xref linkend="release-9-3">を参照してください。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.3.13</title>
+-->
+   <title>バージョン9.3.13への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.3.X.
+-->
+9.3.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if you are upgrading from a version earlier than 9.3.9,
     see <xref linkend="release-9-3-9">.
+-->
+また、9.3.9よりも前のバージョンからアップグレードする場合には、<xref linkend="release-9-3-9">を参照してください。
    </para>
 
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Clear the OpenSSL error queue before OpenSSL calls, rather than
       assuming it's clear already; and make sure we leave it clear
       afterwards (Peter Geoghegan, Dave Vitek, Peter Eisentraut)
+-->
+OpenSSLを呼び出す前にそのエラーキューを、既に消去されているとみなすのではなく、消去します。また、必ず後に消去しておくようにします。
+(Peter Geoghegan, Dave Vitek, Peter Eisentraut)
      </para>
 
      <para>
+<!--
       This change prevents problems when there are multiple connections
       using OpenSSL within a single process and not all the code involved
       follows the same rules for when to clear the error queue.
@@ -50,24 +77,37 @@
       SSL connections using the PHP, Python, or Ruby wrappers for OpenSSL.
       It's possible for similar problems to arise within the server as well,
       if an extension module establishes an outgoing SSL connection.
+-->
+この変更は、一つのプロセスの中でOpenSSLを使った複数の接続があって、含まれるコードの全てがエラーキューを消去するとき同一規則に従っていない場合の問題を防ぎます。
+特に、クライアントアプリケーションがPHPやPython、RubyのOpenSSLラッパーを使ったSSL接続と同時に、<application>libpq</>でSSL接続を使っているときに、障害が報告されました。
+拡張モジュールが外にむけたSSL接続をするのであれば、同様にサーバでも似た問題が起こる可能性があります。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <quote>failed to build any <replaceable>N</>-way joins</quote>
       planner error with a full join enclosed in the right-hand side of a
       left join (Tom Lane)
+-->
+左外部結合の右手側に入っている完全外部結合でのプランナのエラー<quote>failed to build any <replaceable>N</>-way joins (N個立ての結合の構築にいずれも失敗しました)</quote>を修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect handling of equivalence-class tests in multilevel
       nestloop plans (Tom Lane)
+-->
+複数階層の入れ子ループプランにおける等価クラス検査の誤った扱いを修正しました。
+ (Tom Lane)
      </para>
 
      <para>
+<!--
       Given a three-or-more-way equivalence class of variables, such
       as <literal>X.X = Y.Y = Z.Z</>, it was possible for the planner to omit
       some of the tests needed to enforce that all the variables are actually
@@ -75,71 +115,111 @@
       the <literal>WHERE</> clauses.  For various reasons, erroneous plans
       were seldom selected in practice, so that this bug has gone undetected
       for a long time.
+-->
+<literal>X.X = Y.Y = Z.Z</>のような、3つ以上からなる変数の等価クラスが与えられると、プランナが全ての変数が実際に等しいようにするために必要な検査の一部を怠る可能性があり、出力される行が<literal>WHERE</>句を満たさない結合をもたらしました。
+さまざまな理由のため、誤ったプランは実際には滅多に選択されません。
+そのため、このバグは長い間気づかれずにきました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible misbehavior of <literal>TH</>, <literal>th</>,
       and <literal>Y,YYY</> format codes in <function>to_timestamp()</>
       (Tom Lane)
+-->
+<function>to_timestamp()</>の書式コード<literal>TH</>、<literal>th</>、<literal>Y,YYY</>の誤った振る舞いを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       These could advance off the end of the input string, causing subsequent
       format codes to read garbage.
+-->
+これにより、入力文字列の末尾を超えて進み、次の書式コードでゴミが読まれるおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix dumping of rules and views in which the <replaceable>array</>
       argument of a <literal><replaceable>value</> <replaceable>operator</>
       ANY (<replaceable>array</>)</literal> construct is a sub-SELECT
       (Tom Lane)
+-->
+<literal><replaceable>value</> <replaceable>operator</> ANY (<replaceable>array</>)</literal>という構造の<replaceable>array</>引数が副問い合わせである場合のルールとビューのダンプを修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Make <application>pg_regress</> use a startup timeout from the
       <envar>PGCTLTIMEOUT</> environment variable, if that's set (Tom Lane)
+-->
+<envar>PGCTLTIMEOUT</>環境変数が設定されているなら、<application>pg_regress</>がその値による起動タイムアウトを適用するようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This is for consistency with a behavior recently added
       to <application>pg_ctl</>; it eases automated testing on slow machines.
+-->
+これは、最近<application>pg_ctl</>に追加された振る舞いとの一貫性のためで、
+遅いマシンでの自動テストを容易にします。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_upgrade</> to correctly restore extension
       membership for operator families containing only one operator class
       (Tom Lane)
+-->
+一つの演算子クラスだけを含む演算子族の拡張への所属を正しくリストアできるように<application>pg_upgrade</>を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       In such a case, the operator family was restored into the new database,
       but it was no longer marked as part of the extension.  This had no
       immediate ill effects, but would cause later <application>pg_dump</>
       runs to emit output that would cause (harmless) errors on restore.
+-->
+このような場合、演算子族は新しいデータベースにリストアされますが、もはや拡張の一部として記されませんでした。
+これは直ちには悪影響はありませんが、後に<application>pg_dump</>がリストア時に（無害な）エラーを引き起こす出力を吐き出す原因となりました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_upgrade</> to not fail when new-cluster TOAST rules
       differ from old (Tom Lane)
+-->
+新たなクラスタのTOAST規則が古いクラスタと異なるとき失敗しないように<application>pg_upgrade</>を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       <application>pg_upgrade</> had special-case code to handle the
       situation where the new <productname>PostgreSQL</> version thinks that
       a table should have a TOAST table while the old version did not.  That
       code was broken, so remove it, and instead do nothing in such cases;
       there seems no reason to believe that we can't get along fine without
       a TOAST table if that was okay according to the old version's rules.
+-->
+<application>pg_upgrade</>には、新しい<productname>PostgreSQL</>バージョンが、古いバージョンには無いけれどこのテーブルはTOASTテーブルを持つべきとみなした場合を扱う特別な場合のコードがありました。
+このコードは壊れていたため除去し、このような場合には代わりに何もしません。
+古いバージョンの規則に従って問題ないなら、TOASTテーブルがないとうまくいかないと思う理由がないように思われます。
      </para>
     </listitem>
 
@@ -156,73 +236,113 @@ Branch: REL9_3_STABLE [35166fd76] 2016-04-18 13:19:52 -0400
 Branch: REL9_2_STABLE [37f30b251] 2016-04-18 13:19:52 -0400
 -->
      <para>
+<!--
       Back-port 9.4-era memory-barrier code changes into 9.2 and 9.3 (Tom Lane)
+-->
+9.4のメモリバリアコードの変更を9.2と9.3にバックポートしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       These changes were not originally needed in pre-9.4 branches, but we
       recently back-patched a fix that expected the barrier code to work
       properly.  Only IA64 (when using icc), HPPA, and Alpha platforms are
       affected.
+-->
+この変更は本来9.4より前のブランチでは必要ありませんでしたが、バリアコードが正しく動くようにする修正を最近、より前のバージョンにパッチとして適用しました。
+(iccを使用した時の)IA64、HPPA、Alphaプラットフォームのみに影響します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Reduce the number of SysV semaphores used by a build configured with
-      <option>--disable-spinlocks</> (Tom Lane)
+      <option>&#045;&#045;disable-spinlocks</> (Tom Lane)
+-->
+<option>--disable-spinlocks</>と設定されたビルドで、使用されるSysVセマフォの数を減らしました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Rename internal function <function>strtoi()</>
       to <function>strtoint()</> to avoid conflict with a NetBSD library
       function (Thomas Munro)
+-->
+NetBSDのライブラリ関数との衝突を避けるため、内部関数<function>strtoi()</>の名前を<function>strtoint()</>に変えました。
+(Thomas Munro)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix reporting of errors from <function>bind()</>
       and <function>listen()</> system calls on Windows (Tom Lane)
+-->
+Windowsにおけるシステムコール<function>bind()</>と<function>listen()</>からのエラー報告を修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Reduce verbosity of compiler output when building with Microsoft Visual
       Studio (Christian Ullrich)
+-->
+Microsoft Visual Studioでビルドするときのコンパイラ出力の冗長さを減らしました。
+(Christian Ullrich)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <function>putenv()</> to work properly with Visual Studio 2013
       (Michael Paquier)
+-->
+Visual Studio 2013で適切に動作するように<function>putenv()</>を修正しました。
+(Michael Paquier)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid possibly-unsafe use of Windows' <function>FormatMessage()</>
       function (Christian Ullrich)
+-->
+Windowsの<function>FormatMessage()</>関数の安全でない可能性のある使用を回避しました。
+(Christian Ullrich)
      </para>
 
      <para>
+<!--
       Use the <literal>FORMAT_MESSAGE_IGNORE_INSERTS</> flag where
       appropriate.  No live bug is known to exist here, but it seems like a
       good idea to be careful.
+-->
+適切に<literal>FORMAT_MESSAGE_IGNORE_INSERTS</>フラグを使用します。
+これに関連した既知の未修整バグはありませんが、注意深くすることは良い考えと思われます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Update time zone data files to <application>tzdata</> release 2016d
       for DST law changes in Russia and Venezuela.  There are new zone
       names <literal>Europe/Kirov</> and <literal>Asia/Tomsk</> to reflect
       the fact that these regions now have different time zone histories from
       adjacent regions.
+-->
+タイムゾーンデータファイルを<application>tzdata</> release 2016dに更新しました。
+ロシア、ベネズエラの夏時間法の変更、当該地域は今では隣接した地域とは異なるタイムゾーンの歴史を持っているという事実を反映させた新しい地域名<literal>Europe/Kirov</>、<literal>Asia/Tomsk</>が含まれます。
      </para>
     </listitem>
 
@@ -259,7 +379,7 @@ Branch: REL9_2_STABLE [37f30b251] 2016-04-18 13:19:52 -0400
 <!--
    <title>Migration to Version 9.3.12</title>
 -->
-   <title>バージョン 9.3.12への移行</title>
+   <title>バージョン9.3.12への移行</title>
 
    <para>
 <!--
@@ -369,7 +489,6 @@ Branch: REL9_2_STABLE [37f30b251] 2016-04-18 13:19:52 -0400
       Avoid use of <function>sscanf()</> to parse <literal>ispell</>
       dictionary files (Artur Zakirov)
 -->
-
 <literal>ispell</>辞書ファイルを解析するのに<function>sscanf()</>を使わないようにしました。
 (Artur Zakirov)
      </para>
@@ -494,7 +613,6 @@ Branch: REL9_2_STABLE [37f30b251] 2016-04-18 13:19:52 -0400
       Momjian)
 -->
 <application>pg_upgrade</>で、新データディレクトリが旧データディレクトリ内に在るとき、削除スクリプトの作成を省略するようにしました。
-
      </para>
 
      <para>
@@ -598,7 +716,7 @@ Perl本体からもはや提供されなくなったため、MSVCビルドで<li
 <!--
    <title>Migration to Version 9.3.11</title>
 -->
-   <title>バージョン 9.3.11への移行</title>
+   <title>バージョン9.3.11への移行</title>
 
    <para>
 <!--
@@ -1481,7 +1599,6 @@ Python 3.5で通るように<application>PL/Python</>のリグレッションテ
       Install our <filename>missing</> script where PGXS builds can find it
       (Jim Nasby)
 -->
-
 PGXSビルドで見つけられる場所に<filename>missing</>スクリプトを設置するようにしました。 
 (Jim Nasby)
      </para>
@@ -1566,15 +1683,14 @@ MSVCビルドにてインストールされるヘッダファイル群に<filena
    <xref linkend="release-9-3">.
 -->
 このリリースは9.3.9に対し、各種不具合を修正したものです。
-9.3メジャーリリースにおける新機能については、<xref linkend="release-9-3">
-を参照してください。
+9.3メジャーリリースにおける新機能については、<xref linkend="release-9-3">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.3.10</title>
 -->
-   <title>バージョン 9.3.10への移行</title>
+   <title>バージョン9.3.10への移行</title>
 
    <para>
 <!--
@@ -1955,7 +2071,6 @@ SSL再ネゴシエーションの使用は理論的には良い考えですが�
 -->
 小さい<varname>work_mem</>設定でタプルストアを使用するときに、<quote>unexpected out-of-memory situation during sort</>エラーになるのを修正しました。
 (Tom Lane)
-
      </para>
     </listitem>
 
@@ -2152,7 +2267,6 @@ GINインデックスで全ゼロページを再利用可能にしました。
 -->
 SP-GiSTインデックスで全ゼロページの扱いを修正しました。
 (Heikki Linnakangas)
-
      </para>
 
      <para>
@@ -2437,7 +2551,6 @@ subtrans/multixactの切捨て処理で、<quote>apparent wraparound</>に関す
       common.
 -->
 <application>gcc</>が一般的になりつつあるネイティブアセンブラを使う構成である場合に、<application>gcc</>でのビルドができませんでした。
-
      </para>
     </listitem>
 
@@ -2476,7 +2589,6 @@ Perlでは5.8.0以降からこの機能に依存しています。
       Avoid use of inline functions when compiling with
       32-bit <application>xlc</>, due to compiler bugs (Noah Misch)
 -->
-
 コンパイラバグのため、32bit <application>xlc</>でインライン関数展開を使わないようにしました。
 (Noah Misch)
      </para>
@@ -2554,15 +2666,14 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
    <xref linkend="release-9-3">.
 -->
 このリリースは9.3.8に対し、各種不具合を修正したものです。
-9.3メジャーリリースにおける新機能については、<xref linkend="release-9-3">
-を参照してください。
+9.3メジャーリリースにおける新機能については、<xref linkend="release-9-3">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.3.9</title>
 -->
-   <title>バージョン 9.3.9への移行</title>
+   <title>バージョン9.3.9への移行</title>
 
    <para>
 <!--
@@ -2780,15 +2891,14 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
    <xref linkend="release-9-3">.
 -->
 このリリースは9.3.7に対し、各種不具合を修正したものです。
-9.3メジャーリリースにおける新機能については、<xref linkend="release-9-3">
-を参照してください。
+9.3メジャーリリースにおける新機能については、<xref linkend="release-9-3">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.3.8</title>
 -->
-   <title>バージョン 9.3.8への移行</title>
+   <title>バージョン9.3.8への移行</title>
 
    <para>
 <!--
@@ -2915,7 +3025,7 @@ Branch: REL9_0_STABLE [4dddf8552] 2015-05-21 20:41:55 -0400
 長い間、<application>libpq</>はTLS v1のみのプロトコルが利用できるようにコーディングされていました。
 今ではTLSの新しいバージョンは一般的になったため、最新の一般的にサポートされているTLSバージョンでサーバと調停することを許可しました。
 (<productname>PostgreSQL</>サーバーはすでに調停するこは可能であったため、サーバサイドの変更は必要ありませんでした。)
-これは9.4.0ですでにリリースされている変更のバックパッチです。
+これは9.4.0ですでにリリースされている変更の、より前のバージョンへのパッチです。
      </para>
     </listitem>
 
@@ -2945,15 +3055,14 @@ Branch: REL9_0_STABLE [4dddf8552] 2015-05-21 20:41:55 -0400
    <xref linkend="release-9-3">.
 -->
 このリリースは9.3.6に対し、各種不具合を修正したものです。
-9.3メジャーリリースにおける新機能については、<xref linkend="release-9-3">
-を参照してください。
+9.3メジャーリリースにおける新機能については、<xref linkend="release-9-3">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.3.7</title>
 -->
-   <title>バージョン 9.3.7への移行</title>
+   <title>バージョン9.3.7への移行</title>
 
    <para>
 <!--
@@ -3867,7 +3976,7 @@ OS X での一部のビルド警告を黙らせました。
 <!--
    <title>Migration to Version 9.3.6</title>
 -->
-<title>バージョン 9.3.6への移行</title>
+   <title>バージョン9.3.6への移行</title>
 
    <para>
 <!--
@@ -4752,7 +4861,7 @@ Branch: REL9_0_STABLE [39493e4d9] 2014-11-06 20:53:07 -0500
       deemed a back-patchable bug fix rather than a feature addition.
 -->
 以前のコーディングでは辞書のサイズを超えた場合、クラッシュする可能性がありました。
-このため機能追加ではなくバグフィックスとしてバックパッチしました。
+このため、これは機能追加というより、より前のバージョンにパッチとして適用されたバグフィックスと考えられます。
      </para>
     </listitem>
 
@@ -5462,7 +5571,6 @@ Branch: REL9_0_STABLE [2600e4436] 2014-12-31 12:17:12 -0500
       all values for all these variables case-insensitively; previously
       there was a mishmash of case-sensitive and case-insensitive behaviors.
 -->
-
 <literal>ECHO_HIDDEN</>と<literal>ON_ERROR_ROLLBACK</>に対して<literal>on</>と<literal>off</>を異なる書き方（<literal>1</>/<literal>0</>など）で書けるようになります。
 <literal>COMP_KEYWORD_CASE</>、<literal>ECHO</>、<literal>ECHO_HIDDEN</>、<literal>HISTCONTROL</>、<literal>ON_ERROR_ROLLBACK</>、および、<literal>VERBOSITY</>に対して解釈できない値には警告するようになります。
 全ての特別変数の値について大文字小文字の区別なく受け付けるようになります。
@@ -6091,7 +6199,6 @@ Branch: REL9_3_STABLE [05c0059b3] 2014-07-30 12:10:20 -0400
       (Robert Haas)
 -->
 例えばWindowsなどでのEXEC_BACKENDビルド中のバックグラウンドワーカーのセットアップを修正しました。
-
      </para>
     </listitem>
 
@@ -6347,7 +6454,7 @@ SRET(アジア/スレドネコリムスク)、XJT(アジア/ウルムチ)、西�
 <!--
    <title>Migration to Version 9.3.5</title>
 -->
-<title>バージョン 9.3.5への移行</title>
+   <title>バージョン9.3.5への移行</title>
 
    <para>
 <!--
@@ -6355,7 +6462,6 @@ SRET(アジア/スレドネコリムスク)、XJT(アジア/ウルムチ)、西�
 -->
 9.3.Xからの移行ではダンプ/リストアは不要です。
    </para>
-
 
    <para>
 <!--
@@ -6453,8 +6559,8 @@ Branch: REL8_4_STABLE [e31d77c96] 2014-05-13 15:27:43 +0300
       Correctly initialize padding bytes in <filename>contrib/btree_gist</>
       indexes on <type>bit</> columns (Heikki Linnakangas)
 -->
-<filename>contrib/btree_gist</>拡張モジュールにおける<type>bit</>カラムのインデックスの初期化パディングバイトを修正しました。(Heikki Linnakangas)
-
+<filename>contrib/btree_gist</>拡張モジュールにおける<type>bit</>カラムのインデックスの初期化パディングバイトを修正しました。
+(Heikki Linnakangas)
      </para>
 
      <para>
@@ -8415,7 +8521,6 @@ Branch: REL8_4_STABLE [6e6c2c2e1] 2014-03-15 13:36:57 -0400
 その為のもっとも簡単な方法は、疑いのある制約を削除し、再作成することです。
 しかしながら、両方のテーブルには排他ロックを必要とするでしょう。そのため、本番データベースでは受け入れがたいかもしれません。
 その代りとして、一致しない行を探す為に２つのテーブルを結合するクエリーを手動で実行することも可能です。
-
    </para>
 
    <para>
@@ -8573,7 +8678,6 @@ Branch: REL8_4_STABLE [d0ed1a6c0] 2014-02-17 09:33:39 -0500
       Prevent buffer overrun with long datetime strings (Noah Misch)
 -->
 長い日付時刻文字列によるバッファオーバーランを防止しました。(Noah Misch)
-
      </para>
 
      <para>
@@ -8774,7 +8878,6 @@ Branch: REL9_3_STABLE [8e9a16ab8] 2013-12-16 11:29:51 -0300
 これはスタントアロン・サーバでは問題ではないものの、レプリケーションを使用した場合、<emphasis>スタンバイサーバはマスタサーバより先に9.3.3かそれ以上にアップグレードしなければならない</>ことを意味します。
 古いスタンバイサーバは新しいマスタサーバで生成される凍結レコードを解釈できず、パニックメッセージを吐いて失敗します。
 （このような場合、スタンバイサーバの再起動はアップグレードをする良い機会かもしれません）
-
      </para>
     </listitem>
 
@@ -8842,13 +8945,9 @@ Branch: REL9_3_STABLE [db1014bc4] 2013-12-18 13:31:27 -0300
       have any types of row locking that would permit another transaction
       to update the row at all.
 -->
-ある行がトランザクションAでロックされ、トランザクションBで更新された場合、
-新しいバージョンでは、Bからだけ見え、Aからロックされた行がBによって作成されます。
-トランザクションBでその行を再度更新した場合、Aのロックはチェックされないため、
-ロックされるべき場合でも、Bによる更新が完了してしまいます。
-以前のバージョンでは、他のトランザクションで行の更新が許可されてしまうのをブロックする、
-いかなるタイプの行ロックも持っていなかったため、9.3では新しくこのケースを追加しました。
-
+ある行がトランザクションAでロックされ、トランザクションBで更新された場合、新しいバージョンでは、Bからだけ見え、Aからロックされた行がBによって作成されます。
+トランザクションBでその行を再度更新した場合、Aのロックはチェックされないため、ロックされるべき場合でも、Bによる更新が完了してしまいます。
+以前のバージョンでは、他のトランザクションで行の更新が許可されてしまうのをブロックする、いかなるタイプの行ロックも持っていなかったため、9.3では新しくこのケースを追加しました。
      </para>
 
      <para>
@@ -10309,8 +10408,8 @@ Branch: REL8_4_STABLE [c0c2d62ac] 2014-02-14 21:59:56 -0500
     issues.  See the first three changelog entries below to find out whether
     your installation has been affected and what steps you can take if so.
 -->
-しかしながら、本リリースは多くのデータ破損が発生する可能性がある問題を修正しています。下記に示すはじめの3つの変更ログを確認し、使用しているインストレーションが影響を受けるか、その場合どのような処置を施すべきか判断してください。
-
+しかしながら、本リリースは多くのデータ破損が発生する可能性がある問題を修正しています。
+下記に示すはじめの3つの変更ログを確認し、使用しているインストレーションが影響を受けるか、その場合どのような処置を施すべきか判断してください。
    </para>
 
    <para>
@@ -10324,7 +10423,6 @@ Branch: REL8_4_STABLE [c0c2d62ac] 2014-02-14 21:59:56 -0500
   </sect2>
 
   <sect2>
-
 <!--
    <title>Changes</title>
 -->
@@ -10338,8 +10436,8 @@ Branch: REL8_4_STABLE [c0c2d62ac] 2014-02-14 21:59:56 -0500
       Fix <command>VACUUM</>'s tests to see whether it can
       update <structfield>relfrozenxid</> (Andres Freund)
 -->
-<structfield>relfrozenxid</>の値を更新するかどうか判定する<command>VACUUM</>の処理を修正しました。(Andres Freund)
-
+<structfield>relfrozenxid</>の値を更新するかどうか判定する<command>VACUUM</>の処理を修正しました。
+(Andres Freund)
      </para>
 
      <para>
@@ -11057,21 +11155,18 @@ Windowsエラーコード変換のログ取得時に発生する可能性があ�
 <!--
       Users who upgraded a pre-9.3 database containing <literal>hstore</>
       should execute
-<programlisting>
-ALTER EXTENSION hstore UPDATE;
-</programlisting>
-      after installing 9.3.1, to add two new JSON functions and a cast.
-      (If <literal>hstore</> is already up to date, this command does
-      nothing.)
 -->
 <literal>hstore</>を含む9.3以前のデータベースをアップグレードした場合、以下を実行すべきです。
 <programlisting>
 ALTER EXTENSION hstore UPDATE;
 </programlisting>
+<!--
+      after installing 9.3.1, to add two new JSON functions and a cast.
+      (If <literal>hstore</> is already up to date, this command does
+      nothing.)
+-->
 9.3.1をインストール後、2つの新しいJSON関数と1つのキャストを追加すべきです。
 (<literal>hstore</>が既に最新になっている場合、このコマンドは何もしません。)
-
-
      </para>
     </listitem>
 
@@ -11152,7 +11247,6 @@ SSLを使うときの、libpのデッドロックの不具合を修正しまし�
 <!--
   <title>Release 9.3</title>
 -->
-
   <title>リリース9.3</title>
 
   <note>
@@ -11197,7 +11291,6 @@ SSLを使うときの、libpのデッドロックの不具合を修正しまし�
       linkend="SQL-CREATEVIEW-updatable-views">auto-updatable</link>
 -->
 単純なビューを<link linkend="SQL-CREATEVIEW-updatable-views">自動更新可能(auto-updatable)</link>にしました。
-
      </para>
     </listitem>
 
@@ -11231,7 +11324,6 @@ SSLを使うときの、libpのデッドロックの不具合を修正しまし�
       tables
 -->
 <link linkend="SQL-CREATEFOREIGNDATAWRAPPER">外部データラッパ</link>で外部テーブルへの書き込み(挿入/更新/削除)が出来るようになりました。
-
      </para>
     </listitem>
 
@@ -11282,7 +11374,6 @@ SSLを使うときの、libpのデッドロックの不具合を修正しまし�
       memory</link> requirements
 -->
 System Vにおける<link linkend="sysvipc">共有メモリ</link>の要件を大幅に削減しました。
-
      </para>
     </listitem>
 
@@ -11313,7 +11404,6 @@ System Vにおける<link linkend="sysvipc">共有メモリ</link>の要件を�
 -->
 以前のリリースからデータを移行したい時は、どのリリースについても、<link linkend="APP-PG-DUMPALL"><application>pg_dumpall</></link>を利用したダンプとリストア、
 あるいは<link linkend="pgupgrade"><application>pg_upgrade</></link>の利用が必要です。
-
    </para>
 
    <para>
@@ -11424,8 +11514,8 @@ System Vにおける<link linkend="sysvipc">共有メモリ</link>の要件を�
         that modifies rows that are later modified by the query itself.
         Such cases likewise previously resulted in silently skipping updates.
 -->
-このエラーは、クエリがそのクエリ自身によって、後で変更された行を変更するvolatile関数を呼び出す場合に投げられます。このような例は同様に、このような例は同様に、以前は何も発することなく更新をスキップしていました。
-
+このエラーは、クエリがそのクエリ自身によって、後で変更された行を変更するvolatile関数を呼び出す場合に投げられます。
+このような例は同様に、以前は何も発することなく更新をスキップしていました。
        </para>
       </listitem>
 
@@ -11449,7 +11539,6 @@ System Vにおける<link linkend="sysvipc">共有メモリ</link>の要件を�
 -->
 以前は、<command>UPDATE</>文で変更された参照列に該当する列のみ設定されていました。これはSQL-92版で要求されていたものですが、より新しい版のSQL標準では、この新しい動作が明記されています。
        </para>
-
       </listitem>
 
       <listitem>
@@ -11459,8 +11548,8 @@ System Vにおける<link linkend="sysvipc">共有メモリ</link>の要件を�
         linkend="guc-search-path"><varname>search_path</></link> changes
         (Tom Lane)
 -->
-<link linkend="guc-search-path"><varname>search_path</></link>が変わった場合、キャッシュされた計画が再計画されるようになりました。(Tom Lane)
-
+<link linkend="guc-search-path"><varname>search_path</></link>が変わった場合、キャッシュされた計画が再計画されるようになりました。
+(Tom Lane)
        </para>
 
        <para>
@@ -11501,8 +11590,8 @@ System Vにおける<link linkend="sysvipc">共有メモリ</link>の要件を�
         set-returning functions in their arguments to properly return null
         rows (Tom Lane)
 -->
-集合以外を返す<literal>STRICT</>関数の引数に集合を返す関数があるとき、適切にNULLを返すように修正しました。(Tom Lane)
-
+集合以外を返す<literal>STRICT</>関数の引数に集合を返す関数があるとき、適切にNULLを返すように修正しました。
+(Tom Lane)
        </para>
 
        <para>
@@ -11511,7 +11600,6 @@ System Vにおける<link linkend="sysvipc">共有メモリ</link>の要件を�
         output, but instead, that output row was suppressed entirely.
 -->
 strict関数にわたったNULL値は、出力行が完全に隠されるのではなく、NULLという結果に終わるべきです。
-
        </para>
       </listitem>
 
@@ -11624,8 +11712,8 @@ strict関数にわたったNULL値は、出力行が完全に隠されるので�
         allow limiting how long a session will wait to acquire any one lock
         (Zolt&aacute;n B&ouml;sz&ouml;rm&eacute;nyi)
 -->
-セッションがロックを獲得するまで待機する時間を制限できるようにするために、設定変数<link linkend="guc-lock-timeout"><varname>lock_timeout</></link>を追加しました。(Zolt&aacute;n B&ouml;sz&ouml;rm&eacute;nyi)
-
+セッションがロックを獲得するまで待機する時間を制限できるようにするために、設定変数<link linkend="guc-lock-timeout"><varname>lock_timeout</></link>を追加しました。
+(Zolt&aacute;n B&ouml;sz&ouml;rm&eacute;nyi)
        </para>
       </listitem>
 
@@ -11679,7 +11767,6 @@ strict関数にわたったNULL値は、出力行が完全に隠されるので�
 -->
 ハッシュインデックス操作の同時実効性を改善しました。(Robert Haas)
        </para>
-
       </listitem>
 
      </itemizedlist>
@@ -11720,8 +11807,8 @@ strict関数にわたったNULL値は、出力行が完全に隠されるので�
         Improve optimizer's hash table size estimate for
         doing <literal>DISTINCT</> via hash aggregation (Tom Lane)
 -->
-ハッシュ集約を使用した<literal>DISTINCT</>について、オプティマイザによるハッシュテーブルサイズの見積もりを改善しました。(Tom Lane)
-
+ハッシュ集約を使用した<literal>DISTINCT</>について、オプティマイザによるハッシュテーブルサイズの見積もりを改善しました。
+(Tom Lane)
        </para>
       </listitem>
 
@@ -11852,8 +11939,8 @@ Vacuumが無効になったタプルを削除した後に、可視性を再検�
         Avoid scanning the entire relation cache at commit of a transaction
         that creates a new relation (Jeff Janes)
 -->
-新しいリレーションを作るトランザクションのコミット時に、すべてのリレーションキャッシュをスキャンすることをやめました。(Jeff Janes)
-
+新しいリレーションを作るトランザクションのコミット時に、すべてのリレーションキャッシュをスキャンすることをやめました。
+(Jeff Janes)
        </para>
 
        <para>
@@ -11929,8 +12016,8 @@ Vacuumが無効になったタプルを削除した後に、可視性を再検�
         Fix the statistics collector to operate properly in cases where the
         system clock goes backwards (Tom Lane)
 -->
-システム時刻が後戻りしても、適切に操作できるように統計情報コレクタを修正しました。(Tom Lane)
-
+システム時刻が後戻りしても、適切に操作できるように統計情報コレクタを修正しました。
+(Tom Lane)
        </para>
 
        <para>
@@ -11971,7 +12058,6 @@ postmasterが標準エラーへのログ出力を終了する前に、標準エ�
      <title>Authentication</title>
 -->
      <title>認証</title>
-
 
      <itemizedlist>
 
@@ -12353,8 +12439,8 @@ postmasterが複数のUnixドメインソケットを監視できるようにし
         linkend="queries-lateral"><literal>LATERAL</></link> option for
         <literal>FROM</>-clause subqueries and function calls (Tom Lane)
 -->
-<literal>FROM</>句の副問い合わせや関数呼び出しで使用できる<acronym>SQL</>標準<link linkend="queries-lateral">の<literal>LATERAL</></link>オプションを実装しました。(Tom Lane)
-
+<literal>FROM</>句の副問い合わせや関数呼び出しで使用できる<acronym>SQL</>標準<link linkend="queries-lateral">の<literal>LATERAL</></link>オプションを実装しました。
+(Tom Lane)
        </para>
 
        <para>
@@ -12667,8 +12753,8 @@ postmasterが複数のUnixドメインソケットを監視できるようにし
         manufactured table and column aliases when needed to preserve the
         original semantics.
 -->
-テーブル名と列名の変更により、ルールやビューの文字列に新しい名前を用いるだけの場合、結果があいまいになることがありました。この変更では、ルールで生まれるコードが作成したテーブルや列の別名を必要に応じて挿入することで、元の意味を保存します。
-
+テーブル名と列名の変更により、ルールやビューの文字列に新しい名前を用いるだけの場合、結果があいまいになることがありました。
+この変更では、ルールで生まれるコードが作成したテーブルや列の別名を必要に応じて挿入することで、元の意味を保存します。
        </para>
       </listitem>
 
@@ -12683,7 +12769,6 @@ postmasterが複数のUnixドメインソケットを監視できるようにし
     <title>Data Types</title>
 -->
     <title>データ型</title>
-
 
     <itemizedlist>
 
@@ -13015,8 +13100,8 @@ PL/PythonにOIDを適切なPythonのnumeric型に変換させるようにしま�
         explicitly (with PL/Python's <literal>RAISE</>) the same as
         internal <acronym>SPI</> errors (Oskari Saarenmaa and Jan Urbanski)
 -->
-(PL/Pythonの<literal>RAISE</>などで、)明示的に出力された<link linkend="spi"><acronym>SPI</></link>エラーを、内部的な<acronym>SPI</>エラーと同様に扱えるようになりました。(Oskari Saarenmaa and Jan Urbanski)
-
+(PL/Pythonの<literal>RAISE</>などで、)明示的に出力された<link linkend="spi"><acronym>SPI</></link>エラーを、内部的な<acronym>SPI</>エラーと同様に扱えるようになりました。
+(Oskari SaarenmaaとJan Urbanski)
        </para>
       </listitem>
 
@@ -13612,8 +13697,8 @@ libpgcommonを作成し、<function>pg_malloc()</>と他の関数をそこに移
         linkend="SQL-CREATEINDEX"><command>CREATE INDEX
         CONCURRENTLY</></link> (Abhijit Menon-Sen)
 -->
-<link linkend="SQL-CREATEINDEX"><command>CREATE INDEX CONCURRENTLY</></link>に対する隔離性テストを追加しました。(Abhijit Menon-Sen)
-
+<link linkend="SQL-CREATEINDEX"><command>CREATE INDEX CONCURRENTLY</></link>に対する隔離性テストを追加しました。
+(Abhijit Menon-Sen)
        </para>
       </listitem>
 
@@ -13683,8 +13768,8 @@ pgindentが、<application>Perl</>で書き直されました。(Andrew Dunstan)
         Change the way <literal>UESCAPE</> is lexed, to significantly reduce
         the size of the lexer tables (Heikki Linnakangas)
 -->
-<literal>UESCAPE</>の解析方法を変更し、字句解析テーブルのサイズが大幅に小さくなりました。(Heikki Linnakangas)
-
+<literal>UESCAPE</>の解析方法を変更し、字句解析テーブルのサイズが大幅に小さくなりました。
+(Heikki Linnakangas)
        </para>
       </listitem>
 
@@ -13767,8 +13852,8 @@ pgindentが、<application>Perl</>で書き直されました。(Andrew Dunstan)
         Implement a generic binary heap and use it for Merge-Append
         operations (Abhijit Menon-Sen)
 -->
-汎用バイナリヒープが実装しました。これは、マージ、アペンド操作に使用されます。 (Abhijit Menon-Sen)
-
+汎用バイナリヒープが実装しました。これは、マージ、アペンド操作に使用されます。
+(Abhijit Menon-Sen)
        </para>
       </listitem>
 
@@ -13921,8 +14006,8 @@ Mac <productname>OS X</>上の<link linkend="plpython">PL/Python</link>が、カ
         of <productname>pg_trgm</> indexes for non-ASCII data.  In such cases,
         <command>REINDEX</> those indexes to ensure correct search results.
 -->
-wcstombs()、もしくは、towlower()ライブラリ関数を持っていないプラットフォーム上では、非ASCIIデータに対する<productname>pg_trgm</>のインデックス内容に互換性のない変化が起きる可能性があります。このような場合、それらのインデックスに<command>REINDEX</>を行うことにより、正しい検索結果が得られます。
-
+wcstombs()、もしくは、towlower()ライブラリ関数を持っていないプラットフォーム上では、非ASCIIデータに対する<productname>pg_trgm</>のインデックス内容に互換性のない変化が起きる可能性があります。
+このような場合、それらのインデックスに<command>REINDEX</>を行うことにより、正しい検索結果が得られます。
        </para>
       </listitem>
 
@@ -14072,8 +14157,8 @@ wcstombs()、もしくは、towlower()ライブラリ関数を持っていない
         Improve <application>pg_upgrade</>'s status display during
         copy/link (Bruce Momjian)
 -->
-コピーやリンク中の<application>pg_upgrade</>のステータス表示を改善しました。(Bruce Momjian)
-
+コピーやリンク中の<application>pg_upgrade</>のステータス表示を改善しました。
+(Bruce Momjian)
        </para>
       </listitem>
 

--- a/doc/src/sgml/release-9.4.sgml
+++ b/doc/src/sgml/release-9.4.sgml
@@ -2,45 +2,72 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-4-8">
+<!--
   <title>Release 9.4.8</title>
+-->
+  <title>リリース9.4.8</title>
 
   <note>
+<!--
   <title>Release Date</title>
+-->
+  <title>リリース日</title>
   <simpara>2016-05-12</simpara>
   </note>
 
   <para>
+<!--
    This release contains a variety of fixes from 9.4.7.
    For information about new features in the 9.4 major release, see
    <xref linkend="release-9-4">.
+-->
+このリリースは9.4.7に対し、各種不具合を修正したものです。
+9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">を参照してください。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.4.8</title>
+-->
+   <title>バージョン9.4.8への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.4.X.
+-->
+9.4.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if you are upgrading from a version earlier than 9.4.6,
     see <xref linkend="release-9-4-6">.
+-->
+また、9.4.6よりも前のリリースからアップグレードする場合は、<xref linkend="release-9-4-6">を参照して下さい。
    </para>
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Clear the OpenSSL error queue before OpenSSL calls, rather than
       assuming it's clear already; and make sure we leave it clear
       afterwards (Peter Geoghegan, Dave Vitek, Peter Eisentraut)
+-->
+OpenSSLを呼び出す前にそのエラーキューを、既に消去されているとみなすのではなく、消去します。また、必ず後に消去しておくようにします。
+(Peter Geoghegan, Dave Vitek, Peter Eisentraut)
      </para>
 
      <para>
+<!--
       This change prevents problems when there are multiple connections
       using OpenSSL within a single process and not all the code involved
       follows the same rules for when to clear the error queue.
@@ -49,24 +76,37 @@
       SSL connections using the PHP, Python, or Ruby wrappers for OpenSSL.
       It's possible for similar problems to arise within the server as well,
       if an extension module establishes an outgoing SSL connection.
+-->
+この変更は、一つのプロセスの中でOpenSSLを使った複数の接続があって、含まれるコードの全てがエラーキューを消去するとき同一規則に従っていない場合の問題を防ぎます。
+特に、クライアントアプリケーションがPHPやPython、RubyのOpenSSLラッパーを使ったSSL接続と同時に、<application>libpq</>でSSL接続を使っているときに、障害が報告されました。
+拡張モジュールが外にむけたSSL接続をするのであれば、同様にサーバでも似た問題が起こる可能性があります。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <quote>failed to build any <replaceable>N</>-way joins</quote>
       planner error with a full join enclosed in the right-hand side of a
       left join (Tom Lane)
+-->
+左外部結合の右手側に入っている完全外部結合でのプランナのエラー<quote>failed to build any <replaceable>N</>-way joins (N個立ての結合の構築にいずれも失敗しました)</quote>を修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect handling of equivalence-class tests in multilevel
       nestloop plans (Tom Lane)
+-->
+複数階層の入れ子ループプランにおける等価クラス検査の誤った扱いを修正しました。
+ (Tom Lane)
      </para>
 
      <para>
+<!--
       Given a three-or-more-way equivalence class of variables, such
       as <literal>X.X = Y.Y = Z.Z</>, it was possible for the planner to omit
       some of the tests needed to enforce that all the variables are actually
@@ -74,188 +114,293 @@
       the <literal>WHERE</> clauses.  For various reasons, erroneous plans
       were seldom selected in practice, so that this bug has gone undetected
       for a long time.
+-->
+<literal>X.X = Y.Y = Z.Z</>のような、3つ以上からなる変数の等価クラスが与えられると、プランナが全ての変数が実際に等しいようにするために必要な検査の一部を怠る可能性があり、出力される行が<literal>WHERE</>句を満たさない結合をもたらしました。
+さまざまな理由のため、誤ったプランは実際には滅多に選択されません。
+そのため、このバグは長い間気づかれずにきました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix query-lifespan memory leak in GIN index scans (Julien Rouhaud)
+-->
+GINインデックススキャンで問い合わせ処理内のメモリリークを修正しました。
+(Julien Rouhaud)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix query-lifespan memory leak and potential index corruption hazard in
       GIN index insertion (Tom Lane)
+-->
+GINインデックスの挿入で、問い合わせ処理内のメモリリークとインデックス破損の可能性を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       The memory leak would typically not amount to much in simple queries,
       but it could be very substantial during a large GIN index build with
       high <varname>maintenance_work_mem</>.
+-->
+このメモリリークは単純な問い合わせでは通常は大きくなりませんが、大きな<varname>maintenance_work_mem</>で巨大なGINインデックスを構築する間に相当な量になることがありえました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible misbehavior of <literal>TH</>, <literal>th</>,
       and <literal>Y,YYY</> format codes in <function>to_timestamp()</>
       (Tom Lane)
+-->
+<function>to_timestamp()</>の書式コード<literal>TH</>、<literal>th</>、<literal>Y,YYY</>の誤った振る舞いを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       These could advance off the end of the input string, causing subsequent
       format codes to read garbage.
+-->
+これにより、入力文字列の末尾を超えて進み、次の書式コードでゴミが読まれるおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix dumping of rules and views in which the <replaceable>array</>
       argument of a <literal><replaceable>value</> <replaceable>operator</>
       ANY (<replaceable>array</>)</literal> construct is a sub-SELECT
       (Tom Lane)
+-->
+<literal><replaceable>value</> <replaceable>operator</> ANY (<replaceable>array</>)</literal>という構造の<replaceable>array</>引数が副問い合わせである場合のルールとビューのダンプを修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Disallow newlines in <command>ALTER SYSTEM</> parameter values
       (Tom Lane)
+-->
+<command>ALTER SYSTEM</>のパラメータ値で改行を禁止しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       The configuration-file parser doesn't support embedded newlines in
       string literals, so we mustn't allow them in values to be inserted
       by <command>ALTER SYSTEM</>.
+-->
+設定ファイルのパーサは文字列リテラルに含まれた改行に対応していませんので、私たちは<command>ALTER SYSTEM</>で挿入される値においてもこれを許すべきではありません。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <command>ALTER TABLE ... REPLICA IDENTITY USING INDEX</> to
       work properly if an index on OID is selected (David Rowley)
+-->
+<command>ALTER TABLE ... REPLICA IDENTITY USING INDEX</>を、OIDに対するインデックスが指定されても適切に動作するように修正しました。
+(David Rowley)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix crash in logical decoding on alignment-picky platforms (Tom Lane,
       Andres Freund)
+-->
+アラインメントを選り好みするプラットフォームでのロジカルデコーディングのクラッシュを修正しました。
+(Tom Lane, Andres Freund)
      </para>
 
      <para>
+<!--
       The failure occurred only with a transaction large enough to spill to
       disk and a primary-key change within that transaction.
+-->
+ディスクにあふれ出るほど大きいトランザクションで、かつ、主キーがそのトランザクション中で変更されるときだけ、障害が発生します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid repeated requests for feedback from receiver while shutting down
       walsender (Nick Cleaton)
+-->
+walsenderのシャットダウン中に受信側からフィードバックの要求が繰り返されるのを回避しました。
+(Nick Cleaton)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Make <application>pg_regress</> use a startup timeout from the
       <envar>PGCTLTIMEOUT</> environment variable, if that's set (Tom Lane)
+-->
+<envar>PGCTLTIMEOUT</>環境変数が設定されているなら、<application>pg_regress</>がその値による起動タイムアウトを適用するようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This is for consistency with a behavior recently added
       to <application>pg_ctl</>; it eases automated testing on slow machines.
+-->
+これは、最近<application>pg_ctl</>に追加された振る舞いとの一貫性のためで、
+遅いマシンでの自動テストを容易にします。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_upgrade</> to correctly restore extension
       membership for operator families containing only one operator class
       (Tom Lane)
+-->
+一つの演算子クラスだけを含む演算子族の拡張への所属を正しくリストアできるように<application>pg_upgrade</>を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       In such a case, the operator family was restored into the new database,
       but it was no longer marked as part of the extension.  This had no
       immediate ill effects, but would cause later <application>pg_dump</>
       runs to emit output that would cause (harmless) errors on restore.
+-->
+このような場合、演算子族は新しいデータベースにリストアされますが、もはや拡張の一部として記されませんでした。
+これは直ちには悪影響はありませんが、後に<application>pg_dump</>がリストア時に（無害な）エラーを引き起こす出力を吐き出す原因となりました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_upgrade</> to not fail when new-cluster TOAST rules
       differ from old (Tom Lane)
+-->
+新たなクラスタのTOAST規則が古いクラスタと異なるとき失敗しないように<application>pg_upgrade</>を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       <application>pg_upgrade</> had special-case code to handle the
       situation where the new <productname>PostgreSQL</> version thinks that
       a table should have a TOAST table while the old version did not.  That
       code was broken, so remove it, and instead do nothing in such cases;
       there seems no reason to believe that we can't get along fine without
       a TOAST table if that was okay according to the old version's rules.
+-->
+<application>pg_upgrade</>には、新しい<productname>PostgreSQL</>バージョンが、古いバージョンには無いけれどこのテーブルはTOASTテーブルを持つべきとみなした場合を扱う特別な場合のコードがありました。
+このコードは壊れていたため除去し、このような場合には代わりに何もしません。
+古いバージョンの規則に従って問題ないなら、TOASTテーブルがないとうまくいかないと思う理由がないように思われます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Reduce the number of SysV semaphores used by a build configured with
-      <option>--disable-spinlocks</> (Tom Lane)
+      <option>&#045;&#045;disable-spinlocks</> (Tom Lane)
+-->
+<option>--disable-spinlocks</>と設定されたビルドで、使用されるSysVセマフォの数を減らしました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Rename internal function <function>strtoi()</>
       to <function>strtoint()</> to avoid conflict with a NetBSD library
       function (Thomas Munro)
+-->
+NetBSDのライブラリ関数との衝突を避けるため、内部関数<function>strtoi()</>の名前を<function>strtoint()</>に変えました。
+(Thomas Munro)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix reporting of errors from <function>bind()</>
       and <function>listen()</> system calls on Windows (Tom Lane)
+-->
+Windowsにおけるシステムコール<function>bind()</>と<function>listen()</>からのエラー報告を修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Reduce verbosity of compiler output when building with Microsoft Visual
       Studio (Christian Ullrich)
+-->
+Microsoft Visual Studioでビルドするときのコンパイラ出力の冗長さを減らしました。
+(Christian Ullrich)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <function>putenv()</> to work properly with Visual Studio 2013
       (Michael Paquier)
+-->
+Visual Studio 2013で適切に動作するように<function>putenv()</>を修正しました。
+(Michael Paquier)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid possibly-unsafe use of Windows' <function>FormatMessage()</>
       function (Christian Ullrich)
+-->
+Windowsの<function>FormatMessage()</>関数の安全でない可能性のある使用を回避しました。
+(Christian Ullrich)
      </para>
 
      <para>
+<!--
       Use the <literal>FORMAT_MESSAGE_IGNORE_INSERTS</> flag where
       appropriate.  No live bug is known to exist here, but it seems like a
       good idea to be careful.
+-->
+適切に<literal>FORMAT_MESSAGE_IGNORE_INSERTS</>フラグを使用します。
+これに関連した既知の未修整バグはありませんが、注意深くすることは良い考えと思われます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Update time zone data files to <application>tzdata</> release 2016d
       for DST law changes in Russia and Venezuela.  There are new zone
       names <literal>Europe/Kirov</> and <literal>Asia/Tomsk</> to reflect
       the fact that these regions now have different time zone histories from
       adjacent regions.
+-->
+タイムゾーンデータファイルを<application>tzdata</> release 2016dに更新しました。
+ロシア、ベネズエラの夏時間法の変更、当該地域は今では隣接した地域とは異なるタイムゾーンの歴史を持っているという事実を反映させた新しい地域名<literal>Europe/Kirov</>、<literal>Asia/Tomsk</>が含まれます。
      </para>
     </listitem>
 
@@ -285,15 +430,14 @@
    <xref linkend="release-9-4">.
 -->
 このリリースは9.4.6に対し、各種不具合を修正したものです。
-9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">
-を参照してください。
+9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.4.7</title>
 -->
-   <title>バージョン 9.4.7への移行</title>
+   <title>バージョン9.4.7への移行</title>
 
    <para>
 <!--
@@ -337,8 +481,7 @@
       non-NULL <structfield>b</> values associated with later values
       of <structfield>a</>.
 -->
-<literal>ROW(a, b) &gt; ROW('x', 'y')</>のような行比較を使うインデックス検索は、
-<structfield>b</>カラムでNULL項目に到達すると、以降の<structfield>a</>の値に付随した非NULLの<structfield>b</>の値があるのを無視して、そこで止まってしまいました。
+<literal>ROW(a, b) &gt; ROW('x', 'y')</>のような行比較を使うインデックス検索は、<structfield>b</>カラムでNULL項目に到達すると、以降の<structfield>a</>の値に付随した非NULLの<structfield>b</>の値があるのを無視して、そこで止まってしまいました。
      </para>
     </listitem>
 
@@ -429,11 +572,7 @@
       incorrect reports of <quote>subxact logged without previous toplevel
       record</>, and incorrect reporting of a transaction's commit time.
 -->
-問題のある場合には、
-レプリカ識別子が<literal>FULL</>のとき1ページより大きいタプル、
-ディスクにスプールされるほど大きいトランザクション内で主キーを変更する<command>UPDATE</>、
-<quote>subxact logged without previous toplevel record</>（サブトランザクションが前のトップレベルレコード無しに記録されました）という誤った報告、および、
-トランザクションのコミット時刻の誤った報告が含まれます。
+問題のある場合には、レプリカ識別子が<literal>FULL</>のとき1ページより大きいタプル、ディスクにスプールされるほど大きいトランザクション内で主キーを変更する<command>UPDATE</>、<quote>subxact logged without previous toplevel record</>（サブトランザクションが前のトップレベルレコード無しに記録されました）という誤った報告、および、トランザクションのコミット時刻の誤った報告が含まれます。
      </para>
     </listitem>
 
@@ -486,7 +625,6 @@
       Avoid use of <function>sscanf()</> to parse <literal>ispell</>
       dictionary files (Artur Zakirov)
 -->
-
 <literal>ispell</>辞書ファイルを解析するのに<function>sscanf()</>を使わないようにしました。
 (Artur Zakirov)
      </para>
@@ -611,7 +749,6 @@
       Momjian)
 -->
 <application>pg_upgrade</>で、新データディレクトリが旧データディレクトリ内に在るとき、削除スクリプトの作成を省略するようにしました。
-
      </para>
 
      <para>
@@ -715,7 +852,7 @@ Perl本体からもはや提供されなくなったため、MSVCビルドで<li
 <!--
    <title>Migration to Version 9.4.6</title>
 -->
-   <title>バージョン 9.4.6への移行</title>
+   <title>バージョン9.4.6への移行</title>
 
    <para>
 <!--
@@ -779,14 +916,10 @@ Branch: REL9_4_STABLE [788e35ac0] 2015-11-05 18:15:48 -0500
       should <command>REINDEX</> <literal>jsonb_path_ops</> GIN indexes after
       installing this update to make sure that all searches work as expected.
 -->
-例えばスカラと副配列を含む配列のように、
-同じ入れ子レベルにスカラとサブオブジェクトを両方含む<type>jsonb</>値を処理するとき、
-異なる文脈において同じキーに対してキーハッシュ値が異なって計算されることがありました。
+例えばスカラと副配列を含む配列のように、同じ入れ子レベルにスカラとサブオブジェクトを両方含む<type>jsonb</>値を処理するとき、異なる文脈において同じキーに対してキーハッシュ値が異なって計算されることがありました。
 これにより問い合わせで見つかるべき項目が見つからない可能性があります。
-これを修正することは、新しいハッシュ計算コードに対して、
-既存のインデックスは既に一貫性に欠けているかもしれないことを意味します。
-全ての検索が確実に期待通りに動作するように、本アップデートの導入後、
-<literal>jsonb_path_ops</> GINインデックスを<command>REINDEX</>すべきです。
+これを修正することは、新しいハッシュ計算コードに対して、既存のインデックスは既に一貫性に欠けているかもしれないことを意味します。
+全ての検索が確実に期待通りに動作するように、本アップデートの導入後、<literal>jsonb_path_ops</> GINインデックスを<command>REINDEX</>すべきです。
      </para>
     </listitem>
 
@@ -887,8 +1020,7 @@ Branch: REL9_1_STABLE [5f9a86b35] 2015-12-12 14:19:29 +0100
       TABLE ... SET TABLESPACE</> for unlogged relations (Michael Paquier,
       Andres Freund)
 -->
-ログを取らないリレーションに対して<literal>ALTER TABLE ... SET TABLESPACE</>を行うとき、
-適切なWALレコードを出力するのに失敗していたものを修正しました。
+ログを取らないリレーションに対して<literal>ALTER TABLE ... SET TABLESPACE</>を行うとき、適切なWALレコードを出力するのに失敗していたものを修正しました。
 (Michael Paquier, Andres Freund)
      </para>
 
@@ -1070,9 +1202,7 @@ Branch: REL9_3_STABLE [0a34ff7e9] 2015-12-07 17:41:45 -0500
       N-way joins</> or <quote>could not devise a query plan</> planner
       failures.
 -->
-これは、<quote>failed to build any N-way joins</>、あるいは、
-<quote>could not devise a query plan</>というプランナのエラーをもたらす、
-いくつかの稀な状況について修正します。
+これは、<quote>failed to build any N-way joins</>、あるいは、<quote>could not devise a query plan</>というプランナのエラーをもたらす、いくつかの稀な状況について修正します。
      </para>
     </listitem>
 
@@ -1174,8 +1304,7 @@ Branch: REL9_4_STABLE [4f33572ee] 2015-10-20 11:06:24 -0700
       Translation of minus-infinity dates and timestamps to <type>json</>
       or <type>jsonb</> incorrectly rendered them as plus-infinity (Tom Lane)
 -->
-マイナス無限大の日付およびタイムスタンプを<type>json</>および<type>jsonb</>に変換するとき、
-誤ってプラス無限大にされていました。
+マイナス無限大の日付およびタイムスタンプを<type>json</>および<type>jsonb</>に変換するとき、誤ってプラス無限大にされていました。
      </para>
     </listitem>
 
@@ -1228,10 +1357,8 @@ Branch: REL9_1_STABLE [03ee6591d] 2015-11-07 12:43:24 -0500
       inside a parenthesized subexpression, and would give unexpected
       results.
 -->
-マニュアルによれば、先行検索制約に後方参照を含めることは許されていませんし、また、
-先行検索制約内の括弧は常に捕捉されません。
-しかしながら、括弧に入れられた副式の中ではこれらのケースを適切な処理に失敗していて、
-予期せぬ結果をもたらしていました。
+マニュアルによれば、先行検索制約に後方参照を含めることは許されていませんし、また、先行検索制約内の括弧は常に捕捉されません。
+しかしながら、括弧に入れられた副式の中ではこれらのケースを適切な処理に失敗していて、予期せぬ結果をもたらしていました。
      </para>
     </listitem>
 
@@ -1288,8 +1415,7 @@ Branch: REL9_1_STABLE [d394f12c0] 2015-10-16 14:14:41 -0400
 -->
 CVE-2007-4772 対応で加えられたコードは、不完全でかつ正しくありませんでした。
 複数状態に影響を与えるループを処理できません。
-また、（アサート無しのビルドであれば悪い結果には見えないけれども）アサート失敗を
-引き起こす可能性がありました。
+また、（アサート無しのビルドであれば悪い結果には見えないけれども）アサート失敗を引き起こす可能性がありました。
 複数状態ループにより、コンパイラがキャンセルされるか、状態数が多すぎるというエラー条件に達するまで走り続ける可能性がありました。
      </para>
     </listitem>
@@ -1320,8 +1446,7 @@ Branch: REL9_1_STABLE [b94c2b6a6] 2015-10-16 15:36:17 -0400
       complex</> errors in some cases that previously used unreasonable
       amounts of time and memory.
 -->
-本修正により、これまで途方もない時間とメモリを使っていたいくつかのケースで、
-<quote>regular expression is too complex</>(正規表現が複雑すぎます)というエラーを出します。
+本修正により、これまで途方もない時間とメモリを使っていたいくつかのケースで、<quote>regular expression is too complex</>(正規表現が複雑すぎます)というエラーを出します。
      </para>
     </listitem>
 
@@ -2087,7 +2212,6 @@ Branch: REL9_1_STABLE [2a37a103b] 2015-12-11 16:14:48 -0500
       Install our <filename>missing</> script where PGXS builds can find it
       (Jim Nasby)
 -->
-
 PGXSビルドで見つけられる場所に<filename>missing</>スクリプトを設置するようにしました。 
 (Jim Nasby)
      </para>
@@ -2182,15 +2306,14 @@ Branch: REL9_1_STABLE [386dcd539] 2015-12-11 19:08:40 -0500
    <xref linkend="release-9-4">.
 -->
 このリリースは9.4.4に対し、各種不具合を修正したものです。
-9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">
-を参照してください。
+9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.4.5</title>
 -->
-   <title>バージョン 9.4.5への移行</title>
+   <title>バージョン9.4.5への移行</title>
 
    <para>
 <!--
@@ -2204,8 +2327,7 @@ Branch: REL9_1_STABLE [386dcd539] 2015-12-11 19:08:40 -0500
     However, if you are upgrading from a version earlier than 9.4.4,
     see <xref linkend="release-9-4-4">.
 -->
-また、9.4.4よりも前のバージョンからアップグレードする場合は、
-<xref linkend="release-9-4-4">を参照して下さい。
+また、9.4.4よりも前のバージョンからアップグレードする場合は、<xref linkend="release-9-4-4">を参照して下さい。
    </para>
   </sect2>
 
@@ -2275,7 +2397,8 @@ Branch: REL9_0_STABLE [188e081ef] 2015-10-05 10:06:36 -0400
       attacks that arrange for presence of confidential information in the
       disclosed bytes, but they seem unlikely.  (CVE-2015-5288)
 -->
-ある種の無効なソルト引数はサーバをクラッシュさせるか、わずかなバイト数のサーバメモリを露出させました。機密情報を露出するバイト列に在るように配置する攻撃の可能性は排除しませんが、ありそうにないと考えられます。
+ある種の無効なソルト引数はサーバをクラッシュさせるか、わずかなバイト数のサーバメモリを露出させました。
+機密情報を露出するバイト列に在るように配置する攻撃の可能性は排除しませんが、ありそうにないと考えられます。
 (CVE-2015-5288)
      </para>
     </listitem>
@@ -2482,8 +2605,8 @@ SSL再ネゴシエーションをデフォルトで無効にしました。
       of <varname>ssl_renegotiation_limit</> to zero (disabled).
 -->
 SSL再ネゴシエーションの使用は理論的には良い考えですが、OpenSSLライブラリに因るものと私たちのライブラリの使い方に因るものの両方で実際のところ多くのバグが見られました。
-再ネゴシエーションは9.5以降では完全に取り除く予定です。古いバージョン系列では
-<varname>ssl_renegotiation_limit</>のデフォルト値をゼロ（無効）に変更するだけとします。
+再ネゴシエーションは9.5以降では完全に取り除く予定です。
+古いバージョン系列では<varname>ssl_renegotiation_limit</>のデフォルト値をゼロ（無効）に変更するだけとします。
      </para>
     </listitem>
 
@@ -2852,7 +2975,6 @@ Branch: REL9_0_STABLE [bd327627f] 2015-08-04 18:18:47 -0400
 -->
 小さい<varname>work_mem</>設定でタプルストアを使用するときに、<quote>unexpected out-of-memory situation during sort</>エラーになるのを修正しました。
 (Tom Lane)
-
      </para>
     </listitem>
 
@@ -3265,7 +3387,6 @@ Branch: REL9_2_STABLE [f4297f8c5] 2015-07-27 12:32:48 +0300
 -->
 SP-GiSTインデックスで全ゼロページの扱いを修正しました。
 (Heikki Linnakangas)
-
      </para>
 
      <para>
@@ -3846,7 +3967,6 @@ Branch: REL9_0_STABLE [b5a22d8bb] 2015-08-29 16:09:25 -0400
       common.
 -->
 <application>gcc</>が一般的になりつつあるネイティブアセンブラを使う構成である場合に、<application>gcc</>でのビルドができませんでした。
-
      </para>
     </listitem>
 
@@ -3918,7 +4038,6 @@ Branch: REL9_0_STABLE [2d8c136e7] 2015-07-29 22:54:08 -0400
       Avoid use of inline functions when compiling with
       32-bit <application>xlc</>, due to compiler bugs (Noah Misch)
 -->
-
 コンパイラバグのため、32bit <application>xlc</>でインライン関数展開を使わないようにしました。
 (Noah Misch)
      </para>
@@ -4109,15 +4228,14 @@ Branch: REL9_0_STABLE [47ac95f37] 2015-10-02 19:16:37 -0400
    <xref linkend="release-9-4">.
 -->
 このリリースは9.4.3に対し、各種不具合を修正したものです。
-9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">
-を参照してください。
+9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.4.4</title>
 -->
-   <title>バージョン 9.4.4への移行</title>
+   <title>バージョン9.4.4への移行</title>
 
    <para>
 <!--
@@ -4366,15 +4484,14 @@ Branch: REL9_3_STABLE [d3fdec6ae] 2015-06-03 11:58:47 -0400
    <xref linkend="release-9-4">.
 -->
 このリリースは9.4.2に対し、各種不具合を修正したものです。
-9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">
-を参照してください。
+9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.4.3</title>
 -->
-   <title>バージョン 9.4.3への移行</title>
+   <title>バージョン9.4.3への移行</title>
 
    <para>
 <!--
@@ -4563,15 +4680,14 @@ Branch: REL9_0_STABLE [b06649b7f] 2015-05-26 22:15:00 -0400
    <xref linkend="release-9-4">.
 -->
 このリリースは9.4.1に対し、各種不具合を修正したものです。
-9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">
-を参照してください。
+9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.4.2</title>
 -->
-   <title>バージョン 9.4.2への移行</title>
+   <title>バージョン9.4.2への移行</title>
 
    <para>
 <!--
@@ -5198,7 +5314,8 @@ Branch: REL9_0_STABLE [262fbcb9d] 2015-05-05 09:30:07 -0400
       second crash would have to be a system-level crash, not just a database
       crash, for there to be a problem.)
 -->
-これにより別のクラッシュがすぐ後に生じた場合でも一貫性を確実にします（問題となるのは二番目のクラッシュが単なるデータベースクラッシュではなくシステムレベルのクラッシュである場合です）。
+これにより別のクラッシュがすぐ後に生じた場合でも一貫性を確実にします。
+（問題となるのは二番目のクラッシュが単なるデータベースクラッシュではなくシステムレベルのクラッシュである場合です。）
      </para>
     </listitem>
 
@@ -5575,7 +5692,6 @@ Branch: REL9_0_STABLE [e48ce4f33] 2015-02-17 12:49:18 -0500
       Remove code for matching IPv4 <filename>pg_hba.conf</> entries to
       IPv4-in-IPv6 addresses (Tom Lane)
 -->
-
 IPv4の<filename>pg_hba.conf</>項目をIPv4-in-IPv6アドレスと照合する実装を除去しました。
 (Tom Lane)
      </para>
@@ -5919,7 +6035,6 @@ Branch: REL9_3_STABLE [d645273cf] 2015-03-06 13:27:46 -0500
       Avoid possible <application>pg_dump</> failure when concurrent sessions
       are creating and dropping temporary functions (Tom Lane)
 -->
-
 同時実行セッションで一時的な関数の作成と削除をしている場合に<application>pg_dump</>が失敗する可能性があり、防止しました。
 (Tom Lane)
      </para>
@@ -6229,15 +6344,14 @@ Branch: REL9_0_STABLE [3c3749a3b] 2015-05-15 19:36:20 -0400
    <xref linkend="release-9-4">.
 -->
 このリリースは9.4.0に対し、各種不具合を修正したものです。
-9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">
-を参照してください。
+9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">を参照してください。
   </para>
 
   <sect2>
 <!--
    <title>Migration to Version 9.4.1</title>
 -->
-   <title>バージョン 9.4.1への移行</title>
+   <title>バージョン9.4.1への移行</title>
 
    <para>
 <!--
@@ -6969,7 +7083,6 @@ Branch: REL9_4_STABLE [733728ff3] 2015-01-11 12:35:47 -0500
 <function>PQsetdbLogin()</>を実行するとき、<application>libpq</>はOSユーザ名を確認しようとします。それは、ほとんどのUnixプラットフォームで<filename>/etc/passwd</>の読み取りを伴います。
 9.4時点では読み取り失敗をハードエラーとして扱っていましたが、アプリケーションが接続するデータベースロール名を提示しない場合のみ失敗にするという従来の振る舞いに戻しました。
 このことは<filename>/etc/passwd</>ファイルの無いchroot環境での運用を支援します。
-
      </para>
     </listitem>
 
@@ -7451,8 +7564,7 @@ WALデータの<link linkend="logicaldecoding">ロジカルデコーディング
       text values are no longer rendered with the backslash escaped
       (Andrew Dunstan)
 -->
-<link linkend="datatype-json"><type>JSON</type></link>文字列値におけるユニコード
-エスケープで、バックスラッシュではエスケープされなくなりました。
+<link linkend="datatype-json"><type>JSON</type></link>文字列値におけるユニコードエスケープで、バックスラッシュではエスケープされなくなりました。
 (Andrew Dunstan)
      </para>
 
@@ -7464,17 +7576,12 @@ WALデータの<link linkend="logicaldecoding">ロジカルデコーディング
       JSON string value, and escaping the backslash led to some perverse
       results.
 -->
-これまで、JSONに整形されるテキスト中のすべてのバックスラッシュはエスケープ
-されていました。
-エスケープしなくとも正しいJSON文字列値であり、エスケープすることで
-ひねくれた結果がもたらされていたことから、これからは、
-<literal>u</>と16進数4桁に続くバックスラッシュはエスケープされません。
+これまで、JSONに整形されるテキスト中のすべてのバックスラッシュはエスケープされていました。
+エスケープしなくとも正しいJSON文字列値であり、エスケープすることでひねくれた結果がもたらされていたことから、これからは、<literal>u</>と16進数4桁に続くバックスラッシュはエスケープされません。
      </para>
      <para>
 訳注：9.4.1で本修正は取り消されています。
-オリジナルの9.4.1マニュアルでは、
-9.4.0リリースノートから本項目自体が削除されていますが、
-9.4.0 バージョンの情報を残すため、日本語訳では項目を残しました。
+オリジナルの9.4.1マニュアルでは、9.4.0リリースノートから本項目自体が削除されていますが、9.4.0バージョンの情報を残すため、日本語訳では項目を残しました。
      </para>
     </listitem>
 
@@ -7574,10 +7681,7 @@ ISO 8601に従った書式にします。
       conditionally consume adjacent whitespace, if not in <literal>FX</>
       mode (Jeevan Chalke)
 -->
-<link linkend="functions-formatting-table"><function>to_timestamp()</></link>
-と<function>to_date()</>の書式文字列の連続した空白が、（空白文字以外を含め）
-入力文字列から対応した数だけ文字を消費するため、<literal>FX</>モードでなく
-ても条件付きで隣接した空白を消費します。
+<link linkend="functions-formatting-table"><function>to_timestamp()</></link>と<function>to_date()</>の書式文字列の連続した空白が、（空白文字以外を含め）入力文字列から対応した数だけ文字を消費するため、<literal>FX</>モードでなくても条件付きで隣接した空白を消費します。
 (Jeevan Chalke)
      </para>
 
@@ -7603,8 +7707,7 @@ ISO 8601に従った書式にします。
       linkend="textsearch-functions-table"><function>ts_rank_cd()</></link>
       to ignore stripped lexemes (Alex Hill)
 -->
-<link linkend="textsearch-functions-table"><function>ts_rank_cd()</></link>
-関数を除去された語彙素を無視するように修正しました。
+<link linkend="textsearch-functions-table"><function>ts_rank_cd()</></link>関数を除去された語彙素を無視するように修正しました。
      </para>
 
      <para>
@@ -7625,9 +7728,7 @@ ISO 8601に従った書式にします。
       "any"</></link>, an actual parameter marked as <literal>VARIADIC</>
       must be of a determinable array type (Pavel Stehule)
 -->
-引数に<link linkend="xfunc-sql-variadic-functions"><literal>VARIADIC "any"</></link>
-を取る関数で、<literal>VARIADIC</>と指定された引数は決定可能な配列型でなければ
-ならなくなりました。
+引数に<link linkend="xfunc-sql-variadic-functions"><literal>VARIADIC "any"</></link>を取る関数で、<literal>VARIADIC</>と指定された引数は決定可能な配列型でなければならなくなりました。
      </para>
 
      <para>
@@ -8389,7 +8490,6 @@ PL/pgSQL手続き言語の<xref linkend="SQL-DO">ブロックによるメモリ�
     </sect4>
 
     <sect4>
-
 <!--
      <title>Monitoring</title>
 -->
@@ -9273,9 +9373,8 @@ Windowsにて<literal>SQL_ASCII</>エンコーディングのデータベース�
         <command>DELETE</>s are supported, provided that they do not
         attempt to assign new values to any of the non-updatable columns.
 -->
-これまでは、式や定数、関数呼び出しなどの更新不能な出力列があると、
-ビューは自動更新可能にはなりませんでした。これからは、更新不能な列に新しい値を割り当てしようとしないなら<command>INSERT</>、<command>UPDATE</>、<command>DELETE</>がサポートされます。
-
+これまでは、式や定数、関数呼び出しなどの更新不能な出力列があると、ビューは自動更新可能にはなりませんでした。
+これからは、更新不能な列に新しい値を割り当てしようとしないなら<command>INSERT</>、<command>UPDATE</>、<command>DELETE</>がサポートされます。
        </para>
       </listitem>
 
@@ -9359,7 +9458,6 @@ Windowsにて<literal>SQL_ASCII</>エンコーディングのデータベース�
         via <xref linkend="SQL-ALTERTABLE"> ... <literal>ALTER
         CONSTRAINT</> (Simon Riggs)
 -->
-
 <xref linkend="SQL-ALTERTABLE"> ... <literal>ALTER CONSTRAINT</>で外部キー制約が遅延できるかを変更できるようにしました。
 (Simon Riggs)
        </para>
@@ -9582,7 +9680,6 @@ UTCオフセットが変化するタイムゾーン略称をサポートしま�
     </itemizedlist>
 
     <sect4>
-
      <title><link linkend="datatype-json"><acronym>JSON</></link></title>
 
      <itemizedlist>
@@ -10173,7 +10270,6 @@ libpqの<link linkend="libpq-pqconndefaults"><function>PQconndefaults()</></link
         increasing granularity (Peter Eisentraut)
 -->
 <xref linkend="APP-VACUUMDB">粒度を増やして複数段階で解析を行う<option>--analyze-in-stages</>オプションが追加されました。
-
        </para>
 
        <para>
@@ -10585,7 +10681,6 @@ Windowsで相対パスで指定された<option>-D</>オプションを<xref lin
         <option>&#045;&#045;max-rate</> parameter.
 -->
 <application>pg_basebackup</>の<option>--max-rate</>パラメータで制御できます。
-
        </para>
       </listitem>
 
@@ -11065,7 +11160,6 @@ DocBookの<acronym>XML</>検証が改善されました。
 -->
 <xref linkend="auto-explain">に実行時間を含めるオプションを追加しました。
 (Horiguchi Kyotaro)
-
        </para>
       </listitem>
 
@@ -11345,10 +11439,8 @@ DocBookの<acronym>XML</>検証が改善されました。
         Save the statistics file into <filename>$PGDATA/pg_stat</> at server
         shutdown, rather than <filename>$PGDATA/global</> (Fujii Masao)
 -->
-サーバシャットダウン時に、統計ファイルを<filename>$PGDATA/global</>ではなく、
-<filename>$PGDATA/pg_stat</>に保存します。
+サーバシャットダウン時に、統計ファイルを<filename>$PGDATA/global</>ではなく、<filename>$PGDATA/pg_stat</>に保存します。
 (Fujii Masao)
-
        </para>
       </listitem>
 


### PR DESCRIPTION
release-9.[1-4] の9.5.3対応です。恒例のスクリプトを使った作業以外に、以下のようなこともついでにやってます。

- 原文と対応しない空行の削除。
- 文途中での改行の削除。その逆も。
- バージョンもしくはリリースとその番号の間の空白の削除。
- back-patchの訳の見直し。（「バックパッチ」とやるとコンパイラの用語になるっぽいです。）
