### PR TITLE
maintenance_work_memの説明の翻訳改善

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -2201,8 +2201,8 @@ OpenSSLのバージョンにより、利用可能な暗号スィートの詳細�
         too high.  It may be useful to control for this by separately
         setting <xref linkend="guc-autovacuum-work-mem">.
 -->
-       オートバキュームを稼動させると、最大<xref linkend="guc-autovacuum-max-workers">倍ほどこのメモリーが配分されるので、デフォルトの値をあまり高く設定しないよう注意することを覚えておいてください。
-       別の設定項目<xref linkend="guc-autovacuum-work-mem">で制御するのが良いかもしれません。
+自動バキュームが稼動すると、最大でこのメモリの<xref linkend="guc-autovacuum-max-workers">倍が配分されるので、デフォルトの値をあまり高く設定しないよう注意してください。
+別の設定項目<xref linkend="guc-autovacuum-work-mem">で制御するのが良いかもしれません。
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
誤訳というほどではないかもしれませんが、「オートバキューム」「最大ｘ倍『ほど』このメモリーが」などの表現や、冒頭の"Note"の命令文の節はカンマの前の"be allocated"までで終わっていて、次の"so be careful"は別の命令文なのに、「注意することを覚えておいてください」と原文の構文を間違えたと思われる訳になっていることが気になったので、訳を修正しました。