### PR TITLE
func.sgmlの9.7節（パターンマッチ）および9.8節（データ型書式設定）の9.6対応です。

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -5288,7 +5288,7 @@ substring('foobar' from '#"o_b#"%' for '#')    <lineannotation>NULL</lineannotat
     <xref linkend="functions-posix-table"> lists the available
     operators for pattern matching using POSIX regular expressions.
 -->
-<xref linkend="functions-posix-table">に、POSIX正規表現を使ったパターン一致に使用可能な演算子を列挙します。
+<xref linkend="functions-posix-table">に、POSIX正規表現を使ったパターンマッチに使用可能な演算子を列挙します。
    </para>
 
    <table id="functions-posix-table">
@@ -5317,7 +5317,7 @@ substring('foobar' from '#"o_b#"%' for '#')    <lineannotation>NULL</lineannotat
 <!--
         <entry>Matches regular expression, case sensitive</entry>
 -->
-        <entry>正規表現に一致、大文字小文字の区別あり</entry>
+        <entry>正規表現にマッチ、大文字小文字の区別あり</entry>
         <entry><literal>'thomas' ~ '.*thomas.*'</literal></entry>
        </row>
 
@@ -5326,7 +5326,7 @@ substring('foobar' from '#"o_b#"%' for '#')    <lineannotation>NULL</lineannotat
 <!--
         <entry>Matches regular expression, case insensitive</entry>
 -->
-        <entry>正規表現に一致、大文字小文字の区別なし</entry>
+        <entry>正規表現にマッチ、大文字小文字の区別なし</entry>
         <entry><literal>'thomas' ~* '.*Thomas.*'</literal></entry>
        </row>
 
@@ -5335,7 +5335,7 @@ substring('foobar' from '#"o_b#"%' for '#')    <lineannotation>NULL</lineannotat
 <!--
         <entry>Does not match regular expression, case sensitive</entry>
 -->
-        <entry>正規表現に一致しない、大文字小文字の区別あり</entry>
+        <entry>正規表現にマッチしない、大文字小文字の区別あり</entry>
         <entry><literal>'thomas' !~ '.*Thomas.*'</literal></entry>
        </row>
 
@@ -5344,7 +5344,7 @@ substring('foobar' from '#"o_b#"%' for '#')    <lineannotation>NULL</lineannotat
 <!--
         <entry>Does not match regular expression, case insensitive</entry>
 -->
-        <entry>正規表現に一致しない、大文字小文字の区別なし</entry>
+        <entry>正規表現にマッチしない、大文字小文字の区別なし</entry>
         <entry><literal>'thomas' !~* '.*vadim.*'</literal></entry>
        </row>
       </tbody>
@@ -5380,9 +5380,9 @@ substring('foobar' from '#"o_b#"%' for '#')    <lineannotation>NULL</lineannotat
      end of the string.
 -->
 正規表現とは文字列の集合（<firstterm>正規集合</firstterm>）の簡略された定義である文字が連なっているものです。
-ある文字列が正規表現で記述された正規集合の要素になっていれば、その文字列は正規表現に一致していると呼ばれます。
-<function>LIKE</function>と同様、正規表現言語で特殊文字とされているもの以外、パターン文字は文字列と完全に一致されます。とは言っても、正規表現は<function>LIKE</function>関数が使用するのとは異なる特殊文字を使用します。
-<function>LIKE</function>関数のパターンと違って正規表現は、明示的に正規表現が文字列の最初または最後からと位置指定されていない限り文字列内のどの位置でも一致を行えます。
+ある文字列が正規表現で記述された正規集合の要素になっていれば、その文字列は正規表現にマッチしていると呼ばれます。
+<function>LIKE</function>と同様、正規表現言語で特殊文字とされているもの以外、パターン文字は文字列と完全にマッチされます。とは言っても、正規表現は<function>LIKE</function>関数が使用するのとは異なる特殊文字を使用します。
+<function>LIKE</function>関数のパターンと違って正規表現は、明示的に正規表現が文字列の最初または最後からと位置指定されていない限り文字列内のどの位置でもマッチを行えます。
     </para>
 
     <para>
@@ -5423,9 +5423,9 @@ substring('foobar' from '#"o_b#"%' for '#')    <lineannotation>NULL</lineannotat
      subexpression you want to extract, see the non-capturing parentheses
      described below.
 -->
-2つのパラメータを持つ<function>substring</>関数、<function>substring(<parameter>string</parameter> from <replaceable>pattern</replaceable>)</function>を使用して、POSIX正規表現パターンに一致する部分文字列を取り出すことができます。
-この関数は、一致するものがない場合にはNULLを返し、ある場合はパターンにマッチしたテキストの一部を返します。
-しかし、丸括弧を持つパターンの場合、最初の丸括弧内部分正規表現（左丸括弧が最初に来るもの）に一致するテキストの一部が返されます。
+2つのパラメータを持つ<function>substring</>関数、<function>substring(<parameter>string</parameter> from <replaceable>pattern</replaceable>)</function>を使用して、POSIX正規表現パターンにマッチする部分文字列を取り出すことができます。
+この関数は、マッチするものがない場合にはNULLを返し、ある場合はパターンにマッチしたテキストの一部を返します。
+しかし、丸括弧を持つパターンの場合、最初の丸括弧内部分正規表現（左丸括弧が最初に来るもの）にマッチするテキストの一部が返されます。
 この例外を起こさずにパターン中に丸括弧を使用したいのであれば、常に正規表現全体を丸括弧で囲むことができます。
 パターン内の抽出対象の部分文字列より前に丸括弧が必要な場合、後述の捕捉されない丸括弧を参照してください。
     </para>
@@ -5469,14 +5469,14 @@ substring('foobar' from 'o(.)b')   <lineannotation>o</lineannotation>
      not <literal>g</>) are
      described in <xref linkend="posix-embedded-options-table">.
 -->
-<function>regexp_replace</>関数は、POSIX正規表現パターンに一致する部分文字列を新規テキストと置換します。
+<function>regexp_replace</>関数は、POSIX正規表現パターンにマッチする部分文字列を新規テキストと置換します。
 構文は、<function>regexp_replace</function>(<replaceable>source</>, <replaceable>pattern</>, <replaceable>replacement</> <optional>, <replaceable>flags</> </optional>)です。
 <replaceable>pattern</>にマッチしない場合は、<replaceable>source</>文字列がそのまま返されます。
-一致すると、マッチ部分文字列を<replaceable>replacement</>文字列で置換した<replaceable>source</>文字列が返されます。
-<replaceable>replacement</>文字列に<literal>\</><replaceable>n</>（<replaceable>n</>は1から9までの数字）を入れて、パターン内の<replaceable>n</>番目の丸括弧つき部分表現に一致する元の部分文字列を挿入することができます。
-また、<literal>\&amp;</>を入れて、パターン全体と一致する部分文字列を挿入することもできます。
+マッチすると、マッチ部分文字列を<replaceable>replacement</>文字列で置換した<replaceable>source</>文字列が返されます。
+<replaceable>replacement</>文字列に<literal>\</><replaceable>n</>（<replaceable>n</>は1から9までの数字）を入れて、パターン内の<replaceable>n</>番目の丸括弧つき部分表現にマッチする元の部分文字列を挿入することができます。
+また、<literal>\&amp;</>を入れて、パターン全体とマッチする部分文字列を挿入することもできます。
 置換テキスト内にバックスラッシュそのものを挿入する必要がある時は<literal>\\</>と記述します。
-<replaceable>flags</>パラメータは、関数の動作を変更するゼロもしくはそれ以上の1文字フラグを含むオプションのテキスト文字列です。フラグ<literal>i</>は大文字小文字を区別しない一致を指定する一方、フラグ<literal>g</>は、最初に一致したもののみではなく、それぞれ一致した部分文字列の置換を指定します。
+<replaceable>flags</>パラメータは、関数の動作を変更するゼロもしくはそれ以上の1文字フラグを含むオプションのテキスト文字列です。フラグ<literal>i</>は大文字小文字を区別しないマッチを指定する一方、フラグ<literal>g</>は、最初にマッチしたもののみではなく、それぞれマッチした部分文字列の置換を指定します。
 有効なフラグは(<literal>g</>を除く)<xref linkend="posix-embedded-options-table">に記述されています。
     </para>
 
@@ -5524,11 +5524,11 @@ regexp_replace('foobarbaz', 'b(..)', E'X\\1Y', 'g')
 <function>regexp_matches</>関数はPOSIX正規表現パターンマッチの結果捕捉された全ての部分文字列のテキスト配列を返します。
 <function>regexp_matches</function>(<replaceable>string</>, <replaceable>pattern</> <optional>, <replaceable>flags</> </optional>)の構文になります。
 この関数は何も行を返さない、1行を返す、複数行を返す（下記の<literal>g</>フラグを参照）といったことができます。
-もし<replaceable>pattern</>に対して一致しない場合、関数は行を返しません。
-もし、パターンが丸括弧に括られた部分文字列を含まない場合、結果はパターン全体に一致する部分文字列を含む単一要素のテキスト配列となります。
-もし、パターンが丸括弧に括られた部分文字列を含む場合、関数はテキスト配列を返し、その<replaceable>n</>番目の要素は、パターンの<replaceable>n</>番目に丸括弧で括られた部分文字列に一致する部分文字列となります（<quote>捕捉されない</>丸括弧は数えません。詳細は下を見てください。）。
+もし<replaceable>pattern</>に対してマッチしない場合、関数は行を返しません。
+もし、パターンが丸括弧に括られた部分文字列を含まない場合、結果はパターン全体にマッチする部分文字列を含む単一要素のテキスト配列となります。
+もし、パターンが丸括弧に括られた部分文字列を含む場合、関数はテキスト配列を返し、その<replaceable>n</>番目の要素は、パターンの<replaceable>n</>番目に丸括弧で括られた部分文字列にマッチする部分文字列となります（<quote>捕捉されない</>丸括弧は数えません。詳細は下を見てください。）。
 <replaceable>flags</>パラメータは、関数の動作を変更するゼロもしくは複数の単一文字フラグを含むオプションのテキスト文字列です。
-フラグ<literal>g</>を指定すると、関数は最初のマッチだけでなく文字列の中で全てのマッチを検出し、それぞれの一致について1行を返します。
+フラグ<literal>g</>を指定すると、関数は最初のマッチだけでなく文字列の中で全てのマッチを検出し、それぞれのマッチについて1行を返します。
 有効なフラグは(<literal>g</>を除く)<xref linkend="posix-embedded-options-table">に記載されています。
     </para>
 
@@ -5590,8 +5590,8 @@ SELECT col1, (SELECT regexp_matches(col2, '(bar)(beque)')) FROM tab;
      <xref linkend="posix-embedded-options-table">.
 -->
 <function>regexp_split_to_table</>関数はPOSIX正規表現パターンを区切り文字として使用し、文字列を分割します。<function>regexp_split_to_table</function>(<replaceable>string</>, <replaceable>pattern</> <optional>, <replaceable>flags</> </optional>)の構文になります。
-<replaceable>pattern</>に一致しない場合、関数は<replaceable>string</>を返します。
-少なくともひとつの一致があれば、それぞれの一致に対して関数は最後のマッチの終わり（あるいは文字列の始め）から最初のマッチまでのテキストを返します。
+<replaceable>pattern</>にマッチしない場合、関数は<replaceable>string</>を返します。
+少なくともひとつのマッチがあれば、それぞれのマッチに対して関数は最後のマッチの終わり（あるいは文字列の始め）から最初のマッチまでのテキストを返します。
 もはやマッチしなくなると最後のマッチの終わりから文字列の最後までテキストを返します。
 <replaceable>flags</>パラメータは、関数の動作を変更するゼロもしくは複数の単一文字フラグを含むオプションのテキスト文字列です。
 <function>regexp_split_to_table</function>は<xref linkend="posix-embedded-options-table">で記載されているフラグをサポートします。
