### PR TITLE
9.5以前からあるmvcc.sgmlの誤訳を修正しました。

### DIFF
--- a/doc/src/sgml/mvcc.sgml
+++ b/doc/src/sgml/mvcc.sgml
@@ -1185,7 +1185,8 @@ ERROR:  could not serialize access due to read/write dependencies among transact
        in transaction rollbacks and restarts against any overall change in
        query execution time.
 -->
-シーケンシャルスキャンは常にリレーションレベルでの述語ロックを必要とするでしょう。これは直列化失敗の増加した割合に起因する場合があります。
+シーケンシャルスキャンは常にリレーションレベルでの述語ロックを必要とします。
+これによって、直列化失敗の頻度が増える可能性があります。
 <xref linkend="guc-random-page-cost">を縮小および(または)<xref linkend="guc-cpu-tuple-cost">を増加することによりインデックススキャンの使用を促進することは有用かもしれません。
 問い合わせ実行時間の全体的な変化に不利となる、トランザクションのロールバックや再起動を減少させるように、必ず検討してください。
       </para>


### PR DESCRIPTION
元の訳では、原因と結果が逆になっています。