### PR TITLE
Issues #788 （ハイフンのコメントアウトの誤り）の修正

### DIFF
--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -2655,7 +2655,7 @@ GRANT SELECT
   (user_name, uid, gid, real_name, home_phone, extra_info, home_dir, shell)
   ON passwd TO public;
 <!--
-&#045- Allow users to update certain columns
+&#045;- Allow users to update certain columns
 -->
 -- 特定の列についてはユーザによる更新を許可する
 GRANT UPDATE

--- a/doc/src/sgml/isn.sgml
+++ b/doc/src/sgml/isn.sgml
@@ -459,7 +459,7 @@
 
 <programlisting>
 <!--
-&#055;-Using the types directly:
+&#045;-Using the types directly:
 -->
 --型を直接使う
 SELECT isbn('978-0-393-04002-9');
@@ -467,11 +467,11 @@ SELECT isbn13('0901690546');
 SELECT issn('1436-4522');
 
 <!--
-&#055;-Casting types:
-&#055;- note that you can only cast from ean13 to another type when the
-&#055;- number would be valid in the realm of the target type;
-&#055;- thus, the following will NOT work: select isbn(ean13('0220356483481'));
-&#055;- but these will:
+&#045;-Casting types:
+&#045;- note that you can only cast from ean13 to another type when the
+&#045;- number would be valid in the realm of the target type;
+&#045;- thus, the following will NOT work: select isbn(ean13('0220356483481'));
+&#045;- but these will:
 -->
 --型キャスト
 -- 番号が対象の型の範囲として有効な場合にのみean13から他の型へキャストできることに注意
@@ -481,14 +481,14 @@ SELECT upc(ean13('0220356483481'));
 SELECT ean13(upc('220356483481'));
 
 <!--
-&#055;-Create a table with a single column to hold ISBN numbers:
+&#045;-Create a table with a single column to hold ISBN numbers:
 -->
 --ISBN番号を保持する列が１つあるテーブルを作成する
 CREATE TABLE test (id isbn);
 INSERT INTO test VALUES('9780393040029');
 
 <!--
-&#055;-Automatically calculate check digits (observe the '?'):
+&#045;-Automatically calculate check digits (observe the '?'):
 -->
 --検査桁を自動的に計算する('?'を見よ)
 INSERT INTO test VALUES('220500896?');
@@ -498,7 +498,7 @@ SELECT issn('3251231?');
 SELECT ismn('979047213542?');
 
 <!--
-&#055;-Using the weak mode:
+&#045;-Using the weak mode:
 -->
 --弱めのモードを利用する
 SELECT isn_weak(true);

--- a/doc/src/sgml/lobj.sgml
+++ b/doc/src/sgml/lobj.sgml
@@ -949,17 +949,17 @@ CREATE TABLE image (
 );
 
 <!--
-SELECT lo_creat(-1);       &#055;- returns OID of new, empty large object
+SELECT lo_creat(-1);       &#045;- returns OID of new, empty large object
 -->
 SELECT lo_creat(-1);       -- 新しい空のラージオブジェクトのOIDを返します
 
 <!--
-SELECT lo_create(43213);   &#055;- attempts to create large object with OID 43213
+SELECT lo_create(43213);   &#045;- attempts to create large object with OID 43213
 -->
 SELECT lo_create(43213);   -- OID 43213でラージオブジェクトの生成を試行します
 
 <!--
-SELECT lo_unlink(173454);  &#055;- deletes large object with OID 173454
+SELECT lo_unlink(173454);  &#045;- deletes large object with OID 173454
 -->
 SELECT lo_unlink(173454);  -- OID 173454のラージオブジェクトを削除します
 
@@ -967,7 +967,7 @@ INSERT INTO image (name, raster)
     VALUES ('beautiful image', lo_import('/etc/motd'));
 
 <!--
-INSERT INTO image (name, raster)  &#055;&#055; same as above, but specify OID to use
+INSERT INTO image (name, raster)  &#045;&#045; same as above, but specify OID to use
     VALUES ('beautiful image', lo_import('/etc/motd', 68583));
 -->
 INSERT INTO image (name, raster)  -- 上と同じですが使用するOIDを指定します