@@ -5744,7 +5744,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
     branches.
 -->
 正規表現は<literal>|</literal>で区切られた、1つまたは複数の<firstterm>ブランチ</firstterm>として定義されます。
-ブランチのいずれか1つに一致すれば一致したことになります。
+ブランチのいずれか1つにマッチすればマッチしたことになります。
    </para>
 
    <para>
@@ -5755,7 +5755,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
     an empty branch matches the empty string.
 -->
 ブランチはゼロ個以上の<firstterm>量化アトム</firstterm>もしくは<firstterm>制約</>の連結です。
-最初のものにマッチに、次に第２番目のものにマッチを、というふうに一致します。なお、空のブランチは空文字列に一致します。
+最初のものにマッチに、次に第２番目のものにマッチを、というふうにマッチします。なお、空のブランチは空文字列にマッチします。
    </para>
 
    <para>
@@ -5770,8 +5770,8 @@ Perlのような他のソフトウェアシステムも似たような定義を�
     <xref linkend="posix-quantifiers-table">.
 -->
 量化アトムとは、単一の<firstterm>量指定子</>が後ろに付く<firstterm>アトム</>のことです。
-量指定子がないと、アトムに一致するものが一致したことになります。
-量指定子がある場合、アトムとの一致が何回あるかで一致したことになります。
+量指定子がないと、アトムにマッチするものがマッチしたことになります。
+量指定子がある場合、アトムとのマッチが何回あるかでマッチしたことになります。
 <firstterm>アトム</firstterm>は、<xref linkend="posix-atoms-table">に示したもののいずれかを取ることができます。
   <xref linkend="posix-quantifiers-table">に設定可能な量指定子とその意味を示します。
    </para>
@@ -5785,7 +5785,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
     <xref linkend="posix-constraints-table">;
     some more constraints are described later.
 -->
-<firstterm>制約</>は空文字に、特定の条件に合う場合のみに一致します。
+<firstterm>制約</>は空文字に、特定の条件に合う場合のみにマッチします。
 アトムを使用できるところには制約を使用することができます。ただしその後に量指定子を付けることはできません。
 単純な制約を<xref linkend="posix-constraints-table">に示します。後で他のいくつかの制約を説明します。
    </para>
@@ -5828,7 +5828,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
        (a <quote>non-capturing</> set of parentheses)
        (AREs only) </entry>
 -->
-       <entry>上と同じ。ただし、一致は報告用と意味づけられません。（<quote>捕捉されない</>括弧の集合）（AREのみ）</entry>
+       <entry>上と同じ。ただし、マッチは報告用と意味づけられません。（<quote>捕捉されない</>括弧の集合）（AREのみ）</entry>
        </row>
 
        <row>
@@ -5836,7 +5836,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
 <!--
        <entry> matches any single character </entry>
 -->
-       <entry>任意の1文字に一致します。</entry>
+       <entry>任意の1文字にマッチします。</entry>
        </row>
 
        <row>
@@ -5848,7 +5848,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
 -->
        <entry> 
         <firstterm>ブラケット式</>。
-        <replaceable>chars</>のいずれか1つに一致します
+        <replaceable>chars</>のいずれか1つにマッチします
        （詳細は<xref linkend="posix-bracket-expressions">を参照してください）。
        </entry>
        </row>
@@ -5860,7 +5860,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
        matches that character taken as an ordinary character,
        e.g., <literal>\\</> matches a backslash character </entry>
 -->
-       <entry>（ここで<replaceable>k</>は英数字以外です。）普通の文字として指定した文字に一致します。例えば、<literal>\\</>はバックスラッシュ文字です。</entry>
+       <entry>（ここで<replaceable>k</>は英数字以外です。）普通の文字として指定した文字にマッチします。例えば、<literal>\\</>はバックスラッシュ文字です。</entry>
        </row>
 
        <row>
@@ -5875,7 +5875,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
        （おそらく他の文字が後に続きます）。
        <firstterm>エスケープ</>です。
        <xref linkend="posix-escape-sequences">を参照してください
-       （AREのみ、EREとBREではこれは<replaceable>c</>に一致します）。
+       （AREのみ、EREとBREではこれは<replaceable>c</>にマッチします）。
        </entry>
        </row>
 
@@ -5887,7 +5887,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
        when followed by a digit, it is the beginning of a
        <replaceable>bound</> (see below) </entry>
 -->
