### PR TITLE
19.1節 パラメータの設定(config.sgml)の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -67,17 +67,8 @@
        <literal>0</literal>
        (all case-insensitive) or any unambiguous prefix of one of these.
 -->
-      <emphasis>論理型:</emphasis>
-      値は以下のいずれかを取ることができます。
-      <literal>on</literal>,
-      <literal>off</literal>,
-      <literal>true</literal>,
-      <literal>false</literal>,
-      <literal>yes</literal>,
-      <literal>no</literal>,
-      <literal>1</literal>,
-      <literal>0</literal>
-      (すべて大文字小文字の区別なし) あるいは、曖昧でなければこれらの先頭から数文字を省略して使うこともできます。
+<emphasis>論理型:</emphasis>
+値は<literal>on</literal>、<literal>off</literal>、<literal>true</literal>、<literal>false</literal>、<literal>yes</literal>、<literal>no</literal>、<literal>1</literal>、<literal>0</literal>（すべて大文字小文字の区別なし）、あるいは、曖昧でなければ、これらの先頭から数文字を省略形として使うこともできます。
       </para>
      </listitem>
 
@@ -89,8 +80,10 @@
        quotes within the value.  Quotes can usually be omitted if the value
        is a simple number or identifier, however.
 -->
-       <emphasis>文字列型:</emphasis>
-       一般に、単一引用符の中に値を入れます。単一引用符を値として使う場合は単一引用符を重ねます。なお、値が単純な数字や識別子である場合は、通常引用符は省略できます。
+<emphasis>文字列型:</emphasis>
+一般に、単一引用符の中に値を入れます。
+単一引用符を値に含める場合は単一引用符を２つ続けます。
+なお、値が単純な数字や識別子である場合は、通常は引用符を省略できます。
       </para>
      </listitem>
 
@@ -156,9 +149,7 @@
           <literal>s</literal> (seconds), <literal>min</literal> (minutes),
           <literal>h</literal> (hours), and <literal>d</literal> (days).
 -->
-           有効な時間の単位は <literal>ms</literal> (ミリ秒),
-          <literal>s</literal> (秒), <literal>min</literal> (分),
-          <literal>h</literal> (時間), <literal>d</literal> (日数) です。
+有効な時間の単位は <literal>ms</literal> (ミリ秒)、<literal>s</literal> (秒)、<literal>min</literal> (分)、<literal>h</literal> (時間)、<literal>d</literal> (日数) です。
          </para>
         </listitem>
        </itemizedlist>
@@ -219,8 +210,8 @@ shared_buffers = 128MB
      or backslash-quote.
     -->
 1つの行毎に1つのパラメータが指定されます。
-名前と値の間の等号はオプションです。
-引用符の中の空白（white space）を除き、空白は特に意味を持たず、何もない行は無視されます。
+名前と値の間の等号は省略可能です。
+（引用符付きのパラメータ値内を除き）空白は特に意味を持たず、何もない行は無視されます。
 ハッシュ記号（<literal>#</literal>）はその行の後の表記がコメントであることを意味します。
 単純でない識別子、または数値でないパラメータ値は単一引用符で括られなければなりません。
 パラメータ値の中に単一引用符を埋め込むには、引用符を2つ（推奨）もしくはバックスラッシュ-引用符を使います。
@@ -233,9 +224,9 @@ shared_buffers = 128MB
      are overridden.  The following sections describe ways in which the
      administrator or user can override these defaults.
 -->
-   この方法によりクラスタに対してデフォルト値が設定されます。
-   上書きされない限り、アクティブなセッションが見るのはこの値です。
-   次の節では、管理者やユーザがこれらのデフォルト値を上書きする方法を説明します。
+この方法によりクラスタに対してデフォルト値が設定されます。
+上書きされない限り、アクティブなセッションが見るのはこの値です。
+次節以降では、管理者やユーザがこれらのデフォルト値を上書きする方法を説明します。
     </para>
 
     <para>
