### PR TITLE
update auto-explain and install-windows to 9.6.0

### DIFF
--- a/doc/src/sgml/auto-explain.sgml
+++ b/doc/src/sgml/auto-explain.sgml
@@ -310,15 +310,24 @@ LOAD 'auto_explain';
     <term>
      <varname>auto_explain.sample_rate</varname> (<type>real</type>)
      <indexterm>
+<!--
       <primary><varname>auto_explain.sample_rate</> configuration parameter</primary>
+-->
+      <primary><varname>auto_explain.sample_rate</>設定パラメータ</primary>
      </indexterm>
     </term>
     <listitem>
      <para>
+<!--
       <varname>auto_explain.sample_rate</varname> causes auto_explain to only
       explain a fraction of the statements in each session.  The default is 1,
       meaning explain all the queries.  In case of nested statements, either all
       will be explained or none. Only superusers can change this setting.
+-->
+<varname>auto_explain.sample_rate</varname>により、auto_explainは各セッションで一部の文の実行計画のみをログに記録するようになります。
+デフォルトは1で、すべての問い合わせの実行計画をログに記録します。
+入れ子になった文の場合には、実行計画がすべてログに記録されるか、全くされないかのどちらかです。
+スーパーユーザのみがこの設定を変更できます。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/install-windows.sgml
+++ b/doc/src/sgml/install-windows.sgml
@@ -376,7 +376,7 @@ GnuWin32からのBisonディストリビューションでは、<filename>C:\Pro
        MSYS instead.
 -->
 PostgreSQL FTPサイトで配布され、古い文書で参照していた古い<literal>winflex</literal>は、64ビットWindowsホストでは<quote>flex: fatal internal error, exec failed</quote>で失敗します。
-代わりにmsysからのflexを使用してください。
+代わりにMSYSからのflexを使用してください。
        </para>
      </note>
      </listitem>

--- a/doc/src/sgml/install-windows.sgml
+++ b/doc/src/sgml/install-windows.sgml
@@ -375,8 +375,8 @@ GnuWin32からのBisonディストリビューションでは、<filename>C:\Pro
        internal error, exec failed</quote> on 64-bit Windows hosts. Use Flex from
        MSYS instead.
 -->
-PostgreSQL FTPサイトで配布され、古い文書で参照していた古い"winflex"は、64ビットWindowsホストでは"flex: fatal internal error, exec failed"で失敗します。
-代わりにmsysからのflexを使用してください。 ★変更あり
+PostgreSQL FTPサイトで配布され、古い文書で参照していた古い<literal>winflex</literal>は、64ビットWindowsホストでは<quote>flex: fatal internal error, exec failed</quote>で失敗します。
+代わりにmsysからのflexを使用してください。
        </para>
      </note>
      </listitem>
@@ -700,10 +700,12 @@ $ENV{CONFIG}="Debug";
 
   <para>
 <!--
-   Running the regression tests on client programs, with "vcregress bincheck",
-   requires an additional Perl module to be installed:
+   Running the regression tests on client programs, with
+   <command>vcregress bincheck</>, or on recovery tests, with
+   <command>vcregress recoverycheck</>, requires an additional Perl module
+   to be installed:
 -->
-クライアントプログラムで"vcregress bincheck"によりリグレッションテストを実行するには、追加のPerlモジュールをインストールしておかなければなりません。
+クライアントプログラムで<command>vcregress bincheck</>によりリグレッションテストを実行したり、<command>vcregress recoverycheck</>によりリカバリテストを実行したりするには、追加のPerlモジュールをインストールしておかなければなりません。
    <variablelist>
     <varlistentry>
      <term><productname>IPC::Run</productname></term>
@@ -722,31 +724,6 @@ $ENV{CONFIG}="Debug";
 インストールするためには、<ulink url="http://search.cpan.org/dist/IPC-Run/"></>でCPANから<filename>IPC-Run-&lt;version&gt;.tar.gz</>ソースアーカイブをダウンロードして、展開してください。
 <filename>buildenv.pl</>を編集して、取り出されたアーカイブから<filename>lib</>サブディレクトリを指すように変数PERL5LIBを追加してください。
 例えば以下の通りです。
-<programlisting>
-$ENV{PERL5LIB}=$ENV{PERL5LIB} . ';c:\IPC-Run-0.94\lib';
-</programlisting>
-     </para></listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
-  <para>
-   Running the regression tests on client programs, with
-   <command>vcregress bincheck</>, or on recovery tests, with
-   <command>vcregress recoverycheck</>, requires an additional Perl module
-   to be installed:
-   <variablelist>
-    <varlistentry>
-     <term><productname>IPC::Run</productname></term>
-     <listitem><para>
-      As of this writing, <literal>IPC::Run</> is not included in the
-      ActiveState Perl installation, nor in the ActiveState Perl Package
-      Manager (PPM) library. To install, download the
-      <filename>IPC-Run-&lt;version&gt;.tar.gz</> source archive from CPAN,
-      at <ulink url="http://search.cpan.org/dist/IPC-Run/"></>, and
-      uncompress. Edit the <filename>buildenv.pl</> file, and add a PERL5LIB
-      variable to point to the <filename>lib</> subdirectory from the
-      extracted archive. For example:
 <programlisting>
 $ENV{PERL5LIB}=$ENV{PERL5LIB} . ';c:\IPC-Run-0.94\lib';
 </programlisting>


### PR DESCRIPTION
以下のファイルの9.6.0対応です。

auto-explain.sgml
install-windows.sgml

install-windowsで段落がまるまる無くなっているように見えますが、対応する訳は（その直前に）既にありますので問題ないはずです。