### PR TITLE
明示的ロックの説明の翻訳改善

### DIFF
--- a/doc/src/sgml/mvcc.sgml
+++ b/doc/src/sgml/mvcc.sgml
@@ -1235,8 +1235,7 @@ ERROR:  could not serialize access due to read/write dependencies among transact
 <productname>PostgreSQL</productname>は、テーブル内のデータに対する同時アクセスを制御するために様々な種類のロックモードを備えています。
 これらのモードは、<acronym>MVCC</acronym>では必要な動作を得られない場合、アプリケーション制御のロックに使用することができます。
 また、ほとんどの<productname>PostgreSQL</productname>コマンドでは、参照されるテーブルがそのコマンドの実行中に別の方法で削除もしくは変更されていないことを確実にするために、適切なモードのロックを自動的に獲得します。
-（例えば、<command>TRUNCATE</>コマンドは、同じテーブルに対する他の操作とは同時に実行することは危険です。
-そのため、そのテーブルへの排他ロックを強制的に獲得します。）
+（例えば、<command>TRUNCATE</>コマンドは、同じテーブルに対する他の操作と同時に安全に実行することはできないので、それを確実に実行するため、そのテーブルの排他ロックを獲得します。）
    </para>
 
    <para>
@@ -1247,7 +1246,7 @@ ERROR:  could not serialize access due to read/write dependencies among transact
     system view. For more information on monitoring the status of the lock
     manager subsystem, refer to <xref linkend="monitoring">.
 -->
-現在のデータベースサーバで重要なロックの一覧を確認するには、<link linkend="view-pg-locks"><structname>pg_locks</structname></link>システムビューを使用してください。
+現在のデータベースサーバに残っているロックの一覧を確認するには、<link linkend="view-pg-locks"><structname>pg_locks</structname></link>システムビューを使用してください。
 ロック管理サブシステムの状況監視についての詳細は<xref linkend="monitoring">を参照してください。
    </para>
 


### PR DESCRIPTION
誤解を招くと思える表現2箇所を修正しました。
(1) 「ロックを強制的に獲得する」は、他のトランザクションがロックを保持していてもそれを奪い取るような印象さえ受けます。"obtains an exclusive lock ... to enforce that"のenforceが強制するのは、「TRUNCATEを安全な場合にしか実行しないようにすること」であって、そのためにロックを獲得する、と言っているので、そういう意味になるよう、訳し直しました。
(2) "outstanding lock"を「重要なロック」と訳していましたが、"outstanding"には"extremely good"の他に"not yet done"の意味があり、ここは後者の意味で使っていると思うので、「残っている」に変更しました。