### PR TITLE
tcp_keepalives_idleの誤訳訂正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -1298,8 +1298,9 @@ Unixドメインソケットは通常のUnixファイルシステム許可設定
         In sessions connected via a Unix-domain socket, this parameter is
         ignored and always reads as zero.
        -->
-        TCPがkeepaliveパケットをクライアントに送信後、待機状態となっている時間を秒単位で指定します。
-        0の場合はシステムのデフォルト値を使用します。このパラメータは<symbol>TCP_KEEPIDLE</>または<symbol>TCP_KEEPALIVE</>シンボルをサポートするシステムとWindowsのみサポートされます。
+クライアントとのやり取りがなくなった後、TCPがkeepaliveパケットをクライアントに送信するまでの時間を秒単位で指定します。
+0の場合はシステムのデフォルト値を使用します。
+このパラメータは<symbol>TCP_KEEPIDLE</>または<symbol>TCP_KEEPALIVE</>シンボルをサポートするシステムとWindowsのみサポートされます。
 その他のシステムではゼロでなければなりません。
 Unixドメインソケット経由で接続されたセッションでは、このパラメータは無視され、常にゼロとして読み取られます。
        </para>


### PR DESCRIPTION
"after which"の解釈が間違っていて、全くおかしな説明になっていたので修正しました。
"number of seconds of inactivity"は、直訳すると「活動のない秒数」、従前の訳は「待機状態となっている時間」ですが「クライアントとのやり取りがなくなった後（の時間）」としてみました。