### PR TITLE
fsyncの説明の誤訳訂正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -3315,8 +3315,8 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
         This ensures that the database cluster can recover to a
         consistent state after an operating system or hardware crash.
 -->
-このパラメータがオンの場合、<productname>PostgreSQL</>サーバは<function>fsync()</>システムコールを発行したり、もしくはこれに相当する方法（<xref linkend="guc-wal-sync-method">を参照）で、更新が物理的にディスクに書き込まれたかの確証を得ようと試みます。
-これは、オペレーティングシステムもしくはハードウェアがクラッシュした後、確実にデータベースクラスタを一貫した状態に復旧させることを保証します。
+このパラメータがオンの場合、<productname>PostgreSQL</>サーバは<function>fsync()</>システムコールを発行するか、もしくはこれに相当する方法（<xref linkend="guc-wal-sync-method">を参照）で、更新が物理的にディスクに確実に書き込まれるように試みます。
+これは、オペレーティングシステムもしくはハードウェアがクラッシュした後、データベースクラスタを一貫した状態に復旧させることを確実にします。
        </para>
 
        <para>
@@ -3328,8 +3328,8 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
         you can easily recreate your entire database from external
         data.
        -->
-       <varname>fsync</varname>を停止することはしばしば性能上の利益になるとは言っても、停電やクラッシュの際に回復不可能なデータ破壊になることがあります。
-       従って外部データから全てのデータベースを簡単に再構築できる場合のみ<varname>fsync</varname>を停止してください。
+<varname>fsync</varname>を停止することはしばしば性能上の利益になるとは言っても、停電やクラッシュの際に回復不可能なデータ破壊になることがあります。
+従って外部データから全てのデータベースを簡単に再構築できる場合のみ<varname>fsync</varname>を停止してください。
        </para>
 
        <para>
@@ -3344,9 +3344,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
         quality hardware alone is not a sufficient justification for
         turning off <varname>fsync</varname>.
        -->
-        <varname>fsync</varname>を停止しても安全な状況の例としては、以下があげられます。
-        データベースが削除され、そして再構築されたデータの一群の処理のため、または頻繁に再構築され、かつフェイルオーバには使用されない読み取り専用のデータベースクローンに対し、バックアップファイルから新規データベースクラスタの初回読みを行う場合です。
-       高性能なハードウェアであるからと言って、<varname>fsync</varname>を停止することは正当性を主張する十分な理由とはなりません。
+<varname>fsync</varname>を停止しても安全な状況の例としては、以下があげられます。
+バックアップファイルから新しいデータベースクラスタにデータの初期読み込みを行う場合、バッチデータの処理のためにデータベースクラスタを使用し、その後データベースを削除して再構築する場合、読み込み専用のデータベースのクローンを頻繁に再作成するが、それをフェイルオーバーに使用しない場合、などです。
+高性能なハードウェアであるからと言って、<varname>fsync</varname>を停止することは正当性を主張する十分な理由とはなりません。
        </para>
 
        <para>
@@ -3358,8 +3358,8 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
         &#045;sync-only</command>, running <command>sync</>, unmounting the
         file system, or rebooting the server.
        -->
-       <varname>fsync</varname>を無効(off)から有効(on）に変更したときの確実なリカバリに対しては、カーネル内の全ての変更されたバッファを恒久的ストレージに強制移動させることが必要です。
-       クラスタがシャットダウンしている間、または fsyncが<command>initdb--sync-only</command>の稼働しているか、<command>sync</>が稼働しているか、ファイルシステムをにアンマウントしているか、またはサーバを再起動しているかにより成し得られます。
+<varname>fsync</varname>を無効(off)から有効(on）に変更したときの信頼できるリカバリのためには、カーネル内の全ての変更されたバッファを恒久的ストレージに強制的に吐き出させることが必要です。
+クラスタがシャットダウンしている間、またはfsyncが有効のときに、<command>initdb --sync-only</command>を実行する、<command>sync</>を実行する、ファイルシステムをにアンマウントする、またはサーバを再起動するかにより成し得られます。
        </para>
 
        <para>
@@ -3369,7 +3369,7 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
         performance benefit of turning off <varname>fsync</varname>, without
         the attendant risks of data corruption.
        -->
-       多くの場合、致命的ではないトランザクションにおいて<xref linkend="guc-synchronous-commit">を無効にすることにより、データ破壊の付随的危険性を伴うことなく、<varname>fsync</varname>を無効にした場合に潜在する性能上のメリットの多くを得ることができます。
+多くの場合、重要でないトランザクションに対して<xref linkend="guc-synchronous-commit">を無効にすることにより、データ破壊という付随的危険性を伴うことなく、<varname>fsync</varname>を無効にすることで得られるであろう性能上のメリットの多くを得ることができます。
        </para>
 
        <para>
@@ -3379,7 +3379,7 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
         If you turn this parameter off, also consider turning off
         <xref linkend="guc-full-page-writes">.
        -->
-       <varname>fsync</varname> は<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+<varname>fsync</varname> は<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
 このパラメータを無効にする場合、<xref linkend="guc-full-page-writes">も同時に無効にすることを検討してください。
        </para>
       </listitem>

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -3359,7 +3359,7 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
         file system, or rebooting the server.
        -->
 <varname>fsync</varname>を無効(off)から有効(on）に変更したときの信頼できるリカバリのためには、カーネル内の全ての変更されたバッファを恒久的ストレージに強制的に吐き出させることが必要です。
-クラスタがシャットダウンしている間、またはfsyncが有効のときに、<command>initdb --sync-only</command>を実行する、<command>sync</>を実行する、ファイルシステムをにアンマウントする、またはサーバを再起動するかにより成し得られます。
+これは、クラスタがシャットダウンしている間、またはfsyncが有効のときに、<command>initdb --sync-only</command>を実行する、<command>sync</>を実行する、ファイルシステムをにアンマウントする、またはサーバを再起動することによって可能となります。
        </para>
 
        <para>


### PR DESCRIPTION
fsyncを停止して良い状況の例、およびその次の段落については、大幅に訳し直しました。
それ以外についても、おかしな表現を訂正しました。