### PR TITLE
ssl_ecdh_curveの説明の誤訳訂正（notの訳抜け）

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -1718,10 +1718,10 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
         It does not need to be same curve as used by server's Elliptic
         Curve key.  The default is <literal>prime256v1</>.
 -->
-        <acronym>ECDH</>キー交換で使われる曲線の名前を指定します。
-        接続するすべてのクライアントがこの設定をサポートしている必要があります。
-        サーバの楕円曲線キーで使用されるのと同じ曲線である必要があります。
-        デフォルト値は<literal>prime256v1</>です。
+<acronym>ECDH</>キー交換で使われる曲線の名前を指定します。
+接続するすべてのクライアントがこの設定をサポートしている必要があります。
+サーバの楕円曲線キーで使用されるのと同じ曲線である必要はありません。
+デフォルト値は<literal>prime256v1</>です。
        </para>
 
        <para>


### PR DESCRIPTION
notが訳抜けして反対の意味になっていたので修正しました。
ついでにインデントを削除しました。