### PR TITLE
「データベースサーバの起動」についての翻訳改善

### DIFF
--- a/doc/src/sgml/runtime.sgml
+++ b/doc/src/sgml/runtime.sgml
@@ -569,7 +569,7 @@ su postgres -c 'pg_ctl start -D /usr/local/pgsql/data -l serverlog'
       <productname>PostgreSQL</productname> source distribution.
       <indexterm><primary>FreeBSD</><secondary>start script</secondary></>
 -->
-<productname>FreeBSD</productname>では、<productname>PostgreSQL</productname>で配布されるソースの中にある<filename>contrib/start-scripts/freebsd</filename>ファイルを参照してください。
+<productname>FreeBSD</productname>では、<productname>PostgreSQL</productname>のソース配布物の中にある<filename>contrib/start-scripts/freebsd</filename>ファイルを参照してください。
 <indexterm><primary>FreeBSD</><secondary>の起動スクリプト</secondary></>
      </para>
     </listitem>
@@ -610,7 +610,7 @@ fi
       <productname>PostgreSQL</productname> source distribution.
 -->
 を<filename>/etc/rc.d/rc.local</filename>や<filename>/etc/rc.local</filename>に追加してください。
-または、<productname>PostgreSQL</productname>で配布されるソースの中にある<filename>contrib/start-scripts/linux</filename>ファイルを参照してください。
+または、<productname>PostgreSQL</productname>のソース配布物の中にある<filename>contrib/start-scripts/linux</filename>ファイルを参照してください。
      </para>
 
      <para>
@@ -746,7 +746,7 @@ FATAL:  could not create TCP/IP listen socket
      on a reserved port number might draw something like:
 -->
 これはたいていの場合メッセージが示す通りの意味です。
-既にサーバが動いているポートで別の<command>postmaster</command>を起動しようとしたことを示しています。
+既にサーバが動いているポートで別のサーバを起動しようとしたことを示しています。
 しかし、カーネルエラーメッセージが<computeroutput>Address already in use</computeroutput>やそれに類似したものではない場合は、別の問題の可能性もあります。
 例えば、予約済みのポート番号でサーバを起動しようとすると下記のようなメッセージが出るかもしれません。
 <screen>
@@ -779,9 +779,9 @@ DETAIL:  Failed system call was shmget(key=5440001, size=4011376640, 03600).
      servers on the same machine, if their total space requested
      exceeds the kernel limit.
 -->
-これは、おそらくカーネルによる共有メモリのサイズの上限が<productname>PostgreSQL</productname>が作ろうとしている作業領域（この例では4011376640バイト）よりも小さい可能性があります。
+これは、おそらくカーネルによる共有メモリのサイズの上限が<productname>PostgreSQL</productname>が作ろうとしている作業領域（この例では4011376640バイト）よりも小さいことを示しています。
 または、System V方式の共有メモリサポートがカーネルにまったく設定されていない可能性もあります。
-一時的な策として、（<xref linkend="guc-shared-buffers">を使用して）サーバを通常よりも少ないバッファ数で起動することもできます。
+一時的な策として、サーバを通常よりも少ないバッファ数（<xref linkend="guc-shared-buffers">）で起動することもできます。
 しかし最終的には、カーネルを再設定し、使用可能な共有メモリサイズを増やした方が良いでしょう。
 このメッセージは、同じマシン上で複数のサーバを起動しようとした時に、要求された領域の合計がカーネルの上限を超えた場合にも表示されます。
     </para>
@@ -807,7 +807,7 @@ DETAIL:  Failed system call was semget(5440126, 17, 03600).
 -->
 ディスクの空き容量がなくなったということを示しているわけでは<emphasis>ありません</emphasis>。
 これはカーネルの<systemitem class="osname">System V</>セマフォの上限が、<productname>PostgreSQL</productname>が作成しようとしている数よりも小さいということを意味しています。
-上記のように、許可される接続の数を減らして（<xref linkend="guc-max-connections">を使用して）サーバを起動させることで問題は回避できるかもしれませんが、最終的にはカーネルの設定を変えてセマフォの上限を増やした方が良いでしょう。
+上記のように、許可される接続の数（<xref linkend="guc-max-connections">）を減らしてサーバを起動させることで問題は回避できるかもしれませんが、最終的にはカーネルの設定を変えてセマフォの上限を増やした方が良いでしょう。
     </para>
 
     <para>
@@ -817,7 +817,7 @@ DETAIL:  Failed system call was semget(5440126, 17, 03600).
      all. In that case your only option is to reconfigure the kernel to
      enable these features.
 -->
-<quote>illegal system call</>というエラーが表示された場合は、使用しているカーネルでは共有メモリやセマフォがまったくサポートされていない可能性があります。
+<quote>不正なシステムコール</>のエラーが発生した場合は、使用しているカーネルでは共有メモリやセマフォがまったくサポートされていない可能性があります。
 その場合、これらの機能を使えるようにカーネルを設定し直すことが唯一の選択肢となります。
     </para>
 


### PR DESCRIPTION
18.3節についての比較的軽微な翻訳改善です。
(1) "source distribution"の訳語を、他のファイルで主に使われている「ソース配布物」に変更しました（2箇所）。
(2) "server"がなぜか「＜command＞postmaster＜／command＞」となっていたのを「サーバ」に変更しました。
(3) カッコ内にパラメータ名だけが記述されているものを「～を使用して」と訳しているのが不自然だったので、「を使用して」を削除し、訳出箇所を変更しました。
(4) quoteタグ内は原則として訳すべきなので、"illegal system call"を翻訳し、また、その後の日本語を微修正しました。