### PR TITLE
作業途中とみられる記述が残っていたものを修正。

### DIFF
--- a/doc/src/sgml/release-9.5.sgml
+++ b/doc/src/sgml/release-9.5.sgml
@@ -5312,13 +5312,11 @@ PostgreSQLによる丸め関数を使うプラットフォームに<acronym>POSI
         <para>
 <!--
          <application>psql</> now fails if the file specified by
-         an <option>&#045;&#045;output</> or <option>&#045;&#045;log-file</> ★参考　変更前
-         switch cannot be written (Tom Lane, Daniel Verite) ★参考　変更前
          an <option>&#045;&#045;output</> or <option>&#045;&#045;log-file</> switch cannot be
          written (Tom Lane, Daniel V&eacute;rit&eacute;)
 -->
 <option>--output</>または<option>--log-file</>で指定されたファイルに書き込みできない場合、<application>psql</>は失敗するようになります。
-(Tom Lane, Daniel Verite) ★名前の表記の変更が必要
+(Tom Lane, Daniel V&eacute;rit&eacute;)
         </para>
 
         <para>


### PR DESCRIPTION
原文に合わせ Verite を V&eacute;rit&eacute; に変更。
作業コメントを削除。