### PR TITLE
セカンダリファイルシステムの説明の訳抜け部分の翻訳、誤訳訂正と翻訳改善

### DIFF
--- a/doc/src/sgml/runtime.sgml
+++ b/doc/src/sgml/runtime.sgml
@@ -333,10 +333,10 @@ postgres$ <userinput>initdb -D /usr/local/pgsql/data</userinput>
     as <application>pg_upgrade</>, and it also ensures clean failures if
     the secondary volume is taken offline.
 -->
-多くのインストールは、マシンの<quote>ルート</>ボリューム以外のファイルシステム（ボリューム）上でのデータベースクラスタを作成します。
-この選択をした場合、データディレクトリをセカンダリボリュームの最上位ディレクトリ（マウントポイント）を使用することはお勧めできません。
-最善の方法はマウントポイント内に<productname>PostgreSQL</productname>ユーザが所有するディレクトリを作成することです。
-この権限の問題を避けることは、特に<application>pg_upgrade</>の操作やセカンダリボリュームがオフラインになった時のきれいな失敗になることを保証します。
+多くのインストールでは、マシンの<quote>ルート</>ボリューム以外のファイルシステム（ボリューム）上にデータベースクラスタを作成します。
+この選択をした場合、セカンダリボリュームの最上位ディレクトリ（マウントポイント）をデータディレクトリとして使用することはお勧めできません。
+最善の方法はマウントポイントディレクトリ内に<productname>PostgreSQL</productname>ユーザが所有するディレクトリを作成し、その中にデータディレクトリを作成することです。
+これにより、権限の問題、特に<application>pg_upgrade</>などの操作での問題を避けることができ、またセカンダリボリュームがオフラインになったときに、確実にきれいなエラーを起こすようになります。
    </para>
 
   </sect2>


### PR DESCRIPTION
(1) "and then create the data directory within that"が訳されていなかったので、翻訳しました。
(2) "This avoids permissions problems"の解釈が間違っていたので、訳し直しました。
(3) そのついでの翻訳改善として、インストールは」→「インストールでは」、「ファイルシステム上でのデータベースクラスタを作成」→「ファイルシステム上にデータベースクラスタを作成」、「データディレクトリを～最上位ディレクトリを使用」→「最上位ディレクトリをデータディレクトリとして使用」などの修正をしました。