### PR TITLE
update files not in doc/src to 9.6.0

### DIFF
--- a/src/backend/catalog/sql_features.txt.ja
+++ b/src/backend/catalog/sql_features.txt.ja
@@ -316,7 +316,7 @@ F831	完全なカーソル更新			NO
 F831	完全なカーソル更新	01	更新可能なスクロール可能カーソル	NO	
 F831	完全なカーソル更新	02	更新可能な順序付けカーソル	NO	
 F841	LIKE_REGEX述語			NO	
-F842	OCCURENCES_REGEX関数			NO	
+F842	OCCURRENCES_REGEX関数			NO	
 F843	POSITION_REGEX関数			NO	
 F844	SUBSTRING_REGEX関数			NO	
 F845	TRANSLATE_REGEX関数			NO	
@@ -656,10 +656,10 @@ X271	XMLValidate: データ駆動ケース			NO
 X272	XMLValidate: ACCORDING TO句			NO	
 X273	XMLValidate: ELEMENT句			NO	
 X274	XMLValidate: スキーマ位置			NO	
-X281	XMLValidate: DOCUMENTオプション付き			NO	
+X281	XMLValidate DOCUMENTオプション付き			NO	
 X282	XMLValidate CONTENTオプション付き			NO	
 X283	XMLValidate SEQUENCEオプション付き			NO	
-X284	XMLValidate ELEMENT句のないNAMESPACE			NO	
+X284	XMLValidate: ELEMENT句のないNAMESPACE			NO	
 X286	XMLValidate: ELEMENT句付きNO NAMESPACE			NO	
 X300	XMLTable			NO	
 X301	XMLTable: 派生列リストオプション			NO	

--- a/src/backend/utils/errcodes.txt.ja
+++ b/src/backend/utils/errcodes.txt.ja
@@ -2,7 +2,7 @@
 # errcodes.txt
 #      PostgreSQL error codes
 #
-# Copyright (c) 2003-2015, PostgreSQL Global Development Group
+# Copyright (c) 2003-2016, PostgreSQL Global Development Group
 #
 # This list serves as the basis for generating source files containing error
 # codes. It is kept in a common format to make sure all these source files have
@@ -14,6 +14,9 @@
 #
 #   src/pl/plpgsql/src/plerrcodes.h
 #      a list of PL/pgSQL condition names and their SQLSTATE codes
+#
+#   src/pl/tcl/pltclerrcodes.h
+#      the same, for PL/Tcl
 #
 #   doc/src/sgml/errcodes-list.sgml
 #      a SGML table of error codes for inclusion in the documentation
@@ -412,6 +415,10 @@ Section: クラス 58 - システムエラー(PostgreSQL自体の外部のエラ
 58030    E    ERRCODE_IO_ERROR                                               io_error
 58P01    E    ERRCODE_UNDEFINED_FILE                                         undefined_file
 58P02    E    ERRCODE_DUPLICATE_FILE                                         duplicate_file
+
+Section: クラス 72 - スナップショット失敗
+# (class borrowed from Oracle)
+72000    E    ERRCODE_SNAPSHOT_TOO_OLD                                       snapshot_too_old
 
 Section: クラス F0 - 設定ファイルエラー
 


### PR DESCRIPTION
doc/src以外のところにある（のだけれども翻訳が必要な）以下のファイルの9.6.0対応です。

src/backend/catalog/sql_features.txt.ja
src/backend/utils/errcodes.txt.ja
