### PR TITLE
設定パラメータ unix_socket_* に関する誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -1093,11 +1093,14 @@ include_dir 'conf.d'
         <filename>/tmp</filename>, but that can be changed at build time.
         This parameter can only be set at server start.
        -->
-       サーバがクライアントアプリケーションからの接続要求を監視するUnixドメインソケット（複数も）のディレクトリを指定します。
-       複数ソケットはコンマで区切られた複数ディレクトリをリストすることで作成できます。
-       項目間の空白文字は無視されます。もし名前付けに際し空白文字もしくはコンマを使用する必要がある場合、ディレクトリ名を二重引用符で括ります。
-       空の値はいかなるUnixドメインソケットも監視しないようにします。この場合、TCP/IPソケットのみがサーバとの接続に使用されます。
-       デフォルト値は通常<filename>/tmp</filename>ですが、構築時に変更できます。このパラメータはサーバ起動時のみ設定可能です。
+サーバがクライアントアプリケーションからの接続要求を監視するUnixドメインソケットのディレクトリを指定します。
+複数ソケットはコンマで区切られた複数ディレクトリをリストすることで作成できます。
+項目間の空白文字は無視されます。
+ディレクトリ名に空白文字もしくはコンマを使用する必要がある場合、ディレクトリ名を二重引用符で括ります。
+空の値はいかなるUnixドメインソケットも監視しないようにします。
+この場合、TCP/IPソケットのみがサーバとの接続に使用されます。
+デフォルト値は通常<filename>/tmp</filename>ですが、ビルド時に変更できます。
+このパラメータはサーバ起動時のみ設定可能です。
        </para>
 
        <para>
@@ -1109,8 +1112,8 @@ include_dir 'conf.d'
         created in each of the <varname>unix_socket_directories</> directories.
         Neither file should ever be removed manually.
        -->
-       ソケットファイル、これは<replaceable>nnnn</>がポート番号である、<literal>.s.PGSQL.<replaceable>nnnn</></literal>と名前が付いているもの、それ自身に加え、<literal>.s.PGSQL.<replaceable>nnnn</>.lock</literal>と名前が付いている通常のファイルがそれぞれの<varname>unix_socket_directories</>ディレクトリの中に作成されます。
-       いずれのファイルも手作業で削除してはいけません。
+<literal>.s.PGSQL.<replaceable>nnnn</></literal>という名前のソケットファイル（<replaceable>nnnn</>はポート番号）のほかに、<literal>.s.PGSQL.<replaceable>nnnn</>.lock</literal>というの通常ファイルがそれぞれの<varname>unix_socket_directories</>ディレクトリの中に作成されます。
+いずれのファイルも手作業で削除してはいけません。
        </para>
 
        <para>
@@ -1118,7 +1121,7 @@ include_dir 'conf.d'
         This parameter is irrelevant on Windows, which does not have
         Unix-domain sockets.
 -->
-Unixドメインソケットを持たないWindowsではこのパラメータは無関係です。
+Windowsでは、Unixドメインソケットがありませんので、このパラメータは無関係です。
        </para>
       </listitem>
      </varlistentry>
@@ -1144,9 +1147,10 @@ Unixドメインソケットを持たないWindowsではこのパラメータは
         group of the server user.  This parameter can only be set at
         server start.
        -->
-       Unixドメインソケット（複数も）を所有するグループを設定します（ソケットを所有するユーザは常にサーバを起動するユーザです）。
+Unixドメインソケット（複数も）を所有するグループを設定します（ソケットを所有するユーザは常にサーバを起動するユーザです）。
 <varname>unix_socket_permissions</varname>パラメータとの組合せで、Unixドメインソケット接続の追加的アクセス管理機構として使うことができます。
-デフォルトでは空文字列で、どのユーザがサーバユーザのデフォルトグループかを示します。このパラメータはサーバ起動時のみ設定可能です。
+デフォルトでは空文字列で、サーバユーザのデフォルトグループを使用します。
+このパラメータはサーバ起動時のみ設定可能です。
        </para>
 
        <para>
@@ -1154,7 +1158,7 @@ Unixドメインソケットを持たないWindowsではこのパラメータは
         This parameter is irrelevant on Windows, which does not have
         Unix-domain sockets.
        -->
