### PR TITLE
9.6RC1の差分チェック

### DIFF
--- a/doc/src/sgml/auth-delay.sgml
+++ b/doc/src/sgml/auth-delay.sgml
@@ -41,9 +41,9 @@
      <varname>auth_delay.milliseconds</varname> (<type>int</type>)
      <indexterm>
 <!--
-     <primary><varname>auth_delay.milliseconds</> configuration parameter</primary>
+      <primary><varname>auth_delay.milliseconds</> configuration parameter</primary>
 -->
-     <primary><varname>auth_delay.milliseconds</>設定パラメータ</primary>
+      <primary><varname>auth_delay.milliseconds</>設定パラメータ</primary>
 
      </indexterm>
     </term>
@@ -81,7 +81,7 @@ auth_delay.milliseconds = '500'
 
  <sect2>
 <!--
-   <title>Author</title>
+  <title>Author</title>
 -->
   <title>作者</title>
 

--- a/doc/src/sgml/bki.sgml
+++ b/doc/src/sgml/bki.sgml
@@ -379,12 +379,16 @@ NULL値は特別なキーワード、<literal>_null_</literal>によって指定
    <orderedlist>
     <listitem>
      <para>
-      1つの重要なテーブルを<literal>create bootstrap</><!-- one of the critical tables-->
+<!--
+      <literal>create bootstrap</> one of the critical tables
+-->
+      1つの重要なテーブルを<literal>create bootstrap</>
      </para>
     </listitem>
     <listitem>
      <para>
-      少なくとも重要なテーブルを記述するデータを<literal>insert</><!-- data describing at least the critical tables-->
+      <literal>insert</> data describing at least the critical tables
+      少なくとも重要なテーブルを記述するデータを<literal>insert</>
      </para>
     </listitem>
     <listitem>
@@ -402,7 +406,10 @@ NULL値は特別なキーワード、<literal>_null_</literal>によって指定
     </listitem>
     <listitem>
      <para>
-      重要でないテーブルを（<literal>bootstrap</>無しで）<literal>create</><!-- (without <literal>bootstrap</>) a noncritical table-->
+<!--
+      <literal>create</> (without <literal>bootstrap</>) a noncritical table
+-->
+      重要でないテーブルを（<literal>bootstrap</>無しで）<literal>create</>
      </para>
     </listitem>
     <listitem>
@@ -412,7 +419,10 @@ NULL値は特別なキーワード、<literal>_null_</literal>によって指定
     </listitem>
     <listitem>
      <para>
-      求められるデータの<literal>insert</><!-- desired data-->
+<!--
+      <literal>insert</> desired data
+-->
+      求められるデータの<literal>insert</>
      </para>
     </listitem>
     <listitem>

--- a/doc/src/sgml/brin.sgml
+++ b/doc/src/sgml/brin.sgml
@@ -951,6 +951,7 @@ BRINフレームワークは和が変化しない時に操作を省略するこ�
     left-hand-side argument and the other supported data type to be the
     right-hand-side argument of the supported operator.  See
     <literal>float4_minmax_ops</> as an example of minmax, and
+    <literal>box_inclusion_ops</> as an example of inclusion.
 -->
 minmaxとinclusion演算子クラスは、データ型をまたがる演算子をサポートします。
 しかし、これらを使用すると依存関係はより複雑になります。

--- a/doc/src/sgml/catalogs.sgml
+++ b/doc/src/sgml/catalogs.sgml
@@ -12622,7 +12622,21 @@ SQL経由で作成された準備済み文では、これはクライアント�
       <entry>このスロットの利用者に必要かもしれないため、チェックポイント中に自動除去されない、もっとも古いWALの(<literal>LSN</literal>) アドレス。
       </entry>
      </row>
-
+     <row>
+      <entry><structfield>confirmed_flush_lsn</structfield></entry>
+      <entry><type>pg_lsn</type></entry>
+      <entry></entry>
+<!--
+      <entry>The address (<literal>LSN</literal>) up to which the logical
+      slot's consumer has confirmed receiving data. Data older than this is
+      not available anymore. <literal>NULL</> for physical slots.
+      </entry>
+-->
+      <entry>★The address (<literal>LSN</literal>) up to which the logical
+      slot's consumer has confirmed receiving data. Data older than this is
+      not available anymore. <literal>NULL</> for physical slots.
+      </entry>
+     </row>
     </tbody>
    </tgroup>
   </table>

--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -1703,14 +1703,13 @@ SELECT '52093.89'::money::numeric::float8;
      advantages in some other database systems, there is no such advantage in
      <productname>PostgreSQL</productname>; in fact
      <type>character(<replaceable>n</>)</type> is usually the slowest of
