### PR TITLE
superuser_reserved_connectionsの説明に関する誤訳訂正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -1050,9 +1050,9 @@ include_dir 'conf.d'
         connections will be accepted only for superusers, and no
         new replication connections will be accepted.
        -->
-       <productname>PostgreSQL</>のスーパーユーザによる接続のために予約されている接続<quote>開口部（スロット）</quote>の数を決定します。
-       最大、<xref linkend="guc-max-connections">の数までの接続を同時に有効にすることができます。
-       何時の時点にあっても、有効な接続数は、少なくとも<varname>max_connections</>から<varname>superuser_reserved_connections</varname>を差し引いた数であって、新規接続はスーパーユーザのみが許可され、新たなレプリケーション接続は受け入れられません。
+<productname>PostgreSQL</>のスーパーユーザによる接続のために予約されている接続<quote>開口部（スロット）</quote>の数を決定します。
+最大、<xref linkend="guc-max-connections">の数までの接続を同時に有効にすることができます。
+有効な接続数が<varname>max_connections</>から<varname>superuser_reserved_connections</varname>を差し引いた数以上のときは、新規接続はスーパーユーザのみが許可され、新たなレプリケーション接続は受け入れられません。
        </para>
 
        <para>


### PR DESCRIPTION
Wheneverの解釈が間違っていて、意味の通じない日本語になっていたのを修正しました。
そのついでに、当該段落についてのみ、インデントを削除しました。