@@ -260,8 +251,9 @@ shared_buffers = 128MB
 設定ファイルは、メインサーバプロセスが<systemitem>SIGHUP</>シグナルを受け取るたびに再読み込みされます。
 このシグナルを手っ取り早く送信するには、コマンドラインから<literal>pg_ctl reload</>を実行するか、SQL関数の<function>pg_reload_conf()</function>を呼び出します。
 メインサーバプロセスは同時にこのシグナルを、現存のセッションが同様に新しい値を入手できるように、全ての現在実行しているサーバプロセスに伝播します(これは現在実行中のクライアントコマンドの処理を完了してから行われます)。
-他の手段として、直接単一のサーバプロセスにシグナルを送ることも可能です。いくつかのパラメータはサーバの起動時のみ設定されます;設定ファイル中のそれらのエントリのいかなる変更も、サーバが再起動されるまで無視されます。
-設定ファイル内で無効なパラメータが設定された場合はこのように（ログには残りますが）<systemitem>SIGHUP</> 処理中に無視されます。
+他の手段として、直接単一のサーバプロセスにシグナルを送ることも可能です。
+一部のパラメータはサーバの起動時のみ設定されまするので、設定ファイル中のそれらのエントリの変更はすべて、サーバが再起動されるまで無視されます。
+設定ファイル内で無効なパラメータが設定された場合も、同じように（ログには残りますが）<systemitem>SIGHUP</> 処理中は無視されます。
     </para>
 
     <para>
@@ -279,7 +271,7 @@ shared_buffers = 128MB
 <filename>postgresql.conf</>に加え、<productname>PostgreSQL</productname>のデータディレクトリには <filename>postgresql.auto.conf</><indexterm><primary>postgresql.auto.conf</></>というファイルがあります。
 このファイルは <filename>postgresql.conf</> と同じフォーマットですが、決して手動で編集してはいけません。
 このファイルは <xref linkend="SQL-ALTERSYSTEM"> コマンドを使った設定値を保存します。
-このファイルは<filename>postgresql.conf</> が読み込まれるときはいつでも同時に読み込まれ、同じように設定が反映されます。
+このファイルは<filename>postgresql.conf</> が読み込まれるときはいつでも自動的に読み込まれ、同じように設定が反映されます。
 <filename>postgresql.auto.conf</>は、<filename>postgresql.conf</>の設定を上書きします。
     </para>
 
@@ -332,7 +324,7 @@ shared_buffers = 128MB
        The <xref linkend="sql-alterrole"> command allows both global and
        per-database settings to be overridden with user-specific values.
 -->
-      <xref linkend="sql-alterrole">コマンドはグローバルと、データベース単位の両方でユーザ固有の設定値を上書きします。
+      <xref linkend="sql-alterrole">コマンドはグローバルと、データベース単位の両方をユーザ固有の設定値で上書きします。
       </para>
      </listitem>
     </itemizedlist>
@@ -392,8 +384,7 @@ shared_buffers = 128MB
      linkend="view-pg-settings"><structname>pg_settings</></> can be
      used to view and change session-local values:
 -->
-更にシステムビューの<link
-    linkend="view-pg-settings"><structname>pg_settings</></>を使ってセッションローカルな変数の値を参照したり変更することができます。
+更にシステムビューの<link linkend="view-pg-settings"><structname>pg_settings</></>を使ってセッションローカルな値を参照したり変更することができます。
     </para>
 
     <itemizedlist>
@@ -416,14 +407,15 @@ shared_buffers = 128MB
        updating the <structname>setting</> column, is the equivalent
        of issuing <command>SET</> commands.  For example, the equivalent of
 -->
-      このビューの特定の<structname>setting</>列に対して<xref linkend="SQL-UPDATE">を実行することは、<command>SET</>コマンドを実行するのと同等です。たとえば、
+このビューに対して<xref linkend="SQL-UPDATE">を実行する、具体的には<structname>setting</>列を更新することは、<command>SET</>コマンドを実行するのと同等です。
+たとえば、
 <programlisting>
 SET configuration_parameter TO DEFAULT;
 </programlisting>
 <!--
        is:
 -->
