### PR TITLE
[pgsql-jp: 41911] maintenance_work_memのデフォルト値を修正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -2180,7 +2180,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
         performance for vacuuming and for restoring database dumps.
        -->
        <command>VACUUM</command>、<command>CREATE INDEX</>、および<command>ALTER TABLE ADD FOREIGN KEY</>の様な保守操作で使用されるメモリの最大容量を指定します。
-デフォルト値は16メガバイト（<literal>16MB</>）です。
+デフォルト値は64メガバイト（<literal>64MB</>）です。
 1つのデータベースセッションでは、一度に1つしか上記操作はできませんし、通常インストレーションでこうした操作が同時に非常に多く発生することはありませんので、これを<varname>work_mem</varname>よりもかなり多めの値にしても安全です。
 大きい値を設定することでvacuum処理と、ダンプしたデータベースのリストア性能が向上します。
        </para>


### PR DESCRIPTION
9.4/9.5については修正されましたが、9.6がまだだったので、修正しました。