### PR TITLE
pg_xlogdump.sgmlの9.6対応です。

### DIFF
--- a/doc/src/sgml/ref/pg_xlogdump.sgml
+++ b/doc/src/sgml/ref/pg_xlogdump.sgml
@@ -211,7 +211,7 @@ PostgreSQL documentation
         default is 1.
 -->
 ログレコードの読み取り先のタイムラインです。
-デフォルトでは、<literal>startseg</>が指定されている場合は<literal>startseg</>内の値が使用されます。
+デフォルトでは、<replaceable>startseg</>が指定されている場合は<replaceable>startseg</>内の値が使用されます。
 指定がない場合のデフォルトは1です。
        </para>
       </listitem>


### PR DESCRIPTION
literalタグがreplaceableタグに修正されただけです。