### PR TITLE
shared_buffersの説明の翻訳改善

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -1955,10 +1955,10 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
         process of writing large quantities of new or changed data over a
         longer period of time.
        -->
-       1GBまたはそれより多いRAMを載せた専用データベースサーバを使用している場合、<varname>shared_buffers</varname>に対する妥当な初期値はシステムメモリの25%です。
-       <varname>shared_buffers</varname>をこれよりも大きな値に設定することが有効なワークロードもあります。
-       しかし、<productname>PostgreSQL</productname>はオペレーティングシステムキャッシュにも依存するため、<varname>shared_buffers</varname>にRAMの40%以上を割り当てても、それより小さい値の時より動作が良くなる見込みはありません。
-        <varname>shared_buffers</varname>をより大きく設定する場合は、大抵<varname>max_wal_size</varname>も合わせて増やす必要があります。これは、新規または変更された多量のデータを書き出す処理をより長い時間に渡って分散させるためです。
+1GB以上のRAMを載せた専用データベースサーバを使用している場合、<varname>shared_buffers</varname>に対する妥当な初期値はシステムメモリの25%です。
+<varname>shared_buffers</varname>をこれよりも大きな値に設定することが有効なワークロードもあります。
+しかし、<productname>PostgreSQL</productname>はオペレーティングシステムキャッシュにも依存するため、<varname>shared_buffers</varname>にRAMの40%以上を割り当てても、それより小さい値の時より動作が良くなる見込みはありません。
+<varname>shared_buffers</varname>をより大きく設定する場合は、大抵<varname>max_wal_size</varname>も合わせて増やす必要があります。これは、新規または変更された多量のデータを書き出す処理をより長い時間に渡って分散させるためです。
        </para>
 
        <para>
@@ -1971,7 +1971,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
         useful range for <varname>shared_buffers</varname> on Windows systems
         is generally from 64MB to 512MB.
        -->
-1GB以下のRAMのシステムでは、オペレーティングシステムに十分な余裕を残すために、RAMに対してより小さい割合を設定することが適切です。
+1GB未満のRAMのシステムでは、オペレーティングシステムに十分な余裕を残すために、RAMに対してより小さい割合を設定することが適切です。
 また、Windowsでも<varname>shared_buffers</varname>に対し大きな値を設定することはあまり有効でありません。
 設定値を比較的小さく保ち、代わりにオペレーティングシステムのキャッシュを使用することが、より良い結果になるでしょう。
 Windowsシステムでの有効な<varname>shared_buffers</varname>の範囲は一般的に64MBから512MBです。

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -1931,9 +1931,13 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
         settings significantly higher than the minimum are usually needed
         for good performance.  This parameter can only be set at server start.
        -->
-       データベースサーバが使用する共有メモリバッファのために使用するメモリ量を設定します。
-デフォルトは一般的に128メガバイト(<literal>128MB</>)です。しかし、稼働中のカーネルの設定が（<application>initdb</>の過程で決定されます）この値をサポートしていない場合、より少なくなることがあります。
-この設定は最低限128キロバイトなければなりません。（デフォルト値以外の<symbol>BLCKSZ</symbol>でこの最小値は変化します。）しかし、良い性能を引き出すためには、最小値よりかなり高い値の設定が通例必要です。このパラメータはサーバ起動時にのみ設定可能です。
+データベースサーバが共有メモリバッファのために使用するメモリ量を設定します。
+デフォルトは一般的に128メガバイト(<literal>128MB</>)です。
+しかし、稼働中のカーネルの設定がこの値をサポートしていない場合、より少なくなることがあります（<application>initdb</>の過程で決定されます）。
+この設定は最低限128キロバイトなければなりません。
+（<symbol>BLCKSZ</symbol>がデフォルト値と異なる場合、この最小値も異なる値になります。）
+しかし、良い性能を引き出すためには、最小値よりかなり高い値の設定が通例必要です。
+このパラメータはサーバ起動時にのみ設定可能です。
        </para>
 
        <para>
@@ -1967,7 +1971,10 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
         useful range for <varname>shared_buffers</varname> on Windows systems
         is generally from 64MB to 512MB.
        -->
-       1GB以下のRAMのシステムでは、オペレーティングシステムに十分な余裕を残すために、RAMに対してより小さい割合を設定することが適切です。同様に、Windowsでは<varname>shared_buffers</varname>に対し大きな値を設定することは有効でありません。設定値を比較的小さく保ち、代わりにオペレーティングシステムのキャッシュを使用することが、より良い結果になるでしょう。Windowsシステムでの<varname>shared_buffers</varname>の範囲は一般的に64MBから512MBです。
+1GB以下のRAMのシステムでは、オペレーティングシステムに十分な余裕を残すために、RAMに対してより小さい割合を設定することが適切です。
+また、Windowsでも<varname>shared_buffers</varname>に対し大きな値を設定することはあまり有効でありません。
+設定値を比較的小さく保ち、代わりにオペレーティングシステムのキャッシュを使用することが、より良い結果になるでしょう。
+Windowsシステムでの有効な<varname>shared_buffers</varname>の範囲は一般的に64MBから512MBです。
        </para>
 
       </listitem>


### PR DESCRIPTION
変更点は以下のとおりです。
(1) 「データベースサーバが使用する共有メモリバッファのために使用するメモリ量」の1つ目の「使用する」を削除しました。
(2) カッコ付きの「initdbの過程で決定されます」の訳出位置が不自然だったので、移動しました。
(3) カッコ内の「デフォルト値以外のBLOCKSZでこの最小値は変化します」がわかりにくいので、訳し直しました。
(4) 「1GBまたはそれより多い」を、より自然な「1GB以上」に変更しました。
(5) "less than 1GB"が「1GB以下」になっていましたが、より正確に「1GB未満」としました。
(6) "Also, on Windows"の訳し方を「同様にWindowsでは」から「また、Windowsでも」と修正しました。
(7) "not as effective"を「有効ではありません」と訳していましたが、"as"は「Unix系と比較して、それほど」のニュアンスなので「『あまり』有効ではありません」としました。
(8) "The useful range of"の"useful"が訳出されていなかったので、「有効な」を追加しました。