### PR TITLE
update pgstandby and plpython to 9.6.0

### DIFF
--- a/doc/src/sgml/pgstandby.sgml
+++ b/doc/src/sgml/pgstandby.sgml
@@ -541,7 +541,7 @@ recovery_end_command = 'del C:\pgsql.trigger.5442'
 -->
 Windowsの<literal>copy</>コマンドは、ファイルが完全にコピーされる前に、最終的なファイルサイズを設定します。
 これは通常<application>pg_standby</application>を誤動作させます。
-したがって、<application>pg_standby</application>は適切なファイルサイズを見てから、いったん<literal>sleeptime</>秒待ちます。
+したがって、<application>pg_standby</application>は適切なファイルサイズを見てから、いったん<replaceable>sleeptime</>秒待ちます。
 GNUWin32の<literal>cp</>は、ファイルコピーが完了した後にだけ、ファイルサイズを設定します。
   </para>
 

--- a/doc/src/sgml/plpython.sgml
+++ b/doc/src/sgml/plpython.sgml
@@ -1937,7 +1937,7 @@ $$ LANGUAGE plpythonu;
    variables. See <xref linkend="runtime-config"> for more information.
 -->
 <function>plpy.error</function>および<function>plpy.fatal</function>は、実際にPythonの例外を発生させます。
-これが捕捉されない場合、呼び出し中の問い合わせ外部に伝わり、その結果、現在のトランザクションもしくはサブトランザクションがアボートします。
+これが捕捉されない場合、呼び出し中の問い合わせに伝わり、その結果、現在のトランザクションもしくはサブトランザクションがアボートします。
 <literal>raise plpy.Error(<replaceable>msg</>)</literal>および<literal>raise plpy.Fatal(<replaceable>msg</>)</literal>は、それぞれ<function>plpy.error</function>および<function>plpy.fatal</function>の呼び出しと同じですが、<literal>raise</literal>形式ではキーワード引数を渡すことがことができません。
 他の関数は異なる重要度のメッセージを生成するだけです。
 <xref linkend="guc-log-min-messages">と<xref linkend="guc-client-min-messages">設定変数は、特定の重要度のメッセージをクライアントに報告するか、サーバのログに書き出すか、あるいはその両方かを制御します。

--- a/doc/src/sgml/plpython.sgml
+++ b/doc/src/sgml/plpython.sgml
@@ -4,7 +4,7 @@
 <!--
  <title>PL/Python - Python Procedural Language</title>
 -->
-<title>PL/Python - Python手続き言語</title>
+ <title>PL/Python - Python手続き言語</title>
 
  <indexterm zone="plpython"><primary>PL/Python</></>
  <indexterm zone="plpython"><primary>Python</></>
@@ -15,7 +15,7 @@
   <productname>PostgreSQL</productname> functions to be written in the
   <ulink url="http://www.python.org">Python language</ulink>.
 -->
-<application>PL/Python</application>手続き言語を使用して<productname>PostgreSQL</productname>の関数を<ulink url="http://www.python.org/">Python言語</ulink>で作成することができます。
+<application>PL/Python</application>手続き言語を使用して<productname>PostgreSQL</productname>の関数を<ulink url="http://www.python.org/">Python言語</ulink>で作成できます。
  </para>
 
  <para>
@@ -1902,10 +1902,11 @@ $$ LANGUAGE plpythonu;
   <title>Utility Functions</title>
 -->
   <title>ユーティリティ関数</title>
-
   <para>
 <!--
    The <literal>plpy</literal> module also provides the functions
+-->
+<literal>plpy</literal>モジュールでは以下の関数も提供しています。
    <simplelist>
     <member><literal>plpy.debug(<replaceable>msg, **kwargs</>)</literal></member>
     <member><literal>plpy.log(<replaceable>msg, **kwargs</>)</literal></member>
@@ -1915,7 +1916,11 @@ $$ LANGUAGE plpythonu;
     <member><literal>plpy.error(<replaceable>msg, **kwargs</>)</literal></member>
     <member><literal>plpy.fatal(<replaceable>msg, **kwargs</>)</literal></member>
    </simplelist>
