### PR TITLE
19.2節（config.sgml ファイルの場所）の翻訳改善

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -740,9 +740,9 @@ include_dir 'conf.d'
       the configuration files are properly backed-up when they are
       kept separate.)
       -->
-      すでに説明した<filename>postgresql.conf</filename>ファイルに加え、<productname>PostgreSQL</productname>は、（<xref linkend="client-authentication">で使用方法が説明されている）クライアント認証の管理を行うために、他の2つの手作業で編集される設定ファイルを使用します。
-      全ての3つの設定ファイルは、デフォルトではデータベースクラスタのdataディレクトリに格納されます。
-本節で説明するパラメータにより、設定ファイルを何処にでも置くことが可能です。
+すでに説明した<filename>postgresql.conf</filename>ファイルに加え、<productname>PostgreSQL</productname>は、クライアント認証の管理を行うために、他の2つの手作業で編集される設定ファイルを使用します（これらの使用方法は<xref linkend="client-authentication">で説明します）。
+全ての3つの設定ファイルは、デフォルトではデータベースクラスタのdataディレクトリに格納されます。
+本節で説明するパラメータにより、設定ファイルを他の場所に置くことが可能になります。
 （そのようにすると管理がしやすくなります。
 とりわけ、設定ファイルを分けて保存することで、設定ファイルの適切なバックアップを確実に行うことがしばしば容易になります。）
      </para>
@@ -851,8 +851,8 @@ include_dir 'conf.d'
         server should create for use by server administration programs.
         This parameter can only be set at server start.
        -->
-       サーバ管理プログラムの使用のためにサーバが作成しなくてはならない、追加のプロセス識別子（PID)ファイルの名前を指定します。
-       このパラメータはサーバ起動時のみ設定可能です。
+サーバ管理プログラムで使用するためにサーバが作成する、追加のプロセス識別子（PID)ファイルの名前を指定します。
+このパラメータはサーバ起動時のみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -899,7 +899,7 @@ include_dir 'conf.d'
       <varname>data_directory</> are explicitly set, then it is not necessary
       to specify <option>-D</option> or <envar>PGDATA</envar>.
       -->
-      必要に応じて、パラメータ<varname>config_file</>、<varname>hba_file</>、そして/もしくは <varname>ident_file</>を使用し、設定ファイルの名前と場所を個別に指定することができます。
+必要に応じて、パラメータ<varname>config_file</>、<varname>hba_file</>、<varname>ident_file</>を使用し、設定ファイルの名前と場所を個別に指定することができます。
 <varname>config_file</>は<command>postgres</command>コマンドラインによってのみ指定されますが、その他は主設定ファイル内で設定できます。
 全ての3つのパラメータと<varname>data_directory</>が明示的に設定されていれば、<option>-D</option>または<envar>PGDATA</envar>を指定する必要はありません。
      </para>
@@ -910,7 +910,7 @@ include_dir 'conf.d'
       with respect to the directory in which <command>postgres</command>
       is started.
       -->
-      これらのパラメータのいずれかを設定する場合、相対パスは、<command>postgres</command>が起動されるディレクトリから見た相対パスとして解釈されます。
+これらのパラメータのどれを設定する場合でも、相対パスは、<command>postgres</command>が起動されるディレクトリから見た相対パスとして解釈されます。
      </para>
    </sect1>
 


### PR DESCRIPTION
以下の修正を行いました。
(1) カッコ内の文の訳し方と外側の文章への修飾関係が間違っていたので修正しました。また、elsewhereの訳語がおかしかったので修正しました。
(2) "should create for use by..."の解釈が間違っていたので修正しました。
(3) "and/or"を「そして/もしくは」とするのは不自然なので、単純に読点で置換しました。原文の意味を厳密に残すなら「～のうちの1つ以上」などとすることになりますが、意味的に考えて、そこまでする必要はないでしょう。
(4) "any of"の訳し方が不自然だったので、修正しました。 