### PR TITLE
archive_commandの説明の誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -4195,11 +4195,11 @@ WALライタがWALを吐き出す頻度を指定します。
         exit status only if it succeeds. For more information see
         <xref linkend="backup-archiving-wal">.
        -->
-       完了したWALファイルセグメントのアーカイブを実行するローカルのシェルコマンドです。
-文字列内のいかなる<literal>%p</>は、格納されるファイルの絶対パスで置き換えられ、そして、<literal>%f</>はファイル名のみ置換します。
+完了したWALファイルセグメントのアーカイブを実行するローカルのシェルコマンドです。
+文字列内のすべての<literal>%p</>は、格納されるファイルのパスで置き換えられ、そして、<literal>%f</>はファイル名のみ置換します。
 （このパス名はサーバの作業用ディレクトリ、つまり、クラスタのデータディレクトリからの相対パスです。）
-コマンド内で実際の<literal>%</>文字を埋め込むには<literal>%%</>を使用します。
-コマンドが成功した場合に限って終了ステータスゼロを返すことが重要です。
+コマンド内に<literal>%</>文字そのものを埋め込むには<literal>%%</>を使用します。
+コマンドが成功した場合にのみ終了ステータスゼロを返すことが重要です。
 より詳しくは<xref linkend="backup-archiving-wal">を参照ください。
        </para>
        <para>
@@ -4217,10 +4217,10 @@ WALライタがWALを吐き出す頻度を指定します。
         archiving, but also breaks the chain of WAL files needed for
         archive recovery, so it should only be used in unusual circumstances.
        -->
-       このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
 サーバ起動時に<varname>archive_mode</>が有効でなければ、これは無視されます。
 <varname>archive_command</>が空文字列（デフォルト）、かつ、<varname>archive_mode</>が有効な場合、WALアーカイブ処理は一時的に無効になりますが、コマンドが後で提供されることを見越して、サーバはWALセグメントの蓄積を続けます。
-例えば、<literal>/bin/true</>（Windowsでは<literal>REM</>）のように、コマンドに対し<varname>archive_command</>を真を返すだけで何もしないように設定すると効果的にアーカイブ処理を無効にしますが、アーカイブからの復帰に必要なWALファイルの連鎖を同時に断ち切ります。従って、特別な場合のみ使用するようにしなければなりません。
+例えば、<literal>/bin/true</>（Windowsでは<literal>REM</>）のように、真を返すだけで何もしないコマンドを<varname>archive_command</>に設定すると、実質的にアーカイブ処理が無効になりますが、アーカイブからの復帰に必要なWALファイルの連鎖も同時に断ち切るため、特別な場合のみ使用するようにしなければなりません。
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
修正点は以下の通りです。
(1) 「いかなる%pは」はわかりにくいので、「すべての%pは」としました。
(2) 原文が"path"なのに「絶対パス」と訳されていた(しかも実際には相対パス)のを、単に「パス」としました。
(3) 「実際の%文字」はわかりにくいので「%文字そのもの」としました。
(4) archive_commandに/bin/trueのようなコマンドを設定する場合のくだりがわかりにくかったので、訳し直しました。