### PR TITLE
wal_levelの説明の誤訳訂正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -3236,10 +3236,10 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
        -->
 <varname>wal_level</>はどれだけの情報がWALに書かれるかを決定します。
 デフォルト値は<literal>minimal</>で、クラッシュまたは即時停止から回復するのに必要な情報のみ書き出します。
-<literal>replica</>はWALアーカイビングに必要なロギングを追加するとともに、更にスタンバイサーバ上の読み取り専用問い合わせの情報を追加します。
+<literal>replica</>はWALアーカイビングに必要なログ出力、およびスタンバイサーバ上で読み取り専用問い合わせを実行するために必要な情報を追加します。
 最後に、<literal>logical</>は、更にロジカルデコーディングをサポートするのに必要な情報を追加します。
 それぞれのレベルは、下位のレベルのログ出力を含んでいます。
-       このパラメータはサーバ起動時のみ設定可能です。
+このパラメータはサーバ起動時のみ設定可能です。
        </para>
        <para>
        <!--
@@ -3259,8 +3259,8 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
         higher must be used to enable WAL archiving
         (<xref linkend="guc-archive-mode">) and streaming replication.
        -->
-       <literal>minimal</>水準では、何らかの巨大な操作でのWALロギングは安全を期して省略されます。そうすることで、一連の操作をより高速にさせます（<xref linkend="populate-pitr">を参照してください）。
-       この最適化が適用される操作には以下のものがあげられます。
+<literal>minimal</>レベルでは、一部の巨大な操作でのWAL出力は安全に省略でき、そうすることで、それらの操作が大幅に高速になります（<xref linkend="populate-pitr">を参照してください）。
+この最適化が適用される操作には以下のものがあげられます。
         <simplelist>
          <member><command>CREATE TABLE AS</></member>
          <member><command>CREATE INDEX</></member>


### PR DESCRIPTION
(1) 「読み取り専用問い合わせの情報」は"required to run"が訳抜けしているので、訳し直しました。
(2) "can be safely skipped, which can make those operations much faster"の解釈がおかしかったので修正しました。