### PR TITLE
fix typos?

### DIFF
--- a/doc/src/sgml/maintenance.sgml
+++ b/doc/src/sgml/maintenance.sgml
@@ -623,7 +623,7 @@
    <para>
 <!--
     <productname>PostgreSQL</productname>'s
-    <link linkend="mvcc-intro">MVCC</link> transaction semantics ★変更あり
+    <link linkend="mvcc-intro">MVCC</link> transaction semantics
     depend on being able to compare transaction ID (<acronym>XID</>)
     numbers: a row version with an insertion XID greater than the current
     transaction's XID is <quote>in the future</> and should not be visible
@@ -637,7 +637,7 @@
     get at it.)  To avoid this, it is necessary to vacuum every table
     in every database at least once every two billion transactions.
 -->
-<productname>PostgreSQL</productname>のMVCCトランザクションのセマンティックは、トランザクションID（<firstterm>XID</>）番号の比較が可能であることに依存しています。
+<productname>PostgreSQL</productname>の<link linkend="mvcc-intro">MVCC</link>トランザクションのセマンティックは、トランザクションID（<firstterm>XID</>）番号の比較が可能であることに依存しています。
 現在のトランザクションのXIDよりも新しい挿入時のXIDを持ったバージョンの行は、<quote>未来のもの</>であり、現在のトランザクションから可視であってはなりません。
 しかし、トランザクションIDのサイズには制限（32ビット）があり、長時間（40億トランザクション）稼働しているクラスタは<firstterm>トランザクションの周回</>を経験します。
 XIDのカウンタが一周して0に戻り、そして、突然に、過去になされたトランザクションが将来のものと見えるように、つまり、その出力が不可視になります。
@@ -803,7 +803,7 @@ XIDのカウンタが一周して0に戻り、そして、突然に、過去に�
     frequent aggressive vacuuming.
 -->
 <varname>vacuum_freeze_table_age</>に対する有効な最大値は0.95 * <varname>autovacuum_freeze_max_age</>です。
-これより値が高いと値は最大値までに制限されます。 ★変更あり
+これより値が高いと値は最大値までに制限されます。
 <varname>autovacuum_freeze_max_age</>より高い値は、周回防止用の自動バキュームがその時点でいずれにせよ誘発され、0.95という乗算係数がそれが起こる前に手動による<command>VACUUM</>実行の余地を残すため、意味を持ちません。
 経験則に従うと、定期的に計画された<command>VACUUM</>もしくは通常の削除・更新作業により誘発された自動バキュームがその期間で実行されるように十分な間隔を残しておくように、<command>vacuum_freeze_table_age</>は<varname>autovacuum_freeze_max_age</>より多少低い値に設定されるべきです。
 これを余りにも近い値に設定すると、たとえ領域を回収するために最近テーブルがバキュームされたとしても、周回防止用の自動バキュームに帰着します。


### PR DESCRIPTION
maintenance.sgmlに★が残っていましたのでその対応です。

1つ目は対応漏れのようですが、2つ目はよく分かりません。対応する原文は変わっているようには見えませんので、★を付ける場所が間違っているのかもしれません。