### PR TITLE
synchronous_commitの説明の誤訳訂正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -3484,10 +3484,10 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
         asynchronously when the default is the opposite, issue <command>SET
         LOCAL synchronous_commit TO OFF</> within the transaction.
        -->
-       このパラメータはいつでも変更可能です。
-この設定により任意の1つのトランザクションのコミット時の動作が決まります。
+このパラメータはいつでも変更可能です。
+どのトランザクションの動作も、コミット時に有効であった設定によって決まります。
 したがって、一部のトランザクションのコミットを同期的に、その他を非同期的にすることが可能で、かつ、有用です。
-例えば、デフォルトが同期コミットの場合に単一の複数文トランザクションを非同期にコミットさせるためには、トランザクション内で<command>SET LOCAL synchronous_commit TO OFF</>を発行します。
+例えば、デフォルトが同期コミットの場合に複数文トランザクションを一つだけ非同期にコミットさせるためには、トランザクション内で<command>SET LOCAL synchronous_commit TO OFF</>を発行します。
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
"when it commits"の掛かり先の解釈が間違っていたので、訳し直しました。
そのついでに、その2つ後の文の「単一の複数文トランザクション(single multistatement transaction)」がわかりにくいと思ったので、"single"を副詞的に訳して「一つだけ」としました。