### PR TITLE
Cost-based vacuum delayの説明に関する誤訳訂正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -2511,10 +2511,10 @@ OpenSSLのバージョンにより、利用可能な暗号スィートの詳細�
       system to perform other database operations. Cost-based vacuum
       delay provides a way for administrators to achieve this.
       -->
-      この機能の目的は、同時実行的データベース活動上のこれらコマンドのI/Oに対する影響を管理者から軽減させます。
-      <command>VACUUM</command> および <command>ANALYZE</command>の様な保守用コマンドが即座に終了することが重要ではない事態が数多くあります。
-      しかし、他のデータベースの操作を行うに当たって、これらのコマンドがシステムの能力に多大な阻害を与えないことは通常とても重要です。
-      コストに基づいたvacuum遅延はこれを実現するための方法を管理者に提供します。
+この機能の目的は、同時に実行されているデータベースの活動に対するこれらコマンドによるI/Oへの影響を、管理者が軽減できるようにすることです。
+<command>VACUUM</command> および <command>ANALYZE</command>の様な保守用コマンドが即座に終了することが重要ではない事態が数多くあります。
+しかし、他のデータベースの操作を行うに当たって、これらのコマンドがシステムの能力に多大な阻害を与えないことは通常とても重要です。
+コストに基づいたvacuum遅延はこれを実現するための方法を管理者に提供します。
      </para>
 
      <para>
@@ -2524,8 +2524,8 @@ OpenSSLのバージョンにより、利用可能な暗号スィートの詳細�
       <varname>vacuum_cost_delay</varname> variable to a nonzero
       value.
       -->
-      手動で<command>VACUUM</command>コマンドを実行することができるように、デフォルトでこの機能は無効になっています。
-      有効にするには、<varname>vacuum_cost_delay</varname>変数をゼロでない値に設定します。
+手動で実行した<command>VACUUM</command>コマンドについては、デフォルトでこの機能は無効になっています。
+有効にするには、<varname>vacuum_cost_delay</varname>変数をゼロでない値に設定します。
      </para>
 
      <variablelist>


### PR DESCRIPTION
「コストに基づくVacuum遅延」の説明において、"to allow administrators to reduce..."および"for manually issued VACUUM command"の構文解釈に誤りがあったので、それぞれ訳し直しました。