### PR TITLE
注記に翻訳漏れがあったので翻訳しました

### DIFF
--- a/doc/src/sgml/maintenance.sgml
+++ b/doc/src/sgml/maintenance.sgml
@@ -686,6 +686,7 @@ XIDのカウンタが一周して0に戻り、そして、突然に、過去に�
 
    <note>
     <para>
+<!--
      In <productname>PostgreSQL</> versions before 9.4, freezing was
      implemented by actually replacing a row's insertion XID
      with <literal>FrozenTransactionId</>, which was visible in the
@@ -694,13 +695,21 @@ XIDのカウンタが一周して0に戻り、そして、突然に、過去に�
      forensic use.  However, rows with <structname>xmin</> equal
      to <literal>FrozenTransactionId</> (2) may still be found
      in databases <application>pg_upgrade</>'d from pre-9.4 versions.
+-->
+9.4より前のバージョンの<productname>PostgreSQL</>では、行の挿入XIDを実際に<literal>FrozenTransactionId</>で置換することで凍結が実装されており、これは行の<structname>xmin</>システム列として見えていました。
+それより新しいバージョンでは単にフラグのビットをセットするだけで、行の元の<structname>xmin</>はフォレンジックでの利用に備えて保存します。
+しかし、9.4以前のバージョンから<application>pg_upgrade</>でアップグレードしたデータベースでは、<structname>xmin</>が <literal>FrozenTransactionId</> (2)に等しい行がまだあるかもしれません。
     </para>
     <para>
+<!--
      Also, system catalogs may contain rows with <structname>xmin</> equal
      to <literal>BootstrapTransactionId</> (1), indicating that they were
      inserted during the first phase of <application>initdb</>.
      Like <literal>FrozenTransactionId</>, this special XID is treated as
      older than every normal XID.
+-->
+また、システムカタログには<structname>xmin</>が<literal>BootstrapTransactionId</> (1)に等しい行が含まれる場合があり、これはその行が<application>initdb</>の最初の段階で挿入されたことを意味します。
+<literal>FrozenTransactionId</>と同様、この特別なXIDはすべての通常のXIDよりも古いものとして扱われます。
     </para>
    </note>
 

--- a/doc/src/sgml/maintenance.sgml
+++ b/doc/src/sgml/maintenance.sgml
@@ -697,7 +697,7 @@ XIDのカウンタが一周して0に戻り、そして、突然に、過去に�
      in databases <application>pg_upgrade</>'d from pre-9.4 versions.
 -->
 9.4より前のバージョンの<productname>PostgreSQL</>では、行の挿入XIDを実際に<literal>FrozenTransactionId</>で置換することで凍結が実装されており、これは行の<structname>xmin</>システム列として見えていました。
-それより新しいバージョンでは単にフラグのビットをセットするだけで、行の元の<structname>xmin</>はフォレンジックでの利用に備えて保存します。
+それより新しいバージョンでは単にフラグのビットをセットするだけで、行の元の<structname>xmin</>は後の検証での利用に備えて保存します。
 しかし、9.4以前のバージョンから<application>pg_upgrade</>でアップグレードしたデータベースでは、<structname>xmin</>が <literal>FrozenTransactionId</> (2)に等しい行がまだあるかもしれません。
     </para>
     <para>


### PR DESCRIPTION
#854 で報告があった翻訳漏れです。
"forensic"をどうしようかと思いましたが、IT用語ではカタカナで使われているので、ここでもそうしました。
また、一読しただけでは、(2)と(1)の意味がわからなかったのですが、どうやらFrozenTransactionIdとBootstrapTransactionIdがいずれも定数で、その実際の値のようです。もうちょっとわかりやすい訳し方があるかも…と思いつつ、良いアイデアが浮かばないので、そのままにしてあります。