### PR TITLE
fix typos?

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -12749,6 +12749,7 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
         <entry><type>tsquery</type></entry>
 <!--
         <entry>produce <type>tsquery</> that searches for a phrase,
+         ignoring punctuation</entry>
 -->
         <entry>句読点を無視して、語句を検索する<type>tsquery</>を生成</entry>
         <entry><literal>phraseto_tsquery('english', 'The Fat Rats')</literal></entry>
@@ -17434,7 +17435,7 @@ NULL baz</literallayout>(3 rows)</entry>
        整数型の引数であれば全て<type>numeric</type>、浮動小数点の引数であれば<type>double precision</type>、それ以外は引数のデータ型と同じ
       </entry>
 <!--
-      <entry>Yes</entry> ★変更あり
+      <entry>Yes</entry>
       <entry>the average (arithmetic mean) of all input values</entry>
 -->
       <entry>可</entry>
@@ -25559,7 +25560,7 @@ postgres=# SELECT * FROM pg_xlogfile_name_offset(pg_stop_backup());
         <indexterm>
          <primary>pg_replication_origin_xact_reset</primary>
         </indexterm>
-        <literal><function>pg_replication_origin_xact_reset(<parameter>origin_lsn</parameter> <type>pg_lsn</type>, <parameter>origin_timestamp</parameter> <type>timestamptz</type>)</function></literal>
+        <literal><function>pg_replication_origin_xact_reset()</function></literal>
        </entry>
        <entry>
         <type>void</>


### PR DESCRIPTION
func.sgml にも★が残っているのを見つけました。それ以外にも原文と（意図せぬ）差があるところを対処しました。
func?.sgmlに分割して、と思ったのですが、そうすると変更していないところにも大量に差分が出るのでやっていません。

私のところからは変更部分がブラウザーで見えてはいるので問題ないでしょうか。