-       Unixドメインソケットを持たないWindowsではこのパラメータは無関係です。
+Windowsでは、Unixドメインソケットがありませんので、このパラメータは無関係です。
        </para>
       </listitem>
      </varlistentry>
@@ -1179,9 +1183,10 @@ Unixドメインソケットを持たないWindowsではこのパラメータは
         system calls.  (To use the customary octal format the number
         must start with a <literal>0</literal> (zero).)
        -->
-       Unixドメインソケット（複数も）のアクセス許可を設定します。
-Unixドメインソケットは通常のUnixファイルシステム許可設定の一式を使用します。
-パラメータ値は、<function>chmod</function>および<function>umask</function>システムコールが受け付ける数値形式での指定を想定しています。（通常使われる8進数形式を使用するのであれば、<literal>0</literal>（ゼロ）で始まらなければなりません。）
+Unixドメインソケット（複数も）のアクセスパーミッションを設定します。
+Unixドメインソケットは通常のUnixファイルシステムパーミッション設定の一式を使用します。
+パラメータ値は、<function>chmod</function>および<function>umask</function>システムコールが受け付ける数値形式での指定を想定しています。
+（通常使われる8進数形式を使用するのであれば、<literal>0</literal>（ゼロ）で始まらなければなりません。）
        </para>
 
        <para>
@@ -1194,8 +1199,9 @@ Unixドメインソケットは通常のUnixファイルシステム許可設定
         permission matters, so there is no point in setting or revoking
         read or execute permissions.)
        -->
-       デフォルトでの許可は、誰でも接続できる<literal>0777</literal>になっています。
-変更するならば<literal>0770</literal>（ユーザとグループのみです。<option>UNIX_SOCKET_GROUP</option>も参照してください）や<literal>0700</literal>（ユーザのみ）が適切です。（実際、Unixドメインソケットでは書き込み権限だけが問題です。そのため、読み込み許可や実行許可を設定または解除する意味はありません。）
+デフォルトのパーミッションは、誰でも接続できる<literal>0777</literal>になっています。
+変更するならば<literal>0770</literal>（ユーザとグループのみです。<option>UNIX_SOCKET_GROUP</option>も参照してください）や<literal>0700</literal>（ユーザのみ）が適切です。
+（Unixドメインソケットでは書き込み権限だけが問題になるため、読み込みや実行のパーミッションを設定または解除する意味はありません。）
        </para>
 
        <para>
@@ -1203,14 +1209,14 @@ Unixドメインソケットは通常のUnixファイルシステム許可設定
         This access control mechanism is independent of the one
         described in <xref linkend="client-authentication">.
        -->
-       このアクセス制御機構は <xref linkend="client-authentication">で記述されたものとは別個のものです。
+このアクセス制御機構は <xref linkend="client-authentication">で記述されたものとは別個のものです。
        </para>
 
        <para>
        <!--
         This parameter can only be set at server start.
        -->
-       このパラメータはサーバ起動時のみ設定可能です。
+このパラメータはサーバ起動時のみ設定可能です。
        </para>
 
        <para>
@@ -1222,9 +1228,9 @@ Unixドメインソケットは通常のUnixファイルシステム許可設定
         This parameter is also irrelevant on Windows, which does not have
         Unix-domain sockets.
        -->
-       このパラメータはSolaris, 現時点ではSolaris 10のようにソケットのパーミッションを完全に無視するシステムでは無関係です。
+このパラメータはSolaris 10の時点でのSolarisなど、ソケットのパーミッションを完全に無視するシステムでは無関係です。
 こうしたシステムでは、制限したいユーザだけが検索パーミッションを持つディレクトリを<varname>unix_socket_directories</>で指すようにすることによって同じような効果を得ることができます。
-       また、Unixドメインソケットを持たないWindowsではこのパラメータは無関係です。
+Windowsでも、Unixドメインソケットがありませんので、このパラメータは無関係です。
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
unix_socket_directories, unix_socket_group, unix_socket_permissionsの説明に関する誤訳訂正と翻訳改善です。
翻訳部分のインデントの削除、句点での改行の挿入をした部分以外については、別途、変更部分にコメントを入れます。
