### PR TITLE
★が残っていたファイルについて修正(jpug-doc:5292)

### DIFF
--- a/doc/src/sgml/ref/alter_trigger.sgml
+++ b/doc/src/sgml/ref/alter_trigger.sgml
@@ -157,7 +157,7 @@ ALTER TRIGGER emp_stamp ON emp RENAME TO emp_track_chgs;
 <!--
    To mark a trigger as being dependent on an extension:
 -->
-★ To mark a trigger as being dependent on an extension:
+トリガが拡張に依存するという印を付けます。
 <programlisting>
 ALTER TRIGGER emp_stamp ON emp DEPENDS ON EXTENSION emplib;
 </programlisting></para>

--- a/doc/src/sgml/ref/create_function.sgml
+++ b/doc/src/sgml/ref/create_function.sgml
@@ -698,8 +698,7 @@ C原語の関数は、ラベルが間違っていると、理論的には全く�
        to be applied when the function is entered.
 -->
 <literal>SET</>句により、関数が始まった時に指定した設定パラメータを指定した値に設定し、関数の終了時にそれを以前の値に戻すことができます。
-<literal>SET FROM CURRENT</>は、セッションにおけるパラメータの現在値を関数が始まる時に適用する値として保管します。
-★
+<literal>SET FROM CURRENT</>は、<command>CREATE FUNCTION</>の実行時点でのパラメータ値を、関数に入る時に適用する値として保管します。
       </para>
 
       <para>

--- a/doc/src/sgml/ref/create_sequence.sgml
+++ b/doc/src/sgml/ref/create_sequence.sgml
@@ -352,25 +352,6 @@ SELECT * FROM <replaceable>name</replaceable>;
 
   <para>
 <!--
-   Because <function>nextval</> and <function>setval</> calls are never
-   rolled back, sequence objects cannot be used if <quote>gapless</>
-   assignment of sequence numbers is needed.  It is possible to build
-   gapless assignment by using exclusive locking of a table containing a
-   counter; but this solution is much more expensive than sequence
-   objects, especially if many transactions need sequence numbers
-   concurrently.
--->
-★ Because <function>nextval</> and <function>setval</> calls are never
-   rolled back, sequence objects cannot be used if <quote>gapless</>
-   assignment of sequence numbers is needed.  It is possible to build
-   gapless assignment by using exclusive locking of a table containing a
-   counter; but this solution is much more expensive than sequence
-   objects, especially if many transactions need sequence numbers
-   concurrently.
-  </para>
-
-  <para>
-<!--
    Unexpected results might be obtained if a <replaceable
    class="parameter">cache</replaceable> setting greater than one is
    used for a sequence object that will be used concurrently by

--- a/doc/src/sgml/ref/select.sgml
+++ b/doc/src/sgml/ref/select.sgml
@@ -2821,22 +2821,6 @@ SQL標準では、<literal>FROM</>句の任意の要素について適用可能�
 
   <refsect2>
 <!--
-   <title><literal>TABLESAMPLE</literal> Clause Restrictions</title>
--->
-   <title><literal>TABLESAMPLE</literal> Clause Restrictions★訳して</title>
-
-   <para>
-<!--
-    The <literal>TABLESAMPLE</> clause is currently accepted only on
-    regular tables and materialized views.  According to the SQL standard
-    it should be possible to apply it to any <literal>FROM</> item.
--->
-★この節、追加
-   </para>
-  </refsect2>
-
-  <refsect2>
-<!--
    <title>Function Calls in <literal>FROM</literal></title>
 -->
    <title><literal>FROM</literal>内の関数呼び出し</title>


### PR DESCRIPTION
alter_triggerとcreate_sequenceは翻訳漏れなので、訳しました。
create_sequenceとselectは、該当する原文が2重に入っていたので、単純に削除しました。