### PR TITLE
max_prepared_transactionsの誤訳訂正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -2090,8 +2090,8 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
         disables the prepared-transaction feature.
         This parameter can only be set at server start.
        -->
-       <quote>プリペアド</>状態におけるトランザクションの最大数を同時に設定します（<xref linkend="sql-prepare-transaction">を参照してください）。
-このパラメータをゼロ（これがデフォルトです）に設定すると、プリペアドトランザクション機能を無効にします。
+同時に<quote>プリペアド</>状態にできるトランザクションの最大数を設定します（<xref linkend="sql-prepare-transaction">を参照してください）。
+このパラメータをゼロ（これがデフォルトです）に設定すると、プリペアドトランザクション機能が無効になります。
 このパラメータはサーバ起動時にのみ設定可能です。
        </para>
 
@@ -2104,7 +2104,8 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
         least as large as <xref linkend="guc-max-connections">, so that every
         session can have a prepared transaction pending.
        -->
-        プリペアドトランザクションの使用を意図しないのであれば、このパラメータはプリペアドトランザクションが偶然に作成されないようゼロに設定されなければなりません。プリペアドトランザクションを使用する場合、全てのセッションがプリペアドトランザクションを保留できるように、<varname>max_prepared_transactions</varname>を最低<xref linkend="guc-max-connections">と同じ大きさに設定しても構いません。
+プリペアドトランザクションの使用を意図しないのであれば、このパラメータはプリペアドトランザクションが偶然に作成されないようゼロに設定すべきです。
+プリペアドトランザクションを使用する場合、全てのセッションがプリペアドトランザクションを保留できるように、<varname>max_prepared_transactions</varname>を少なくとも<xref linkend="guc-max-connections">と同じ大きさに設定するのが良いでしょう。
        </para>
 
        <para>


### PR DESCRIPTION
"simultaneously"が"set"に掛かるように訳されていましたが、正しくは"can be in the prepared state"に掛かっているので、訳を修正しました。
そのついでに、少し、軽微な修正をしました。
(1) 「トランザクション機能を無効にします」は主語が存在せず、不自然な感じがするので、「トランザクション機能が無効になります」に変更しました。
(2) should, want, at leastの訳し方を変更しました。