### PR TITLE
Partial Modeの誤訳訂正

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -17832,7 +17832,7 @@ NULL baz</literallayout>(3 rows)</entry>
    are eligible to participate in various optimizations, such as parallel
    aggregation.
 -->
-<firstterm>並列モード</firstterm>をサポートする集約関数は並列集約など、様々な最適化に参加することができます。
+<firstterm>部分モード</firstterm>をサポートする集約関数は並列集約など、様々な最適化に参加することができます。
   </para>
 
   <note>

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -3479,7 +3479,7 @@ NULL baz</literallayout>(3 rows)</entry>
    are eligible to participate in various optimizations, such as parallel
    aggregation.
 -->
-<firstterm>並列モード</firstterm>をサポートする集約関数は並列集約など、様々な最適化に参加することができます。
+<firstterm>部分モード</firstterm>をサポートする集約関数は並列集約など、様々な最適化に参加することができます。
   </para>
 
   <note>


### PR DESCRIPTION
"Partial Mode"がなぜか「並列モード」と訳されていたので、「部分モード」に変更しました。