### PR TITLE
wal_sync_methodの説明の誤訳訂正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -3517,7 +3517,7 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
        <!--
          <literal>open_datasync</> (write WAL files with <function>open()</> option <symbol>O_DSYNC</>)
         -->
-        <literal>open_datasync</>（<function>open()</>オプション<symbol>O_DSYNC</>でWALファイルの書き込み）
+        <literal>open_datasync</>（<function>open()</>のオプション<symbol>O_DSYNC</>でWALファイルに書き込む）
         </para>
         </listitem>
         <listitem>
@@ -3525,7 +3525,7 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
        <!--
          <literal>fdatasync</> (call <function>fdatasync()</> at each commit)
         -->
-        <literal>fdatasync</>（コミット毎に<function>fdatasync()</>を呼び出し）
+        <literal>fdatasync</>（コミット毎に<function>fdatasync()</>を呼び出す）
         </para>
         </listitem>
         <listitem>
@@ -3533,7 +3533,7 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
         <!--
          <literal>fsync</> (call <function>fsync()</> at each commit)
         -->
-        <literal>fsync</>（コミット毎に<function>fsync()</>を呼び出し）
+        <literal>fsync</>（コミット毎に<function>fsync()</>を呼び出す）
         </para>
         </listitem>
         <listitem>
@@ -3541,7 +3541,7 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
        <!--
          <literal>fsync_writethrough</> (call <function>fsync()</> at each commit, forcing write-through of any disk write cache)
         -->
-        <literal>fsync_writethrough</>（いかなるディスク書き込みキャッシュもライトスルーさせるため、コミット毎に<function>fsync()</>を呼び出し）
+        <literal>fsync_writethrough</>（すべてのディスク書き込みキャッシュをライトスルーさせるため、コミット毎に<function>fsync()</>を呼び出す）
         </para>
         </listitem>
         <listitem>
@@ -3549,7 +3549,7 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
        <!--
          <literal>open_sync</> (write WAL files with <function>open()</> option <symbol>O_SYNC</>)
         -->
-        <literal>open_sync</>（<function>open()</>オプション<symbol>O_SYNC</>でWALファイルの書き込み）
+        <literal>open_sync</>（<function>open()</>のオプション<symbol>O_SYNC</>でWALファイルに書き込む）
         </para>
         </listitem>
        </itemizedlist>
@@ -3567,13 +3567,13 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
         This parameter can only be set in the <filename>postgresql.conf</>
         file or on the server command line.
        -->
-       もし可能なら<literal>open_</>*オプションも<literal>O_DIRECT</>を使用します。
-       全てのプラットフォームでこれら全ての選択肢が使えるわけではありません。
-デフォルトは、上のリストのプラットフォームでサポートされるものの最初に列挙されているものです。ただしLinuxでは<literal>fdatasync</>
-がデフォルトです。
+可能なら<literal>open_</>*オプションも<literal>O_DIRECT</>を使用します。
+全てのプラットフォームでこれら全ての選択肢が使えるわけではありません。
+デフォルトは、上のリストのプラットフォームでサポートされるものの最初に列挙されているものです。
+ただしLinuxでは<literal>fdatasync</>がデフォルトです。
 デフォルトは必ずしも理想的なものではありません。
-この設定、あるいはクラッシュに適応した構成か、アーカイブの最適性能を導くために使用しているシステム構成の形態を変更することが必要かもしれません。これらの側面は
-<xref linkend="wal-reliability">で解説されます。
+クラッシュに適応した構成にする、あるいはアーカイブの最適性能を導くためには、この設定あるいはシステム構成の他の部分を変更することが必要かもしれません。
+これらの側面は <xref linkend="wal-reliability">で解説されます。
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>


### PR DESCRIPTION
"it might be necessary..."の文の構文解釈を誤っていたので、訳し直しました。
そのついでに、オプションを列挙している部分の説明の括弧書きが連用形になっているのが不自然だったので、終止形に変更しました。
「ライトスルー」が気になったのですが、目をつぶってしまいました。良い訳語の案があれば、追加修正します。