### PR TITLE
SQLのCASCADEオプションに関連した記述の変更をまとめてPR

### DIFF
--- a/doc/src/sgml/ref/alter_domain.sgml
+++ b/doc/src/sgml/ref/alter_domain.sgml
@@ -292,7 +292,7 @@ ALTER DOMAIN <replaceable class="PARAMETER">name</replaceable>
         and in turn all objects that depend on those objects
         (see <xref linkend="ddl-depend">).
 -->
-その制約に依存するオブジェクトを自動的に削除します。★
+その制約に依存するオブジェクトを自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/ref/alter_foreign_table.sgml
+++ b/doc/src/sgml/ref/alter_foreign_table.sgml
@@ -593,7 +593,7 @@ ALTER FOREIGN TABLE [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceab
         and in turn all objects that depend on those objects
         (see <xref linkend="ddl-depend">).
 -->
-削除される列または制約に依存するオブジェクト（その列を参照するビューなど）を自動的に削除します。★
+削除される列または制約に依存するオブジェクト（その列を参照するビューなど）を自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/ref/drop_aggregate.sgml
+++ b/doc/src/sgml/ref/drop_aggregate.sgml
@@ -153,8 +153,7 @@ DROP AGGREGATE [ IF EXISTS ] <replaceable>name</replaceable> ( <replaceable>aggr
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-その集約関数に依存しているオブジェクトを自動的に削除します。
-★
+その集約関数に依存しているオブジェクト（集約関数を利用しているビューなど）を自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_collation.sgml
+++ b/doc/src/sgml/ref/drop_collation.sgml
@@ -88,7 +88,7 @@ DROP COLLATION [ IF EXISTS ] <replaceable>name</replaceable> [ CASCADE | RESTRIC
        and in turn all objects that depend on those objects
        (see <xref linkend="ddl-depend">).
 -->
-照合順序に依存するオブジェクトを自動的に削除します。★
+照合順序に依存するオブジェクトを自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
       </para>
      </listitem>
     </varlistentry>

--- a/doc/src/sgml/ref/drop_domain.sgml
+++ b/doc/src/sgml/ref/drop_domain.sgml
@@ -90,8 +90,7 @@ DROP DOMAIN [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable> [, .
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-ドメインに依存するオブジェクト（テーブルの列など）を自動的に削除します。
-★
+ドメインに依存するオブジェクト（テーブルの列など）を自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_event_trigger.sgml
+++ b/doc/src/sgml/ref/drop_event_trigger.sgml
@@ -91,8 +91,7 @@ DROP EVENT TRIGGER [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceabl
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-トリガに依存するオブジェクトを自動的に削除します。
-★
+トリガに依存するオブジェクトを自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_extension.sgml
+++ b/doc/src/sgml/ref/drop_extension.sgml
@@ -97,8 +97,7 @@ DROP EXTENSION [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable> [
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-削除する拡張に依存しているオブジェクトを自動的に削除します。
-★
+削除する拡張に依存しているオブジェクトを自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_foreign_data_wrapper.sgml
+++ b/doc/src/sgml/ref/drop_foreign_data_wrapper.sgml
@@ -91,8 +91,7 @@ DROP FOREIGN DATA WRAPPER [ IF EXISTS ] <replaceable class="parameter">name</rep
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-外部データラッパに依存するオブジェクト（サーバなど）を自動的に削除します。
-★
+外部データラッパに依存するオブジェクト（外部テーブルやサーバなど）を自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_foreign_table.sgml
+++ b/doc/src/sgml/ref/drop_foreign_table.sgml
@@ -86,7 +86,7 @@ DROP FOREIGN TABLE [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceabl
       views), and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-削除する外部テーブルに依存しているオブジェクト（ビューなど）を自動的に削除します。
+削除する外部テーブルに依存しているオブジェクト（ビューなど）を自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_function.sgml
+++ b/doc/src/sgml/ref/drop_function.sgml
@@ -150,8 +150,7 @@ DROP FUNCTION [ IF EXISTS ] <replaceable class="parameter">name</replaceable> ( 
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-関数に依存するオブジェクト（演算子やトリガなど）を自動的に削除します。
-★
+関数に依存するオブジェクト（演算子やトリガなど）を自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_index.sgml
+++ b/doc/src/sgml/ref/drop_index.sgml
@@ -123,8 +123,7 @@ DROP INDEX [ CONCURRENTLY ] [ IF EXISTS ] <replaceable class="PARAMETER">name</r
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-そのインデックスに依存しているオブジェクトを自動的に削除します。
-★
+そのインデックスに依存しているオブジェクトを自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_language.sgml
+++ b/doc/src/sgml/ref/drop_language.sgml
@@ -106,8 +106,7 @@ DROP [ PROCEDURAL ] LANGUAGE [ IF EXISTS ] <replaceable class="PARAMETER">name</
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-その言語に依存するオブジェクト（その言語で記述された関数など）を自動的に削除します。
-★
+その言語に依存するオブジェクト（その言語で記述された関数など）を自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_materialized_view.sgml
+++ b/doc/src/sgml/ref/drop_materialized_view.sgml
@@ -92,8 +92,7 @@ DROP MATERIALIZED VIEW [ IF EXISTS ] <replaceable class="PARAMETER">name</replac
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-マテリアライズドビューに依存するオブジェクト（他のマテリアライズドビューや通常のビュー）を自動的に削除します。
-★
+マテリアライズドビューに依存するオブジェクト（他のマテリアライズドビューや通常のビューなど）を自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_opclass.sgml
+++ b/doc/src/sgml/ref/drop_opclass.sgml
@@ -113,8 +113,8 @@ DROP OPERATOR CLASS [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceab
       indexes), and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-      この演算子クラスに依存しているオブジェクトを自動的に削除します。
-★
+この演算子クラスに依存しているオブジェクト（インデックスなど）を自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します
+（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_operator.sgml
+++ b/doc/src/sgml/ref/drop_operator.sgml
@@ -119,8 +119,7 @@ DROP OPERATOR [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable> ( 
       using it), and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-演算子に依存するオブジェクトを自動的に削除します。
-★
+演算子に依存するオブジェクト（その演算子を使用するビューなど）を自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_opfamily.sgml
+++ b/doc/src/sgml/ref/drop_opfamily.sgml
@@ -115,8 +115,7 @@ DROP OPERATOR FAMILY [ IF EXISTS ] <replaceable class="PARAMETER">name</replacea
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-演算子族に依存するオブジェクトを自動的に削除します。
-★
+演算子族に依存するオブジェクトを自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_owned.sgml
+++ b/doc/src/sgml/ref/drop_owned.sgml
@@ -79,8 +79,7 @@ DROP OWNED BY { <replaceable class="PARAMETER">name</replaceable> | CURRENT_USER
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-関連するオブジェクトに依存するオブジェクトを自動的に削除します。
-★
+関連するオブジェクトに依存するオブジェクトを自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_policy.sgml
+++ b/doc/src/sgml/ref/drop_policy.sgml
@@ -109,8 +109,8 @@ DROP POLICY [ IF EXISTS ] <replaceable class="parameter">name</replaceable> ON <
       These key words do not have any effect, since there are no
       dependencies on policies.
 -->
-★    These key words do not have any effect, since there are no
-      dependencies on policies.
+これらのキーワードには何の効果もありません。
+ポリシーには依存関係がないからです。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_rule.sgml
+++ b/doc/src/sgml/ref/drop_rule.sgml
@@ -101,8 +101,7 @@ DROP RULE [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable> ON <re
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-ルールに依存するオブジェクトを自動的に削除します。
-★
+ルールに依存するオブジェクトを自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_schema.sgml
+++ b/doc/src/sgml/ref/drop_schema.sgml
@@ -52,7 +52,6 @@ DROP SCHEMA [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable> [, .
 -->
 スキーマを削除できるのは、所有者またはスーパーユーザのみです。
 所有者は、スキーマ内に自分が所有していないオブジェクトが含まれていても、そのスキーマ（およびそこに含まれる全てのオブジェクト）を削除できます。
-★
   </para>
  </refsect1>
 
@@ -99,8 +98,7 @@ DROP SCHEMA [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable> [, .
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-スキーマに含まれるオブジェクト（テーブル、関数など）を自動的に削除します。
-★
+スキーマに含まれるオブジェクト（テーブル、関数など）を自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>
@@ -132,8 +130,7 @@ DROP SCHEMA [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable> [, .
    Using the <literal>CASCADE</literal> option might make the command
    remove objects in other schemas besides the one(s) named.
 -->
-★ Using the <literal>CASCADE</literal> option might make the command
-   remove objects in other schemas besides the one(s) named.
+<literal>CASCADE</literal>オプションを使用すると、指定されたスキーマ以外にあるオブジェクトを削除することになる可能性があります。
 
   </para>
  </refsect1>

--- a/doc/src/sgml/ref/drop_sequence.sgml
+++ b/doc/src/sgml/ref/drop_sequence.sgml
@@ -89,8 +89,7 @@ DROP SEQUENCE [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable> [,
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-このシーケンスに依存しているオブジェクトを自動的に削除します。
-★
+このシーケンスに依存しているオブジェクトを自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_server.sgml
+++ b/doc/src/sgml/ref/drop_server.sgml
@@ -91,8 +91,7 @@ DROP SERVER [ IF EXISTS ] <replaceable class="parameter">name</replaceable> [ CA
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-サーバに依存するオブジェクト（ユーザマップなど）を自動的に削除します。
-★
+サーバに依存するオブジェクト（ユーザマップなど）を自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_table.sgml
+++ b/doc/src/sgml/ref/drop_table.sgml
@@ -109,8 +109,7 @@ DROP TABLE [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable> [, ..
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-削除するテーブルに依存しているオブジェクト（ビューなど）を自動的に削除します。
-★
+削除するテーブルに依存しているオブジェクト（ビューなど）を自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_transform.sgml
+++ b/doc/src/sgml/ref/drop_transform.sgml
@@ -108,8 +108,7 @@ DROP TRANSFORM [ IF EXISTS ] FOR <replaceable>type_name</replaceable> LANGUAGE <
        and in turn all objects that depend on those objects
        (see <xref linkend="ddl-depend">).
 -->
-変換に依存するオブジェクトを自動的に削除します。
-★
+変換に依存するオブジェクトを自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
       </para>
      </listitem>
     </varlistentry>

--- a/doc/src/sgml/ref/drop_trigger.sgml
+++ b/doc/src/sgml/ref/drop_trigger.sgml
@@ -103,8 +103,7 @@ DROP TRIGGER [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable> ON 
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-このトリガに依存しているオブジェクトを自動的に削除します。
-★
+このトリガに依存しているオブジェクトを自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_tsconfig.sgml
+++ b/doc/src/sgml/ref/drop_tsconfig.sgml
@@ -92,8 +92,7 @@ DROP TEXT SEARCH CONFIGURATION [ IF EXISTS ] <replaceable class="PARAMETER">name
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-テキスト検索設定に依存するオブジェクトを自動的に削除します。
-★
+テキスト検索設定に依存するオブジェクトを自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_tsdictionary.sgml
+++ b/doc/src/sgml/ref/drop_tsdictionary.sgml
@@ -92,8 +92,7 @@ DROP TEXT SEARCH DICTIONARY [ IF EXISTS ] <replaceable class="PARAMETER">name</r
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-テキスト検索辞書に依存するオブジェクトを自動的に削除します。
-★
+テキスト検索辞書に依存するオブジェクトを自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_tsparser.sgml
+++ b/doc/src/sgml/ref/drop_tsparser.sgml
@@ -90,8 +90,7 @@ DROP TEXT SEARCH PARSER [ IF EXISTS ] <replaceable class="PARAMETER">name</repla
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-テキスト検索パーサに依存するオブジェクトを自動的に削除します。
-★
+テキスト検索パーサに依存するオブジェクトを自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_tstemplate.sgml
+++ b/doc/src/sgml/ref/drop_tstemplate.sgml
@@ -91,8 +91,7 @@ DROP TEXT SEARCH TEMPLATE [ IF EXISTS ] <replaceable class="PARAMETER">name</rep
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-テキスト検索テンプレートに依存するオブジェクトを自動的に削除します。
-★
+テキスト検索テンプレートに依存するオブジェクトを自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_type.sgml
+++ b/doc/src/sgml/ref/drop_type.sgml
@@ -90,8 +90,7 @@ DROP TYPE [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable> [, ...
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-削除するデータ型に依存するオブジェクト（テーブルの列、関数、演算子など）を自動的に削除します。
-★
+削除するデータ型に依存するオブジェクト（テーブルの列、関数、演算子など）を自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/drop_view.sgml
+++ b/doc/src/sgml/ref/drop_view.sgml
@@ -90,8 +90,7 @@ DROP VIEW [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable> [, ...
       and in turn all objects that depend on those objects
       (see <xref linkend="ddl-depend">).
 -->
-削除するビューに依存しているオブジェクト（他のビューなど）を自動的に削除します。
-★
+削除するビューに依存しているオブジェクト（他のビューなど）を自動的に削除し、さらにそれらのオブジェクトに依存するすべてのオブジェクトも削除します（<xref linkend="ddl-depend">参照）。
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
同じ修正内容のものだけを全部まとめるつもりだったのですが、1件(drop_policy.sgml)だけ、記述内容の異なるものが混じってしまいました。
他は、操作ミスがなければ、同じ修正(のはず)です。