### PR TITLE
"logging collector"の訳語を「ログ収集機構」に統一

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -6339,11 +6339,11 @@ local0.*    /var/log/postgresql
          produced by scripts such as <varname>archive_command</>.)
          This parameter can only be set at server start.
         -->
-        このパラメータは<firstterm>logging collector</>を有効にします。
-        それは<systemitem>stderr</>に送られたログメッセージを捕捉し、ログファイルにリダイレクトするバックグラウンドプロセスです。
-        この手法は<application>syslog</>へのログよりもしばしば有用です。
-        メッセージの一部の種類が<application>syslog</>では出力されない可能性があるためです。
-        （一般的な例として、ダイナミックリンカのエラーメッセージがあり、その他の例として<varname>archive_command</>のようなスクリプトにより生成されたエラーメッセージが挙げられます）。
+このパラメータは<firstterm>ログ収集機構</>を有効にします。
+それは<systemitem>stderr</>に送られたログメッセージを捕捉し、ログファイルにリダイレクトするバックグラウンドプロセスです。
+この手法は<application>syslog</>へのログよりもしばしば有用です。
+メッセージの一部の種類が<application>syslog</>では出力されない可能性があるためです。
+（一般的な例として、ダイナミックリンカのエラーメッセージがあり、その他の例として<varname>archive_command</>のようなスクリプトにより生成されたエラーメッセージが挙げられます）。
 このパラメータはサーバ起動時のみ設定可能です。
        </para>
 
@@ -6377,10 +6377,10 @@ local0.*    /var/log/postgresql
           may fail to log some messages in such cases but it will not block
           the rest of the system.
          -->
-         ログ取得機構はメッセージを決して失わないために設計されています。
-         これは、極端に高い負荷の場合、サーバプロセスはコレクタが遅れをとった場合、追加のログメッセージを送信しようと試みる時に阻止される可能性があります。
-         それとは対象的に<application>syslog</>は、もし書き込みができなかったときメッセージの廃棄を選びます。
-         これらの場合にはいくつかのログメッセージを失うことになりますが、残ったシステムを阻止しません。
+ログ収集機構はメッセージを決して失わないために設計されています。
+これは、極端に高い負荷の場合、サーバプロセスはコレクタが遅れをとった場合、追加のログメッセージを送信しようと試みる時に阻止される可能性があります。
+それとは対象的に<application>syslog</>は、もし書き込みができなかったときメッセージの廃棄を選びます。
+これらの場合にはいくつかのログメッセージを失うことになりますが、残ったシステムを阻止しません。
         </para>
        </note>
 

--- a/doc/src/sgml/release-8.3.sgml
+++ b/doc/src/sgml/release-8.3.sgml
@@ -1472,7 +1472,7 @@ Windowsの<function>PGSemaphoreLock()</>の実装は、戻る前に<varname>Imme
       Fix logging collector to not lose log coherency under high load (Andrew
       Dunstan)
 -->
-高負荷時にログの干渉性が失われないようにログコレクタを修正しました。(Andrew Dunstan)
+高負荷時にログの干渉性が失われないようにログ収集機構を修正しました。(Andrew Dunstan)
      </para>
 
      <para>
@@ -1490,7 +1490,7 @@ Windowsの<function>PGSemaphoreLock()</>の実装は、戻る前に<varname>Imme
       Fix logging collector to ensure it will restart file rotation
       after receiving <systemitem>SIGHUP</> (Tom Lane)
 -->
-<systemitem>SIGHUP</>を受信した後にファイルのローテーションを確実に再開するようにログコレクタを修正しました。 (Tom Lane)
+<systemitem>SIGHUP</>を受信した後にファイルのローテーションを確実に再開するようにログ収集機構を修正しました。 (Tom Lane)
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-8.4.sgml
+++ b/doc/src/sgml/release-8.4.sgml
@@ -3913,7 +3913,7 @@ Windowsの<function>PGSemaphoreLock()</>の実装は、戻る前に<varname>Imme
       Fix logging collector to not lose log coherency under high load (Andrew
       Dunstan)
 -->
