### PR TITLE
Fix typo for issues #823

### DIFF
--- a/doc/src/sgml/logicaldecoding.sgml
+++ b/doc/src/sgml/logicaldecoding.sgml
@@ -44,7 +44,7 @@ PostgreSQLは、SQLによって実行された更新結果を外部のコンシ�
 追加のプラグインを書くことにより、PostgreSQLのコア部分のコードを一切変更することなく、利用可能なフォーマットの選択肢を増やすことができます。
 すべてのプラグインから、
 <command>INSERT</command>によって作成された個々の新しい行と、<command>UPDATE</command>によって作成された新しい個々の行のバージョンにアクセスできます。
-<command>UPDATE</command>と<command>DELETE</command>によって古いバージョンの行へのアクセスが可能かどうかは、
+<command>UPDATE</command>と<command>DELETE</command>によって生じた古いバージョンの行へのアクセスが可能かどうかは、
 レプリカアイデンティティ(replica identity)の設定によって決まります(<xref linkend="SQL-CREATETABLE-REPLICA-IDENTITY">参照)。
   </para>
 

--- a/doc/src/sgml/logicaldecoding.sgml
+++ b/doc/src/sgml/logicaldecoding.sgml
@@ -45,7 +45,7 @@ PostgreSQLは、SQLによって実行された更新結果を外部のコンシ�
 すべてのプラグインから、
 <command>INSERT</command>によって作成された個々の新しい行と、<command>UPDATE</command>によって作成された新しい個々の行のバージョンにアクセスできます。
 <command>UPDATE</command>と<command>DELETE</command>によって古いバージョンの行へのアクセスが可能かどうかは、
-レプリカエンティティ(replica entity)の設定によって決まります(<xref linkend="SQL-CREATETABLE-REPLICA-IDENTITY">参照)。
+レプリカアイデンティティ(replica identity)の設定によって決まります(<xref linkend="SQL-CREATETABLE-REPLICA-IDENTITY">参照)。
   </para>
 
   <para>


### PR DESCRIPTION
Issuesで報告された"replica identity"が「レプリカエンティティ(replica entity)」となっているのは、どう見ても単純ミスのようなので修正しました。
実は該当の文を読み返してちょっと気になった箇所があります。その直前の「UPDATEとDELETEによって古いバージョンの行へのアクセスが可能かどうか」は"The availability of old row versions for UPDATE and DELETE"を訳したもので、構文解釈的にはこれが正しいように思いますが、言いたいことは「UPDATEとDELETEが古い行バージョンにアクセスできるかどうか」ではなく、「UPDATEあるいはDELETEによって削除された古い行バージョンを、プラグインが参照できるかどうか」ではないかと思うのです。