-       <entry>直後に数字以外がある場合、左中括弧<literal>{</>に一致します。
+       <entry>直後に数字以外がある場合、左中括弧<literal>{</>にマッチします。
 直後に数字が続く場合、<replaceable>bound</>（後述）の始まりです。</entry>
        </row>
 
@@ -5898,7 +5898,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
        significance, matches that character </entry>
 -->
        <entry>ここで<replaceable>x</>は他に意味を持たない1文字です。
-<replaceable>x</>に一致します。</entry>
+<replaceable>x</>にマッチします。</entry>
        </row>
       </tbody>
      </tgroup>
@@ -5947,7 +5947,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
 <!--
        <entry> a sequence of 0 or more matches of the atom </entry>
 -->
-       <entry>アトムの0個以上複数の並びに一致</entry>
+       <entry>アトムの0個以上複数の並びにマッチ</entry>
        </row>
 
        <row>
@@ -5955,7 +5955,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
 <!--
        <entry> a sequence of 1 or more matches of the atom </entry>
 -->
-       <entry>アトムの1個以上複数の並びに一致</entry>
+       <entry>アトムの1個以上複数の並びにマッチ</entry>
        </row>
 
        <row>
@@ -5963,7 +5963,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
 <!--
        <entry> a sequence of 0 or 1 matches of the atom </entry>
 -->
-       <entry>アトムの0個または1個の並びに一致</entry>
+       <entry>アトムの0個または1個の並びにマッチ</entry>
        </row>
 
        <row>
@@ -5971,7 +5971,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
 <!--
        <entry> a sequence of exactly <replaceable>m</> matches of the atom </entry>
 -->
-       <entry>アトムの正確に<replaceable>m</>個の並びに一致</entry>
+       <entry>アトムの正確に<replaceable>m</>個の並びにマッチ</entry>
        </row>
 
        <row>
@@ -5979,7 +5979,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
 <!--
        <entry> a sequence of <replaceable>m</> or more matches of the atom </entry>
 -->
-       <entry>アトムの<replaceable>m</>個以上の並びに一致</entry>
+       <entry>アトムの<replaceable>m</>個以上の並びにマッチ</entry>
        </row>
 
        <row>
@@ -5990,7 +5990,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
        (inclusive) matches of the atom; <replaceable>m</> cannot exceed
        <replaceable>n</> </entry>
 -->
-       <entry> アトムの<replaceable>m</>個以上<replaceable>n</>以下の並びに一致。
+       <entry> アトムの<replaceable>m</>個以上<replaceable>n</>以下の並びにマッチ。
 <replaceable>m</>は<replaceable>n</>を超えることはできません。</entry>
        </row>
 
@@ -6066,7 +6066,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
      number of matches.
      See <xref linkend="posix-matching-rules"> for more detail.
 -->
-<firstterm>最短マッチを行う</>量指定子（AREのみで使用可能）は、対応する通常の（<firstterm>欲張りの</>）ものと同じものに一致しますが、最大のマッチではなく最小のマッチを取ります。
+<firstterm>最短マッチを行う</>量指定子（AREのみで使用可能）は、対応する通常の（<firstterm>欲張りの</>）ものと同じものにマッチしますが、最大のマッチではなく最小のマッチを取ります。
 詳細は<xref linkend="posix-matching-rules">を参照してください。
    </para>
 
@@ -6108,7 +6108,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
 <!--
        <entry> matches at the beginning of the string </entry>
 -->
-       <entry>文字列の先頭に一致</entry>
+       <entry>文字列の先頭にマッチ</entry>
        </row>
 
        <row>
@@ -6116,7 +6116,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
 <!--
        <entry> matches at the end of the string </entry>
 -->
-       <entry>文字列の末尾に一致</entry>
+       <entry>文字列の末尾にマッチ</entry>
        </row>
 
        <row>
@@ -6126,7 +6126,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
        where a substring matching <replaceable>re</> begins
        (AREs only) </entry>
 -->
-       <entry><firstterm>先行肯定検索</>は、<replaceable>re</>に一致する部分文字列から始まる任意の場所に一致します（AREのみ）。</entry>
+       <entry><firstterm>先行肯定検索</>は、<replaceable>re</>にマッチする部分文字列が始まる任意の場所にマッチします（AREのみ）。</entry>
        </row>
 
        <row>
@@ -6136,21 +6136,27 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
        where no substring matching <replaceable>re</> begins
        (AREs only) </entry>
 -->
-       <entry><firstterm>先行否定検索</>は、<replaceable>re</>に一致しない部分文字列から始まる任意の場所に一致します（AREのみ）。</entry>
+       <entry><firstterm>先行否定検索</>は、<replaceable>re</>にマッチしない部分文字列が始まる任意の場所にマッチします（AREのみ）。</entry>
        </row>
 
        <row>
        <entry> <literal>(?&lt;=</><replaceable>re</><literal>)</> </entry>
+<!--
        <entry> <firstterm>positive lookbehind</> matches at any point
        where a substring matching <replaceable>re</> ends
        (AREs only) </entry>
+-->
+       <entry> <firstterm>後方肯定検索</>は<replaceable>re</>にマッチする部分文字列が終わる任意の場所にマッチします（AREのみ）。</entry>
        </row>
 
        <row>
        <entry> <literal>(?&lt;!</><replaceable>re</><literal>)</> </entry>
+<!--
        <entry> <firstterm>negative lookbehind</> matches at any point
        where no substring matching <replaceable>re</> ends
        (AREs only) </entry>
+-->
+       <entry> <firstterm>後方否定検索</><replaceable>re</>にマッチしない部分文字列が終わる任意の場所にマッチします（AREのみ）。</entry>
        </row>
       </tbody>
      </tgroup>
@@ -6162,7 +6168,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
     references</> (see <xref linkend="posix-escape-sequences">),
     and all parentheses within them are considered non-capturing.
 -->
-先行検索制約には<firstterm>後方参照</>（<xref linkend="posix-escape-sequences">を参照）を含めることはできません。また、その中の括弧は全て取り込むものではないとみなされます。 ★　変更あり
+先行検索制約および後方検索制約には<firstterm>後方参照</>（<xref linkend="posix-escape-sequences">を参照）を含めることはできません。また、その中の括弧は全て取り込むものではないとみなされます。
    </para>
    </sect3>
 
@@ -6190,9 +6196,9 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
     relying on them.
 -->
 <firstterm>ブラケット式</firstterm>とは、<literal>[]</literal>内の文字のリストです。
-通常これはそのリスト内の任意の1文字に一致します（しかし、以降を参照してください）。
-リストが<literal>^</literal>から始まる場合、そのリストの残りには<emphasis>ない</>任意の1文字に一致します。
-リスト内の2文字が<literal>-</literal>で区切られていた場合、これは2つ（を含む）の間にある文字範囲全体を表す省略形となります。例えば、<acronym>ASCII</acronym>における<literal>[0-9]</literal>は全ての数字に一致します。
+通常これはそのリスト内の任意の1文字にマッチします（しかし、以降を参照してください）。
+リストが<literal>^</literal>から始まる場合、そのリストの残りには<emphasis>ない</>任意の1文字にマッチします。
+リスト内の2文字が<literal>-</literal>で区切られていた場合、これは2つ（を含む）の間にある文字範囲全体を表す省略形となります。例えば、<acronym>ASCII</acronym>における<literal>[0-9]</literal>は全ての数字にマッチします。
 例えば<literal>a-c-e</literal>といった、終端を共有する2つの範囲は不正です。
 範囲は並びの照合順に非常に依存しています。ですので、移植予定のプログラムではこれに依存してはなりません。
    </para>
@@ -6237,7 +6243,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
 -->
 ブラケット式内に、照合要素（文字、単一文字であるかのように照合する複数文字の並び、もしくはそれぞれの照合並びの名前）が<literal>[.</literal>と<literal>.]</literal>の間にあると、その照合要素の文字の並びを意味します。
 この並びはブラケット式のリストの一要素として取り扱われます。
-このことにより、ブラケット式は要素を照合する複数文字を含むブラケット式を1文字以上に一致させることができます。例えば、照合並びが<literal>ch</literal>照合要素を含む場合、正規表現<literal>[[.ch.]]*c</literal>は<literal>chchcc</literal>という文字の最初の5文字に一致します。
+このことにより、ブラケット式は要素を照合する複数文字を含むブラケット式を1文字以上にマッチさせることができます。例えば、照合並びが<literal>ch</literal>照合要素を含む場合、正規表現<literal>[[.ch.]]*c</literal>は<literal>chchcc</literal>という文字の最初の5文字にマッチします。
    </para>
 
    <note>
@@ -6312,7 +6318,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
     The constraint escapes described below are usually preferable; they
     are no more standard, but are easier to type.
 -->
-ブラケット式には2つの特殊な場合があります。<literal>[[:&lt;:]]</literal>と<literal>[[:&gt;:]]</literal>というブラケット式は、先頭と終端の単語がそれぞれ空文字であることに一致する制約です。
+ブラケット式には2つの特殊な場合があります。<literal>[[:&lt;:]]</literal>と<literal>[[:&gt;:]]</literal>というブラケット式は、先頭と終端の単語がそれぞれ空文字であることにマッチする制約です。
 単語は、単語文字が前後に付かない単語文字の並びとして定義されます。
 単語文字とは（<citerefentry><refentrytitle>ctype</refentrytitle><manvolnum>3</manvolnum></citerefentry>で定義されている）1つの<literal>alnum</>文字またはアンダースコアです。
 これは、<acronym>POSIX</acronym> 1003.2との互換性はありますが、そこでは定義されていない式です。ですので、他システムへ移植予定のソフトウェアでの使用には注意が必要です。
@@ -6373,7 +6379,7 @@ EREにはエスケープはありません。ブラケット式の外側では�
     written as an escape.  They are
     shown in <xref linkend="posix-constraint-escapes-table">.
 -->
-<firstterm>制約エスケープ</>は、指定した条件に合う場合に空文字に一致する制約をエスケープとして表したものです。
+<firstterm>制約エスケープ</>は、指定した条件に合う場合に空文字にマッチする制約をエスケープとして表したものです。
 これらを<xref linkend="posix-constraint-escapes-table">に示します。
    </para>
 
@@ -6389,8 +6395,8 @@ EREにはエスケープはありません。ブラケット式の外側では�
     Subexpressions are numbered in the order of their leading parentheses.
     Non-capturing parentheses do not define subexpressions.
 -->
-<firstterm>後方参照</>（<literal>\</><replaceable>n</>）は、直前に括弧で囲まれた副式によって一致された、<replaceable>n</>番目の同一文字列に一致します（<xref linkend="posix-constraint-backref-table">を参照してください）。
-  例えば、<literal>([bc])\1</>は<literal>bb</>もしくは<literal>cc</>に一致しますが、<literal>bc</>や<literal>cb</>には一致しません。REでは副式全体は後方参照の前になければなりません。
+<firstterm>後方参照</>（<literal>\</><replaceable>n</>）は、直前に括弧で囲まれた副式によってマッチされた、<replaceable>n</>番目の同一文字列にマッチします（<xref linkend="posix-constraint-backref-table">を参照してください）。
+  例えば、<literal>([bc])\1</>は<literal>bb</>もしくは<literal>cc</>にマッチしますが、<literal>bc</>や<literal>cb</>にはマッチしません。REでは副式全体は後方参照の前になければなりません。
 副式は開括弧の順番で番号付けされます。
 取り込まない括弧は副式を定義しません。
    </para>
@@ -6592,7 +6598,7 @@ EREにはエスケープはありません。ブラケット式の外側では�
 ASCIIの範囲(0-127)外の値を指定した数字のエントリエスケープは、その意味がデータベースエンコーディングに依存します。
 エンコーディングがUTF-8の場合、エスケープ値はユニコード符号位置に相当します。例えば、<literal>\u1234</>は文字<literal>U+1234</>を意味します。
 その他のマルチバイトエンコーディングでは、文字エントリエスケープはたいてい文字のバイト値の連結を指定します。
-エスケープ値がデータベースエンコーディングでのいかなる正当な文字にも対応しない場合、エラーは起こりませんが、いかなるデータにも一致しません。
+エスケープ値がデータベースエンコーディングでのいかなる正当な文字にも対応しない場合、エラーは起こりませんが、いかなるデータにもマッチしません。
    </para>
 
    <para>
@@ -6716,7 +6722,7 @@ ASCIIの範囲(0-127)外の値を指定した数字のエントリエスケー�
        (see <xref linkend="posix-matching-rules"> for how this differs from
        <literal>^</>) </entry>
 -->
-       <entry>文字列の先頭にのみ一致します（<literal>^</>との違いについては<xref linkend="posix-matching-rules">を参照してください）。</entry> 
+       <entry>文字列の先頭にのみマッチします（<literal>^</>との違いについては<xref linkend="posix-matching-rules">を参照してください）。</entry> 
        </row>
 
        <row>
@@ -6724,7 +6730,7 @@ ASCIIの範囲(0-127)外の値を指定した数字のエントリエスケー�
 <!--
        <entry> matches only at the beginning of a word </entry>
 -->
-       <entry> 単語の先頭にのみ一致します。 </entry>
+       <entry> 単語の先頭にのみマッチします。 </entry>
        </row>
 
        <row>
@@ -6732,7 +6738,7 @@ ASCIIの範囲(0-127)外の値を指定した数字のエントリエスケー�
 <!--
        <entry> matches only at the end of a word </entry>
 -->
-       <entry> 単語の末尾にのみ一致します。 </entry>
+       <entry> 単語の末尾にのみマッチします。 </entry>
        </row>
 
        <row>
@@ -6740,7 +6746,7 @@ ASCIIの範囲(0-127)外の値を指定した数字のエントリエスケー�
 <!--
        <entry> matches only at the beginning or end of a word </entry>
 -->
-       <entry> 単語の先頭もしくは末尾にのみ一致します。</entry>
+       <entry> 単語の先頭もしくは末尾にのみマッチします。</entry>
        </row>
 
        <row>
@@ -6749,7 +6755,7 @@ ASCIIの範囲(0-127)外の値を指定した数字のエントリエスケー�
        <entry> matches only at a point that is not the beginning or end of a
        word </entry>
 -->
-       <entry>単語の先頭もしくは末尾以外の場所にのみ一致します。</entry>
+       <entry>単語の先頭もしくは末尾以外の場所にのみマッチします。</entry>
        </row>
 
        <row>
@@ -6759,7 +6765,7 @@ ASCIIの範囲(0-127)外の値を指定した数字のエントリエスケー�
        (see <xref linkend="posix-matching-rules"> for how this differs from
        <literal>$</>) </entry>
 -->
-       <entry>文字列の末尾にのみ一致します（<literal>$</>との違いについては<xref linkend="posix-matching-rules">を参照してください）。</entry>
+       <entry>文字列の末尾にのみマッチします（<literal>$</>との違いについては<xref linkend="posix-matching-rules">を参照してください）。</entry>
        </row>
       </tbody>
      </tgroup>
@@ -6924,7 +6930,7 @@ AREは<firstterm>埋め込みオプション</>から始められます。<liter
 <!--
        <entry> case-sensitive matching (overrides operator type) </entry>
 -->
-       <entry> 大文字小文字を区別する一致（演算子で規定される大文字小文字の区別よりこの指定が優先されます）。 </entry>
+       <entry> 大文字小文字を区別するマッチ（演算子で規定される大文字小文字の区別よりこの指定が優先されます）。 </entry>
        </row>
 
        <row>
@@ -6941,7 +6947,7 @@ AREは<firstterm>埋め込みオプション</>から始められます。<liter
        <entry> case-insensitive matching (see
        <xref linkend="posix-matching-rules">) (overrides operator type) </entry>
 -->
-       <entry> 大文字小文字を区別しない一致（<xref linkend="posix-matching-rules">を参照）（演算子で規定される大文字小文字の区別よりこの指定が優先されます）。 </entry>
+       <entry> 大文字小文字を区別しないマッチ（<xref linkend="posix-matching-rules">を参照）（演算子で規定される大文字小文字の区別よりこの指定が優先されます）。 </entry>
        </row>
 
        <row>
@@ -6958,7 +6964,7 @@ AREは<firstterm>埋め込みオプション</>から始められます。<liter
        <entry> newline-sensitive matching (see
        <xref linkend="posix-matching-rules">) </entry>
 -->
-       <entry> 改行を区別する一致（<xref linkend="posix-matching-rules">を参照）</entry>
+       <entry> 改行を区別するマッチ（<xref linkend="posix-matching-rules">を参照）</entry>
        </row>
 
        <row>
@@ -6967,7 +6973,7 @@ AREは<firstterm>埋め込みオプション</>から始められます。<liter
        <entry> partial newline-sensitive matching (see
        <xref linkend="posix-matching-rules">) </entry>
 -->
-       <entry> 部分的な改行を区別する一致（<xref linkend="posix-matching-rules">を参照）</entry>
+       <entry> 部分的な改行を区別するマッチ（<xref linkend="posix-matching-rules">を参照）</entry>
        </row>
 
        <row>
@@ -7120,8 +7126,8 @@ AREの先頭（もし<literal>***:</>決定子があればその後）でのみ�
     be taken, depending on whether the RE is <firstterm>greedy</> or
     <firstterm>non-greedy</>.
 -->
-REが文字列の中の1つ以上の部分文字列と一致する場合において、REは最初にマッチが始まった部分文字列と一致します。
-その位置からまた1つ以上の部分文字列とマッチした際は、正規表現は<firstterm>最短マッチを行わない（欲張り型）</>か<firstterm>最短マッチを行う（非欲張り型）</>かによって、最長一致もしくは最短一致の文字列のどちらかに一致します
+REが文字列の中の1つ以上の部分文字列とマッチする場合において、REは最初にマッチが始まった部分文字列とマッチします。
+その位置からまた1つ以上の部分文字列とマッチした際は、正規表現は<firstterm>最短マッチを行わない（欲張り型）</>か<firstterm>最短マッチを行う（非欲張り型）</>かによって、最長マッチもしくは最短マッチの文字列のどちらかにマッチします
    </para>
 
    <para>
@@ -7136,7 +7142,7 @@ REが最長マッチかどうかは以下の規則によって決まります。
        Most atoms, and all constraints, have no greediness attribute (because
        they cannot match variable amounts of text anyway).
 -->
-ほとんどのアトムおよび全ての式は欲張り属性を持ちません（これらは変動する量のテキストにまったく一致しないからです）。
+ほとんどのアトムおよび全ての式は欲張り属性を持ちません（これらは変動する量のテキストにまったくマッチしないからです）。
       </para>
      </listitem>
      <listitem>
@@ -7216,8 +7222,8 @@ REを括弧で括ることは欲張りかどうかを変更しません。
     priority over ones starting later.
 -->
 上の規則は、個々の量指定付きアトムだけではなく、量指定付きアトムを複数含むブランチやRE全体の欲張り属性に関連します。
-つまり、ブランチやRE全体が<emphasis>全体として</>最長または最短の部分文字列に一致するという方法でマッチ処理が行われます。
-全体のマッチの長さが決まると、特定の部分式に一致する部分がその部分式の欲張り属性によって決まります。この時、RE内でより前にある部分式が後にある部分式よりも高い優先度を持ちます。
+つまり、ブランチやRE全体が<emphasis>全体として</>最長または最短の部分文字列にマッチするという方法でマッチ処理が行われます。
+全体のマッチの長さが決まると、特定の部分式にマッチする部分がその部分式の欲張り属性によって決まります。この時、RE内でより前にある部分式が後にある部分式よりも高い優先度を持ちます。
    </para>
 
    <para>
@@ -7244,11 +7250,11 @@ SELECT SUBSTRING('XY1234Z', 'Y*?([0-9]{1,3})');
     just <literal>1</>.
 -->
 最初の例では、<literal>Y*</>が欲張り型であるため、REは全体として欲張り型です。
-マッチは<literal>Y</>の位置から始まり、そこから可能な限り最長の文字列に一致します。つまり<literal>Y123</>となります。
+マッチは<literal>Y</>の位置から始まり、そこから可能な限り最長の文字列にマッチします。つまり<literal>Y123</>となります。
 出力は括弧で括られた部分、つまり<literal>123</>となります。
 2番目の例では、<literal>Y*?</>が非欲張り型のため、REは全体として非欲張り型です。
-マッチは<literal>Y</>の位置から始まり、そこから可能な限り最短の文字列に一致します。つまり<literal>Y1</>となります。
-部分式<literal>[0-9]{1,3}</>は欲張り型ですが、決定された一致する全体の長さを変更することはできません。したがって、強制的に<literal>1</>に一致することになります。
+マッチは<literal>Y</>の位置から始まり、そこから可能な限り最短の文字列にマッチします。つまり<literal>Y1</>となります。
+部分式<literal>[0-9]{1,3}</>は欲張り型ですが、決定されたマッチする全体の長さを変更することはできません。したがって、強制的に<literal>1</>にマッチすることになります。
    </para>
 
    <para>
@@ -7299,7 +7305,7 @@ SELECT regexp_matches('abc01234xyz', '(.*?)(\d+)(.*)');
     and so it ends the overall match as soon as possible.  We can get what
     we want by forcing the RE as a whole to be greedy:
 -->
-またもや上手くいきませんでした。今度は、REが全体として欲張りでなくなってしまい、できる限り早く全体に渡る一致を終わらせてしまうからです。
+またもや上手くいきませんでした。今度は、REが全体として欲張りでなくなってしまい、できる限り早く全体に渡るマッチを終わらせてしまうからです。
 RE全体として欲張りにすることで欲しいものが得られます。
 <screen>
 SELECT regexp_matches('abc01234xyz', '(?:(.*?)(\d+)(.*)){1,1}');
@@ -7330,8 +7336,8 @@ REの全体に渡る欲張りさをその要素の欲張りさと別に制御す
     subexpression match an empty string.
 -->
 マッチが長いか短いかを判断する時には、マッチの長さは照合要素ではなく文字列で測られます。
-空文字列はまったく一致する要素がない文字列よりも長いと考えられます。
-例えば、<literal>bb*</literal>は<literal>abbbc</literal>の真中の3文字と一致し、<literal>(week|wee)(night|knights)</literal>は<literal>weeknights</literal>の全ての10文字と一致し、<literal>abc</literal>に対して<literal>(.*).*</literal>が一致されると、括弧内の部分正規表現は3つの文字全てに一致し、<literal>bc</literal>に対して<literal>(a*)*</literal>が一致されると、全体のREと括弧内の正規表現は空文字列に一致します。
+空文字列はまったくマッチする要素がない文字列よりも長いと考えられます。
+例えば、<literal>bb*</literal>は<literal>abbbc</literal>の真中の3文字とマッチし、<literal>(week|wee)(night|knights)</literal>は<literal>weeknights</literal>の全ての10文字とマッチし、<literal>abc</literal>に対して<literal>(.*).*</literal>がマッチされると、括弧内の部分正規表現は3つの文字全てにマッチし、<literal>bc</literal>に対して<literal>(a*)*</literal>がマッチされると、全体のREと括弧内の正規表現は空文字列にマッチします。
    </para>
 
    <para>
@@ -7348,7 +7354,7 @@ REの全体に渡る欲張りさをその要素の欲張りさと別に制御す
     <literal>[x]</> becomes <literal>[xX]</>
     and <literal>[^x]</> becomes <literal>[^xX]</>.
 -->
-もし大文字小文字を区別しない一致が指定されると、アルファベット文字の大文字小文字の区別がまったくなくなったのと同じ効果を与えます。
+もし大文字小文字を区別しないマッチが指定されると、アルファベット文字の大文字小文字の区別がまったくなくなったのと同じ効果を与えます。
 ブラケット式の外側にアルファベットの大文字小文字が混ざった通常の文字が出てきた場合、例えば、<literal>x</literal>が<literal>[xX]</literal>となるように大文字小文字ともにブラケット式に実質的に転換されます。
 ブラケット式の中に現れた時は、（例えば）<literal>[x]</literal>が<literal>[xX]</literal>となり、また<literal>[^x]</literal>が<literal>[^xX]</literal>となるように、全ての大文字小文字それぞれの対がブラケット式に追加されます。
    </para>
@@ -7367,8 +7373,8 @@ REの全体に渡る欲張りさをその要素の欲張りさと別に制御す
     But the ARE escapes <literal>\A</> and <literal>\Z</>
     continue to match beginning or end of string <emphasis>only</>.
 -->
-改行を区別するマッチが指定されると、<literal>.</>と<literal>^</>を使用するブラケット式は（REが明示的に調整されていたとしてもマッチが改行をまたがらないようにするために）改行文字に一致しなくなります。また、<literal>^</>と<literal>$</>はそれぞれ改行直後と直前の空文字列に一致し、さらに、それぞれ文字列の先頭と末尾に一致します。
-しかし、AREエスケープの<literal>\A</>と<literal>\Z</>は、継続して、文字列の先頭と末尾<emphasis>のみ</>に一致します。
+改行を区別するマッチが指定されると、<literal>.</>と<literal>^</>を使用するブラケット式は（REが明示的に調整されていたとしてもマッチが改行をまたがらないようにするために）改行文字にマッチしなくなります。また、<literal>^</>と<literal>$</>はそれぞれ改行直後と直前の空文字列にマッチし、さらに、それぞれ文字列の先頭と末尾にマッチします。
+しかし、AREエスケープの<literal>\A</>と<literal>\Z</>は、継続して、文字列の先頭と末尾<emphasis>のみ</>にマッチします。
    </para>
 
    <para>
@@ -7378,7 +7384,7 @@ REの全体に渡る欲張りさをその要素の欲張りさと別に制御す
     as with newline-sensitive matching, but not <literal>^</>
     and <literal>$</>.
 -->
-部分的に改行を区別するマッチが指定されると、<literal>.</>とブラケット式は改行を区別する一致を行うようになりますが、<literal>^</>と<literal>$</>は変更されません。
+部分的に改行を区別するマッチが指定されると、<literal>.</>とブラケット式は改行を区別するマッチを行うようになりますが、<literal>^</>と<literal>$</>は変更されません。
    </para>
 
    <para>
@@ -7389,7 +7395,7 @@ REの全体に渡る欲張りさをその要素の欲張りさと別に制御す
     and bracket expressions.
     This isn't very useful but is provided for symmetry.
 -->
-部分的に改行を区別する逆マッチが指定されると、<literal>^</>と<literal>$</>は改行を区別する一致を行うようになりますが、<literal>.</>とブラケット式は変更されません。
+部分的に改行を区別する逆マッチが指定されると、<literal>^</>と<literal>$</>は改行を区別するマッチを行うようになりますが、<literal>.</>とブラケット式は変更されません。
 これはあまり有用ではありません。対称性のために提供されています。
    </para>
    </sect3>
@@ -7438,7 +7444,9 @@ AREの機能のうち、POSIX EREと実質的な非互換性があるのは、<l
     constraints, and the longest/shortest-match (rather than first-match)
     matching semantics.
 -->
-多くのARE拡張はPerlから拝借したものです。しかし、いくつかは整理され、Perlの拡張のいくつかは存在しません。注意すべき非互換性には、<literal>\b</>、<literal>\B</>、改行の取り扱いに関する特殊な措置の欠落、改行を区別する一致に影響する点について補足したブラケット式の追加、括弧と先行検索制約内の後方参照についての制限、最長/最短（最初に一致するではなく）マッチのセマンティックがあります。
+多くのARE拡張はPerlから拝借したものです。
+しかし、いくつかは整理され、Perlの拡張のいくつかは存在しません。
+注意すべき非互換性には、<literal>\b</>、<literal>\B</>、改行の取り扱いに関する特殊な措置の欠落、改行を区別するマッチに影響する点について補足したブラケット式の追加、括弧と先行・後方検索制約内の後方参照についての制限、最長/最短（最初にマッチするではなく）マッチのセマンティックがあります。
    </para>
 
    <para>
@@ -7676,8 +7684,12 @@ BREにおいては、<literal>|</>、<literal>+</>、<literal>?</>は普通の�
 
    <note>
     <para>
+<!--
      There is also a single-argument <function>to_timestamp</function>
      function; see <xref linkend="functions-datetime-table">.
+-->
+引数が１つの<function>to_timestamp</function>関数もあります。
+<xref linkend="functions-datetime-table">を参照して下さい。
     </para>
    </note>
 
@@ -8706,9 +8718,10 @@ Oracleの実装では<literal>9</literal>の前に<literal>MI</literal>が置か
        <literal>V</literal> combined with a decimal point
        (e.g., <literal>99.9V99</literal> is not allowed).
 -->
-<literal>V</literal>は入力値を実質的に<literal>10^<replaceable>n</replaceable></literal>乗します。
+<literal>V</literal>を<function>to_char</function>につけると、入力値を<literal>10^<replaceable>n</replaceable></literal>倍します。
 ここで<replaceable>n</replaceable>は<literal>V</literal>に続く桁数です。
-<function>to_char</function>関数は小数点と<literal>V</literal>との混在をサポートしません（例えば、<literal>99.9V99</literal> とはできません）。 ★変更あり
+<literal>V</literal>を<function>to_number</function>につけると、同じように割り算をします。
+<function>to_char</function>および<function>to_number</function>は、小数点と<literal>V</literal>との混在をサポートしません（例えば、<literal>99.9V99</literal> とはできません）。
       </para>
      </listitem>
 

--- a/doc/src/sgml/func1.sgml
+++ b/doc/src/sgml/func1.sgml
@@ -5240,7 +5240,7 @@ substring('foobar' from '#"o_b#"%' for '#')    <lineannotation>NULL</lineannotat
     <xref linkend="functions-posix-table"> lists the available
     operators for pattern matching using POSIX regular expressions.
 -->
-<xref linkend="functions-posix-table">に、POSIX正規表現を使ったパターン一致に使用可能な演算子を列挙します。
+<xref linkend="functions-posix-table">に、POSIX正規表現を使ったパターンマッチに使用可能な演算子を列挙します。
    </para>
 
    <table id="functions-posix-table">
@@ -5269,7 +5269,7 @@ substring('foobar' from '#"o_b#"%' for '#')    <lineannotation>NULL</lineannotat
 <!--
         <entry>Matches regular expression, case sensitive</entry>
 -->
-        <entry>正規表現に一致、大文字小文字の区別あり</entry>
+        <entry>正規表現にマッチ、大文字小文字の区別あり</entry>
         <entry><literal>'thomas' ~ '.*thomas.*'</literal></entry>
        </row>
 
@@ -5278,7 +5278,7 @@ substring('foobar' from '#"o_b#"%' for '#')    <lineannotation>NULL</lineannotat
 <!--
         <entry>Matches regular expression, case insensitive</entry>
 -->
-        <entry>正規表現に一致、大文字小文字の区別なし</entry>
+        <entry>正規表現にマッチ、大文字小文字の区別なし</entry>
         <entry><literal>'thomas' ~* '.*Thomas.*'</literal></entry>
        </row>
 
@@ -5287,7 +5287,7 @@ substring('foobar' from '#"o_b#"%' for '#')    <lineannotation>NULL</lineannotat
 <!--
         <entry>Does not match regular expression, case sensitive</entry>
 -->
-        <entry>正規表現に一致しない、大文字小文字の区別あり</entry>
+        <entry>正規表現にマッチしない、大文字小文字の区別あり</entry>
         <entry><literal>'thomas' !~ '.*Thomas.*'</literal></entry>
        </row>
 
@@ -5296,7 +5296,7 @@ substring('foobar' from '#"o_b#"%' for '#')    <lineannotation>NULL</lineannotat
 <!--
         <entry>Does not match regular expression, case insensitive</entry>
 -->
-        <entry>正規表現に一致しない、大文字小文字の区別なし</entry>
+        <entry>正規表現にマッチしない、大文字小文字の区別なし</entry>
         <entry><literal>'thomas' !~* '.*vadim.*'</literal></entry>
        </row>
       </tbody>
@@ -5332,9 +5332,9 @@ substring('foobar' from '#"o_b#"%' for '#')    <lineannotation>NULL</lineannotat
      end of the string.
 -->
 正規表現とは文字列の集合（<firstterm>正規集合</firstterm>）の簡略された定義である文字が連なっているものです。
-ある文字列が正規表現で記述された正規集合の要素になっていれば、その文字列は正規表現に一致していると呼ばれます。
-<function>LIKE</function>と同様、正規表現言語で特殊文字とされているもの以外、パターン文字は文字列と完全に一致されます。とは言っても、正規表現は<function>LIKE</function>関数が使用するのとは異なる特殊文字を使用します。
-<function>LIKE</function>関数のパターンと違って正規表現は、明示的に正規表現が文字列の最初または最後からと位置指定されていない限り文字列内のどの位置でも一致を行えます。
+ある文字列が正規表現で記述された正規集合の要素になっていれば、その文字列は正規表現にマッチしていると呼ばれます。
+<function>LIKE</function>と同様、正規表現言語で特殊文字とされているもの以外、パターン文字は文字列と完全にマッチされます。とは言っても、正規表現は<function>LIKE</function>関数が使用するのとは異なる特殊文字を使用します。
+<function>LIKE</function>関数のパターンと違って正規表現は、明示的に正規表現が文字列の最初または最後からと位置指定されていない限り文字列内のどの位置でもマッチを行えます。
     </para>
 
     <para>
@@ -5375,9 +5375,9 @@ substring('foobar' from '#"o_b#"%' for '#')    <lineannotation>NULL</lineannotat
      subexpression you want to extract, see the non-capturing parentheses
      described below.
 -->
-2つのパラメータを持つ<function>substring</>関数、<function>substring(<parameter>string</parameter> from <replaceable>pattern</replaceable>)</function>を使用して、POSIX正規表現パターンに一致する部分文字列を取り出すことができます。
-この関数は、一致するものがない場合にはNULLを返し、ある場合はパターンにマッチしたテキストの一部を返します。
-しかし、丸括弧を持つパターンの場合、最初の丸括弧内部分正規表現（左丸括弧が最初に来るもの）に一致するテキストの一部が返されます。
+2つのパラメータを持つ<function>substring</>関数、<function>substring(<parameter>string</parameter> from <replaceable>pattern</replaceable>)</function>を使用して、POSIX正規表現パターンにマッチする部分文字列を取り出すことができます。
+この関数は、マッチするものがない場合にはNULLを返し、ある場合はパターンにマッチしたテキストの一部を返します。
+しかし、丸括弧を持つパターンの場合、最初の丸括弧内部分正規表現（左丸括弧が最初に来るもの）にマッチするテキストの一部が返されます。
 この例外を起こさずにパターン中に丸括弧を使用したいのであれば、常に正規表現全体を丸括弧で囲むことができます。
 パターン内の抽出対象の部分文字列より前に丸括弧が必要な場合、後述の捕捉されない丸括弧を参照してください。
     </para>
@@ -5421,14 +5421,14 @@ substring('foobar' from 'o(.)b')   <lineannotation>o</lineannotation>
      not <literal>g</>) are
      described in <xref linkend="posix-embedded-options-table">.
 -->
-<function>regexp_replace</>関数は、POSIX正規表現パターンに一致する部分文字列を新規テキストと置換します。
+<function>regexp_replace</>関数は、POSIX正規表現パターンにマッチする部分文字列を新規テキストと置換します。
 構文は、<function>regexp_replace</function>(<replaceable>source</>, <replaceable>pattern</>, <replaceable>replacement</> <optional>, <replaceable>flags</> </optional>)です。
 <replaceable>pattern</>にマッチしない場合は、<replaceable>source</>文字列がそのまま返されます。
-一致すると、マッチ部分文字列を<replaceable>replacement</>文字列で置換した<replaceable>source</>文字列が返されます。
-<replaceable>replacement</>文字列に<literal>\</><replaceable>n</>（<replaceable>n</>は1から9までの数字）を入れて、パターン内の<replaceable>n</>番目の丸括弧つき部分表現に一致する元の部分文字列を挿入することができます。
-また、<literal>\&amp;</>を入れて、パターン全体と一致する部分文字列を挿入することもできます。
+マッチすると、マッチ部分文字列を<replaceable>replacement</>文字列で置換した<replaceable>source</>文字列が返されます。
+<replaceable>replacement</>文字列に<literal>\</><replaceable>n</>（<replaceable>n</>は1から9までの数字）を入れて、パターン内の<replaceable>n</>番目の丸括弧つき部分表現にマッチする元の部分文字列を挿入することができます。
+また、<literal>\&amp;</>を入れて、パターン全体とマッチする部分文字列を挿入することもできます。
 置換テキスト内にバックスラッシュそのものを挿入する必要がある時は<literal>\\</>と記述します。
-<replaceable>flags</>パラメータは、関数の動作を変更するゼロもしくはそれ以上の1文字フラグを含むオプションのテキスト文字列です。フラグ<literal>i</>は大文字小文字を区別しない一致を指定する一方、フラグ<literal>g</>は、最初に一致したもののみではなく、それぞれ一致した部分文字列の置換を指定します。
+<replaceable>flags</>パラメータは、関数の動作を変更するゼロもしくはそれ以上の1文字フラグを含むオプションのテキスト文字列です。フラグ<literal>i</>は大文字小文字を区別しないマッチを指定する一方、フラグ<literal>g</>は、最初にマッチしたもののみではなく、それぞれマッチした部分文字列の置換を指定します。
 有効なフラグは(<literal>g</>を除く)<xref linkend="posix-embedded-options-table">に記述されています。
     </para>
 
@@ -5476,11 +5476,11 @@ regexp_replace('foobarbaz', 'b(..)', E'X\\1Y', 'g')
 <function>regexp_matches</>関数はPOSIX正規表現パターンマッチの結果捕捉された全ての部分文字列のテキスト配列を返します。
 <function>regexp_matches</function>(<replaceable>string</>, <replaceable>pattern</> <optional>, <replaceable>flags</> </optional>)の構文になります。
 この関数は何も行を返さない、1行を返す、複数行を返す（下記の<literal>g</>フラグを参照）といったことができます。
-もし<replaceable>pattern</>に対して一致しない場合、関数は行を返しません。
-もし、パターンが丸括弧に括られた部分文字列を含まない場合、結果はパターン全体に一致する部分文字列を含む単一要素のテキスト配列となります。
-もし、パターンが丸括弧に括られた部分文字列を含む場合、関数はテキスト配列を返し、その<replaceable>n</>番目の要素は、パターンの<replaceable>n</>番目に丸括弧で括られた部分文字列に一致する部分文字列となります（<quote>捕捉されない</>丸括弧は数えません。詳細は下を見てください。）。
+もし<replaceable>pattern</>に対してマッチしない場合、関数は行を返しません。
+もし、パターンが丸括弧に括られた部分文字列を含まない場合、結果はパターン全体にマッチする部分文字列を含む単一要素のテキスト配列となります。
+もし、パターンが丸括弧に括られた部分文字列を含む場合、関数はテキスト配列を返し、その<replaceable>n</>番目の要素は、パターンの<replaceable>n</>番目に丸括弧で括られた部分文字列にマッチする部分文字列となります（<quote>捕捉されない</>丸括弧は数えません。詳細は下を見てください。）。
 <replaceable>flags</>パラメータは、関数の動作を変更するゼロもしくは複数の単一文字フラグを含むオプションのテキスト文字列です。
-フラグ<literal>g</>を指定すると、関数は最初のマッチだけでなく文字列の中で全てのマッチを検出し、それぞれの一致について1行を返します。
+フラグ<literal>g</>を指定すると、関数は最初のマッチだけでなく文字列の中で全てのマッチを検出し、それぞれのマッチについて1行を返します。
 有効なフラグは(<literal>g</>を除く)<xref linkend="posix-embedded-options-table">に記載されています。
     </para>
 
@@ -5542,8 +5542,8 @@ SELECT col1, (SELECT regexp_matches(col2, '(bar)(beque)')) FROM tab;
      <xref linkend="posix-embedded-options-table">.
 -->
 <function>regexp_split_to_table</>関数はPOSIX正規表現パターンを区切り文字として使用し、文字列を分割します。<function>regexp_split_to_table</function>(<replaceable>string</>, <replaceable>pattern</> <optional>, <replaceable>flags</> </optional>)の構文になります。
-<replaceable>pattern</>に一致しない場合、関数は<replaceable>string</>を返します。
-少なくともひとつの一致があれば、それぞれの一致に対して関数は最後のマッチの終わり（あるいは文字列の始め）から最初のマッチまでのテキストを返します。
+<replaceable>pattern</>にマッチしない場合、関数は<replaceable>string</>を返します。
+少なくともひとつのマッチがあれば、それぞれのマッチに対して関数は最後のマッチの終わり（あるいは文字列の始め）から最初のマッチまでのテキストを返します。
 もはやマッチしなくなると最後のマッチの終わりから文字列の最後までテキストを返します。
 <replaceable>flags</>パラメータは、関数の動作を変更するゼロもしくは複数の単一文字フラグを含むオプションのテキスト文字列です。
 <function>regexp_split_to_table</function>は<xref linkend="posix-embedded-options-table">で記載されているフラグをサポートします。
@@ -5696,7 +5696,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
     branches.
 -->
 正規表現は<literal>|</literal>で区切られた、1つまたは複数の<firstterm>ブランチ</firstterm>として定義されます。
-ブランチのいずれか1つに一致すれば一致したことになります。
+ブランチのいずれか1つにマッチすればマッチしたことになります。
    </para>
 
    <para>
@@ -5707,7 +5707,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
     an empty branch matches the empty string.
 -->
 ブランチはゼロ個以上の<firstterm>量化アトム</firstterm>もしくは<firstterm>制約</>の連結です。
-最初のものにマッチに、次に第２番目のものにマッチを、というふうに一致します。なお、空のブランチは空文字列に一致します。
+最初のものにマッチに、次に第２番目のものにマッチを、というふうにマッチします。なお、空のブランチは空文字列にマッチします。
    </para>
 
    <para>
@@ -5722,8 +5722,8 @@ Perlのような他のソフトウェアシステムも似たような定義を�
     <xref linkend="posix-quantifiers-table">.
 -->
 量化アトムとは、単一の<firstterm>量指定子</>が後ろに付く<firstterm>アトム</>のことです。
-量指定子がないと、アトムに一致するものが一致したことになります。
-量指定子がある場合、アトムとの一致が何回あるかで一致したことになります。
+量指定子がないと、アトムにマッチするものがマッチしたことになります。
+量指定子がある場合、アトムとのマッチが何回あるかでマッチしたことになります。
 <firstterm>アトム</firstterm>は、<xref linkend="posix-atoms-table">に示したもののいずれかを取ることができます。
   <xref linkend="posix-quantifiers-table">に設定可能な量指定子とその意味を示します。
    </para>
@@ -5737,7 +5737,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
     <xref linkend="posix-constraints-table">;
     some more constraints are described later.
 -->
-<firstterm>制約</>は空文字に、特定の条件に合う場合のみに一致します。
+<firstterm>制約</>は空文字に、特定の条件に合う場合のみにマッチします。
 アトムを使用できるところには制約を使用することができます。ただしその後に量指定子を付けることはできません。
 単純な制約を<xref linkend="posix-constraints-table">に示します。後で他のいくつかの制約を説明します。
    </para>
@@ -5780,7 +5780,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
        (a <quote>non-capturing</> set of parentheses)
        (AREs only) </entry>
 -->
-       <entry>上と同じ。ただし、一致は報告用と意味づけられません。（<quote>捕捉されない</>括弧の集合）（AREのみ）</entry>
+       <entry>上と同じ。ただし、マッチは報告用と意味づけられません。（<quote>捕捉されない</>括弧の集合）（AREのみ）</entry>
        </row>
 
        <row>
@@ -5788,7 +5788,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
 <!--
        <entry> matches any single character </entry>
 -->
-       <entry>任意の1文字に一致します。</entry>
+       <entry>任意の1文字にマッチします。</entry>
        </row>
 
        <row>
@@ -5800,7 +5800,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
 -->
        <entry> 
         <firstterm>ブラケット式</>。
-        <replaceable>chars</>のいずれか1つに一致します
+        <replaceable>chars</>のいずれか1つにマッチします
        （詳細は<xref linkend="posix-bracket-expressions">を参照してください）。
        </entry>
        </row>
@@ -5812,7 +5812,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
        matches that character taken as an ordinary character,
        e.g., <literal>\\</> matches a backslash character </entry>
 -->
-       <entry>（ここで<replaceable>k</>は英数字以外です。）普通の文字として指定した文字に一致します。例えば、<literal>\\</>はバックスラッシュ文字です。</entry>
+       <entry>（ここで<replaceable>k</>は英数字以外です。）普通の文字として指定した文字にマッチします。例えば、<literal>\\</>はバックスラッシュ文字です。</entry>
        </row>
 
        <row>
@@ -5827,7 +5827,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
        （おそらく他の文字が後に続きます）。
        <firstterm>エスケープ</>です。
        <xref linkend="posix-escape-sequences">を参照してください
-       （AREのみ、EREとBREではこれは<replaceable>c</>に一致します）。
+       （AREのみ、EREとBREではこれは<replaceable>c</>にマッチします）。
        </entry>
        </row>
 
@@ -5839,7 +5839,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
        when followed by a digit, it is the beginning of a
        <replaceable>bound</> (see below) </entry>
 -->
-       <entry>直後に数字以外がある場合、左中括弧<literal>{</>に一致します。
+       <entry>直後に数字以外がある場合、左中括弧<literal>{</>にマッチします。
 直後に数字が続く場合、<replaceable>bound</>（後述）の始まりです。</entry>
        </row>
 
@@ -5850,7 +5850,7 @@ Perlのような他のソフトウェアシステムも似たような定義を�
        significance, matches that character </entry>
 -->
        <entry>ここで<replaceable>x</>は他に意味を持たない1文字です。
-<replaceable>x</>に一致します。</entry>
+<replaceable>x</>にマッチします。</entry>
        </row>
       </tbody>
      </tgroup>
@@ -5899,7 +5899,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
 <!--
        <entry> a sequence of 0 or more matches of the atom </entry>
 -->
-       <entry>アトムの0個以上複数の並びに一致</entry>
+       <entry>アトムの0個以上複数の並びにマッチ</entry>
        </row>
 
        <row>
@@ -5907,7 +5907,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
 <!--
        <entry> a sequence of 1 or more matches of the atom </entry>
 -->
-       <entry>アトムの1個以上複数の並びに一致</entry>
+       <entry>アトムの1個以上複数の並びにマッチ</entry>
        </row>
 
        <row>
@@ -5915,7 +5915,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
 <!--
        <entry> a sequence of 0 or 1 matches of the atom </entry>
 -->
-       <entry>アトムの0個または1個の並びに一致</entry>
+       <entry>アトムの0個または1個の並びにマッチ</entry>
        </row>
 
        <row>
@@ -5923,7 +5923,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
 <!--
        <entry> a sequence of exactly <replaceable>m</> matches of the atom </entry>
 -->
-       <entry>アトムの正確に<replaceable>m</>個の並びに一致</entry>
+       <entry>アトムの正確に<replaceable>m</>個の並びにマッチ</entry>
        </row>
 
        <row>
@@ -5931,7 +5931,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
 <!--
        <entry> a sequence of <replaceable>m</> or more matches of the atom </entry>
 -->
-       <entry>アトムの<replaceable>m</>個以上の並びに一致</entry>
+       <entry>アトムの<replaceable>m</>個以上の並びにマッチ</entry>
        </row>
 
        <row>
@@ -5942,7 +5942,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
        (inclusive) matches of the atom; <replaceable>m</> cannot exceed
        <replaceable>n</> </entry>
 -->
-       <entry> アトムの<replaceable>m</>個以上<replaceable>n</>以下の並びに一致。
+       <entry> アトムの<replaceable>m</>個以上<replaceable>n</>以下の並びにマッチ。
 <replaceable>m</>は<replaceable>n</>を超えることはできません。</entry>
        </row>
 
@@ -6018,7 +6018,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
      number of matches.
      See <xref linkend="posix-matching-rules"> for more detail.
 -->
-<firstterm>最短マッチを行う</>量指定子（AREのみで使用可能）は、対応する通常の（<firstterm>欲張りの</>）ものと同じものに一致しますが、最大のマッチではなく最小のマッチを取ります。
+<firstterm>最短マッチを行う</>量指定子（AREのみで使用可能）は、対応する通常の（<firstterm>欲張りの</>）ものと同じものにマッチしますが、最大のマッチではなく最小のマッチを取ります。
 詳細は<xref linkend="posix-matching-rules">を参照してください。
    </para>
 
@@ -6060,7 +6060,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
 <!--
        <entry> matches at the beginning of the string </entry>
 -->
-       <entry>文字列の先頭に一致</entry>
+       <entry>文字列の先頭にマッチ</entry>
        </row>
 
        <row>
@@ -6068,7 +6068,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
 <!--
        <entry> matches at the end of the string </entry>
 -->
-       <entry>文字列の末尾に一致</entry>
+       <entry>文字列の末尾にマッチ</entry>
        </row>
 
        <row>
@@ -6078,7 +6078,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
        where a substring matching <replaceable>re</> begins
        (AREs only) </entry>
 -->
-       <entry><firstterm>先行肯定検索</>は、<replaceable>re</>に一致する部分文字列から始まる任意の場所に一致します（AREのみ）。</entry>
+       <entry><firstterm>先行肯定検索</>は、<replaceable>re</>にマッチする部分文字列が始まる任意の場所にマッチします（AREのみ）。</entry>
        </row>
 
        <row>
@@ -6088,21 +6088,27 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
        where no substring matching <replaceable>re</> begins
        (AREs only) </entry>
 -->
-       <entry><firstterm>先行否定検索</>は、<replaceable>re</>に一致しない部分文字列から始まる任意の場所に一致します（AREのみ）。</entry>
+       <entry><firstterm>先行否定検索</>は、<replaceable>re</>にマッチしない部分文字列が始まる任意の場所にマッチします（AREのみ）。</entry>
        </row>
 
        <row>
        <entry> <literal>(?&lt;=</><replaceable>re</><literal>)</> </entry>
+<!--
        <entry> <firstterm>positive lookbehind</> matches at any point
        where a substring matching <replaceable>re</> ends
        (AREs only) </entry>
+-->
+       <entry> <firstterm>後方肯定検索</>は<replaceable>re</>にマッチする部分文字列が終わる任意の場所にマッチします（AREのみ）。</entry>
        </row>
 
        <row>
        <entry> <literal>(?&lt;!</><replaceable>re</><literal>)</> </entry>
+<!--
        <entry> <firstterm>negative lookbehind</> matches at any point
        where no substring matching <replaceable>re</> ends
        (AREs only) </entry>
+-->
+       <entry> <firstterm>後方否定検索</><replaceable>re</>にマッチしない部分文字列が終わる任意の場所にマッチします（AREのみ）。</entry>
        </row>
       </tbody>
      </tgroup>
@@ -6114,7 +6120,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
     references</> (see <xref linkend="posix-escape-sequences">),
     and all parentheses within them are considered non-capturing.
 -->
-先行検索制約には<firstterm>後方参照</>（<xref linkend="posix-escape-sequences">を参照）を含めることはできません。また、その中の括弧は全て取り込むものではないとみなされます。 ★　変更あり
+先行検索制約および後方検索制約には<firstterm>後方参照</>（<xref linkend="posix-escape-sequences">を参照）を含めることはできません。また、その中の括弧は全て取り込むものではないとみなされます。
    </para>
    </sect3>
 
@@ -6142,9 +6148,9 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
     relying on them.
 -->
 <firstterm>ブラケット式</firstterm>とは、<literal>[]</literal>内の文字のリストです。
-通常これはそのリスト内の任意の1文字に一致します（しかし、以降を参照してください）。
-リストが<literal>^</literal>から始まる場合、そのリストの残りには<emphasis>ない</>任意の1文字に一致します。
-リスト内の2文字が<literal>-</literal>で区切られていた場合、これは2つ（を含む）の間にある文字範囲全体を表す省略形となります。例えば、<acronym>ASCII</acronym>における<literal>[0-9]</literal>は全ての数字に一致します。
+通常これはそのリスト内の任意の1文字にマッチします（しかし、以降を参照してください）。
+リストが<literal>^</literal>から始まる場合、そのリストの残りには<emphasis>ない</>任意の1文字にマッチします。
+リスト内の2文字が<literal>-</literal>で区切られていた場合、これは2つ（を含む）の間にある文字範囲全体を表す省略形となります。例えば、<acronym>ASCII</acronym>における<literal>[0-9]</literal>は全ての数字にマッチします。
 例えば<literal>a-c-e</literal>といった、終端を共有する2つの範囲は不正です。
 範囲は並びの照合順に非常に依存しています。ですので、移植予定のプログラムではこれに依存してはなりません。
    </para>
@@ -6189,7 +6195,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
 -->
 ブラケット式内に、照合要素（文字、単一文字であるかのように照合する複数文字の並び、もしくはそれぞれの照合並びの名前）が<literal>[.</literal>と<literal>.]</literal>の間にあると、その照合要素の文字の並びを意味します。
 この並びはブラケット式のリストの一要素として取り扱われます。
-このことにより、ブラケット式は要素を照合する複数文字を含むブラケット式を1文字以上に一致させることができます。例えば、照合並びが<literal>ch</literal>照合要素を含む場合、正規表現<literal>[[.ch.]]*c</literal>は<literal>chchcc</literal>という文字の最初の5文字に一致します。
+このことにより、ブラケット式は要素を照合する複数文字を含むブラケット式を1文字以上にマッチさせることができます。例えば、照合並びが<literal>ch</literal>照合要素を含む場合、正規表現<literal>[[.ch.]]*c</literal>は<literal>chchcc</literal>という文字の最初の5文字にマッチします。
    </para>
 
    <note>
@@ -6264,7 +6270,7 @@ REはバックスラッシュ<literal>\</>を終端とすることはできま�
     The constraint escapes described below are usually preferable; they
     are no more standard, but are easier to type.
 -->
-ブラケット式には2つの特殊な場合があります。<literal>[[:&lt;:]]</literal>と<literal>[[:&gt;:]]</literal>というブラケット式は、先頭と終端の単語がそれぞれ空文字であることに一致する制約です。
+ブラケット式には2つの特殊な場合があります。<literal>[[:&lt;:]]</literal>と<literal>[[:&gt;:]]</literal>というブラケット式は、先頭と終端の単語がそれぞれ空文字であることにマッチする制約です。
 単語は、単語文字が前後に付かない単語文字の並びとして定義されます。
 単語文字とは（<citerefentry><refentrytitle>ctype</refentrytitle><manvolnum>3</manvolnum></citerefentry>で定義されている）1つの<literal>alnum</>文字またはアンダースコアです。
 これは、<acronym>POSIX</acronym> 1003.2との互換性はありますが、そこでは定義されていない式です。ですので、他システムへ移植予定のソフトウェアでの使用には注意が必要です。
@@ -6325,7 +6331,7 @@ EREにはエスケープはありません。ブラケット式の外側では�
     written as an escape.  They are
     shown in <xref linkend="posix-constraint-escapes-table">.
 -->
-<firstterm>制約エスケープ</>は、指定した条件に合う場合に空文字に一致する制約をエスケープとして表したものです。
+<firstterm>制約エスケープ</>は、指定した条件に合う場合に空文字にマッチする制約をエスケープとして表したものです。
 これらを<xref linkend="posix-constraint-escapes-table">に示します。
    </para>
 
@@ -6341,8 +6347,8 @@ EREにはエスケープはありません。ブラケット式の外側では�
     Subexpressions are numbered in the order of their leading parentheses.
     Non-capturing parentheses do not define subexpressions.
 -->
-<firstterm>後方参照</>（<literal>\</><replaceable>n</>）は、直前に括弧で囲まれた副式によって一致された、<replaceable>n</>番目の同一文字列に一致します（<xref linkend="posix-constraint-backref-table">を参照してください）。
-  例えば、<literal>([bc])\1</>は<literal>bb</>もしくは<literal>cc</>に一致しますが、<literal>bc</>や<literal>cb</>には一致しません。REでは副式全体は後方参照の前になければなりません。
+<firstterm>後方参照</>（<literal>\</><replaceable>n</>）は、直前に括弧で囲まれた副式によってマッチされた、<replaceable>n</>番目の同一文字列にマッチします（<xref linkend="posix-constraint-backref-table">を参照してください）。
+  例えば、<literal>([bc])\1</>は<literal>bb</>もしくは<literal>cc</>にマッチしますが、<literal>bc</>や<literal>cb</>にはマッチしません。REでは副式全体は後方参照の前になければなりません。
 副式は開括弧の順番で番号付けされます。
 取り込まない括弧は副式を定義しません。
    </para>
@@ -6544,7 +6550,7 @@ EREにはエスケープはありません。ブラケット式の外側では�
 ASCIIの範囲(0-127)外の値を指定した数字のエントリエスケープは、その意味がデータベースエンコーディングに依存します。
 エンコーディングがUTF-8の場合、エスケープ値はユニコード符号位置に相当します。例えば、<literal>\u1234</>は文字<literal>U+1234</>を意味します。
 その他のマルチバイトエンコーディングでは、文字エントリエスケープはたいてい文字のバイト値の連結を指定します。
-エスケープ値がデータベースエンコーディングでのいかなる正当な文字にも対応しない場合、エラーは起こりませんが、いかなるデータにも一致しません。
+エスケープ値がデータベースエンコーディングでのいかなる正当な文字にも対応しない場合、エラーは起こりませんが、いかなるデータにもマッチしません。
    </para>
 
    <para>
@@ -6668,7 +6674,7 @@ ASCIIの範囲(0-127)外の値を指定した数字のエントリエスケー�
        (see <xref linkend="posix-matching-rules"> for how this differs from
        <literal>^</>) </entry>
 -->
-       <entry>文字列の先頭にのみ一致します（<literal>^</>との違いについては<xref linkend="posix-matching-rules">を参照してください）。</entry> 
+       <entry>文字列の先頭にのみマッチします（<literal>^</>との違いについては<xref linkend="posix-matching-rules">を参照してください）。</entry> 
        </row>
 
        <row>
@@ -6676,7 +6682,7 @@ ASCIIの範囲(0-127)外の値を指定した数字のエントリエスケー�
 <!--
        <entry> matches only at the beginning of a word </entry>
 -->
-       <entry> 単語の先頭にのみ一致します。 </entry>
+       <entry> 単語の先頭にのみマッチします。 </entry>
        </row>
 
        <row>
@@ -6684,7 +6690,7 @@ ASCIIの範囲(0-127)外の値を指定した数字のエントリエスケー�
 <!--
        <entry> matches only at the end of a word </entry>
 -->
-       <entry> 単語の末尾にのみ一致します。 </entry>
+       <entry> 単語の末尾にのみマッチします。 </entry>
        </row>
 
        <row>
@@ -6692,7 +6698,7 @@ ASCIIの範囲(0-127)外の値を指定した数字のエントリエスケー�
 <!--
        <entry> matches only at the beginning or end of a word </entry>
 -->
-       <entry> 単語の先頭もしくは末尾にのみ一致します。</entry>
+       <entry> 単語の先頭もしくは末尾にのみマッチします。</entry>
        </row>
 
        <row>
@@ -6701,7 +6707,7 @@ ASCIIの範囲(0-127)外の値を指定した数字のエントリエスケー�
        <entry> matches only at a point that is not the beginning or end of a
        word </entry>
 -->
-       <entry>単語の先頭もしくは末尾以外の場所にのみ一致します。</entry>
+       <entry>単語の先頭もしくは末尾以外の場所にのみマッチします。</entry>
        </row>
 
        <row>
@@ -6711,7 +6717,7 @@ ASCIIの範囲(0-127)外の値を指定した数字のエントリエスケー�
        (see <xref linkend="posix-matching-rules"> for how this differs from
        <literal>$</>) </entry>
 -->
-       <entry>文字列の末尾にのみ一致します（<literal>$</>との違いについては<xref linkend="posix-matching-rules">を参照してください）。</entry>
+       <entry>文字列の末尾にのみマッチします（<literal>$</>との違いについては<xref linkend="posix-matching-rules">を参照してください）。</entry>
        </row>
       </tbody>
      </tgroup>
@@ -6876,7 +6882,7 @@ AREは<firstterm>埋め込みオプション</>から始められます。<liter
 <!--
        <entry> case-sensitive matching (overrides operator type) </entry>
 -->
-       <entry> 大文字小文字を区別する一致（演算子で規定される大文字小文字の区別よりこの指定が優先されます）。 </entry>
+       <entry> 大文字小文字を区別するマッチ（演算子で規定される大文字小文字の区別よりこの指定が優先されます）。 </entry>
        </row>
 
        <row>
@@ -6893,7 +6899,7 @@ AREは<firstterm>埋め込みオプション</>から始められます。<liter
        <entry> case-insensitive matching (see
        <xref linkend="posix-matching-rules">) (overrides operator type) </entry>
 -->
-       <entry> 大文字小文字を区別しない一致（<xref linkend="posix-matching-rules">を参照）（演算子で規定される大文字小文字の区別よりこの指定が優先されます）。 </entry>
+       <entry> 大文字小文字を区別しないマッチ（<xref linkend="posix-matching-rules">を参照）（演算子で規定される大文字小文字の区別よりこの指定が優先されます）。 </entry>
        </row>
 
        <row>
@@ -6910,7 +6916,7 @@ AREは<firstterm>埋め込みオプション</>から始められます。<liter
        <entry> newline-sensitive matching (see
        <xref linkend="posix-matching-rules">) </entry>
 -->
-       <entry> 改行を区別する一致（<xref linkend="posix-matching-rules">を参照）</entry>
+       <entry> 改行を区別するマッチ（<xref linkend="posix-matching-rules">を参照）</entry>
        </row>
 
        <row>
@@ -6919,7 +6925,7 @@ AREは<firstterm>埋め込みオプション</>から始められます。<liter
        <entry> partial newline-sensitive matching (see
        <xref linkend="posix-matching-rules">) </entry>
 -->
-       <entry> 部分的な改行を区別する一致（<xref linkend="posix-matching-rules">を参照）</entry>
+       <entry> 部分的な改行を区別するマッチ（<xref linkend="posix-matching-rules">を参照）</entry>
        </row>
 
        <row>
@@ -7072,8 +7078,8 @@ AREの先頭（もし<literal>***:</>決定子があればその後）でのみ�
     be taken, depending on whether the RE is <firstterm>greedy</> or
     <firstterm>non-greedy</>.
 -->
-REが文字列の中の1つ以上の部分文字列と一致する場合において、REは最初にマッチが始まった部分文字列と一致します。
-その位置からまた1つ以上の部分文字列とマッチした際は、正規表現は<firstterm>最短マッチを行わない（欲張り型）</>か<firstterm>最短マッチを行う（非欲張り型）</>かによって、最長一致もしくは最短一致の文字列のどちらかに一致します
+REが文字列の中の1つ以上の部分文字列とマッチする場合において、REは最初にマッチが始まった部分文字列とマッチします。
+その位置からまた1つ以上の部分文字列とマッチした際は、正規表現は<firstterm>最短マッチを行わない（欲張り型）</>か<firstterm>最短マッチを行う（非欲張り型）</>かによって、最長マッチもしくは最短マッチの文字列のどちらかにマッチします
    </para>
 
    <para>
@@ -7088,7 +7094,7 @@ REが最長マッチかどうかは以下の規則によって決まります。
        Most atoms, and all constraints, have no greediness attribute (because
        they cannot match variable amounts of text anyway).
 -->
-ほとんどのアトムおよび全ての式は欲張り属性を持ちません（これらは変動する量のテキストにまったく一致しないからです）。
+ほとんどのアトムおよび全ての式は欲張り属性を持ちません（これらは変動する量のテキストにまったくマッチしないからです）。
       </para>
      </listitem>
      <listitem>
@@ -7168,8 +7174,8 @@ REを括弧で括ることは欲張りかどうかを変更しません。
     priority over ones starting later.
 -->
 上の規則は、個々の量指定付きアトムだけではなく、量指定付きアトムを複数含むブランチやRE全体の欲張り属性に関連します。
-つまり、ブランチやRE全体が<emphasis>全体として</>最長または最短の部分文字列に一致するという方法でマッチ処理が行われます。
-全体のマッチの長さが決まると、特定の部分式に一致する部分がその部分式の欲張り属性によって決まります。この時、RE内でより前にある部分式が後にある部分式よりも高い優先度を持ちます。
+つまり、ブランチやRE全体が<emphasis>全体として</>最長または最短の部分文字列にマッチするという方法でマッチ処理が行われます。
+全体のマッチの長さが決まると、特定の部分式にマッチする部分がその部分式の欲張り属性によって決まります。この時、RE内でより前にある部分式が後にある部分式よりも高い優先度を持ちます。
    </para>
 
    <para>
@@ -7196,11 +7202,11 @@ SELECT SUBSTRING('XY1234Z', 'Y*?([0-9]{1,3})');
     just <literal>1</>.
 -->
 最初の例では、<literal>Y*</>が欲張り型であるため、REは全体として欲張り型です。
-マッチは<literal>Y</>の位置から始まり、そこから可能な限り最長の文字列に一致します。つまり<literal>Y123</>となります。
+マッチは<literal>Y</>の位置から始まり、そこから可能な限り最長の文字列にマッチします。つまり<literal>Y123</>となります。
 出力は括弧で括られた部分、つまり<literal>123</>となります。
 2番目の例では、<literal>Y*?</>が非欲張り型のため、REは全体として非欲張り型です。
-マッチは<literal>Y</>の位置から始まり、そこから可能な限り最短の文字列に一致します。つまり<literal>Y1</>となります。
-部分式<literal>[0-9]{1,3}</>は欲張り型ですが、決定された一致する全体の長さを変更することはできません。したがって、強制的に<literal>1</>に一致することになります。
+マッチは<literal>Y</>の位置から始まり、そこから可能な限り最短の文字列にマッチします。つまり<literal>Y1</>となります。
+部分式<literal>[0-9]{1,3}</>は欲張り型ですが、決定されたマッチする全体の長さを変更することはできません。したがって、強制的に<literal>1</>にマッチすることになります。
    </para>
 
    <para>
@@ -7251,7 +7257,7 @@ SELECT regexp_matches('abc01234xyz', '(.*?)(\d+)(.*)');
     and so it ends the overall match as soon as possible.  We can get what
     we want by forcing the RE as a whole to be greedy:
 -->
-またもや上手くいきませんでした。今度は、REが全体として欲張りでなくなってしまい、できる限り早く全体に渡る一致を終わらせてしまうからです。
+またもや上手くいきませんでした。今度は、REが全体として欲張りでなくなってしまい、できる限り早く全体に渡るマッチを終わらせてしまうからです。
 RE全体として欲張りにすることで欲しいものが得られます。
 <screen>
 SELECT regexp_matches('abc01234xyz', '(?:(.*?)(\d+)(.*)){1,1}');
@@ -7282,8 +7288,8 @@ REの全体に渡る欲張りさをその要素の欲張りさと別に制御す
     subexpression match an empty string.
 -->
 マッチが長いか短いかを判断する時には、マッチの長さは照合要素ではなく文字列で測られます。
-空文字列はまったく一致する要素がない文字列よりも長いと考えられます。
-例えば、<literal>bb*</literal>は<literal>abbbc</literal>の真中の3文字と一致し、<literal>(week|wee)(night|knights)</literal>は<literal>weeknights</literal>の全ての10文字と一致し、<literal>abc</literal>に対して<literal>(.*).*</literal>が一致されると、括弧内の部分正規表現は3つの文字全てに一致し、<literal>bc</literal>に対して<literal>(a*)*</literal>が一致されると、全体のREと括弧内の正規表現は空文字列に一致します。
+空文字列はまったくマッチする要素がない文字列よりも長いと考えられます。
+例えば、<literal>bb*</literal>は<literal>abbbc</literal>の真中の3文字とマッチし、<literal>(week|wee)(night|knights)</literal>は<literal>weeknights</literal>の全ての10文字とマッチし、<literal>abc</literal>に対して<literal>(.*).*</literal>がマッチされると、括弧内の部分正規表現は3つの文字全てにマッチし、<literal>bc</literal>に対して<literal>(a*)*</literal>がマッチされると、全体のREと括弧内の正規表現は空文字列にマッチします。
    </para>
 
    <para>
@@ -7300,7 +7306,7 @@ REの全体に渡る欲張りさをその要素の欲張りさと別に制御す
     <literal>[x]</> becomes <literal>[xX]</>
     and <literal>[^x]</> becomes <literal>[^xX]</>.
 -->
-もし大文字小文字を区別しない一致が指定されると、アルファベット文字の大文字小文字の区別がまったくなくなったのと同じ効果を与えます。
+もし大文字小文字を区別しないマッチが指定されると、アルファベット文字の大文字小文字の区別がまったくなくなったのと同じ効果を与えます。
 ブラケット式の外側にアルファベットの大文字小文字が混ざった通常の文字が出てきた場合、例えば、<literal>x</literal>が<literal>[xX]</literal>となるように大文字小文字ともにブラケット式に実質的に転換されます。
 ブラケット式の中に現れた時は、（例えば）<literal>[x]</literal>が<literal>[xX]</literal>となり、また<literal>[^x]</literal>が<literal>[^xX]</literal>となるように、全ての大文字小文字それぞれの対がブラケット式に追加されます。
    </para>
@@ -7319,8 +7325,8 @@ REの全体に渡る欲張りさをその要素の欲張りさと別に制御す
     But the ARE escapes <literal>\A</> and <literal>\Z</>
     continue to match beginning or end of string <emphasis>only</>.
 -->
-改行を区別するマッチが指定されると、<literal>.</>と<literal>^</>を使用するブラケット式は（REが明示的に調整されていたとしてもマッチが改行をまたがらないようにするために）改行文字に一致しなくなります。また、<literal>^</>と<literal>$</>はそれぞれ改行直後と直前の空文字列に一致し、さらに、それぞれ文字列の先頭と末尾に一致します。
-しかし、AREエスケープの<literal>\A</>と<literal>\Z</>は、継続して、文字列の先頭と末尾<emphasis>のみ</>に一致します。
+改行を区別するマッチが指定されると、<literal>.</>と<literal>^</>を使用するブラケット式は（REが明示的に調整されていたとしてもマッチが改行をまたがらないようにするために）改行文字にマッチしなくなります。また、<literal>^</>と<literal>$</>はそれぞれ改行直後と直前の空文字列にマッチし、さらに、それぞれ文字列の先頭と末尾にマッチします。
+しかし、AREエスケープの<literal>\A</>と<literal>\Z</>は、継続して、文字列の先頭と末尾<emphasis>のみ</>にマッチします。
    </para>
 
    <para>
@@ -7330,7 +7336,7 @@ REの全体に渡る欲張りさをその要素の欲張りさと別に制御す
     as with newline-sensitive matching, but not <literal>^</>
     and <literal>$</>.
 -->
-部分的に改行を区別するマッチが指定されると、<literal>.</>とブラケット式は改行を区別する一致を行うようになりますが、<literal>^</>と<literal>$</>は変更されません。
+部分的に改行を区別するマッチが指定されると、<literal>.</>とブラケット式は改行を区別するマッチを行うようになりますが、<literal>^</>と<literal>$</>は変更されません。
    </para>
 
    <para>
@@ -7341,7 +7347,7 @@ REの全体に渡る欲張りさをその要素の欲張りさと別に制御す
     and bracket expressions.
     This isn't very useful but is provided for symmetry.
 -->
-部分的に改行を区別する逆マッチが指定されると、<literal>^</>と<literal>$</>は改行を区別する一致を行うようになりますが、<literal>.</>とブラケット式は変更されません。
+部分的に改行を区別する逆マッチが指定されると、<literal>^</>と<literal>$</>は改行を区別するマッチを行うようになりますが、<literal>.</>とブラケット式は変更されません。
 これはあまり有用ではありません。対称性のために提供されています。
    </para>
    </sect3>
@@ -7390,7 +7396,9 @@ AREの機能のうち、POSIX EREと実質的な非互換性があるのは、<l
     constraints, and the longest/shortest-match (rather than first-match)
     matching semantics.
 -->
-多くのARE拡張はPerlから拝借したものです。しかし、いくつかは整理され、Perlの拡張のいくつかは存在しません。注意すべき非互換性には、<literal>\b</>、<literal>\B</>、改行の取り扱いに関する特殊な措置の欠落、改行を区別する一致に影響する点について補足したブラケット式の追加、括弧と先行検索制約内の後方参照についての制限、最長/最短（最初に一致するではなく）マッチのセマンティックがあります。
+多くのARE拡張はPerlから拝借したものです。
+しかし、いくつかは整理され、Perlの拡張のいくつかは存在しません。
+注意すべき非互換性には、<literal>\b</>、<literal>\B</>、改行の取り扱いに関する特殊な措置の欠落、改行を区別するマッチに影響する点について補足したブラケット式の追加、括弧と先行・後方検索制約内の後方参照についての制限、最長/最短（最初にマッチするではなく）マッチのセマンティックがあります。
    </para>
 
    <para>

--- a/doc/src/sgml/func2.sgml
+++ b/doc/src/sgml/func2.sgml
@@ -157,8 +157,12 @@
 
    <note>
     <para>
+<!--
      There is also a single-argument <function>to_timestamp</function>
      function; see <xref linkend="functions-datetime-table">.
+-->
+引数が１つの<function>to_timestamp</function>関数もあります。
+<xref linkend="functions-datetime-table">を参照して下さい。
     </para>
    </note>
 
@@ -1187,9 +1191,10 @@ Oracleの実装では<literal>9</literal>の前に<literal>MI</literal>が置か
        <literal>V</literal> combined with a decimal point
        (e.g., <literal>99.9V99</literal> is not allowed).
 -->
-<literal>V</literal>は入力値を実質的に<literal>10^<replaceable>n</replaceable></literal>乗します。
+<literal>V</literal>を<function>to_char</function>につけると、入力値を<literal>10^<replaceable>n</replaceable></literal>倍します。
 ここで<replaceable>n</replaceable>は<literal>V</literal>に続く桁数です。
-<function>to_char</function>関数は小数点と<literal>V</literal>との混在をサポートしません（例えば、<literal>99.9V99</literal> とはできません）。 ★変更あり
+<literal>V</literal>を<function>to_number</function>につけると、同じように割り算をします。
+<function>to_char</function>および<function>to_number</function>は、小数点と<literal>V</literal>との混在をサポートしません（例えば、<literal>99.9V99</literal> とはできません）。
       </para>
      </listitem>
 


### PR DESCRIPTION
パターンマッチの9.6対応時に気になってしまったので、Issues #480 のmatchの訳語を一括で対応しました。
そのため、9.6の変更が埋もれてしまっている感じですが、9.7節（パターンマッチ）の変更は、6143行目からの"positive/negative lookbehind"のみです。
9.8節（データ型書式設定関数）は分割ファイルがfunc2.sgmlになっているので、そちらをレビューしていただければ良いかと思います。