### PR TITLE
grant.sgmlの9.6対応です。

### DIFF
--- a/doc/src/sgml/ref/grant.sgml
+++ b/doc/src/sgml/ref/grant.sgml
@@ -185,7 +185,6 @@ GRANT <replaceable class="PARAMETER">role_name</replaceable> [, ...] TO <replace
 -->
 所有者（通常はオブジェクトを作成したユーザ）はデフォルトで全ての権限を保持しているため、オブジェクトの所有者に権限を許可する必要はありません
 （ただし、オブジェクトの作成者が、安全性のために自らの権限を取り消すことは可能です）。
-★
   </para>
 
   <para>
@@ -516,7 +515,7 @@ PostgreSQLは、一部の種類のオブジェクトに対し、デフォルト�
        tables using the server, and also to create, alter, or drop their own
        user's user mappings associated with that server.
 -->
-対象がサーバの場合、この権限を与えられると、サーバを使用する外部テーブルの作成を行うことができ、サーバと関連し自身が所有するユーザのユーザマップを作成、変更、削除を行うことができます。★
+対象がサーバの場合、この権限を与えられると、サーバを使用する外部テーブルの作成を行うことができ、サーバと関連し自身が所有するユーザのユーザマップを作成、変更、削除を行うことができます。
       </para>
      </listitem>
     </varlistentry>
@@ -631,7 +630,7 @@ PostgreSQLは、一部の種類のオブジェクトに対し、デフォルト�
     revoking it for one column will not do what one might wish: the
     table-level grant is unaffected by a column-level operation.
 -->
-★ユーザは特定の列あるいはテーブル全体に対する権限を持つ場合に<command>SELECT</>、<command>INSERT</>などを実行することができます。
+ユーザは特定の列あるいはテーブル全体に対する権限を持つ場合に<command>SELECT</>、<command>INSERT</>などを実行することができます。
 テーブルレベルの権限を付与してからある列に対する権限を取り消しても、望むことは実現できません。
 テーブルレベルの権限は列レベルの操作による影響を受けないからです。
    </para>
@@ -930,7 +929,7 @@ GRANT admins TO joe;
     granted by an assumed entity <quote>_SYSTEM</>.  Not being
     <quote>_SYSTEM</>, the owner cannot revoke these rights.
 -->
-★<productname>PostgreSQL</productname>では、オブジェクトの所有者は、自身が持つ権限を取り消すことができます。
+<productname>PostgreSQL</productname>では、オブジェクトの所有者は、自身が持つ権限を取り消すことができます。
 例えば、テーブル所有者は自身の<literal>INSERT</>、<literal>UPDATE</>、<literal>DELETE</>、<literal>TRUNCATE</>権限を取り消すことで、自分にとってそのテーブルが読み取り専用になるよう変更することができます。
 これは、標準SQLでは不可能です。
 <productname>PostgreSQL</productname>では、所有者の権限を、所有者自身により与えられたものとして扱っているため、同様に所有者自身で権限を取り消すことができるようになっています。


### PR DESCRIPTION
明示的には訳出されない"his"→"their"などの変更のみなので、訳文は変更していません。