### PR TITLE
sources.sgmlの9.6.2対応

### DIFF
--- a/doc/src/sgml/sources.sgml
+++ b/doc/src/sgml/sources.sgml
@@ -1440,9 +1440,6 @@ BETTER: unrecognized node type: 42
      code.
 -->
 インライン関数の定義がバックエンドの一部としてのみ利用可能なシンボル（つまり、変数、関数）を参照する場合、その関数はフロントエンドのコードからインクルードされたときに不可視かもしれません。
-<!-- 訳注：
-     "the definition"と"an inline"の間に"of"が欠落しているものとして訳した。
--->
 <programlisting>
 #ifndef FRONTEND
 static inline MemoryContext


### PR DESCRIPTION
原文の修正に伴い、訳注が不要になったので削除しました。