### PR TITLE
effective_io_concurrencyの説明の翻訳改善

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -2912,8 +2912,10 @@ bgwriterが<varname>bgwriter_flush_after</varname>バイトより多く書く度
          or zero to disable issuance of asynchronous I/O requests. Currently,
          this setting only affects bitmap heap scans.
         -->
-        <productname>PostgreSQL</>が同時処理を予定している同時実行ディスクI/O作業の数を設定します。この値を大きくすると、あらゆる個別の<productname>PostgreSQL</>セッションが並行して開始を試みるI/O作業数が増加します。許容範囲は1から1000まで、または非同期I/Oリクエストの発行を無効にするゼロです。
-        現在、この設定はビットマップヒープスキャンのみに有効です。
+<productname>PostgreSQL</>が同時実行可能であると想定する同時ディスクI/O操作の数を設定します。
+この値を大きくすると、あらゆる個別の<productname>PostgreSQL</>セッションが並行して開始を試みるI/O操作の数が増加します。
+設定可能な範囲は1から1000まで、または非同期I/Oリクエストの発行を無効にするゼロです。
+現在、この設定はビットマップヒープスキャンのみに影響します。
         </para>
 
         <para>


### PR DESCRIPTION
'PostgreSQL expects "can" be executed'の"can"が訳出されておらず、意味的に重要だと思うので、訳し直しました。
そのついでの 細かな修正ですが、'I/O operation'の訳を「I/O作業」から「I/O操作」に変更しましたが「I/O処理」の方が良いかも、とも思っていますので、ご意見がありましたら、遠慮なく、コメントください。
また、"affect"を「有効です」と訳していたのを、「影響します」に変更しました。