+<!--
    <indexterm><primary>elog</><secondary>in PL/Python</></indexterm>
+-->
+   <indexterm><primary>elog</><secondary>PL/Pythonにおける</></indexterm>
+<!--
    <function>plpy.error</function> and <function>plpy.fatal</function>
    actually raise a Python exception which, if uncaught, propagates out to
    the calling query, causing the current transaction or subtransaction to
@@ -1931,11 +1936,9 @@ $$ LANGUAGE plpythonu;
    <xref linkend="guc-client-min-messages"> configuration
    variables. See <xref linkend="runtime-config"> for more information.
 -->
-★<literal>plpy</literal>では、<literal>plpy.debug(<replaceable>msg</>)</literal>、<literal>plpy.log(<replaceable>msg</>)</literal>、<literal>plpy.info(<replaceable>msg</>)</literal>、<literal>plpy.notice(<replaceable>msg</>)</literal>、<literal>plpy.warning(<replaceable>msg</>)</literal>、<literal>plpy.error(<replaceable>msg</>)</literal>、および<literal>plpy.fatal(<replaceable>msg</>)</literal>関数を提供しています。
-<indexterm><primary>elog</><secondary>PL/Pythonにおける</></indexterm>
 <function>plpy.error</function>および<function>plpy.fatal</function>は、実際にPythonの例外を発生させます。
 これが捕捉されない場合、呼び出し中の問い合わせ外部に伝わり、その結果、現在のトランザクションもしくはサブトランザクションがアボートします。
-<literal>raise plpy.Error(<replaceable>msg</>)</literal>および<literal>raise plpy.Fatal(<replaceable>msg</>)</literal>は、それぞれ<function>plpy.error</function>および<function>plpy.fatal</function>の呼び出しと同じです。
+<literal>raise plpy.Error(<replaceable>msg</>)</literal>および<literal>raise plpy.Fatal(<replaceable>msg</>)</literal>は、それぞれ<function>plpy.error</function>および<function>plpy.fatal</function>の呼び出しと同じですが、<literal>raise</literal>形式ではキーワード引数を渡すことがことができません。
 他の関数は異なる重要度のメッセージを生成するだけです。
 <xref linkend="guc-log-min-messages">と<xref linkend="guc-client-min-messages">設定変数は、特定の重要度のメッセージをクライアントに報告するか、サーバのログに書き出すか、あるいはその両方かを制御します。
 詳細は<xref linkend="runtime-config">を参照してください。
@@ -1948,14 +1951,16 @@ $$ LANGUAGE plpythonu;
    that case, the string representation of the tuple of positional arguments
    becomes the message reported to the client.
 -->
-★ The <replaceable>msg</> argument is given as a positional argument.  For
-   backward compatibility, more than one positional argument can be given. In
-   that case, the string representation of the tuple of positional arguments
-   becomes the message reported to the client.
+<replaceable>msg</>引数は位置引数として与えられます。
+後方互換性のために、2つ以上の位置引数を与えることができます。
+その場合、位置引数のタプルの文字列表現がクライアントに報告されるメッセージになります。
   </para>
 
   <para>
+<!--
    The following keyword-only arguments are accepted:
+-->
+以下のキーワードのみの引数を受け付けます。
    <simplelist>
     <member><literal>detail</literal></member>
     <member><literal>hint</literal></member>
@@ -1970,8 +1975,8 @@ $$ LANGUAGE plpythonu;
    The string representation of the objects passed as keyword-only arguments
    is used to enrich the messages reported to the client. For example:
 -->
-★ The string representation of the objects passed as keyword-only arguments
-   is used to enrich the messages reported to the client. For example:
+キーワードのみの引数として渡されたオブジェクトの文字列表現は、クライアントへ報告されるメッセージを豊富にするのに使われます。
+例えば、
 
 <programlisting>
 CREATE FUNCTION raise_custom_exception() RETURNS void AS $$


### PR DESCRIPTION
以下のファイルの9.6.0対応です。

plpython.sgml
pgstandby.sgml

plpythonの方はPythonに詳しい人に見て頂けると助かります。(私個人はPythonを良く知っている訳ではないので、、、)