### PR TITLE
high-availability.sgmlのタイポ修正です

### DIFF
--- a/doc/src/sgml/high-availability.sgml
+++ b/doc/src/sgml/high-availability.sgml
@@ -2867,7 +2867,7 @@ WALからのバキュームクリーンアップレコードの適用は、そ�
          queries accessing the target page on the standby, whether or not
          the data to be removed is visible.
 -->
-WALからレコードを消去するバキュームクリーンアップレコードは、消去されるデータが可視か否かに関係なく、スタンバイで対象ページにアクセスする問い合わせとコンフリクトします。
+WALからのバキュームクリーンアップレコードは、消去されるデータが可視か否かに関係なく、スタンバイで対象ページにアクセスする問い合わせとコンフリクトします。
         </para>
        </listitem>
       </itemizedlist>


### PR DESCRIPTION
同じ "Application of a vacuum cleanup record from WAL" に対する訳語が、
その一つ上の文と違っていたので、一つ上の文に合せました。