### PR TITLE
9.1のリリースノートの文言を修正しました。

### DIFF
--- a/doc/src/sgml/release-9.1.sgml
+++ b/doc/src/sgml/release-9.1.sgml
@@ -12873,7 +12873,7 @@ BEFORE/AFTERトリガに対する不適切な検査を修正しました。(Tom 
        linkend="functions-recovery-info-table"><function>pg_last_xlog_receive_location()</></link>
        so it never moves backwards (Fujii Masao)
 -->
-返り値が戻らないように<link linkend="functions-recovery-info-table"><function>pg_last_xlog_receive_location()</></link>を変更しました。(Fujii Masao)
+返り値が減少することのないように<link linkend="functions-recovery-info-table"><function>pg_last_xlog_receive_location()</></link>を変更しました。(Fujii Masao)
       </para>
 
       <para>

--- a/doc/src/sgml/release-9.1.sgml
+++ b/doc/src/sgml/release-9.1.sgml
@@ -12873,7 +12873,7 @@ BEFORE/AFTERトリガに対する不適切な検査を修正しました。(Tom 
        linkend="functions-recovery-info-table"><function>pg_last_xlog_receive_location()</></link>
        so it never moves backwards (Fujii Masao)
 -->
-後方に移動することがないように<link linkend="functions-recovery-info-table"><function>pg_last_xlog_receive_location()</></link>を変更しました。(Fujii Masao)
+返り値が戻らないように<link linkend="functions-recovery-info-table"><function>pg_last_xlog_receive_location()</></link>を変更しました。(Fujii Masao)
       </para>
 
       <para>
@@ -12881,7 +12881,7 @@ BEFORE/AFTERトリガに対する不適切な検査を修正しました。(Tom 
        Previously, the value of <function>pg_last_xlog_receive_location()</>
        could move backward when streaming replication is restarted.
 -->
-これまでは、ストリーミングレプリケーションが再開する時に<function>pg_last_xlog_receive_location()</>の値が後方に移ることがあり得ました。
+これまでは、ストリーミングレプリケーションが再開する時に<function>pg_last_xlog_receive_location()</>の値が減少することがあり得ました。
       </para>
      </listitem>
 


### PR DESCRIPTION
「後方に移動」や「後方に移る」ではまったく意味が通じないので、より適切なものに変更しました。