-       は
+は
 <programlisting>
 UPDATE pg_settings SET setting = reset_val WHERE name = 'configuration_parameter';
 </programlisting>
@@ -558,7 +550,7 @@ include 'ファイル名'
       the directory containing the referencing configuration file.
       Inclusions can be nested.
 -->
-もしファイル名が絶対パスにない場合、参照する設定ファイルを含むディレクトリに相対的であると受け取られます。
+ファイル名が絶対パスでない場合、参照する設定ファイルを含むディレクトリからの相対パスであると受け取られます。
 Includeコマンドは入れ子にすることができます。
      </para>
 
@@ -580,7 +572,7 @@ Includeコマンドは入れ子にすることができます。
 -->
 <literal>include_if_exists</>ディレクティブもあります。
 これは参照ファイルが存在しないか、または読み込むことができない場合の動作を除き、<literal>include</>ディレクティブと同一の動作をします。
-通常の<literal>include</>はこれをエラーと解釈しますが、<literal>include_if_exists</>はただ単にログをとり、そして参照している設定ファイルの処理を続けます。
+通常の<literal>include</>はこれをエラーと解釈しますが、<literal>include_if_exists</>はただ単にメッセージをログ出力し、そして参照している設定ファイルの処理を続けます。
      </para>
 
      <para>
@@ -596,7 +588,7 @@ Includeコマンドは入れ子にすることができます。
       <literal>include_dir</literal> directives, which specify an entire
       directory of configuration files to include.  These look like
 -->
-includeする設定ファイルを含むディレクトリ全体を指定する<literal>include_dir</literal>ディレクティブを、<filename>postgresql.conf</>ファイルに含めることもできます
+includeする設定ファイルを含むディレクトリ全体を指定する<literal>include_dir</literal>ディレクティブを、<filename>postgresql.conf</>ファイルに含めることもできます。
 このような感じです。
 <!--
 <programlisting>
@@ -617,10 +609,11 @@ include_dir 'ディレクトリ名'
       (according to C locale rules, i.e. numbers before letters, and
       uppercase letters before lowercase ones).
        -->
-        絶対パスではないディレクトリ名はその設定ファイルがあるディレクトリへの相対パスと見なされます。
+絶対パスではないディレクトリ名はその設定ファイルがあるディレクトリへの相対パスと見なされます。
 指定したディレクトリの中で、ディレクトリではないファイルで末尾が<literal>.conf</literal>で終わるファイルだけがincludeされます。
-       また、文字<literal>.</literal> で開始するファイル名はあるプラットフォームでは隠しファイルとされるので、判断違いを防止するため無視されます。
-       includeされるディレクトリにある複数ファイルはファイル名順に処理されます(ファイル名は C ロケール規則で順位付けされます。つまり、文字より数字、小文字より大文字が優先されます)。
+また、文字<literal>.</literal> で開始するファイル名は一部のプラットフォームでは隠しファイルとされるので、間違いを防止するため無視されます。
+includeされるディレクトリにある複数ファイルはファイル名順に処理されます(ファイル名は C ロケール規則で順序付けされます。
+つまり、文字より数字、小文字より大文字が先になります)。
      </para>
 
      <para>
@@ -637,11 +630,13 @@ include_dir 'ディレクトリ名'
       this to the end of your <filename>postgresql.conf</> file to include
       them:
       -->
