### PR TITLE
他と違う訳語の修正

### DIFF
--- a/doc/src/sgml/release-8.3.sgml
+++ b/doc/src/sgml/release-8.3.sgml
@@ -673,7 +673,7 @@ Unixドメインソケットのパス名がプラットフォーム依存の最�
       Fix <application>pgxs</> support for building loadable modules on AIX
       (Tom Lane)
 -->
-AIX上でのロードモジュールのビルドについて<application>pgxs</>のサポートを修正しました。(Tom Lane)
+AIX上でのロード可能モジュールのビルドについて<application>pgxs</>のサポートを修正しました。(Tom Lane)
      </para>
 
      <para>

--- a/doc/src/sgml/release-8.4.sgml
+++ b/doc/src/sgml/release-8.4.sgml
@@ -3048,7 +3048,7 @@ Unixドメインソケットのパス名がプラットフォーム依存の最�
       Fix <application>pgxs</> support for building loadable modules on AIX
       (Tom Lane)
 -->
-AIX上でのロードモジュールのビルドについて<application>pgxs</>のサポートを修正しました。(Tom Lane)
+AIX上でのロード可能モジュールのビルドについて<application>pgxs</>のサポートを修正しました。(Tom Lane)
      </para>
 
      <para>

--- a/doc/src/sgml/release-9.0.sgml
+++ b/doc/src/sgml/release-9.0.sgml
@@ -6501,7 +6501,7 @@ Unixドメインソケットのパス名がプラットフォーム依存の最�
       Fix <application>pgxs</> support for building loadable modules on AIX
       (Tom Lane)
 -->
-AIX上でのロードモジュールのビルドについて<application>pgxs</>のサポートを修正しました。(Tom Lane)
+AIX上でのロード可能モジュールのビルドについて<application>pgxs</>のサポートを修正しました。(Tom Lane)
      </para>
 
      <para>

--- a/doc/src/sgml/release-9.1.sgml
+++ b/doc/src/sgml/release-9.1.sgml
@@ -8729,7 +8729,7 @@ Unixドメインソケットのパス名がプラットフォーム依存の最�
       Fix <application>pgxs</> support for building loadable modules on AIX
       (Tom Lane)
 -->
-AIX上でのロードモジュールのビルドについて<application>pgxs</>のサポートを修正しました。(Tom Lane)
+AIX上でのロード可能モジュールのビルドについて<application>pgxs</>のサポートを修正しました。(Tom Lane)
      </para>
 
      <para>

--- a/doc/src/sgml/release-9.2.sgml
+++ b/doc/src/sgml/release-9.2.sgml
@@ -7956,7 +7956,7 @@ C99標準では、<literal>inf</>、<literal>+inf</>、 <literal>-inf</>、 <lit
       Prevent crash when <application>psql</>'s <envar>PSQLRC</> variable
       contains a tilde (Bruce Momjian)
 -->
-<application>psql</>の<envar>PSQLRC</>がティルダ(~)を含んでいるときにクラッシュしないようにしました。(Bruce Momjian)
+<application>psql</>の<envar>PSQLRC</>がチルダ(~)を含んでいるときにクラッシュしないようにしました。(Bruce Momjian)
      </para>
     </listitem>
 
@@ -10319,7 +10319,7 @@ Unixドメインソケットのパス名がプラットフォーム依存の最�
       Fix <application>pgxs</> support for building loadable modules on AIX
       (Tom Lane)
 -->
-AIX上でのロードモジュールのビルドについて<application>pgxs</>のサポートを修正しました。(Tom Lane)
+AIX上でのロード可能モジュールのビルドについて<application>pgxs</>のサポートを修正しました。(Tom Lane)
      </para>
 
      <para>


### PR DESCRIPTION
該当の箇所しか使われいなかった訳語を他に合わせました。
ロード -> ロード可能
ティルダ -> チルダ