-高負荷時にログの干渉性が失われないようにログコレクタを修正しました。(Andrew Dunstan)
+高負荷時にログの干渉性が失われないようにログ収集機構を修正しました。(Andrew Dunstan)
      </para>
 
      <para>
@@ -3931,7 +3931,7 @@ Windowsの<function>PGSemaphoreLock()</>の実装は、戻る前に<varname>Imme
       Fix logging collector to ensure it will restart file rotation
       after receiving <systemitem>SIGHUP</> (Tom Lane)
 -->
-<systemitem>SIGHUP</>を受信した後にファイルのローテーションを確実に再開するようにログコレクタを修正しました。 (Tom Lane)
+<systemitem>SIGHUP</>を受信した後にファイルのローテーションを確実に再開するようにログ収集機構を修正しました。 (Tom Lane)
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.0.sgml
+++ b/doc/src/sgml/release-9.0.sgml
@@ -7521,7 +7521,7 @@ Windowsの<function>PGSemaphoreLock()</>の実装は、戻る前に<varname>Imme
       Fix logging collector to not lose log coherency under high load (Andrew
       Dunstan)
 -->
-高負荷時にログの干渉性が失われないようにログコレクタを修正しました。(Andrew Dunstan)
+高負荷時にログの干渉性が失われないようにログ収集機構を修正しました。(Andrew Dunstan)
      </para>
 
      <para>
@@ -7539,7 +7539,7 @@ Windowsの<function>PGSemaphoreLock()</>の実装は、戻る前に<varname>Imme
       Fix logging collector to ensure it will restart file rotation
       after receiving <systemitem>SIGHUP</> (Tom Lane)
 -->
-<systemitem>SIGHUP</>を受信した後にファイルのローテーションを確実に再開するようにログコレクタを修正しました。 (Tom Lane)
+<systemitem>SIGHUP</>を受信した後にファイルのローテーションを確実に再開するようにログ収集機構を修正しました。 (Tom Lane)
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.1.sgml
+++ b/doc/src/sgml/release-9.1.sgml
@@ -11020,7 +11020,7 @@ Windowsの<function>PGSemaphoreLock()</>の実装は、戻る前に<varname>Imme
       Fix logging collector to not lose log coherency under high load (Andrew
       Dunstan)
 -->
-高負荷時にログの干渉性が失われないようにログコレクタを修正しました。(Andrew Dunstan)
+高負荷時にログの干渉性が失われないようにログ収集機構を修正しました。(Andrew Dunstan)
      </para>
 
      <para>
@@ -11038,7 +11038,7 @@ Windowsの<function>PGSemaphoreLock()</>の実装は、戻る前に<varname>Imme
       Fix logging collector to ensure it will restart file rotation
       after receiving <systemitem>SIGHUP</> (Tom Lane)
 -->
-<systemitem>SIGHUP</>を受信した後にファイルのローテーションを確実に再開するようにログコレクタを修正しました。 (Tom Lane)
+<systemitem>SIGHUP</>を受信した後にファイルのローテーションを確実に再開するようにログ収集機構を修正しました。 (Tom Lane)
      </para>
     </listitem>
 
@@ -14296,7 +14296,7 @@ Unixソケット接続をサポートしないプラットフォームにおい�
          which controls the permissions on log files created by the
          logging collector (Martin Pihlak)
 -->
-ログ処理コントローラにより作成されるログファイルの権限を制御する、<link linkend="guc-log-file-mode"><varname>log_file_mode</></link>が追加されました。(Martin Pihlak)
+ログ収集機構により作成されるログファイルの権限を制御する、<link linkend="guc-log-file-mode"><varname>log_file_mode</></link>が追加されました。(Martin Pihlak)
        </para>
       </listitem>
 


### PR DESCRIPTION
[jpug-doc:5346]で提起した件で、"logging collector"の訳語を「ログ収集機構」に統一しました。