### PR TITLE
原文が残っていた部分を削除 ( #821 )

### DIFF
--- a/doc/src/sgml/ref/alter_table.sgml
+++ b/doc/src/sgml/ref/alter_table.sgml
@@ -636,21 +636,6 @@ ALTER TABLE ALL IN TABLESPACE <replaceable class="PARAMETER">name</replaceable> 
    </varlistentry>
 
    <varlistentry>
-    <term><literal>NO FORCE</literal>/<literal>FORCE ROW LEVEL SECURITY</literal></term>
-    <listitem>
-     <para>
-      These forms control the application of row security policies belonging
-      to the table when the user is the table owner.  If enabled, row level
-      security policies will be applied when the user is the table owner.  If
-      disabled (the default) then row level security will not be applied when
-      the user is the table owner.
-      See also
-      <xref linkend="SQL-CREATEPOLICY">.
-     </para>
-    </listitem>
-   </varlistentry>
-
-   <varlistentry>
     <term><literal>CLUSTER ON</literal></term>
     <listitem>
      <para>


### PR DESCRIPTION
960のマージの時に、原文が重複して挿入されてしまっていたようです。
同じものが翻訳部分にコメントアウトされて残っているので、重複する英文のブロックを丸ごと削除しました。