### PR TITLE
UUIDの別形式の説明の訳を修正

### DIFF
--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -6018,7 +6018,7 @@ a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
     braces, omitting some or all hyphens, adding a hyphen after any
     group of four digits.  Examples are:
 -->
-また、<productname>PostgreSQL</productname>は入力として、大文字表記の桁、中括弧でくくった標準形式、いくつかまたはすべてのハイフンを省略したもの、４桁のすべてのグループにハイフンを付加した別形式も受け付けます。
+また、<productname>PostgreSQL</productname>は入力の別形式として、桁を大文字表記したもの、標準形式を中括弧でくくったもの、いくつかまたはすべてのハイフンを省略したもの、４桁ごとのグループの間の任意の箇所にハイフンを付加したものも受け付けます。
 以下に例を示します。
 <programlisting>
 A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11


### PR DESCRIPTION
どうしても直したかったのは、"adding a hyphen after any group of four digits"の"any"が「すべて」になっていた部分です。「すべて」だと4桁ごとにハイフンを挿入することになるけど、正しくは、4桁ごとに区切った場所であれば、どこでもハイフンを挿入可能（挿入しなくても良い）なので、訂正しました。
合わせて、その前後も、意味が明確になる（誤解されない）ように訳文を修正しました。