-       includeされるファイルもしくはディレクトリは、大きな単一の<filename>postgresql.conf</>ファイルを使うのではなくデータベース設定の一部分を論理的に分離するために使用することが可能です。
-       異なるメモリー容量を持つ二つのデータベースサーバを所有する会社を考えてみてください。
-       例えばログ取得のように、二つが共有する設定の要素があると思われます。しかし、サーバ上のメモリに関連したパラメータは二つの間では異なります。更に、サーバ特有のカスタマイズも存在することがあります。
-       この状況に対処する一つの方法として、そのサイトに対するカスタマイズされた設定の変更を三つのファイルにすることです。
-       そのためには<filename>postgresql.conf</>ファイルの最後に以下をincludeのため追加します。
+includeされるファイルもしくはディレクトリは、大きな単一の<filename>postgresql.conf</>ファイルを使う代わりに、データベース設定の一部分を論理的に分離するために使用することが可能です。
+異なるメモリー容量を持つ二つのデータベースサーバを所有する会社を考えてみてください。
+例えばログ取得のように、二つが共有する設定の要素があると思われます。
+しかし、サーバ上のメモリに関連したパラメータは二つの間では異なります。
+更に、サーバ特有のカスタマイズも存在することがあります。
+この状況に対処する一つの方法として、そのサイトに対するカスタマイズされた設定の変更を三つのファイルにすることです。
+それらをincludeするためには<filename>postgresql.conf</>ファイルの最後に以下を追加します。
 <programlisting>
 include 'shared.conf'
 include 'memory.conf'
@@ -667,8 +662,8 @@ RAMが8GBのすべてのサーバには共通の<filename>memory.conf</>を1つ�
       put this information into files there. For example, a <filename>conf.d</>
       directory could be referenced at the end of <filename>postgresql.conf</>:
 -->
-       別の可能性として、設定ファイルディレクトリを作成し、その情報をそこのファイルに格納します。
-       たとえば、<filename>conf.d</>ディレクトリは<filename>postgresql.conf</>の最後で参照されます。
+別の方法として、設定ファイルディレクトリを作成し、この情報をそこのファイルに格納することができます。
+たとえば、<filename>conf.d</>ディレクトリを<filename>postgresql.conf</>の最後で参照するようにできます。
 <programlisting>
 include_dir 'conf.d'
 </programlisting>
@@ -676,7 +671,7 @@ include_dir 'conf.d'
       Then you could name the files in the <filename>conf.d</> directory
       like this:
 -->
-       そうすると、以下のように<filename>conf.d</>の中にファイルを列挙できます。
+そして、<filename>conf.d</>の中のファイルを以下のような名前にすることができます。
 <programlisting>
 00shared.conf
 01memory.conf
@@ -690,9 +685,9 @@ include_dir 'conf.d'
        something set in <filename>conf.d/02server.conf</> would override a
        value set in <filename>conf.d/01memory.conf</>.
        -->
-       これはこれらのファイルが読み込まれる順序を明確に示しています。
-       サーバがその設定を読み込んだ時点で最後の宣言文のみ使用されるので重要です。
-       この例の<filename>conf.d/02server.conf</>で何らかの指定がなされたことが<filename>conf.d/01memory.conf</>により上書きされます。
+この命名規則により、これらのファイルが読み込まれる順序が明確になります。
+サーバが設定を読み込んでいるときに各パラメータについて最後にあった設定だけが使用されるので、このことは重要です。
+この例では、<filename>conf.d/02server.conf</>でされた指定は<filename>conf.d/01memory.conf</>の設定値よりも優先します。
      </para>
 
      <para>
@@ -700,7 +695,7 @@ include_dir 'conf.d'
       You might instead use this approach to naming the files
       descriptively:
 -->
-      この方法を使えば、もっとわかりやすい名前をファイルに付けることもできるでしょう。
+代わりに以下の方法を使って、ファイルにわかりやすい名前をつけることもできます。
 <programlisting>
 00shared.conf
 01memory-8GB.conf


### PR DESCRIPTION
いくつか修正すべき点（誤訳、わかりにくい訳）があったので、まとめてPRします。
改行を入れる・消すべき箇所、インデントを消すべき箇所も多数ありますが、訳を直したブロック以外は放置しています。
Issues #810 のoverrideの該当箇所も多数ありますが、それについてはごく一部しか直していません。
