### PR TITLE
wal_compressionの説明で訳抜けしていた文を翻訳しました

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -3711,6 +3711,7 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
         Only superusers can change this setting.
 -->
 このパラメータが<literal>on</>なら、<xref linkend="guc-full-page-writes">がonあるいはベースバックアップの際、<productname>PostgreSQL</>サーバはWALに書き出すフルページイメージを圧縮します。
+圧縮されたページイメージは、WALリプレイのときに伸張されます。
 デフォルト値は<literal>off</>です。
 スーパーユーザだけがこの設定を変更できます。
        </para>


### PR DESCRIPTION
好みで言えば、"WAL replay"は「WAL再生」、"decompression"は「解凍」と訳したいのですが、すぐ次の段落にも同じ用語があったので、そちらに訳語を合わせました。