### PR TITLE
テーブルレベルロックの説明の翻訳改善

### DIFF
--- a/doc/src/sgml/mvcc.sgml
+++ b/doc/src/sgml/mvcc.sgml
@@ -1284,7 +1284,7 @@ ERROR:  could not serialize access due to read/write dependencies among transact
     transaction at a time) while others are not self-conflicting (for example,
     an <literal>ACCESS SHARE</literal> lock can be held by multiple transactions).
 -->
-以下のリストに、<productname>PostgreSQL</productname>で自動的に使用される、使用可能なロックモードとその文脈を示します。
+以下のリストに、使用可能なロックモードとそれらが<productname>PostgreSQL</productname>で自動的に使用される文脈を示します。
 また、<xref linkend="sql-lock">コマンドを使用して、こうしたロックを明示的に獲得することもできます。
 これらのロックモードは、たとえその名前に<quote>row（行）</quote>という言葉が付いていても、全てテーブルレベルのロックであることに注意してください。
 ロックモードの名前は歴史的なものです。


### PR DESCRIPTION
"in which"は"the contexts"だけに掛かると解釈すべきだと思いますが、"the available lock modes and the contexts"に掛かるとして訳されていて、不自然な文章になっていたので、訳し直しました。