### PR TITLE
commit_siblingsの説明の誤訳訂正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -3918,8 +3918,8 @@ WALライタがWALを吐き出す頻度を指定します。
         transaction will become ready to commit during the delay
         interval. The default is five transactions.
        -->
-       <varname>commit_delay</>遅延を実行する前に必要とされる同時に開いているトランザクションの最小数です。
-より大きい値は、遅延周期の間に、少なくとも1つの他のトランザクションがコミットの準備を整わせることを確実にします。
+<varname>commit_delay</>の遅延を実行するときに必要とされる同時に開いているトランザクションの最小数です。
+より大きい値にすると、遅延周期の間に、少なくとも1つの他のトランザクションのコミットの準備が整う確率が高くなります。
 デフォルトは5トランザクションです。
        </para>
       </listitem>


### PR DESCRIPTION
"more probable"を「確実にします」と訳していたので、正確に「確率が高くなります」としました。
そのついでに、より自然な日本語にするために、「commit_delay遅延」に『の』を補う、"before"を(原文に忠実に)「前に」としていたのを、(意味的に適切と考えられる)「ときに」に変更しました。