### PR TITLE
「exclusion constraint」の訳を「排他制約」に修正

### DIFF
--- a/doc/src/sgml/catalogs.sgml
+++ b/doc/src/sgml/catalogs.sgml
@@ -8918,7 +8918,7 @@ N番目の<quote>スロット</quote>に保存されている統計情報を引�
       <entry>The index supporting a unique, primary key, referential integrity,
        or exclusion constraint</entry>
 -->
-      <entry>一意性、主キー、参照整合性制約や除外制約をサポートするインデックス</entry>
+      <entry>一意性、主キー、参照整合性制約や排他制約をサポートするインデックス</entry>
      </row>
 
      <row>

--- a/doc/src/sgml/ref/create_table.sgml
+++ b/doc/src/sgml/ref/create_table.sgml
@@ -807,9 +807,9 @@ TRUEまたはUNKNOWNと評価される式は成功します。
       (see <xref linkend="datatype-geometric">) by using the
       <literal>&amp;&amp;</> operator.
 -->
-<literal>EXCLUDE</>句は除外制約を定義し、任意の2行について指定した列(複数可)または式(複数可)を指定した演算子(複数可)を使用して比較した場合、比較結果のすべてが<literal>TRUE</>を返さないことを保証します。
+<literal>EXCLUDE</>句は排他制約を定義し、任意の2行について指定した列(複数可)または式(複数可)を指定した演算子(複数可)を使用して比較した場合、比較結果のすべてが<literal>TRUE</>を返さないことを保証します。
 指定した演算子のすべてが等価性を試験するものであれば、これは<literal>UNIQUE</>制約と同じですが、通常の一意性制約のほうが高速です。
-しかし、除外制約では単純な等価性よりも一般的な制約を指定することができます。
+しかし、排他制約では単純な等価性よりも一般的な制約を指定することができます。
 例えば、テーブル内の2つの行が重複する円(<xref linkend="datatype-geometric">参照)を持たないといった制約を<literal>&amp;&amp;</>演算子を使用して指定することができます。
      </para>
 
@@ -826,7 +826,7 @@ TRUEまたはUNKNOWNと評価される式は成功します。
       these are described fully under
       <xref linkend="sql-createindex">.
 -->
-除外制約はインデックスを使用して実装されています。
+排他制約はインデックスを使用して実装されています。
 このため指定した演算子はそれぞれ適切な演算子クラス(<xref linkend="indexes-opclass">参照)で<replaceable>index_method</>インデックスアクセスメソッドと関連付けされていなければなりません。
 演算子は交換可能でなければなりません。
 オプションで、各<replaceable class="parameter">exclude_element</replaceable>は演算子クラス、順序付けオプション、またはその両方を指定することができます。
@@ -845,7 +845,7 @@ TRUEまたはUNKNOWNと評価される式は成功します。
 -->
 アクセスメソッドは<literal>amgettuple</>をサポートしなければなりません(<xref linkend="indexam">参照)。
 現時点では、これは<acronym>GIN</>を使用できないことを意味します。
-B-treeやHashインデックスを除外制約で使用することは許容されますが、そうすることにあまり意味はありません。
+B-treeやHashインデックスを排他制約で使用することは許容されますが、そうすることにあまり意味はありません。
 これが通常の一意性制約より良いことは何もないからです。
 このため現実的にはアクセスメソッドは常に<acronym>GiST</>もしくは<acronym>SP-GiST</>となります。
      </para>
@@ -856,7 +856,7 @@ B-treeやHashインデックスを除外制約で使用することは許容さ�
       exclusion constraint on a subset of the table; internally this creates a
       partial index. Note that parentheses are required around the predicate.
 -->
-<replaceable class="parameter">predicate</>により、除外制約をテーブルの部分集合に指定することができます。
+<replaceable class="parameter">predicate</>により、排他制約をテーブルの部分集合に指定することができます。
 内部的には、これは部分インデックスを作成します。
 predicateの前後に括弧が必要であることに注意して下さい。
      </para>
@@ -1873,7 +1873,7 @@ WITH (fillfactor=70);
    Create table <structname>circles</> with an exclusion
    constraint that prevents any two circles from overlapping:
 -->
-2つの円の重複を許さない除外制約を持つ<structname>circles</>テーブルを作成します。
+2つの円の重複を許さない排他制約を持つ<structname>circles</>テーブルを作成します。
 
 <programlisting>
 CREATE TABLE circles (

--- a/doc/src/sgml/ref/insert.sgml
+++ b/doc/src/sgml/ref/insert.sgml
@@ -660,7 +660,7 @@ aliasを指定すると、テーブルの実際の名前が完全に隠されま
     <literal>NOT DEFERRABLE</literal> constraints and unique indexes
     are supported as arbiters.
 -->
-除外制約は<literal>ON CONFLICT DO UPDATE</literal>の競合解決としてはサポートされないことに注意して下さい。
+排他制約は<literal>ON CONFLICT DO UPDATE</literal>の競合解決としてはサポートされないことに注意して下さい。
 すべての場合について、<literal>NOT DEFERRABLE</literal>である制約と一意インデックスのみが競合解決としてサポートされます。
    </para>
 


### PR DESCRIPTION
「exclusion constraint」が「除外制約」となっていた箇所を「排他制約」に修正しました。
対訳集に合わせています。

よろしくお願いします。