-     the three because of its additional storage costs and slower
-     sorting.  In most situations
+     the three because of its additional storage costs.  In most situations
      <type>text</type> or <type>character varying</type> should be used
      instead.
 -->
 空白で埋められる型を使用した場合の保存領域の増加、および、長さ制限付きの列に格納する際に長さを検査するためにいくつか余計なCPUサイクルが加わる点を別にして、これら3つの型の間で性能に関する差異はありません。
 他の一部のデータベースシステムでは<type>character(<replaceable>n</>)</type>には性能的な優位性がありますが、<productname>PostgreSQL</productname>ではこうした利点はありません。
-実際には、格納の際に追加のコストがあったり、ソートが遅かったりするため、<type>character(<replaceable>n</>)</type>は3つの中でもっとも低速です。
+実際には、格納の際に追加のコストがあったり、ソートが遅かったりするため、<type>character(<replaceable>n</>)</type>は3つの中でもっとも低速です。★
 多くの場合、代わりに<type>text</type>か<type>character varying</type>を使うのがお薦めです。
     </para>
    </tip>

--- a/doc/src/sgml/ecpg.sgml
+++ b/doc/src/sgml/ecpg.sgml
@@ -11467,7 +11467,7 @@ NULL指示子データの長さです。
       <listitem>
        <para>
 <!--
-        It equals to <literal>sqldata</literal> if <literal>sqllen</literal> is larger than 32KB.
+        It equals to <literal>sqldata</literal> if <literal>sqllen</literal> is larger than 32kB.
 -->
 <literal>sqllen</literal>が32キロバイトより大きい場合<literal>sqldata</literal>と同じです。
        </para>

--- a/doc/src/sgml/external-projects.sgml
+++ b/doc/src/sgml/external-projects.sgml
@@ -264,7 +264,7 @@
      <row>
       <entry>PL/Java</entry>
       <entry>Java</entry>
-      <entry><ulink url="https://github.com/tada/pljava">https://github.com/tada/pljava</ulink></entry>
+      <entry><ulink url="https://github.com/tada/pljava"></ulink></entry>
      </row>
 
      <row>

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -584,7 +584,7 @@
      <primary>NOTNULL</primary>
     </indexterm>
 <!--
-    To check whether a value is or is not null, use the constructs:
+    To check whether a value is or is not null, use the predicates:
 -->
 値がNULLかNULLでないかを検証するには次の構文を使います。
 <synopsis>
@@ -592,7 +592,7 @@
 <replaceable>expression</replaceable> IS NOT NULL
 </synopsis>
 <!--
-    or the equivalent, but nonstandard, constructs:
+    or the equivalent, but nonstandard, predicates:
 -->
 あるいは、これと同等の、非標準の構文も使えます。
 <synopsis>
@@ -14380,7 +14380,7 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
    ordering rules for B-tree operations outlined at <xref
    linkend="json-indexing">.
 -->
-<xref linkend="functions-comparison-table">に示されている標準の比較演算子が<type>jsonb</type>で利用可能ですが、<type>json</type>ではそうではありません。
+<xref linkend="functions-comparison-op-table">に示されている標準の比較演算子が<type>jsonb</type>で利用可能ですが、<type>json</type>ではそうではありません。
 それらは<xref linkend="json-indexing">で概略を述べたB-tree演算子の順序規則に従います。
   </para>
   <para>

--- a/doc/src/sgml/indexam.sgml
+++ b/doc/src/sgml/indexam.sgml
@@ -72,9 +72,9 @@ MVCCでは1つの論理的な行に複数の現在のバージョンがあるこ
 
  <sect1 id="index-api">
 <!--
-  <title>Catalog Entries for Indexes</title>
+  <title>Basic API Structure for Indexes</title>
 -->
-  <title>インデックス用のカタログ項目</title>
+  <title>★インデックス用のカタログ項目</title>
 
   <para>
 <!--

--- a/doc/src/sgml/indices.sgml
+++ b/doc/src/sgml/indices.sgml
@@ -482,6 +482,9 @@ GiSTやSP-GiST同様、GINも多くの異なるユーザ定義のインデック
   </para>
 
   <para>
+<!--
+   Like GiST and SP-GiST, GIN can support
+   many different user-defined indexing strategies, and the particular
    operators with which a GIN index can be used vary depending on the
    indexing strategy.
    As an example, the standard distribution of
@@ -489,6 +492,14 @@ GiSTやSP-GiST同様、GINも多くの異なるユーザ定義のインデック
    for one-dimensional arrays, which support indexed
    queries using these operators:
 -->
+★ Like GiST and SP-GiST, GIN can support
+   many different user-defined indexing strategies, and the particular
+   operators with which a GIN index can be used vary depending on the
+   indexing strategy.
+   As an example, the standard distribution of
+   <productname>PostgreSQL</productname> includes GIN operator classes
+   for one-dimensional arrays, which support indexed
+   queries using these operators:
 
    <simplelist>
     <member><literal>&lt;@</literal></member>


### PR DESCRIPTION
原文が9.6RC1とdiffがあるものを修正（一部は以前のバージョンからも含む）
func.sgmlのみfunctions-comparison-tableがfunctions-comparison-op-tableに
変更されていたためエラーとなっていた箇所を修正