### PR TITLE
unintended original sentence exposure

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -4573,6 +4573,7 @@ WALライタがWALを吐き出す頻度を指定します。
 どちらにおいても、<literal>s1</>か<literal>s2</>が同期スタンバイとして選ばれます。
        </para>
        <para>
+<!--
         The name of a standby server for this purpose is the
         <varname>application_name</> setting of the standby, as set in the
         <varname>primary_conninfo</> of the standby's WAL receiver.  There is
@@ -4582,7 +4583,7 @@ WALライタがWALを吐き出す頻度を指定します。
         The special entry <literal>*</> matches any
         <varname>application_name</>, including the default application name
         of <literal>walreceiver</>.
-       -->
+-->
 この目的のスタンバイサーバの名前は、スタンバイサーバのWAL receiverの<varname>primary_conninfo</>で設定されるのと同じく、スタンバイサーバの<varname>application_name</>設定となります。
 一意性を強要する仕組みにはなっていません。
 重複があった場合、一致したスタンバイは優先順位が高いと見なされますが、どれが選ばれるかは非決定的です。

--- a/doc/src/sgml/extend.sgml
+++ b/doc/src/sgml/extend.sgml
@@ -569,6 +569,7 @@
    </para>
 
    <para>
+<!--
     The extension mechanism also has provisions for packaging modification
     scripts that adjust the definitions of the SQL objects contained in an
     extension.  For example, if version 1.1 of an extension adds one function

--- a/doc/src/sgml/ref/psql-ref.sgml
+++ b/doc/src/sgml/ref/psql-ref.sgml
@@ -2818,13 +2818,6 @@ hello 10
 これは対話的な入力とファイルからの入力を混在させるために使うことができます。
 Readlineと同じ挙動は、それが最も外部のレベルで動作している場合にのみ利用されることに注意してください。
         </para>
-        <para>
-        If <replaceable>filename</replaceable> is <literal>-</literal>
-        (hyphen), then standard input is read until an EOF indication
-        or <command>\q</> meta-command.  This can be used to intersperse
-        interactive input with input from files.  Note that Readline behavior
-        will be used only if it is active at the outermost level.
-        </para>
         <note>
         <para>
 <!--
@@ -4985,6 +4978,7 @@ testdb=&gt; <userinput>SELECT * FROM :"foo";</userinput>
 testdb=&gt; <userinput>\set content `cat my_file.txt`</userinput>
 testdb=&gt; <userinput>INSERT INTO my_table VALUES (:'content');</userinput>
 </programlisting>
+<!--
     (Note that this still won't work if <filename>my_file.txt</filename> contains NUL bytes.
     <application>psql</application> does not support embedded NUL bytes in variable values.)
 -->

--- a/doc/src/sgml/tsm-system-rows.sgml
+++ b/doc/src/sgml/tsm-system-rows.sgml
@@ -31,6 +31,7 @@
  </para>
 
  <para>
+<!--
   Like the built-in <literal>SYSTEM</literal> sampling
   method, <literal>SYSTEM_ROWS</literal> performs block-level sampling, so
   that the sample is not completely random but may be subject to clustering


### PR DESCRIPTION
原文のコメントアウトに失敗しているところをいくつか見つけましたので対処してみました。
のつもりだったのですが、一ヶ所、コメントアウト失敗ではなく、「原文が重複していて、重複して居る方には一切手当がされていない」というのも見つけました。なのでそこは重複分をばっさり削除です。