--- a/doc/src/sgml/problems.sgml
+++ b/doc/src/sgml/problems.sgml
@@ -351,7 +351,7 @@ OSの起動時にデータベースサーバを起動するようにパッケー
       The <productname>PostgreSQL</productname> version. You can run the command
       <literal>SELECT version();</literal> to
       find out the version of the server you are connected to.  Most executable
-      programs also support a <option>&#045&#045version</option> option; at least
+      programs also support a <option>&#045;&#045;version</option> option; at least
       <literal>postgres &#045;&#045;version</literal> and <literal>psql &#045;&#045;version</literal>
       should work.
       If the function or the options do not exist then your version is

--- a/doc/src/sgml/ref/clusterdb.sgml
+++ b/doc/src/sgml/ref/clusterdb.sgml
@@ -120,7 +120,7 @@ PostgreSQL documentation
 <!--
         Specifies the name of the database to be clustered.
         If this is not specified and <option>-a</option> (or
-        <option>&055;&055;all</option>) is not used, the database name is read
+        <option>&#045;&#045;all</option>) is not used, the database name is read
         from the environment variable <envar>PGDATABASE</envar>.  If
         that is not set, the user name specified for the connection is
         used.

--- a/doc/src/sgml/ref/create_aggregate.sgml
+++ b/doc/src/sgml/ref/create_aggregate.sgml
@@ -151,7 +151,7 @@ CREATE AGGREGATE <replaceable class="PARAMETER">name</replaceable> (
 <programlisting>
 <!--
 <replaceable class="PARAMETER">sfunc</replaceable>( internal-state, next-data-values ) &#045;&#045;&#045;> next-internal-state
-<replaceable class="PARAMETER">ffunc</replaceable>( internal-state ) &#055;&#055;&#055;> aggregate-value
+<replaceable class="PARAMETER">ffunc</replaceable>( internal-state ) &#045;&#045;&#045;> aggregate-value
 -->
 <replaceable class="PARAMETER">sfunc</replaceable>( 内部状態, 次のデータ値 ) ---> 次の内部状態
 <replaceable class="PARAMETER">ffunc</replaceable>( 内部状態 ) ---> 集約の結果

--- a/doc/src/sgml/ref/create_conversion.sgml
+++ b/doc/src/sgml/ref/create_conversion.sgml
@@ -152,11 +152,11 @@ CREATE [ DEFAULT ] CONVERSION <replaceable>name</replaceable>
 <programlisting>
 conv_proc(
 <!--
-    integer,  &#055;&#055; source encoding ID
-    integer,  &#055;&#055; destination encoding ID
-    cstring,  &#055;&#055; source string (null terminated C string)
-    internal, &#055;&#055; destination (fill with a null terminated C string)
-    integer   &#055;&#055; source string length
+    integer,  &#045;&#045; source encoding ID
+    integer,  &#045;&#045; destination encoding ID
+    cstring,  &#045;&#045; source string (null terminated C string)
+    internal, &#045;&#045; destination (fill with a null terminated C string)
+    integer   &#045;&#045; source string length
 -->
     integer,  -- 変換元符号化方式ID
     integer,  -- 変換先符号化方式ID

--- a/doc/src/sgml/ref/createlang.sgml
+++ b/doc/src/sgml/ref/createlang.sgml
@@ -329,7 +329,7 @@ PostgreSQL documentation
    <para>
 <!--
     Most error messages are self-explanatory. If not, run
-    <application>createlang</application> with the <option>&#055;&#055;echo</option>
+    <application>createlang</application> with the <option>&#045;&#045;echo</option>
     option and see the respective <acronym>SQL</acronym> command
     for details.  Also, any default connection settings and environment
     variables used by the <application>libpq</application> front-end

--- a/doc/src/sgml/ref/droplang.sgml
+++ b/doc/src/sgml/ref/droplang.sgml
@@ -331,7 +331,7 @@ PostgreSQL documentation
    <para>
 <!--
     Most error messages are self-explanatory. If not, run
-    <application>droplang</application> with the <option>&#055;&#055;echo</option>
+    <application>droplang</application> with the <option>&#045;&#045;echo</option>
     option and see under the respective <acronym>SQL</acronym> command
     for details.  Also, any default connection settings and environment
     variables used by the <application>libpq</application> front-end

--- a/doc/src/sgml/ref/fetch.sgml
+++ b/doc/src/sgml/ref/fetch.sgml
@@ -502,13 +502,13 @@ FETCH <replaceable class="parameter">count</replaceable>
 BEGIN WORK;
 
 <!--
-&055;&055; Set up a cursor:
+&#045;&#045; Set up a cursor:
 -->
 -- カーソルを設定します。
 DECLARE liahona SCROLL CURSOR FOR SELECT * FROM films;
 
 <!--
-&#055;&055; Fetch the first 5 rows in the cursor liahona:
+&#045;&#045; Fetch the first 5 rows in the cursor liahona:
 -->
 -- カーソルliahonaから最初の5行を取り出します。
 FETCH FORWARD 5 FROM liahona;
@@ -522,7 +522,7 @@ FETCH FORWARD 5 FROM liahona;
  P_302 | Becket                  | 103 | 1964-02-03 | Drama    | 02:28
 
 <!--
-&#055;&#055; Fetch the previous row:
+&#045;&#045; Fetch the previous row:
 -->
 -- 1つ前の行を取り出します。
 FETCH PRIOR FROM liahona;
@@ -532,7 +532,7 @@ FETCH PRIOR FROM liahona;
  P_301 | Vertigo | 103 | 1958-11-14 | Action | 02:08
 
 <!--
-&055;&055; Close the cursor and end the transaction:
+&#045;&#045; Close the cursor and end the transaction:
 -->
 -- カーソルを閉じ、トランザクションを終了します。
 CLOSE liahona;

--- a/doc/src/sgml/ref/initdb.sgml
+++ b/doc/src/sgml/ref/initdb.sgml
@@ -307,7 +307,7 @@ I/Oシステムによる破損検知を補助するために、データペー�
       <listitem>
        <para>
 <!--
-        Like <option>&055;&055;locale</option>, but only sets the locale in
+        Like <option>&#045;&#045;locale</option>, but only sets the locale in
         the specified category.
 -->
 <option>--locale</option>と似ていますが、指定したカテゴリのロケールのみを設定します。

--- a/doc/src/sgml/ref/insert.sgml
+++ b/doc/src/sgml/ref/insert.sgml
@@ -834,7 +834,7 @@ INSERT INTO films SELECT * FROM tmp_films WHERE date_prod &lt; '2004-05-07';
 
 <programlisting>
 <!--
-&055;&055; Create an empty 3x3 gameboard for noughts-and-crosses
+&#045;&#045; Create an empty 3x3 gameboard for noughts-and-crosses
 -->
 -- 三目並べ用の3×3マスのゲーム盤を作成します。
 INSERT INTO tictactoe (game, board[1:3][1:3])

--- a/doc/src/sgml/ref/lock.sgml
+++ b/doc/src/sgml/ref/lock.sgml
@@ -309,7 +309,7 @@ LOCK TABLE films IN SHARE MODE;
 SELECT id FROM films
     WHERE name = 'Star Wars: Episode I - The Phantom Menace';
 <!--
-&055;&055; Do ROLLBACK if record was not returned
+&#045;&#045; Do ROLLBACK if record was not returned
 -->
 -- レコードがなければROLLBACKしてください。
 INSERT INTO films_user_comments VALUES

--- a/doc/src/sgml/ref/pg_config-ref.sgml
+++ b/doc/src/sgml/ref/pg_config-ref.sgml
@@ -412,12 +412,12 @@ Cコンパイラスイッチが表示されます。
 
   <para>
 <!--
-   The options <option>&#055;-docdir</option>, <option>&#055;-pkgincludedir</option>,
-   <option>&#055;-localedir</option>, <option>&#055;-mandir</option>,
-   <option>&#055;-sharedir</option>, <option>&#055;-sysconfdir</option>,
-   <option>-&#055;cc</option>, <option>&#055;-cppflags</option>,
-   <option>&#055;&#055;cflags</option>, <option>&#055;&#055;cflags_sl</option>,
-   <option>&#055;&#055;ldflags</option>, <option>&#055;&#055;ldflags_sl</option>,
+   The options <option>&#045;-docdir</option>, <option>&#045;-pkgincludedir</option>,
+   <option>&#045;-localedir</option>, <option>&#045;-mandir</option>,
+   <option>&#045;-sharedir</option>, <option>&#045;-sysconfdir</option>,
+   <option>-&#045;cc</option>, <option>&#045;-cppflags</option>,
+   <option>&#045;&#045;cflags</option>, <option>&#045;&#045;cflags_sl</option>,
+   <option>&#045;&#045;ldflags</option>, <option>&#045;&#045;ldflags_sl</option>,
    and <option>&#045;-libs</option> were added in <productname>PostgreSQL</> 8.1.
    The option <option>&#045;-htmldir</option> was added in <productname>PostgreSQL</> 8.4.
    The option <option>&#045;-ldflags_ex</option> was added in <productname>PostgreSQL</> 9.0.
@@ -445,7 +445,7 @@ Cコンパイラスイッチが表示されます。
 eval ./configure `pg_config --configure`
 </programlisting>
 <!--
-   The output of <literal>pg_config &#055;&#055;configure</literal> contains
+   The output of <literal>pg_config &#045;&#045;configure</literal> contains
    shell quotation marks so arguments with spaces are represented
    correctly.  Therefore, using <literal>eval</literal> is required
    for proper results.

--- a/doc/src/sgml/ref/pg_ctl-ref.sgml
+++ b/doc/src/sgml/ref/pg_ctl-ref.sgml
@@ -283,7 +283,7 @@ Windowsではデフォルトで、サーバの標準出力と標準エラーは�
    <option>kill</option> mode allows you to send a signal to a specified
     process.  This is particularly valuable for <productname>Microsoft Windows</>
     which does not have a <application>kill</> command.  Use
-    <literal>&#055;&#055;help</> to see a list of supported signal names.
+    <literal>&#045;&#045;help</> to see a list of supported signal names.
 -->
 <option>kill</option>モードでは指定したプロセスにシグナルを送信することができます。
 これは特に、<application>kill</>コマンドを持たない<productname>Microsoft Windows</>で有用です。

--- a/doc/src/sgml/ref/pg_dump.sgml
+++ b/doc/src/sgml/ref/pg_dump.sgml
@@ -962,7 +962,7 @@ tarアーカイブ形式では現在圧縮を全くサポートしていませ�
 
        <para>
 <!--
-        Presently, the commands emitted for <option>&#055;&#055;disable-triggers</>
+        Presently, the commands emitted for <option>&#045;&#045;disable-triggers</>
         must be done as superuser.  So, you should also specify
         a superuser name with <option>-S</>, or preferably be careful to
         start the resulting script as a superuser.

--- a/doc/src/sgml/ref/pg_dumpall.sgml
+++ b/doc/src/sgml/ref/pg_dumpall.sgml
@@ -389,7 +389,7 @@ SQLスクリプトは標準出力に書き込まれます。
 
        <para>
 <!--
-        Presently, the commands emitted for <option>&#055;&#055;disable-triggers</>
+        Presently, the commands emitted for <option>&#045;&#045;disable-triggers</>
         must be done as superuser.  So, you should also specify
         a superuser name with <option>-S</>, or preferably be careful to
         start the resulting script as a superuser.

--- a/doc/src/sgml/ref/unlisten.sgml
+++ b/doc/src/sgml/ref/unlisten.sgml
@@ -159,7 +159,7 @@ Asynchronous notification "virtual" received from server process with PID 8448.
 UNLISTEN virtual;
 NOTIFY virtual;
 <!--
-&055;&055; no NOTIFY event is received
+&#045;&#045; no NOTIFY event is received
 -->
 -- NOTIFYイベントを受け取りません。
 </programlisting></para>

--- a/doc/src/sgml/ref/update.sgml
+++ b/doc/src/sgml/ref/update.sgml
@@ -540,21 +540,21 @@ UPDATE summary s SET (sum_x, sum_y, avg_x, avg_y) =
 <programlisting>
 BEGIN;
 <!--
-&#055;- other operations
+&#045;- other operations
 -->
 -- 何かしらの他の操作を行います。
 SAVEPOINT sp1;
 INSERT INTO wines VALUES('Chateau Lafite 2003', '24');
 <!--
-&#055;- Assume the above fails because of a unique key violation,
-&055;- so now we issue these commands:
+&#045;- Assume the above fails because of a unique key violation,
+&#045;- so now we issue these commands:
 -->
 -- 上記のコマンドが一意キー違反により失敗したとします。
 -- この場合、次のコマンドを実行します。
 ROLLBACK TO sp1;
 UPDATE wines SET stock = stock + 24 WHERE winename = 'Chateau Lafite 2003';
 <!--
-&#055;- continue with other operations, and eventually
+&#045;- continue with other operations, and eventually
 -->
 -- 他の操作を続けた後、最後に次を実行します。
 COMMIT;

--- a/doc/src/sgml/release-7.4.sgml
+++ b/doc/src/sgml/release-7.4.sgml
@@ -1310,7 +1310,7 @@ readlineとeditlineライブラリの両方がインストールされている�
      <para>
 <!--
       Fix improper display of fractional seconds in interval values when
-      using a non-ISO datestyle in an <option>&#055;-enable-integer-datetimes</>
+      using a non-ISO datestyle in an <option>&#045;-enable-integer-datetimes</>
       build (Ron Mayer)
 -->
 <option>--enable-integer-datetimes</>で構築された場合、ISO以外の日付書式を使用した時の時間間隔値における不適切な秒端数表示を修正しました。(Ron Mayer)
@@ -3422,8 +3422,8 @@ UPDATE pg_proc SET proargtypes[3] = 'internal'::regtype
 WHERE pronamespace = 11 AND pronargs = 5
      AND proargtypes[2] = 'cstring'::regtype;
 <!--
-&#055;- The command should report having updated 90 rows;
-&#055;- if not, rollback and investigate instead of committing!
+&#045;- The command should report having updated 90 rows;
+&#045;- if not, rollback and investigate instead of committing!
 -->
 -- このコマンドは90行を更新したと報告するはずです。
 -- 異なる場合は、コミットせずにロールバックして調査を行ってください。
@@ -3446,8 +3446,8 @@ WHERE oid IN (
    'syn_init(text)'::regprocedure
 );
 <!--
-&#055;- The command should report having updated 5 rows;
-&#055;- if not, rollback and investigate instead of committing!
+&#045;- The command should report having updated 5 rows;
+&#045;- if not, rollback and investigate instead of committing!
 -->
 -- このコマンドは5行を更新したと報告するはずです。
 -- 異なる場合は、コミットせずにロールバックして調査を行ってください。
@@ -3489,12 +3489,12 @@ UPDATE pg_database SET datallowconn = true WHERE datname = 'template0';
 最後に以下を実行してください。
 <programlisting>
 <!--
-&#055;- re-freeze template0:
+&#045;- re-freeze template0:
 -->
 -- 再度template0を凍結させます
 VACUUM FREEZE;
 <!--
-&#055;- and protect it against future alterations:
+&#045;- and protect it against future alterations:
 -->
 -- そして、今後の変更に対し保護します。
 UPDATE pg_database SET datallowconn = false WHERE datname = 'template0';
@@ -3558,7 +3558,7 @@ There are no known cases of it having caused more than an Assert failure.
 <listitem><para>Fix comparisons of <type>TIME WITH TIME ZONE</> values</para>
 <para>
 The comparison code was wrong in the case where the
-<literal>&#055;-enable-integer-datetimes</> configuration switch had been used.
+<literal>&#045;-enable-integer-datetimes</> configuration switch had been used.
 NOTE: if you have an index on a <type>TIME WITH TIME ZONE</> column,
 it will need to be <command>REINDEX</>ed after installing this update, because
 the fix corrects the sort order of column values.
@@ -3588,7 +3588,7 @@ the fix corrects the sort order of column values.
 <para>
 <!--
 This error only occurred when the
-<literal>&#055;-enable-integer-datetimes</> configuration switch had been used.
+<literal>&#045;-enable-integer-datetimes</> configuration switch had been used.
 -->
 このエラーは、<literal>--enable-integer-datetimes</>設定スイッチが使用された場合にのみ発生します。
 </para></listitem>
@@ -4872,7 +4872,7 @@ SSL APIに非常に詳しい方々により、SSLコードは書き直され、S
       already supported threads, this release improves thread safety
       by fixing some non-thread-safe code that was used during
       database connection startup.  The <command>configure</command>
-      option <option>&#055;&#055;enable-thread-safety</option> must be used to
+      option <option>&#045;&#045;enable-thread-safety</option> must be used to
       enable this feature.
 -->
 以前の<application>libpq</application> のリリースでも既にスレッドをサポートしていましたが、このリリースでは、データベース接続開始期間に使用されていたスレッドセーフでないいくつかのコードを修正し、スレッドセーフに改良されました。

--- a/doc/src/sgml/release-8.0.sgml
+++ b/doc/src/sgml/release-8.0.sgml
@@ -1638,7 +1638,7 @@ readlineとeditlineライブラリの両方がインストールされている�
      <para>
 <!--
       Fix improper display of fractional seconds in interval values when
-      using a non-ISO datestyle in an <option>&#055;-enable-integer-datetimes</>
+      using a non-ISO datestyle in an <option>&#045;-enable-integer-datetimes</>
       build (Ron Mayer)
 -->
 <option>--enable-integer-datetimes</>で構築された場合、ISO以外の日付書式を使用した時の時間間隔値における不適切な秒端数表示を修正しました。(Ron Mayer)
@@ -4671,7 +4671,7 @@ There are no known cases of it having caused more than an Assert failure.
 <listitem><para>Fix comparisons of <type>TIME WITH TIME ZONE</> values</para>
 <para>
 The comparison code was wrong in the case where the
-<literal>&#055;-enable-integer-datetimes</> configuration switch had been used.
+<literal>&#045;-enable-integer-datetimes</> configuration switch had been used.
 NOTE: if you have an index on a <type>TIME WITH TIME ZONE</> column,
 it will need to be <command>REINDEX</>ed after installing this update, because
 the fix corrects the sort order of column values.
@@ -4701,7 +4701,7 @@ the fix corrects the sort order of column values.
 <para>
 <!--
 This error only occurred when the
-<literal>&#055;-enable-integer-datetimes</> configuration switch had been used.
+<literal>&#045;-enable-integer-datetimes</> configuration switch had been used.
 -->
 このエラーは、<literal>--enable-integer-datetimes</>設定スイッチが使用された場合にのみ発生します。
 </para></listitem>
@@ -7277,7 +7277,7 @@ Windowsはバックエンドにシグナルを送信するための<literal>kill
      <listitem>
       <para>
 <!--
-       Add <option>&#055;-pwfile</> option to
+       Add <option>&#045;-pwfile</> option to
        <application>initdb</application> so the initial password can be
        set by GUI tools (Magnus)
 -->
@@ -8373,8 +8373,8 @@ WindowsをサポートするためにシェルスクリプトコマンドをC言
      <listitem>
       <para>
 <!--
-       Use <option>&#055;-with-docdir</> to choose installation location of documentation; also
-       allow <option>&#055;-infodir</> (Peter)
+       Use <option>&#045;-with-docdir</> to choose installation location of documentation; also
+       allow <option>&#045;-infodir</> (Peter)
 -->
 文書のインストール先を指定するための<option>--with-docdir</>の使用。<option>--infodir</>も可能(Peter)
       </para>
@@ -8383,7 +8383,7 @@ WindowsをサポートするためにシェルスクリプトコマンドをC言
      <listitem>
       <para>
 <!--
-       Add <option>&#055;-without-docdir</> to prevent installation of documentation (Peter)
+       Add <option>&#045;-without-docdir</> to prevent installation of documentation (Peter)
 -->
 文書のインストールを防止する<option>--without-docdir</>の追加(Peter)
       </para>

--- a/doc/src/sgml/release-8.1.sgml
+++ b/doc/src/sgml/release-8.1.sgml
@@ -2213,7 +2213,7 @@ TOASTの行型に対する権限は通常のデータベース操作ではまっ
      <para>
 <!--
       Fix improper display of fractional seconds in interval values when
-      using a non-ISO datestyle in an <option>&#055;-enable-integer-datetimes</>
+      using a non-ISO datestyle in an <option>&#045;-enable-integer-datetimes</>
       build (Ron Mayer)
 -->
 <option>--enable-integer-datetimes</>で構築された場合、ISO以外の日付書式を使用した時の時間間隔値における不適切な秒端数表示を修正しました。(Ron Mayer)
@@ -5292,7 +5292,7 @@ possible bigint value (Andrew, Tom)</para>
 <!--
 These problems only appeared on platforms that were using our
 <filename>port/snprintf.c</> code, which includes BSD variants if
-<literal>&#055;&#055;enable-nls</> was given, and perhaps others.  In addition,
+<literal>&#045;&#045;enable-nls</> was given, and perhaps others.  In addition,
 a different form of the translated-error-message problem could appear
 on Windows depending on which version of <filename>libintl</> was used.
 -->
@@ -8030,7 +8030,7 @@ Perlの<literal>strict</>モードを有効にできるようになりました�
      <listitem>
       <para>
 <!--
-       Add <option>-n</> / <option>&#055;&#055;schema</> switch to
+       Add <option>-n</> / <option>&#045;&#045;schema</> switch to
        <application>pg_restore</> (Richard van den Berg)
 -->
 <application>pg_restore</>に<option>-n</>および<option>--schema</>スイッチを追加しました。 (Richard van den Berg)
@@ -8083,7 +8083,7 @@ Perlの<literal>strict</>モードを有効にできるようになりました�
      <listitem>
       <para>
 <!--
-       Add <option>&#055;-encoding</> to <application>pg_dump</>
+       Add <option>&#045;-encoding</> to <application>pg_dump</>
        (Magnus Hagander)
 -->
        <application>pg_dump</> に<option>--encoding</> を追加しました。

--- a/doc/src/sgml/release-8.2.sgml
+++ b/doc/src/sgml/release-8.2.sgml
@@ -4118,7 +4118,7 @@ Windowsにおいて<function>CallNamedPipe()</>呼び出しが失敗した時に
      <para>
 <!--
       Fix improper display of fractional seconds in interval values when
-      using a non-ISO datestyle in an <option>&#055;-enable-integer-datetimes</>
+      using a non-ISO datestyle in an <option>&#045;-enable-integer-datetimes</>
       build (Ron Mayer)
 -->
 <option>--enable-integer-datetimes</>で構築された場合、ISO以外の日付書式を使用した時の時間間隔値における不適切な秒端数表示を修正しました。(Ron Mayer)
@@ -5227,7 +5227,7 @@ Windows Vistaにおいてプロセス処理の取扱いを修正しました。(
 
      <para>
 <!--
-      This bug affects only builds with <option>&#055;-enable-integer-datetimes</>.
+      This bug affects only builds with <option>&#045;-enable-integer-datetimes</>.
 -->
 この不具合は<option>--enable-integer-datetimes</>で構築した場合にのみ影響します。
      </para>

--- a/doc/src/sgml/release-8.3.sgml
+++ b/doc/src/sgml/release-8.3.sgml
@@ -7112,7 +7112,7 @@ GiSTインデックスの<literal>IS NULL</>検索の再スキャン中のアサ
      <para>
 <!--
       Fix improper display of fractional seconds in interval values when
-      using a non-ISO datestyle in an <option>&#055;-enable-integer-datetimes</>
+      using a non-ISO datestyle in an <option>&#045;-enable-integer-datetimes</>
       build (Ron Mayer)
 -->
 <option>--enable-integer-datetimes</>で構築された場合、ISO以外の日付書式を使用した時の時間間隔値における不適切な秒端数表示を修正しました。(Ron Mayer)

--- a/doc/src/sgml/release-old.sgml
+++ b/doc/src/sgml/release-old.sgml
@@ -1322,8 +1322,8 @@ UPDATE pg_proc SET proargtypes[3] = 'internal'::regtype
 WHERE pronamespace = 11 AND pronargs = 5
      AND proargtypes[2] = 'cstring'::regtype;
 <!--
-&#055;- The command should report having updated 90 rows;
-&#055;- if not, rollback and investigate instead of committing!
+&#045;- The command should report having updated 90 rows;
+&#045;- if not, rollback and investigate instead of committing!
 -->
 -- このコマンドは90行を更新したと報告するはずです。
 -- 異なる場合は、コミットせずにロールバックして調査を行ってください。
@@ -1357,12 +1357,12 @@ UPDATE pg_database SET datallowconn = true WHERE datname = 'template0';
 最後に以下を実行してください。
 <programlisting>
 <!--
-&#055;- re-freeze template0:
+&#045;- re-freeze template0:
 -->
 -- 再度template0を凍結させます
 VACUUM FREEZE;
 <!--
-&#055;- and protect it against future alterations:
+&#045;- and protect it against future alterations:
 -->
 -- そして、今後の変更に対し保護します。
 UPDATE pg_database SET datallowconn = false WHERE datname = 'template0';
@@ -1424,7 +1424,7 @@ There are no known cases of it having caused more than an Assert failure.
 <para>
 <!--
 The comparison code was wrong in the case where the
-<literal>&#055;-enable-integer-datetimes</> configuration switch had been used.
+<literal>&#045;-enable-integer-datetimes</> configuration switch had been used.
 NOTE: if you have an index on a <type>TIME WITH TIME ZONE</> column,
 it will need to be <command>REINDEX</>ed after installing this update, because
 the fix corrects the sort order of column values.
@@ -1449,7 +1449,7 @@ the fix corrects the sort order of column values.
 <para>
 <!--
 This error only occurred when the
-<literal>&#055;-enable-integer-datetimes</> configuration switch had been used.
+<literal>&#045;-enable-integer-datetimes</> configuration switch had been used.
 -->
 このエラーは、<literal>--enable-integer-datetimes</>設定スイッチが使用された場合にのみ発生します。
 </para></listitem>

--- a/doc/src/sgml/tablefunc.sgml
+++ b/doc/src/sgml/tablefunc.sgml
@@ -1037,7 +1037,7 @@ INSERT INTO connectby_tree VALUES('row8','row6', 0);
 INSERT INTO connectby_tree VALUES('row9','row5', 0);
 
 <!--
-&#055;- with branch, without orderby_fld (order of results is not guaranteed)
+&#045;- with branch, without orderby_fld (order of results is not guaranteed)
 -->
 -- 分岐あり、orderby_fldなし(結果の順序は保証されない)
 SELECT * FROM connectby('connectby_tree', 'keyid', 'parent_keyid', 'row2', 0, '~')
@@ -1053,7 +1053,7 @@ SELECT * FROM connectby('connectby_tree', 'keyid', 'parent_keyid', 'row2', 0, '~
 (6 rows)
 
 <!--
-&#055;- without branch, without orderby_fld (order of results is not guaranteed)
+&#045;- without branch, without orderby_fld (order of results is not guaranteed)
 -->
 -- 分岐なし、orderby_fldなし(結果の順序は保証されない)
 SELECT * FROM connectby('connectby_tree', 'keyid', 'parent_keyid', 'row2', 0)
@@ -1069,7 +1069,7 @@ SELECT * FROM connectby('connectby_tree', 'keyid', 'parent_keyid', 'row2', 0)
 (6 rows)
 
 <!--
-&#055;- with branch, with orderby_fld (notice that row5 comes before row4)
+&#045;- with branch, with orderby_fld (notice that row5 comes before row4)
 -->
 -- 分岐あり、orderby_fldあり(row5がrow4の前に来ていることに注目)
 SELECT * FROM connectby('connectby_tree', 'keyid', 'parent_keyid', 'pos', 'row2', 0, '~')
@@ -1085,7 +1085,7 @@ SELECT * FROM connectby('connectby_tree', 'keyid', 'parent_keyid', 'pos', 'row2'
 (6 rows)
 
 <!--
-&#055;- without branch, with orderby_fld (notice that row5 comes before row4)
+&#045;- without branch, with orderby_fld (notice that row5 comes before row4)
 -->
 -- 分岐なし、orderby_fldあり(row5がrow4の前に来ていることに注目)
 SELECT * FROM connectby('connectby_tree', 'keyid', 'parent_keyid', 'pos', 'row2', 0)


### PR DESCRIPTION
「－－」のコメントアウトについて、「－」を「＆＃０４５；」とすべきものが、＃や；が欠落していたり、０４５ではなく０５５になっているものがあったので、grepで見つかったものをすべて置換しました。
なお、grepで探した後、grep -v で正しいパターンがある行を除外したので、１行内に正しいパターンと誤ったパターンが混在している場合は、見落としている可能性を排除できません。