### PR TITLE
update release-9.[2-5] for 9.6.2

### DIFF
--- a/doc/src/sgml/release-9.2.sgml
+++ b/doc/src/sgml/release-9.2.sgml
@@ -122,6 +122,7 @@ Branch: REL9_2_STABLE [38bec1805] 2017-01-25 07:02:25 +0900
       Fix WAL page header validation when re-reading segments (Takayuki
       Tsunakawa, Amit Kapila)
 -->
+セグメントの再読み込みでのWALページヘッダの検証を修正しました。(Takayuki Tsunakawa, Amit Kapila)
      </para>
 
      <para>
@@ -129,6 +130,7 @@ Branch: REL9_2_STABLE [38bec1805] 2017-01-25 07:02:25 +0900
       In corner cases, a spurious <quote>out-of-sequence TLI</> error
       could be reported during recovery.
 -->
+稀に、リカバリ中に誤った<quote>out-of-sequence TLI</>エラーが報告される可能性がありました。
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.2.sgml
+++ b/doc/src/sgml/release-9.2.sgml
@@ -2,52 +2,82 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-2-20">
+<!--
   <title>Release 9.2.20</title>
+-->
+  <title>リリース9.2.20</title>
 
   <note>
+<!--
   <title>Release Date</title>
+-->
+  <title>リリース日</title>
   <simpara>2017-02-09</simpara>
   </note>
 
   <para>
+<!--
    This release contains a variety of fixes from 9.2.19.
    For information about new features in the 9.2 major release, see
    <xref linkend="release-9-2">.
+-->
+このリリースは9.2.19に対し、各種不具合を修正したものです。
+9.2メジャーリリースにおける新機能については、<xref linkend="release-9-2">を参照してください。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.2.20</title>
+-->
+   <title>バージョン9.2.20への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.2.X.
+-->
+9.2.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if your installation has been affected by the bug described in
     the first changelog entry below, then after updating you may need
     to take action to repair corrupted indexes.
+-->
+しかしながら、インストレーションが下記変更点の最初の項目に書かれたバグの影響を受けている場合には、アップデート後に壊れたインデックスを修復する作業が必要になるでしょう。
    </para>
 
    <para>
+<!--
     Also, if you are upgrading from a version earlier than 9.2.11,
     see <xref linkend="release-9-2-11">.
+-->
+また、9.2.11よりも前のリリースからアップグレードする場合は、<xref linkend="release-9-2-11">を参照して下さい。
    </para>
 
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Fix a race condition that could cause indexes built
       with <command>CREATE INDEX CONCURRENTLY</> to be corrupt
       (Pavan Deolasee, Tom Lane)
+-->
+<command>CREATE INDEX CONCURRENTLY</>で作られたインデックスの破損をもたらす競合状態を修正しました。
+(Pavan Deolasee, Tom Lane)
      </para>
 
      <para>
+<!--
       If <command>CREATE INDEX CONCURRENTLY</> was used to build an index
       that depends on a column not previously indexed, then rows inserted
       or updated by transactions that ran concurrently with
@@ -55,20 +85,30 @@
       index entries.  If you suspect this may have happened, the most
       reliable solution is to rebuild affected indexes after installing
       this update.
+-->
+<command>CREATE INDEX CONCURRENTLY</>が前もってインデックスされていない列に依存するインデックスの作成に使われていたなら、<command>CREATE INDEX</>コマンドと同時実行するトランザクションにより挿入あるいは更新された行が誤ったインデックスエントリを受け入れるおそれがありました。
+この現象が生じた疑いがあるなら、最も確実な対応はアップデート実施後に影響をうけたインデックスを再作成することです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Unconditionally WAL-log creation of the <quote>init fork</> for an
       unlogged table (Michael Paquier)
+-->
+ログをとらないテーブルに対する<quote>init fork</>生成を無条件にWAL出力するようにしました。
+(Michael Paquier)
      </para>
 
      <para>
+<!--
       Previously, this was skipped when <xref linkend="guc-wal-level">
       = <literal>minimal</>, but actually it's necessary even in that case
       to ensure that the unlogged table is properly reset to empty after a
       crash.
+-->
+これまで<xref linkend="guc-wal-level"> = <literal>minimal</>のときには省略されていましたが、ログをとらないテーブルがクラッシュ後に適切に空に初期化されることを保証するために、実際にはその場合でも必要でした。
      </para>
     </listitem>
 
@@ -78,101 +118,153 @@ Author: Fujii Masao <fujii@postgresql.org>
 Branch: REL9_2_STABLE [38bec1805] 2017-01-25 07:02:25 +0900
 -->
      <para>
+<!--
       Fix WAL page header validation when re-reading segments (Takayuki
       Tsunakawa, Amit Kapila)
+-->
      </para>
 
      <para>
+<!--
       In corner cases, a spurious <quote>out-of-sequence TLI</> error
       could be reported during recovery.
+-->
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       If the stats collector dies during hot standby, restart it (Takayuki
       Tsunakawa)
+-->
+統計情報コレクタがホットスタンバイ動作中に落ちたときに、それを再起動するようにしました。
+(Takayuki Tsunakawa)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Check for interrupts while hot standby is waiting for a conflicting
       query (Simon Riggs)
+-->
+ホットスタンバイが衝突する問い合わせを待機している間、割り込みを検査するようにしました。
+(Simon Riggs)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid constantly respawning the autovacuum launcher in a corner case
       (Amit Khandekar)
+-->
+稀な場合に絶えず自動バキュームランチャーが再生成されるのを回避しました。
+(Amit Khandekar)
      </para>
 
      <para>
+<!--
       This fix avoids problems when autovacuum is nominally off and there
       are some tables that require freezing, but all such tables are
       already being processed by autovacuum workers.
+-->
+この修正は自動バキュームが名目上offでいくつか凍結を要するテーブルがあるけれども全てのそのようなテーブルは既に自動バキュームワーカにより処理中である場合の問題を回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix check for when an extension member object can be dropped (Tom Lane)
+-->
+拡張のメンバオブジェクトが削除できるときのチェックを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Extension upgrade scripts should be able to drop member objects,
       but this was disallowed for serial-column sequences, and possibly
       other cases.
+-->
+拡張のアップグレードスクリプトはメンバオブジェクトを削除できなければいけませんが、serial列のシーケンスについてできませんでした。また、他の場合でもそうなる可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Make sure <command>ALTER TABLE</> preserves index tablespace
       assignments when rebuilding indexes (Tom Lane, Michael Paquier)
+-->
+インデックス再作成のときに<command>ALTER TABLE</>がインデックスのテーブル空間の割り当てを確実に維持するようにしました。
+(Tom Lane, Michael Paquier)
      </para>
 
      <para>
+<!--
       Previously, non-default settings
       of <xref linkend="guc-default-tablespace"> could result in broken
       indexes.
+-->
+これまでは<xref linkend="guc-default-tablespace">のデフォルト以外の設定によりインデックス破壊をもたらす可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent dropping a foreign-key constraint if there are pending
       trigger events for the referenced relation (Tom Lane)
+-->
+参照先リレーションに対する待機中トリガイベントがあるときに外部キー制約を削除しないようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This avoids <quote>could not find trigger <replaceable>NNN</></quote>
       or <quote>relation <replaceable>NNN</> has no triggers</quote> errors.
+-->
+これにより<quote>could not find trigger <replaceable>NNN</></quote>（トリガNNNが見つかりません）または<quote>relation <replaceable>NNN</> has no triggers</quote>（リレーションNNNにトリガがありません）というエラーを回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix processing of OID column when a table with OIDs is associated to
       a parent with OIDs via <command>ALTER TABLE ... INHERIT</> (Amit
       Langote)
+-->
+OIDを持つテーブルがOIDを持つ親テーブルと<command>ALTER TABLE ... INHERIT</>を通して関連づけられているときのOID列の処理を修正しました。
+(Amit Langote)
      </para>
 
      <para>
+<!--
       The OID column should be treated the same as regular user columns in
       this case, but it wasn't, leading to odd behavior in later
       inheritance changes.
+-->
+この場合、OID列は通常のユーザ列と同様に扱われるべきでしたが、そうなっておらず、後の継承の変更で奇妙な振る舞いをひき起こしていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Check for serializability conflicts before reporting
       constraint-violation failures (Thomas Munro)
+-->
+直列化可能かを、制約違反エラーを報告する前に検査するようにしました。
+(Thomas Munro)
      </para>
 
      <para>
+<!--
       When using serializable transaction isolation, it is desirable
       that any error due to concurrent transactions should manifest
       as a serialization failure, thereby cueing the application that
@@ -182,229 +274,356 @@ Branch: REL9_2_STABLE [38bec1805] 2017-01-25 07:02:25 +0900
       serialization error if the application explicitly checked for
       the presence of a conflicting key (and did not find it) earlier
       in the transaction.
+-->
+シリアライザブルトランザクション隔離を使っているとき、同時トランザクションを原因とするいかなるエラーも直列化の失敗として表明するのが望ましく、それによりアプリケーションにリトライが成功するかもしれないという手がかりを与えます。
+残念ながら、キー重複の失敗が同時挿入で引き起こされた場合には、これは確実には生じません。
+本変更は、アプリケーションがトランザクションのより早くに明示的に競合するキーの存在をチェックした（そして見つからなかった）なら、このようなエラーが直列化のエラーとして報告されることを保証します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that column typmods are determined accurately for
       multi-row <literal>VALUES</> constructs (Tom Lane)
+-->
+複数行の<literal>VALUES</>コンストラクトに対して列のtypemodが精密に決定されるようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fixes problems occurring when the first value in a column has a
       determinable typmod (e.g., length for a <type>varchar</> value) but
       later values don't share the same limit.
+-->
+これは、列の最初の値が決定可能なtypmod（例えば<type>varchar</>の長さ）を持つけれど続く値は同じ制限を共有しないときに発生する問題を修正します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Throw error for an unfinished Unicode surrogate pair at the end of a
       Unicode string (Tom Lane)
+-->
+ユニコード文字列の末尾における完結しないユニコードのサロゲートペアにエラーを出すようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Normally, a Unicode surrogate leading character must be followed by a
       Unicode surrogate trailing character, but the check for this was
       missed if the leading character was the last character in a Unicode
       string literal (<literal>U&amp;'...'</>) or Unicode identifier
       (<literal>U&amp;"..."</>).
+-->
+通常、ユニコードのサロゲート先頭文字にはユニコードのサロゲート末尾文字が続かなければなりませんが、先頭文字がユニコード文字列リテラル(<literal>U&amp;'...'</>)またはユニコード識別子(<literal>U&amp;"..."</>)の最後の文字である場合に、これについての検査が見逃されていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that a purely negative text search query, such
       as <literal>!foo</>, matches empty <type>tsvector</>s (Tom Dunstan)
+-->
+<literal>!foo</>のような純粋な否定のテキスト検索問い合わせが空の<type>tsvector</>にマッチするようにしました。
+(Tom Dunstan)
      </para>
 
      <para>
+<!--
       Such matches were found by GIN index searches, but not by sequential
       scans or GiST index searches.
+-->
+このようなマッチはGINインデックス検索では見つかりましたが、シーケンシャルスキャンやGiSTインデックススキャンでは見つかりませんでした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent crash when <function>ts_rewrite()</> replaces a non-top-level
       subtree with an empty query (Artur Zakirov)
+-->
+<function>ts_rewrite()</>が非トップレベルのサブツリーを空クエリで置き換えるときのクラッシュを、防止しました。
+(Artur Zakirov)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix performance problems in <function>ts_rewrite()</> (Tom Lane)
+-->
+<function>ts_rewrite()</>での性能問題を修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <function>ts_rewrite()</>'s handling of nested NOT operators
       (Tom Lane)
+-->
+<function>ts_rewrite()</>の入れ子NOT演算子の扱いを修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <function>array_fill()</> to handle empty arrays properly (Tom Lane)
+-->
+空配列を適切に扱うように<function>array_fill()</>を修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix one-byte buffer overrun in <function>quote_literal_cstr()</>
       (Heikki Linnakangas)
+-->
+<function>quote_literal_cstr()</>で1バイトのバッファオーバランを修正しました。
+(Heikki Linnakangas)
      </para>
 
      <para>
+<!--
       The overrun occurred only if the input consisted entirely of single
       quotes and/or backslashes.
+-->
+このオーバランは入力全体がのシングルクォートおよび/またはバックスラッシュで構成される場合でのみ発生します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent multiple calls of <function>pg_start_backup()</>
       and <function>pg_stop_backup()</> from running concurrently (Michael
       Paquier)
+-->
+<function>pg_start_backup()</>と<function>pg_stop_backup()</>の複数回の呼び出しが同時に実行されないようにしました。
+(Michael Paquier)
      </para>
 
      <para>
+<!--
       This avoids an assertion failure, and possibly worse things, if
       someone tries to run these functions in parallel.
+-->
+誰かがこれらの関数を並列に実行しようとしたときの、アサート失敗あるいはもっと悪い事態を回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid discarding <type>interval</>-to-<type>interval</> casts
       that aren't really no-ops (Tom Lane)
+-->
+実際にはノーオペレーションではない<type>interval</>から<type>interval</>へのキャストを捨てないようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       In some cases, a cast that should result in zeroing out
       low-order <type>interval</> fields was mistakenly deemed to be a
       no-op and discarded.  An example is that casting from <type>INTERVAL
       MONTH</> to <type>INTERVAL YEAR</> failed to clear the months field.
+-->
+一部の場合に下位の<type>interval</>フィールドのゼロ埋めした結果になるべきキャストが誤って何もしない処理と認識され、捨てられていました。
+一例は<type>INTERVAL MONTH</>から<type>INTERVAL YEAR</>へのキャストが月フィールドをクリアしないことです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_dump</> to dump user-defined casts and transforms
       that use built-in functions (Stephen Frost)
+-->
+組み込み関数を使うユーザ定義キャストと変換をダンプするように<application>pg_dump</>を修正しました。
+(Stephen Frost)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible <application>pg_basebackup</> failure on standby
       server when including WAL files (Amit Kapila, Robert Haas)
+-->
+WALファイルを含めたときスタンバイサーバで起こりうる<application>pg_basebackup</>の失敗を修正しました。
+(Amit Kapila, Robert Haas)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that the Python exception objects we create for PL/Python are
       properly reference-counted (Rafa de la Torre, Tom Lane)
+-->
+PL/Pythonむけに作成したPython例外オブジェクトが確実に適切にリファレンスカウントされるようにしました。
+(Rafa de la Torre, Tom Lane)
      </para>
 
      <para>
+<!--
       This avoids failures if the objects are used after a Python garbage
       collection cycle has occurred.
+-->
+これはPythonのガーベージコレクションのサイクルが起きた後にオブジェクトが使われた場合の失敗を回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix PL/Tcl to support triggers on tables that have <literal>.tupno</>
       as a column name (Tom Lane)
+-->
+列名として<literal>.tupno</>を持つテーブルのトリガに対応するようにPL/Tclを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This matches the (previously undocumented) behavior of
       PL/Tcl's <command>spi_exec</> and <command>spi_execp</> commands,
       namely that a magic <literal>.tupno</> column is inserted only if
       there isn't a real column named that.
+-->
+これは（以前の文書化されていない）PL/Tclの<command>spi_exec</>および<command>spi_execp</>コマンドの振る舞いと調和させます。
+すなわち、<literal>.tupno</>マジック列はその名前の真の列が無い場合だけ挿入されます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Allow DOS-style line endings in <filename>~/.pgpass</> files,
       even on Unix (Vik Fearing)
+-->
+Unix上であってもDOS形式の改行文字が<filename>~/.pgpass</>ファイルで許されるようにしました。
+(Vik Fearing)
      </para>
 
      <para>
+<!--
       This change simplifies use of the same password file across Unix and
       Windows machines.
+-->
+この変更は同じパスワードファイルをUnixマシンとWindowsマシンとで使うのを簡単にします。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix one-byte buffer overrun if <application>ecpg</> is given a file
       name that ends with a dot (Takayuki Tsunakawa)
+-->
+<application>ecpg</>にドットで終わるファイル名が与えられた際の1バイトのバッファオーバランを修正しました。
+(Takayuki Tsunakawa)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>psql</>'s tab completion for <command>ALTER DEFAULT
       PRIVILEGES</> (Gilles Darold, Stephen Frost)
+-->
+<command>ALTER DEFAULT PRIVILEGES</>に対する<application>psql</>のタブ補完を修正しました。
+(Gilles Darold, Stephen Frost)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       In <application>psql</>, treat an empty or all-blank setting of
       the <envar>PAGER</> environment variable as meaning <quote>no
       pager</> (Tom Lane)
+-->
+<application>psql</>で、空または全てブランクの<envar>PAGER</>環境変数設定を<quote>ページャ無し</>という意味で扱うようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Previously, such a setting caused output intended for the pager to
       vanish entirely.
+-->
+これまでは、このような設定はページャにむけようとした出力を全く見えなくしていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Improve <filename>contrib/dblink</>'s reporting of
       low-level <application>libpq</> errors, such as out-of-memory
       (Joe Conway)
+-->
+<filename>contrib/dblink</>のメモリ不足などの低レベル<application>libpq</>エラーの報告を改善しました。
+(Joe Conway)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       On Windows, ensure that environment variable changes are propagated
       to DLLs built with debug options (Christian Ullrich)
+-->
+Windowsで環境変数の変更がデバッグオプションを有効にしてビルドされたDLLに確実に伝播するようにしました。
+(Christian Ullrich)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Sync our copy of the timezone library with IANA release tzcode2016j
       (Tom Lane)
+-->
+タイムゾーンライブラリをIANA release tzcode2016jに同期しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fixes various issues, most notably that timezone data
       installation failed if the target directory didn't support hard
       links.
+-->
+多数の問題が修正されており、最も重要なものとしては対象ディレクトリがハードリンクをサポートしない場合はタイムゾーンデータ導入に失敗していたことがあります。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Update time zone data files to <application>tzdata</> release 2016j
       for DST law changes in northern Cyprus (adding a new zone
       Asia/Famagusta), Russia (adding a new zone Europe/Saratov), Tonga,
       and Antarctica/Casey.
       Historical corrections for Italy, Kazakhstan, Malta, and Palestine.
       Switch to preferring numeric zone abbreviations for Tonga.
+-->
+タイムゾーンデータを<application>tzdata</> release 2016jに更新しました。
+北キプロス（新タイムゾーン Asia/Famagusta 追加）、ロシア（新タイムゾーン Europe/Saratov 追加）、トンガ、Antarctica/Casey における夏時間法の変更と、イタリア、カザフスタン、マルタ、パレスチナにおける歴史的修正、トンガにおける数値によるゾーン略記法を選択する変更が含まれます。 
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.3.sgml
+++ b/doc/src/sgml/release-9.3.sgml
@@ -58,7 +58,10 @@
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 

--- a/doc/src/sgml/release-9.3.sgml
+++ b/doc/src/sgml/release-9.3.sgml
@@ -2,35 +2,57 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-3-16">
+<!--
   <title>Release 9.3.16</title>
+-->
+  <title>リリース9.3.16</title>
 
   <note>
+<!--
   <title>Release Date</title>
+-->
+  <title>リリース日</title>
   <simpara>2017-02-09</simpara>
   </note>
 
   <para>
+<!--
    This release contains a variety of fixes from 9.3.15.
    For information about new features in the 9.3 major release, see
    <xref linkend="release-9-3">.
+-->
+このリリースは9.3.15に対し、各種不具合を修正したものです。
+9.3メジャーリリースにおける新機能については、<xref linkend="release-9-3">を参照してください。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.3.16</title>
+-->
+   <title>バージョン9.3.16への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.3.X.
+-->
+9.3.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if your installation has been affected by the bug described in
     the first changelog entry below, then after updating you may need
     to take action to repair corrupted indexes.
+-->
+しかしながら、インストレーションが下記変更点の最初の項目に書かれたバグの影響を受けている場合には、アップデート後に壊れたインデックスを修復する作業が必要になるでしょう。
    </para>
 
    <para>
+<!--
     Also, if you are upgrading from a version earlier than 9.3.15,
     see <xref linkend="release-9-3-15">.
+-->
+また、9.3.15よりも前のバージョンからアップグレードする場合には、<xref linkend="release-9-3-15">を参照してください。
    </para>
 
   </sect2>
@@ -42,12 +64,17 @@
 
     <listitem>
      <para>
+<!--
       Fix a race condition that could cause indexes built
       with <command>CREATE INDEX CONCURRENTLY</> to be corrupt
       (Pavan Deolasee, Tom Lane)
+-->
+<command>CREATE INDEX CONCURRENTLY</>で作られたインデックスの破損をもたらす競合状態を修正しました。
+(Pavan Deolasee, Tom Lane)
      </para>
 
      <para>
+<!--
       If <command>CREATE INDEX CONCURRENTLY</> was used to build an index
       that depends on a column not previously indexed, then rows inserted
       or updated by transactions that ran concurrently with
@@ -55,127 +82,196 @@
       index entries.  If you suspect this may have happened, the most
       reliable solution is to rebuild affected indexes after installing
       this update.
+-->
+<command>CREATE INDEX CONCURRENTLY</>が前もってインデックスされていない列に依存するインデックスの作成に使われていたなら、<command>CREATE INDEX</>コマンドと同時実行するトランザクションにより挿入あるいは更新された行が誤ったインデックスエントリを受け入れるおそれがありました。
+この現象が生じた疑いがあるなら、最も確実な対応はアップデート実施後に影響をうけたインデックスを再作成することです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Unconditionally WAL-log creation of the <quote>init fork</> for an
       unlogged table (Michael Paquier)
+-->
+ログをとらないテーブルに対する<quote>init fork</>生成を無条件にWAL出力するようにしました。
+(Michael Paquier)
      </para>
 
      <para>
+<!--
       Previously, this was skipped when <xref linkend="guc-wal-level">
       = <literal>minimal</>, but actually it's necessary even in that case
       to ensure that the unlogged table is properly reset to empty after a
       crash.
+-->
+これまで<xref linkend="guc-wal-level"> = <literal>minimal</>のときには省略されていましたが、ログをとらないテーブルがクラッシュ後に適切に空に初期化されることを保証するために、実際にはその場合でも必要でした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       If the stats collector dies during hot standby, restart it (Takayuki
       Tsunakawa)
+-->
+統計情報コレクタがホットスタンバイ動作中に落ちたときに、それを再起動するようにしました。
+(Takayuki Tsunakawa)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that hot standby feedback works correctly when it's enabled at
       standby server start (Ants Aasma, Craig Ringer)
+-->
+ホットスタンバイフィードバックがスタンバイサーバ開始時に有効にされた場合に正しく動作するようにしました。
+(Ants Aasma, Craig Ringer)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Check for interrupts while hot standby is waiting for a conflicting
       query (Simon Riggs)
+-->
+ホットスタンバイが衝突する問い合わせを待機している間、割り込みを検査するようにしました。
+(Simon Riggs)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid constantly respawning the autovacuum launcher in a corner case
       (Amit Khandekar)
+-->
+稀な場合に絶えず自動バキュームランチャーが再生成されるのを回避しました。
+(Amit Khandekar)
      </para>
 
      <para>
+<!--
       This fix avoids problems when autovacuum is nominally off and there
       are some tables that require freezing, but all such tables are
       already being processed by autovacuum workers.
+-->
+この修正は自動バキュームが名目上offでいくつか凍結を要するテーブルがあるけれども全てのそのようなテーブルは既に自動バキュームワーカにより処理中である場合の問題を回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix check for when an extension member object can be dropped (Tom Lane)
+-->
+拡張のメンバオブジェクトが削除できるときのチェックを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Extension upgrade scripts should be able to drop member objects,
       but this was disallowed for serial-column sequences, and possibly
       other cases.
+-->
+拡張のアップグレードスクリプトはメンバオブジェクトを削除できなければいけませんが、serial列のシーケンスについてできませんでした。また、他の場合でもそうなる可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Make sure <command>ALTER TABLE</> preserves index tablespace
       assignments when rebuilding indexes (Tom Lane, Michael Paquier)
+-->
+インデックス再作成のときに<command>ALTER TABLE</>がインデックスのテーブル空間の割り当てを確実に維持するようにしました。
+(Tom Lane, Michael Paquier)
      </para>
 
      <para>
+<!--
       Previously, non-default settings
       of <xref linkend="guc-default-tablespace"> could result in broken
       indexes.
+-->
+これまでは<xref linkend="guc-default-tablespace">のデフォルト以外の設定によりインデックス破壊をもたらす可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent dropping a foreign-key constraint if there are pending
       trigger events for the referenced relation (Tom Lane)
+-->
+参照先リレーションに対する待機中トリガイベントがあるときに外部キー制約を削除しないようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This avoids <quote>could not find trigger <replaceable>NNN</></quote>
       or <quote>relation <replaceable>NNN</> has no triggers</quote> errors.
+-->
+これにより<quote>could not find trigger <replaceable>NNN</></quote>（トリガNNNが見つかりません）または<quote>relation <replaceable>NNN</> has no triggers</quote>（リレーションNNNにトリガがありません）というエラーを回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix processing of OID column when a table with OIDs is associated to
       a parent with OIDs via <command>ALTER TABLE ... INHERIT</> (Amit
       Langote)
+-->
+OIDを持つテーブルがOIDを持つ親テーブルと<command>ALTER TABLE ... INHERIT</>を通して関連づけられているときのOID列の処理を修正しました。
+(Amit Langote)
      </para>
 
      <para>
+<!--
       The OID column should be treated the same as regular user columns in
       this case, but it wasn't, leading to odd behavior in later
       inheritance changes.
+-->
+この場合、OID列は通常のユーザ列と同様に扱われるべきでしたが、そうなっておらず、後の継承の変更で奇妙な振る舞いをひき起こしていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Report correct object identity during <command>ALTER TEXT SEARCH
       CONFIGURATION</> (Artur Zakirov)
+-->
+<command>ALTER TEXT SEARCH CONFIGURATION</>のとき、正しいオブジェクト識別を報告するようにしました。
+(Artur Zakirov)
      </para>
 
      <para>
+<!--
       The wrong catalog OID was reported to extensions such as logical
       decoding.
+-->
+ロジカルデコーディングなどの拡張に誤ったカタログOIDが報告されていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Check for serializability conflicts before reporting
       constraint-violation failures (Thomas Munro)
+-->
+直列化可能かを、制約違反エラーを報告する前に検査するようにしました。
+(Thomas Munro)
      </para>
 
      <para>
+<!--
       When using serializable transaction isolation, it is desirable
       that any error due to concurrent transactions should manifest
       as a serialization failure, thereby cueing the application that
@@ -185,262 +281,409 @@
       serialization error if the application explicitly checked for
       the presence of a conflicting key (and did not find it) earlier
       in the transaction.
+-->
+シリアライザブルトランザクション隔離を使っているとき、同時トランザクションを原因とするいかなるエラーも直列化の失敗として表明するのが望ましく、それによりアプリケーションにリトライが成功するかもしれないという手がかりを与えます。
+残念ながら、キー重複の失敗が同時挿入で引き起こされた場合には、これは確実には生じません。
+本変更は、アプリケーションがトランザクションのより早くに明示的に競合するキーの存在をチェックした（そして見つからなかった）なら、このようなエラーが直列化のエラーとして報告されることを保証します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent multicolumn expansion of <replaceable>foo</><literal>.*</> in
       an <command>UPDATE</> source expression (Tom Lane)
+-->
+
+<command>UPDATE</>のソース式での<replaceable>foo</><literal>.*</>の複数列の展開を防止しました。
+(Tom Lane)
      </para>
 
      <para>
-      This led to <quote>UPDATE target count mismatch --- internal
+<!--
+      This led to <quote>UPDATE target count mismatch -&#045;- internal
       error</>.  Now the syntax is understood as a whole-row variable,
       as it would be in other contexts.
+-->
+これは<quote>UPDATE target count mismatch --- internal error</>（UPDATE対象数が不一致です --- 内部エラー）をもたらしました。
+これからは、この構文は他のコンテキストと同様に行全体の変数として解釈されます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that column typmods are determined accurately for
       multi-row <literal>VALUES</> constructs (Tom Lane)
+-->
+複数行の<literal>VALUES</>コンストラクトに対して列のtypemodが精密に決定されるようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fixes problems occurring when the first value in a column has a
       determinable typmod (e.g., length for a <type>varchar</> value) but
       later values don't share the same limit.
+-->
+これは、列の最初の値が決定可能なtypmod（例えば<type>varchar</>の長さ）を持つけれど続く値は同じ制限を共有しないときに発生する問題を修正します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Throw error for an unfinished Unicode surrogate pair at the end of a
       Unicode string (Tom Lane)
+-->
+ユニコード文字列の末尾における完結しないユニコードのサロゲートペアにエラーを出すようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Normally, a Unicode surrogate leading character must be followed by a
       Unicode surrogate trailing character, but the check for this was
       missed if the leading character was the last character in a Unicode
       string literal (<literal>U&amp;'...'</>) or Unicode identifier
       (<literal>U&amp;"..."</>).
+-->
+通常、ユニコードのサロゲート先頭文字にはユニコードのサロゲート末尾文字が続かなければなりませんが、先頭文字がユニコード文字列リテラル(<literal>U&amp;'...'</>)またはユニコード識別子(<literal>U&amp;"..."</>)の最後の文字である場合に、これについての検査が見逃されていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that a purely negative text search query, such
       as <literal>!foo</>, matches empty <type>tsvector</>s (Tom Dunstan)
+-->
+<literal>!foo</>のような純粋な否定のテキスト検索問い合わせが空の<type>tsvector</>にマッチするようにしました。
+(Tom Dunstan)
      </para>
 
      <para>
+<!--
       Such matches were found by GIN index searches, but not by sequential
       scans or GiST index searches.
+-->
+このようなマッチはGINインデックス検索では見つかりましたが、シーケンシャルスキャンやGiSTインデックススキャンでは見つかりませんでした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent crash when <function>ts_rewrite()</> replaces a non-top-level
       subtree with an empty query (Artur Zakirov)
+-->
+<function>ts_rewrite()</>が非トップレベルのサブツリーを空クエリで置き換えるときのクラッシュを、防止しました。
+(Artur Zakirov)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix performance problems in <function>ts_rewrite()</> (Tom Lane)
+-->
+<function>ts_rewrite()</>での性能問題を修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <function>ts_rewrite()</>'s handling of nested NOT operators
       (Tom Lane)
+-->
+<function>ts_rewrite()</>の入れ子NOT演算子の扱いを修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <function>array_fill()</> to handle empty arrays properly (Tom Lane)
+-->
+空配列を適切に扱うように<function>array_fill()</>を修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix one-byte buffer overrun in <function>quote_literal_cstr()</>
       (Heikki Linnakangas)
+-->
+<function>quote_literal_cstr()</>で1バイトのバッファオーバランを修正しました。
+(Heikki Linnakangas)
      </para>
 
      <para>
+<!--
       The overrun occurred only if the input consisted entirely of single
       quotes and/or backslashes.
+-->
+このオーバランは入力全体がのシングルクォートおよび/またはバックスラッシュで構成される場合でのみ発生します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent multiple calls of <function>pg_start_backup()</>
       and <function>pg_stop_backup()</> from running concurrently (Michael
       Paquier)
+-->
+<function>pg_start_backup()</>と<function>pg_stop_backup()</>の複数回の呼び出しが同時に実行されないようにしました。
+(Michael Paquier)
      </para>
 
      <para>
+<!--
       This avoids an assertion failure, and possibly worse things, if
       someone tries to run these functions in parallel.
+-->
+誰かがこれらの関数を並列に実行しようとしたときの、アサート失敗あるいはもっと悪い事態を回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid discarding <type>interval</>-to-<type>interval</> casts
       that aren't really no-ops (Tom Lane)
+-->
+実際にはノーオペレーションではない<type>interval</>から<type>interval</>へのキャストを捨てないようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       In some cases, a cast that should result in zeroing out
       low-order <type>interval</> fields was mistakenly deemed to be a
       no-op and discarded.  An example is that casting from <type>INTERVAL
       MONTH</> to <type>INTERVAL YEAR</> failed to clear the months field.
+-->
+一部の場合に下位の<type>interval</>フィールドのゼロ埋めした結果になるべきキャストが誤って何もしない処理と認識され、捨てられていました。
+一例は<type>INTERVAL MONTH</>から<type>INTERVAL YEAR</>へのキャストが月フィールドをクリアしないことです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that cached plans are invalidated by changes in foreign-table
       options (Amit Langote, Etsuro Fujita, Ashutosh Bapat)
+-->
+キャッシュされたプランが外部テーブルオプションの変更により確実に無効化されるようにしました。
+(Amit Langote, Etsuro Fujita, Ashutosh Bapat)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_dump</> to dump user-defined casts and transforms
       that use built-in functions (Stephen Frost)
+-->
+組み込み関数を使うユーザ定義キャストと変換をダンプするように<application>pg_dump</>を修正しました。
+(Stephen Frost)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible <application>pg_basebackup</> failure on standby
       server when including WAL files (Amit Kapila, Robert Haas)
+-->
+WALファイルを含めたときスタンバイサーバで起こりうる<application>pg_basebackup</>の失敗を修正しました。
+(Amit Kapila, Robert Haas)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that the Python exception objects we create for PL/Python are
       properly reference-counted (Rafa de la Torre, Tom Lane)
+-->
+PL/Pythonむけに作成したPython例外オブジェクトが確実に適切にリファレンスカウントされるようにしました。
+(Rafa de la Torre, Tom Lane)
      </para>
 
      <para>
+<!--
       This avoids failures if the objects are used after a Python garbage
       collection cycle has occurred.
+-->
+これはPythonのガーベージコレクションのサイクルが起きた後にオブジェクトが使われた場合の失敗を回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix PL/Tcl to support triggers on tables that have <literal>.tupno</>
       as a column name (Tom Lane)
+-->
+列名として<literal>.tupno</>を持つテーブルのトリガに対応するようにPL/Tclを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This matches the (previously undocumented) behavior of
       PL/Tcl's <command>spi_exec</> and <command>spi_execp</> commands,
       namely that a magic <literal>.tupno</> column is inserted only if
       there isn't a real column named that.
+-->
+これは（以前の文書化されていない）PL/Tclの<command>spi_exec</>および<command>spi_execp</>コマンドの振る舞いと調和させます。
+すなわち、<literal>.tupno</>マジック列はその名前の真の列が無い場合だけ挿入されます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Allow DOS-style line endings in <filename>~/.pgpass</> files,
       even on Unix (Vik Fearing)
+-->
+Unix上であってもDOS形式の改行文字が<filename>~/.pgpass</>ファイルで許されるようにしました。
+(Vik Fearing)
      </para>
 
      <para>
+<!--
       This change simplifies use of the same password file across Unix and
       Windows machines.
+-->
+この変更は同じパスワードファイルをUnixマシンとWindowsマシンとで使うのを簡単にします。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix one-byte buffer overrun if <application>ecpg</> is given a file
       name that ends with a dot (Takayuki Tsunakawa)
+-->
+<application>ecpg</>にドットで終わるファイル名が与えられた際の1バイトのバッファオーバランを修正しました。
+(Takayuki Tsunakawa)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>psql</>'s tab completion for <command>ALTER DEFAULT
       PRIVILEGES</> (Gilles Darold, Stephen Frost)
+-->
+<command>ALTER DEFAULT PRIVILEGES</>に対する<application>psql</>のタブ補完を修正しました。
+(Gilles Darold, Stephen Frost)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       In <application>psql</>, treat an empty or all-blank setting of
       the <envar>PAGER</> environment variable as meaning <quote>no
       pager</> (Tom Lane)
+-->
+<application>psql</>で、空または全てブランクの<envar>PAGER</>環境変数設定を<quote>ページャ無し</>という意味で扱うようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Previously, such a setting caused output intended for the pager to
       vanish entirely.
+-->
+これまでは、このような設定はページャにむけようとした出力を全く見えなくしていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Improve <filename>contrib/dblink</>'s reporting of
       low-level <application>libpq</> errors, such as out-of-memory
       (Joe Conway)
+-->
+<filename>contrib/dblink</>のメモリ不足などの低レベル<application>libpq</>エラーの報告を改善しました。
+(Joe Conway)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Teach <filename>contrib/dblink</> to ignore irrelevant server options
       when it uses a <filename>contrib/postgres_fdw</> foreign server as
       the source of connection options (Corey Huinker)
+-->
+接続オプションのソースとして<filename>contrib/postgres_fdw</>外部サーバを使うとき、<filename>contrib/dblink</>に無関係なサーバオプションを無視させました。
+(Corey Huinker)
      </para>
 
      <para>
+<!--
       Previously, if the foreign server object had options that were not
       also <application>libpq</> connection options, an error occurred.
+-->
+これまでは、外部サーバオブジェクトが<application>libpq</>接続オプションでは無いオプションを持っているなら、エラーが生じました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       On Windows, ensure that environment variable changes are propagated
       to DLLs built with debug options (Christian Ullrich)
+-->
+Windowsで環境変数の変更がデバッグオプションを有効にしてビルドされたDLLに確実に伝播するようにしました。
+(Christian Ullrich)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Sync our copy of the timezone library with IANA release tzcode2016j
       (Tom Lane)
+-->
+タイムゾーンライブラリをIANA release tzcode2016jに同期しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fixes various issues, most notably that timezone data
       installation failed if the target directory didn't support hard
       links.
+-->
+多数の問題が修正されており、最も重要なものとしては対象ディレクトリがハードリンクをサポートしない場合はタイムゾーンデータ導入に失敗していたことがあります。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Update time zone data files to <application>tzdata</> release 2016j
       for DST law changes in northern Cyprus (adding a new zone
       Asia/Famagusta), Russia (adding a new zone Europe/Saratov), Tonga,
       and Antarctica/Casey.
       Historical corrections for Italy, Kazakhstan, Malta, and Palestine.
       Switch to preferring numeric zone abbreviations for Tonga.
+-->
+タイムゾーンデータを<application>tzdata</> release 2016jに更新しました。
+北キプロス（新タイムゾーン Asia/Famagusta 追加）、ロシア（新タイムゾーン Europe/Saratov 追加）、トンガ、Antarctica/Casey における夏時間法の変更と、イタリア、カザフスタン、マルタ、パレスチナにおける歴史的修正、トンガにおける数値によるゾーン略記法を選択する変更が含まれます。 
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.4.sgml
+++ b/doc/src/sgml/release-9.4.sgml
@@ -2,51 +2,81 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-4-11">
+<!--
   <title>Release 9.4.11</title>
+-->
+  <title>リリース9.4.11</title>
 
   <note>
+<!--
   <title>Release Date</title>
+-->
+  <title>リリース日</title>
   <simpara>2017-02-09</simpara>
   </note>
 
   <para>
+<!--
    This release contains a variety of fixes from 9.4.10.
    For information about new features in the 9.4 major release, see
    <xref linkend="release-9-4">.
+-->
+このリリースは9.4.10に対し、各種不具合を修正したものです。
+9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">を参照してください。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.4.11</title>
+-->
+   <title>バージョン9.4.11への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.4.X.
+-->
+9.4.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if your installation has been affected by the bug described in
     the first changelog entry below, then after updating you may need
     to take action to repair corrupted indexes.
+-->
+しかしながら、インストレーションが下記変更点の最初の項目に書かれたバグの影響を受けている場合には、アップデート後に壊れたインデックスを修復する作業が必要になるでしょう。
    </para>
 
    <para>
+<!--
     Also, if you are upgrading from a version earlier than 9.4.10,
     see <xref linkend="release-9-4-10">.
+-->
+また、9.4.10よりも前のリリースからアップグレードする場合は、<xref linkend="release-9-4-10">を参照して下さい。
    </para>
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Fix a race condition that could cause indexes built
       with <command>CREATE INDEX CONCURRENTLY</> to be corrupt
       (Pavan Deolasee, Tom Lane)
+-->
+<command>CREATE INDEX CONCURRENTLY</>で作られたインデックスの破損をもたらす競合状態を修正しました。
+(Pavan Deolasee, Tom Lane)
      </para>
 
      <para>
+<!--
       If <command>CREATE INDEX CONCURRENTLY</> was used to build an index
       that depends on a column not previously indexed, then rows inserted
       or updated by transactions that ran concurrently with
@@ -54,34 +84,52 @@
       index entries.  If you suspect this may have happened, the most
       reliable solution is to rebuild affected indexes after installing
       this update.
+-->
+<command>CREATE INDEX CONCURRENTLY</>が前もってインデックスされていない列に依存するインデックスの作成に使われていたなら、<command>CREATE INDEX</>コマンドと同時実行するトランザクションにより挿入あるいは更新された行が誤ったインデックスエントリを受け入れるおそれがありました。
+この現象が生じた疑いがあるなら、最も確実な対応はアップデート実施後に影響をうけたインデックスを再作成することです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that the special snapshot used for catalog scans is not
       invalidated by premature data pruning (Tom Lane)
+-->
+カタログのスキャンに使われる特別なスナップショットが早すぎるデータ除去処理により無効化されないようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Backends failed to account for this snapshot when advertising their
       oldest xmin, potentially allowing concurrent vacuuming operations to
       remove data that was still needed.  This led to transient failures
       along the lines of <quote>cache lookup failed for relation 1255</>.
+-->
+バックエンドが自身の最も古いxminを知らせるときにこのスナップショットを考慮しておらず、潜在的に同時実行のバキューム操作が未だ必要なデータを削除するのを許していました。 
+これは<quote>cache lookup failed for relation 1255</>（リレーション1255のキャッシュ検索に失敗しました）という一時的なエラーをもたらしていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Unconditionally WAL-log creation of the <quote>init fork</> for an
       unlogged table (Michael Paquier)
+-->
+ログをとらないテーブルに対する<quote>init fork</>生成を無条件にWAL出力するようにしました。
+(Michael Paquier)
      </para>
 
      <para>
+<!--
       Previously, this was skipped when <xref linkend="guc-wal-level">
       = <literal>minimal</>, but actually it's necessary even in that case
       to ensure that the unlogged table is properly reset to empty after a
       crash.
+-->
+これまで<xref linkend="guc-wal-level"> = <literal>minimal</>のときには省略されていましたが、ログをとらないテーブルがクラッシュ後に適切に空に初期化されることを保証するために、実際にはその場合でも必要でした。
      </para>
     </listitem>
 
@@ -99,133 +147,206 @@
 
     <listitem>
      <para>
+<!--
       If the stats collector dies during hot standby, restart it (Takayuki
       Tsunakawa)
+-->
+統計情報コレクタがホットスタンバイ動作中に落ちたときに、それを再起動するようにしました。
+(Takayuki Tsunakawa)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that hot standby feedback works correctly when it's enabled at
       standby server start (Ants Aasma, Craig Ringer)
+-->
+ホットスタンバイフィードバックがスタンバイサーバ開始時に有効にされた場合に正しく動作するようにしました。
+(Ants Aasma, Craig Ringer)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Check for interrupts while hot standby is waiting for a conflicting
       query (Simon Riggs)
+-->
+ホットスタンバイが衝突する問い合わせを待機している間、割り込みを検査するようにしました。
+(Simon Riggs)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid constantly respawning the autovacuum launcher in a corner case
       (Amit Khandekar)
+-->
+稀な場合に絶えず自動バキュームランチャーが再生成されるのを回避しました。
+(Amit Khandekar)
      </para>
 
      <para>
+<!--
       This fix avoids problems when autovacuum is nominally off and there
       are some tables that require freezing, but all such tables are
       already being processed by autovacuum workers.
+-->
+この修正は自動バキュームが名目上offでいくつか凍結を要するテーブルがあるけれども全てのそのようなテーブルは既に自動バキュームワーカにより処理中である場合の問題を回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix check for when an extension member object can be dropped (Tom Lane)
+-->
+拡張のメンバオブジェクトが削除できるときのチェックを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Extension upgrade scripts should be able to drop member objects,
       but this was disallowed for serial-column sequences, and possibly
       other cases.
+-->
+拡張のアップグレードスクリプトはメンバオブジェクトを削除できなければいけませんが、serial列のシーケンスについてできませんでした。また、他の場合でもそうなる可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Make sure <command>ALTER TABLE</> preserves index tablespace
       assignments when rebuilding indexes (Tom Lane, Michael Paquier)
+-->
+インデックス再作成のときに<command>ALTER TABLE</>がインデックスのテーブル空間の割り当てを確実に維持するようにしました。
+(Tom Lane, Michael Paquier)
      </para>
 
      <para>
+<!--
       Previously, non-default settings
       of <xref linkend="guc-default-tablespace"> could result in broken
       indexes.
+-->
+これまでは<xref linkend="guc-default-tablespace">のデフォルト以外の設定によりインデックス破壊をもたらす可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect updating of trigger function properties when changing a
       foreign-key constraint's deferrability properties with <command>ALTER
       TABLE ... ALTER CONSTRAINT</> (Tom Lane)
+-->
+<command>ALTER TABLE ... ALTER CONSTRAINT</>で外部キー制約の遅延可能性属性を変更するときのトリガ関数属性の誤った更新を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This led to odd failures during subsequent exercise of the foreign
       key, as the triggers were fired at the wrong times.
+-->
+これは、その後に外部キーを使用する際にトリガが間違ったタイミングで発動することで奇妙なエラーをもたらしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent dropping a foreign-key constraint if there are pending
       trigger events for the referenced relation (Tom Lane)
+-->
+参照先リレーションに対する待機中トリガイベントがあるときに外部キー制約を削除しないようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This avoids <quote>could not find trigger <replaceable>NNN</></quote>
       or <quote>relation <replaceable>NNN</> has no triggers</quote> errors.
+-->
+これにより<quote>could not find trigger <replaceable>NNN</></quote>（トリガNNNが見つかりません）または<quote>relation <replaceable>NNN</> has no triggers</quote>（リレーションNNNにトリガがありません）というエラーを回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix processing of OID column when a table with OIDs is associated to
       a parent with OIDs via <command>ALTER TABLE ... INHERIT</> (Amit
       Langote)
+-->
+OIDを持つテーブルがOIDを持つ親テーブルと<command>ALTER TABLE ... INHERIT</>を通して関連づけられているときのOID列の処理を修正しました。
+(Amit Langote)
      </para>
 
      <para>
+<!--
       The OID column should be treated the same as regular user columns in
       this case, but it wasn't, leading to odd behavior in later
       inheritance changes.
+-->
+この場合、OID列は通常のユーザ列と同様に扱われるべきでしたが、そうなっておらず、後の継承の変更で奇妙な振る舞いをひき起こしていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <command>CREATE OR REPLACE VIEW</> to update the view query
       before attempting to apply the new view options (Dean Rasheed)
+-->
+新たなビューオプションを適用しようとする前にビュー問い合わせを更新するように<command>CREATE OR REPLACE VIEW</>を修正しました。
+(Dean Rasheed)
      </para>
 
      <para>
+<!--
       Previously the command would fail if the new options were
       inconsistent with the old view definition.
+-->
+これまでは新たなオプションが古いビュー定義と矛盾するときにコマンドが失敗していました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Report correct object identity during <command>ALTER TEXT SEARCH
       CONFIGURATION</> (Artur Zakirov)
+-->
+<command>ALTER TEXT SEARCH CONFIGURATION</>のとき、正しいオブジェクト識別を報告するようにしました。
+(Artur Zakirov)
      </para>
 
      <para>
+<!--
       The wrong catalog OID was reported to extensions such as logical
       decoding.
+-->
+ロジカルデコーディングなどの拡張に誤ったカタログOIDが報告されていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Check for serializability conflicts before reporting
       constraint-violation failures (Thomas Munro)
+-->
+直列化可能かを、制約違反エラーを報告する前に検査するようにしました。
+(Thomas Munro)
      </para>
 
      <para>
+<!--
       When using serializable transaction isolation, it is desirable
       that any error due to concurrent transactions should manifest
       as a serialization failure, thereby cueing the application that
@@ -235,297 +356,462 @@
       serialization error if the application explicitly checked for
       the presence of a conflicting key (and did not find it) earlier
       in the transaction.
+-->
+シリアライザブルトランザクション隔離を使っているとき、同時トランザクションを原因とするいかなるエラーも直列化の失敗として表明するのが望ましく、それによりアプリケーションにリトライが成功するかもしれないという手がかりを与えます。
+残念ながら、キー重複の失敗が同時挿入で引き起こされた場合には、これは確実には生じません。
+本変更は、アプリケーションがトランザクションのより早くに明示的に競合するキーの存在をチェックした（そして見つからなかった）なら、このようなエラーが直列化のエラーとして報告されることを保証します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent multicolumn expansion of <replaceable>foo</><literal>.*</> in
       an <command>UPDATE</> source expression (Tom Lane)
+-->
+
+<command>UPDATE</>のソース式での<replaceable>foo</><literal>.*</>の複数列の展開を防止しました。
+(Tom Lane)
      </para>
 
      <para>
-      This led to <quote>UPDATE target count mismatch --- internal
+<!--
+      This led to <quote>UPDATE target count mismatch -&#045;- internal
       error</>.  Now the syntax is understood as a whole-row variable,
       as it would be in other contexts.
+-->
+これは<quote>UPDATE target count mismatch --- internal error</>（UPDATE対象数が不一致です --- 内部エラー）をもたらしました。
+これからは、この構文は他のコンテキストと同様に行全体の変数として解釈されます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that column typmods are determined accurately for
       multi-row <literal>VALUES</> constructs (Tom Lane)
+-->
+複数行の<literal>VALUES</>コンストラクトに対して列のtypemodが精密に決定されるようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fixes problems occurring when the first value in a column has a
       determinable typmod (e.g., length for a <type>varchar</> value) but
       later values don't share the same limit.
+-->
+これは、列の最初の値が決定可能なtypmod（例えば<type>varchar</>の長さ）を持つけれど続く値は同じ制限を共有しないときに発生する問題を修正します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Throw error for an unfinished Unicode surrogate pair at the end of a
       Unicode string (Tom Lane)
+-->
+ユニコード文字列の末尾における完結しないユニコードのサロゲートペアにエラーを出すようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Normally, a Unicode surrogate leading character must be followed by a
       Unicode surrogate trailing character, but the check for this was
       missed if the leading character was the last character in a Unicode
       string literal (<literal>U&amp;'...'</>) or Unicode identifier
       (<literal>U&amp;"..."</>).
+-->
+通常、ユニコードのサロゲート先頭文字にはユニコードのサロゲート末尾文字が続かなければなりませんが、先頭文字がユニコード文字列リテラル(<literal>U&amp;'...'</>)またはユニコード識別子(<literal>U&amp;"..."</>)の最後の文字である場合に、これについての検査が見逃されていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that a purely negative text search query, such
       as <literal>!foo</>, matches empty <type>tsvector</>s (Tom Dunstan)
+-->
+<literal>!foo</>のような純粋な否定のテキスト検索問い合わせが空の<type>tsvector</>にマッチするようにしました。
+(Tom Dunstan)
      </para>
 
      <para>
+<!--
       Such matches were found by GIN index searches, but not by sequential
       scans or GiST index searches.
+-->
+このようなマッチはGINインデックス検索では見つかりましたが、シーケンシャルスキャンやGiSTインデックススキャンでは見つかりませんでした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent crash when <function>ts_rewrite()</> replaces a non-top-level
       subtree with an empty query (Artur Zakirov)
+-->
+<function>ts_rewrite()</>が非トップレベルのサブツリーを空クエリで置き換えるときのクラッシュを、防止しました。
+(Artur Zakirov)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix performance problems in <function>ts_rewrite()</> (Tom Lane)
+-->
+<function>ts_rewrite()</>での性能問題を修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <function>ts_rewrite()</>'s handling of nested NOT operators
       (Tom Lane)
+-->
+<function>ts_rewrite()</>の入れ子NOT演算子の扱いを修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <function>array_fill()</> to handle empty arrays properly (Tom Lane)
+-->
+空配列を適切に扱うように<function>array_fill()</>を修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix one-byte buffer overrun in <function>quote_literal_cstr()</>
       (Heikki Linnakangas)
+-->
+<function>quote_literal_cstr()</>で1バイトのバッファオーバランを修正しました。
+(Heikki Linnakangas)
      </para>
 
      <para>
+<!--
       The overrun occurred only if the input consisted entirely of single
       quotes and/or backslashes.
+-->
+このオーバランは入力全体がのシングルクォートおよび/またはバックスラッシュで構成される場合でのみ発生します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent multiple calls of <function>pg_start_backup()</>
       and <function>pg_stop_backup()</> from running concurrently (Michael
       Paquier)
+-->
+<function>pg_start_backup()</>と<function>pg_stop_backup()</>の複数回の呼び出しが同時に実行されないようにしました。
+(Michael Paquier)
      </para>
 
      <para>
+<!--
       This avoids an assertion failure, and possibly worse things, if
       someone tries to run these functions in parallel.
+-->
+誰かがこれらの関数を並列に実行しようとしたときの、アサート失敗あるいはもっと悪い事態を回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid discarding <type>interval</>-to-<type>interval</> casts
       that aren't really no-ops (Tom Lane)
+-->
+実際にはノーオペレーションではない<type>interval</>から<type>interval</>へのキャストを捨てないようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       In some cases, a cast that should result in zeroing out
       low-order <type>interval</> fields was mistakenly deemed to be a
       no-op and discarded.  An example is that casting from <type>INTERVAL
       MONTH</> to <type>INTERVAL YEAR</> failed to clear the months field.
+-->
+一部の場合に下位の<type>interval</>フィールドのゼロ埋めした結果になるべきキャストが誤って何もしない処理と認識され、捨てられていました。
+一例は<type>INTERVAL MONTH</>から<type>INTERVAL YEAR</>へのキャストが月フィールドをクリアしないことです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that cached plans are invalidated by changes in foreign-table
       options (Amit Langote, Etsuro Fujita, Ashutosh Bapat)
+-->
+キャッシュされたプランが外部テーブルオプションの変更により確実に無効化されるようにしました。
+(Amit Langote, Etsuro Fujita, Ashutosh Bapat)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_dump</> to dump user-defined casts and transforms
       that use built-in functions (Stephen Frost)
+-->
+組み込み関数を使うユーザ定義キャストと変換をダンプするように<application>pg_dump</>を修正しました。
+(Stephen Frost)
      </para>
     </listitem>
 
     <listitem>
      <para>
-      Fix <application>pg_restore</> with <option>--create --if-exists</>
+<!--
+      Fix <application>pg_restore</> with <option>&#045;-create &#045;-if-exists</>
       to behave more sanely if an archive contains
       unrecognized <command>DROP</> commands (Tom Lane)
+-->
+アーカイブが認識できない<command>DROP</>コマンドを含む場合に<option>--create --if-exists</>を伴う<application>pg_restore</>をより分別のある振る舞いをするように修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This doesn't fix any live bug, but it may improve the behavior in
       future if <application>pg_restore</> is used with an archive
       generated by a later <application>pg_dump</> version.
+-->
+これは今あるバグを修正するわけではありませんが、将来<application>pg_restore</>が、後の<application>pg_dump</>バージョンで生成されたアーカイブに使用する場合の振る舞いを改善すると考えられます。 
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_basebackup</>'s rate limiting in the presence of
       slow I/O (Antonin Houska)
+-->
+遅いI/Oがある中での<application>pg_basebackup</>のレート制限を修正しました。
+(Antonin Houska)
      </para>
 
      <para>
+<!--
       If disk I/O was transiently much slower than the specified rate
       limit, the calculation overflowed, effectively disabling the rate
       limit for the rest of the run.
+-->
+ディスクI/Oが一時的に指定されたレート制限よりも非常に遅い場合、計算がオーバーフローして、残りの実行に対してレート制限が事実上使えませんでした。 
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_basebackup</>'s handling of
       symlinked <filename>pg_stat_tmp</> and <filename>pg_replslot</>
       subdirectories (Magnus Hagander, Michael Paquier)
+-->
+<application>pg_basebackup</>のシンボリックリンクされたサブディレクトリ<filename>pg_stat_tmp</>および<filename>pg_replslot</>の扱いが修正されました。
+(Magnus Hagander, Michael Paquier)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible <application>pg_basebackup</> failure on standby
       server when including WAL files (Amit Kapila, Robert Haas)
+-->
+WALファイルを含めたときスタンバイサーバで起こりうる<application>pg_basebackup</>の失敗を修正しました。
+(Amit Kapila, Robert Haas)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that the Python exception objects we create for PL/Python are
       properly reference-counted (Rafa de la Torre, Tom Lane)
+-->
+PL/Pythonむけに作成したPython例外オブジェクトが確実に適切にリファレンスカウントされるようにしました。
+(Rafa de la Torre, Tom Lane)
      </para>
 
      <para>
+<!--
       This avoids failures if the objects are used after a Python garbage
       collection cycle has occurred.
+-->
+これはPythonのガーベージコレクションのサイクルが起きた後にオブジェクトが使われた場合の失敗を回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix PL/Tcl to support triggers on tables that have <literal>.tupno</>
       as a column name (Tom Lane)
+-->
+列名として<literal>.tupno</>を持つテーブルのトリガに対応するようにPL/Tclを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This matches the (previously undocumented) behavior of
       PL/Tcl's <command>spi_exec</> and <command>spi_execp</> commands,
       namely that a magic <literal>.tupno</> column is inserted only if
       there isn't a real column named that.
+-->
+これは（以前の文書化されていない）PL/Tclの<command>spi_exec</>および<command>spi_execp</>コマンドの振る舞いと調和させます。
+すなわち、<literal>.tupno</>マジック列はその名前の真の列が無い場合だけ挿入されます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Allow DOS-style line endings in <filename>~/.pgpass</> files,
       even on Unix (Vik Fearing)
+-->
+Unix上であってもDOS形式の改行文字が<filename>~/.pgpass</>ファイルで許されるようにしました。
+(Vik Fearing)
      </para>
 
      <para>
+<!--
       This change simplifies use of the same password file across Unix and
       Windows machines.
+-->
+この変更は同じパスワードファイルをUnixマシンとWindowsマシンとで使うのを簡単にします。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix one-byte buffer overrun if <application>ecpg</> is given a file
       name that ends with a dot (Takayuki Tsunakawa)
+-->
+<application>ecpg</>にドットで終わるファイル名が与えられた際の1バイトのバッファオーバランを修正しました。
+(Takayuki Tsunakawa)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>psql</>'s tab completion for <command>ALTER DEFAULT
       PRIVILEGES</> (Gilles Darold, Stephen Frost)
+-->
+<command>ALTER DEFAULT PRIVILEGES</>に対する<application>psql</>のタブ補完を修正しました。
+(Gilles Darold, Stephen Frost)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       In <application>psql</>, treat an empty or all-blank setting of
       the <envar>PAGER</> environment variable as meaning <quote>no
       pager</> (Tom Lane)
+-->
+<application>psql</>で、空または全てブランクの<envar>PAGER</>環境変数設定を<quote>ページャ無し</>という意味で扱うようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Previously, such a setting caused output intended for the pager to
       vanish entirely.
+-->
+これまでは、このような設定はページャにむけようとした出力を全く見えなくしていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Improve <filename>contrib/dblink</>'s reporting of
       low-level <application>libpq</> errors, such as out-of-memory
       (Joe Conway)
+-->
+<filename>contrib/dblink</>のメモリ不足などの低レベル<application>libpq</>エラーの報告を改善しました。
+(Joe Conway)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Teach <filename>contrib/dblink</> to ignore irrelevant server options
       when it uses a <filename>contrib/postgres_fdw</> foreign server as
       the source of connection options (Corey Huinker)
+-->
+接続オプションのソースとして<filename>contrib/postgres_fdw</>外部サーバを使うとき、<filename>contrib/dblink</>に無関係なサーバオプションを無視させました。
+(Corey Huinker)
      </para>
 
      <para>
+<!--
       Previously, if the foreign server object had options that were not
       also <application>libpq</> connection options, an error occurred.
+-->
+これまでは、外部サーバオブジェクトが<application>libpq</>接続オプションでは無いオプションを持っているなら、エラーが生じました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       On Windows, ensure that environment variable changes are propagated
       to DLLs built with debug options (Christian Ullrich)
+-->
+Windowsで環境変数の変更がデバッグオプションを有効にしてビルドされたDLLに確実に伝播するようにしました。
+(Christian Ullrich)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Sync our copy of the timezone library with IANA release tzcode2016j
       (Tom Lane)
+-->
+タイムゾーンライブラリをIANA release tzcode2016jに同期しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fixes various issues, most notably that timezone data
       installation failed if the target directory didn't support hard
       links.
+-->
+多数の問題が修正されており、最も重要なものとしては対象ディレクトリがハードリンクをサポートしない場合はタイムゾーンデータ導入に失敗していたことがあります。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Update time zone data files to <application>tzdata</> release 2016j
       for DST law changes in northern Cyprus (adding a new zone
       Asia/Famagusta), Russia (adding a new zone Europe/Saratov), Tonga,
       and Antarctica/Casey.
       Historical corrections for Italy, Kazakhstan, Malta, and Palestine.
       Switch to preferring numeric zone abbreviations for Tonga.
+-->
+タイムゾーンデータを<application>tzdata</> release 2016jに更新しました。
+北キプロス（新タイムゾーン Asia/Famagusta 追加）、ロシア（新タイムゾーン Europe/Saratov 追加）、トンガ、Antarctica/Casey における夏時間法の変更と、イタリア、カザフスタン、マルタ、パレスチナにおける歴史的修正、トンガにおける数値によるゾーン略記法を選択する変更が含まれます。 
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.5.sgml
+++ b/doc/src/sgml/release-9.5.sgml
@@ -2,51 +2,81 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-5-6">
+<!--
   <title>Release 9.5.6</title>
+-->
+  <title>リリース9.5.5</title>
 
   <note>
+<!--
   <title>Release Date</title>
+-->
+  <title>リリース日</title>
   <simpara>2017-02-09</simpara>
   </note>
 
   <para>
+<!--
    This release contains a variety of fixes from 9.5.5.
    For information about new features in the 9.5 major release, see
    <xref linkend="release-9-5">.
+-->
+このリリースは9.5.5に対し、各種不具合を修正したものです。
+9.5メジャーリリースにおける新機能については、<xref linkend="release-9-5">を参照してください。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.5.6</title>
+-->
+   <title>バージョン9.5.6への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.5.X.
+-->
+9.5.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if your installation has been affected by the bug described in
     the first changelog entry below, then after updating you may need
     to take action to repair corrupted indexes.
+-->
+しかしながら、インストレーションが下記変更点の最初の項目に書かれたバグの影響を受けている場合には、アップデート後に壊れたインデックスを修復する作業が必要になるでしょう。
    </para>
 
    <para>
+<!--
     Also, if you are upgrading from a version earlier than 9.5.5,
     see <xref linkend="release-9-5-5">.
+-->
+また、9.5.5よりも前のリリースからアップグレードする場合は、<xref linkend="release-9-5-5">を参照して下さい。
    </para>
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Fix a race condition that could cause indexes built
       with <command>CREATE INDEX CONCURRENTLY</> to be corrupt
       (Pavan Deolasee, Tom Lane)
+-->
+<command>CREATE INDEX CONCURRENTLY</>で作られたインデックスの破損をもたらす競合状態を修正しました。
+(Pavan Deolasee, Tom Lane)
      </para>
 
      <para>
+<!--
       If <command>CREATE INDEX CONCURRENTLY</> was used to build an index
       that depends on a column not previously indexed, then rows inserted
       or updated by transactions that ran concurrently with
@@ -54,46 +84,72 @@
       index entries.  If you suspect this may have happened, the most
       reliable solution is to rebuild affected indexes after installing
       this update.
+-->
+<command>CREATE INDEX CONCURRENTLY</>が前もってインデックスされていない列に依存するインデックスの作成に使われていたなら、<command>CREATE INDEX</>コマンドと同時実行するトランザクションにより挿入あるいは更新された行が誤ったインデックスエントリを受け入れるおそれがありました。
+この現象が生じた疑いがあるなら、最も確実な対応はアップデート実施後に影響をうけたインデックスを再作成することです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that the special snapshot used for catalog scans is not
       invalidated by premature data pruning (Tom Lane)
+-->
+カタログのスキャンに使われる特別なスナップショットが早すぎるデータ除去処理により無効化されないようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Backends failed to account for this snapshot when advertising their
       oldest xmin, potentially allowing concurrent vacuuming operations to
       remove data that was still needed.  This led to transient failures
       along the lines of <quote>cache lookup failed for relation 1255</>.
+-->
+バックエンドが自身の最も古いxminを知らせるときにこのスナップショットを考慮しておらず、潜在的に同時実行のバキューム操作が未だ必要なデータを削除するのを許していました。 
+これは<quote>cache lookup failed for relation 1255</>（リレーション1255のキャッシュ検索に失敗しました）という一時的なエラーをもたらしていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect WAL logging for BRIN indexes (Kuntal Ghosh)
+-->
+BRINインデックスの誤ったWALログ出力を修正しました。
+(Kuntal Ghosh)
      </para>
 
      <para>
+<!--
       The WAL record emitted for a BRIN <quote>revmap</> page when moving an
       index tuple to a different page was incorrect.  Replay would make the
       related portion of the index useless, forcing it to be recomputed.
+-->
+インデックスタプルを異なるページに移動するときにBRINの<quote>revmap</>ページに対して出力されるWALレコードが誤っていました。
+リプレイでインデックスの関連する部分が使えなくなり、再計算を強いられるでしょう。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Unconditionally WAL-log creation of the <quote>init fork</> for an
       unlogged table (Michael Paquier)
+-->
+ログをとらないテーブルに対する<quote>init fork</>生成を無条件にWAL出力するようにしました。
+(Michael Paquier)
      </para>
 
      <para>
+<!--
       Previously, this was skipped when <xref linkend="guc-wal-level">
       = <literal>minimal</>, but actually it's necessary even in that case
       to ensure that the unlogged table is properly reset to empty after a
       crash.
+-->
+これまで<xref linkend="guc-wal-level"> = <literal>minimal</>のときには省略されていましたが、ログをとらないテーブルがクラッシュ後に適切に空に初期化されることを保証するために、実際にはその場合でも必要でした。
      </para>
     </listitem>
 
@@ -104,157 +160,244 @@ Branch: REL9_5_STABLE [c0db1ec26] 2016-11-17 13:31:30 -0300
 Branch: REL9_4_STABLE [30e3cb307] 2016-11-17 13:31:30 -0300
 -->
      <para>
+<!--
       Reduce interlocking on standby servers during the replay of btree
       index vacuuming operations (Simon Riggs)
+-->
+Btreeインデックスのバキューム操作の再生中のスタンバイサーバ上のインターロックを減らしました。
+(Simon Riggs)
      </para>
 
      <para>
+<!--
       This change avoids substantial replication delays that sometimes
       occurred while replaying such operations.
+-->
+この変更はこのような操作の再生で時々発生するかなりのレプリケーション遅延を回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       If the stats collector dies during hot standby, restart it (Takayuki
       Tsunakawa)
+-->
+統計情報コレクタがホットスタンバイ動作中に落ちたときに、それを再起動するようにしました。
+(Takayuki Tsunakawa)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that hot standby feedback works correctly when it's enabled at
       standby server start (Ants Aasma, Craig Ringer)
+-->
+ホットスタンバイフィードバックがスタンバイサーバ開始時に有効にされた場合に正しく動作するようにしました。
+(Ants Aasma, Craig Ringer)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Check for interrupts while hot standby is waiting for a conflicting
       query (Simon Riggs)
+-->
+ホットスタンバイが衝突する問い合わせを待機している間、割り込みを検査するようにしました。
+(Simon Riggs)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid constantly respawning the autovacuum launcher in a corner case
       (Amit Khandekar)
+-->
+稀な場合に絶えず自動バキュームランチャーが再生成されるのを回避しました。
+(Amit Khandekar)
      </para>
 
      <para>
+<!--
       This fix avoids problems when autovacuum is nominally off and there
       are some tables that require freezing, but all such tables are
       already being processed by autovacuum workers.
+-->
+この修正は自動バキュームが名目上offでいくつか凍結を要するテーブルがあるけれども全てのそのようなテーブルは既に自動バキュームワーカにより処理中である場合の問題を回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix check for when an extension member object can be dropped (Tom Lane)
+-->
+拡張のメンバオブジェクトが削除できるときのチェックを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Extension upgrade scripts should be able to drop member objects,
       but this was disallowed for serial-column sequences, and possibly
       other cases.
+-->
+拡張のアップグレードスクリプトはメンバオブジェクトを削除できなければいけませんが、serial列のシーケンスについてできませんでした。また、他の場合でもそうなる可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Make sure <command>ALTER TABLE</> preserves index tablespace
       assignments when rebuilding indexes (Tom Lane, Michael Paquier)
+-->
+インデックス再作成のときに<command>ALTER TABLE</>がインデックスのテーブル空間の割り当てを確実に維持するようにしました。
+(Tom Lane, Michael Paquier)
      </para>
 
      <para>
+<!--
       Previously, non-default settings
       of <xref linkend="guc-default-tablespace"> could result in broken
       indexes.
+-->
+これまでは<xref linkend="guc-default-tablespace">のデフォルト以外の設定によりインデックス破壊をもたらす可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect updating of trigger function properties when changing a
       foreign-key constraint's deferrability properties with <command>ALTER
       TABLE ... ALTER CONSTRAINT</> (Tom Lane)
+-->
+<command>ALTER TABLE ... ALTER CONSTRAINT</>で外部キー制約の遅延可能性属性を変更するときのトリガ関数属性の誤った更新を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This led to odd failures during subsequent exercise of the foreign
       key, as the triggers were fired at the wrong times.
+-->
+これは、その後に外部キーを使用する際にトリガが間違ったタイミングで発動することで奇妙なエラーをもたらしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent dropping a foreign-key constraint if there are pending
       trigger events for the referenced relation (Tom Lane)
+-->
+参照先リレーションに対する待機中トリガイベントがあるときに外部キー制約を削除しないようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This avoids <quote>could not find trigger <replaceable>NNN</></quote>
       or <quote>relation <replaceable>NNN</> has no triggers</quote> errors.
+-->
+これにより<quote>could not find trigger <replaceable>NNN</></quote>（トリガNNNが見つかりません）または<quote>relation <replaceable>NNN</> has no triggers</quote>（リレーションNNNにトリガがありません）というエラーを回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <command>ALTER TABLE ... SET DATA TYPE ... USING</> when child
       table has different column ordering than the parent
       (&Aacute;lvaro Herrera)
+-->
+子テーブルが親テーブルとは異なる列の順序を持つときの<command>ALTER TABLE ... SET DATA TYPE ... USING</>を修正しました。
+(&Aacute;lvaro Herrera)
      </para>
 
      <para>
+<!--
       Failure to adjust the column numbering in the <literal>USING</>
       expression led to errors,
       typically <quote>attribute <replaceable>N</> has wrong type</quote>.
+-->
+<literal>USING</>式で列の番号付けの調整に失敗して、エラーをもたらしました。
+典型的には<quote>attribute <replaceable>N</> has wrong type</quote>（属性Nの型が間違っています）です。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix processing of OID column when a table with OIDs is associated to
       a parent with OIDs via <command>ALTER TABLE ... INHERIT</> (Amit
       Langote)
+-->
+OIDを持つテーブルがOIDを持つ親テーブルと<command>ALTER TABLE ... INHERIT</>を通して関連づけられているときのOID列の処理を修正しました。
+(Amit Langote)
      </para>
 
      <para>
+<!--
       The OID column should be treated the same as regular user columns in
       this case, but it wasn't, leading to odd behavior in later
       inheritance changes.
+-->
+この場合、OID列は通常のユーザ列と同様に扱われるべきでしたが、そうなっておらず、後の継承の変更で奇妙な振る舞いをひき起こしていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <command>CREATE OR REPLACE VIEW</> to update the view query
       before attempting to apply the new view options (Dean Rasheed)
+-->
+新たなビューオプションを適用しようとする前にビュー問い合わせを更新するように<command>CREATE OR REPLACE VIEW</>を修正しました。
+(Dean Rasheed)
      </para>
 
      <para>
+<!--
       Previously the command would fail if the new options were
       inconsistent with the old view definition.
+-->
+これまでは新たなオプションが古いビュー定義と矛盾するときにコマンドが失敗していました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Report correct object identity during <command>ALTER TEXT SEARCH
       CONFIGURATION</> (Artur Zakirov)
+-->
+<command>ALTER TEXT SEARCH CONFIGURATION</>のとき、正しいオブジェクト識別を報告するようにしました。
+(Artur Zakirov)
      </para>
 
      <para>
+<!--
       The wrong catalog OID was reported to extensions such as logical
       decoding.
+-->
+ロジカルデコーディングなどの拡張に誤ったカタログOIDが報告されていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix commit timestamp mechanism to not fail when queried about
       the special XIDs <literal>FrozenTransactionId</>
       and <literal>BootstrapTransactionId</> (Craig Ringer)
+-->
+特別なXIDの<literal>FrozenTransactionId</>と<literal>BootstrapTransactionId</>について問われたとき、コミットタイムスタンプの仕組みが失敗しないように修正しました。
+(Craig Ringer)
      </para>
     </listitem>
 
@@ -267,11 +410,16 @@ Branch: REL9_3_STABLE [5d80171ad] 2016-12-13 19:05:35 -0600
 Branch: REL9_2_STABLE [60314e28e] 2016-12-13 19:08:09 -0600
 -->
      <para>
+<!--
       Check for serializability conflicts before reporting
       constraint-violation failures (Thomas Munro)
+-->
+直列化可能かを、制約違反エラーを報告する前に検査するようにしました。
+(Thomas Munro)
      </para>
 
      <para>
+<!--
       When using serializable transaction isolation, it is desirable
       that any error due to concurrent transactions should manifest
       as a serialization failure, thereby cueing the application that
@@ -281,34 +429,54 @@ Branch: REL9_2_STABLE [60314e28e] 2016-12-13 19:08:09 -0600
       serialization error if the application explicitly checked for
       the presence of a conflicting key (and did not find it) earlier
       in the transaction.
+-->
+シリアライザブルトランザクション隔離を使っているとき、同時トランザクションを原因とするいかなるエラーも直列化の失敗として表明するのが望ましく、それによりアプリケーションにリトライが成功するかもしれないという手がかりを与えます。
+残念ながら、キー重複の失敗が同時挿入で引き起こされた場合には、これは確実には生じません。
+本変更は、アプリケーションがトランザクションのより早くに明示的に競合するキーの存在をチェックした（そして見つからなかった）なら、このようなエラーが直列化のエラーとして報告されることを保証します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect use of view reloptions as regular table reloptions (Tom
       Lane)
+-->
+誤って通常テーブルのreloptionと同様にビューのreloptionを使用しているのを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       The symptom was spurious <quote>ON CONFLICT is not supported on table
       ... used as a catalog table</> errors when the target
       of <command>INSERT ... ON CONFLICT</> is a view with cascade option.
+-->
+症状は<command>INSERT ... ON CONFLICT</>の対象がカスケードオプションを伴うビューであるときの偽性の<quote>ON CONFLICT is not supported on table ... used as a catalog table</>（ON CONFLICTはカタログテーブルとして使われるテーブル...ではサポートされません）エラーです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect <quote>target lists can have at most <replaceable>N</>
       entries</quote> complaint when using <literal>ON CONFLICT</> with
       wide tables (Tom Lane)
+-->
+幅の広いテーブルに<literal>ON CONFLICT</>を使ったときの誤った<quote>target lists can have at most <replaceable>N</> entries</quote>（対象リストは最大でNエントリ持つことができます）エラーを修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent multicolumn expansion of <replaceable>foo</><literal>.*</> in
       an <command>UPDATE</> source expression (Tom Lane)
+-->
+
+<command>UPDATE</>のソース式での<replaceable>foo</><literal>.*</>の複数列の展開を防止しました。
+(Tom Lane)
      </para>
 
      <para>
@@ -320,154 +488,240 @@ Branch: REL9_2_STABLE [60314e28e] 2016-12-13 19:08:09 -0600
 
     <listitem>
      <para>
+<!--
       Ensure that column typmods are determined accurately for
       multi-row <literal>VALUES</> constructs (Tom Lane)
+-->
+複数行の<literal>VALUES</>コンストラクトに対して列のtypemodが精密に決定されるようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fixes problems occurring when the first value in a column has a
       determinable typmod (e.g., length for a <type>varchar</> value) but
       later values don't share the same limit.
+-->
+これは、列の最初の値が決定可能なtypmod（例えば<type>varchar</>の長さ）を持つけれど続く値は同じ制限を共有しないときに発生する問題を修正します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Throw error for an unfinished Unicode surrogate pair at the end of a
       Unicode string (Tom Lane)
+-->
+ユニコード文字列の末尾における完結しないユニコードのサロゲートペアにエラーを出すようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Normally, a Unicode surrogate leading character must be followed by a
       Unicode surrogate trailing character, but the check for this was
       missed if the leading character was the last character in a Unicode
       string literal (<literal>U&amp;'...'</>) or Unicode identifier
       (<literal>U&amp;"..."</>).
+-->
+通常、ユニコードのサロゲート先頭文字にはユニコードのサロゲート末尾文字が続かなければなりませんが、先頭文字がユニコード文字列リテラル(<literal>U&amp;'...'</>)またはユニコード識別子(<literal>U&amp;"..."</>)の最後の文字である場合に、これについての検査が見逃されていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that a purely negative text search query, such
       as <literal>!foo</>, matches empty <type>tsvector</>s (Tom Dunstan)
+-->
+<literal>!foo</>のような純粋な否定のテキスト検索問い合わせが空の<type>tsvector</>にマッチするようにしました。
+(Tom Dunstan)
      </para>
 
      <para>
+<!--
       Such matches were found by GIN index searches, but not by sequential
       scans or GiST index searches.
+-->
+このようなマッチはGINインデックス検索では見つかりましたが、シーケンシャルスキャンやGiSTインデックススキャンでは見つかりませんでした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent crash when <function>ts_rewrite()</> replaces a non-top-level
       subtree with an empty query (Artur Zakirov)
+-->
+<function>ts_rewrite()</>が非トップレベルのサブツリーを空クエリで置き換えるときのクラッシュを、防止しました。
+(Artur Zakirov)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix performance problems in <function>ts_rewrite()</> (Tom Lane)
+-->
+<function>ts_rewrite()</>での性能問題を修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <function>ts_rewrite()</>'s handling of nested NOT operators
       (Tom Lane)
+-->
+<function>ts_rewrite()</>の入れ子NOT演算子の扱いを修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Improve speed of user-defined aggregates that
       use <function>array_append()</> as transition function (Tom Lane)
+-->
+遷移関数として<function>array_append()</>を使うユーザ定義集約の速度を改善しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <function>array_fill()</> to handle empty arrays properly (Tom Lane)
+-->
+空配列を適切に扱うように<function>array_fill()</>を修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible crash in <function>array_position()</>
       or <function>array_positions()</> when processing arrays of records
       (Junseok Yang)
+-->
+レコードの配列を処理しているときに<function>array_position()</>または<function>array_positions()</>でクラッシュの可能性があり、修正しました。
+(Junseok Yang)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix one-byte buffer overrun in <function>quote_literal_cstr()</>
       (Heikki Linnakangas)
+-->
+<function>quote_literal_cstr()</>で1バイトのバッファオーバランを修正しました。
+(Heikki Linnakangas)
      </para>
 
      <para>
+<!--
       The overrun occurred only if the input consisted entirely of single
       quotes and/or backslashes.
+-->
+このオーバランは入力全体がのシングルクォートおよび/またはバックスラッシュで構成される場合でのみ発生します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent multiple calls of <function>pg_start_backup()</>
       and <function>pg_stop_backup()</> from running concurrently (Michael
       Paquier)
+-->
+<function>pg_start_backup()</>と<function>pg_stop_backup()</>の複数回の呼び出しが同時に実行されないようにしました。
+(Michael Paquier)
      </para>
 
      <para>
+<!--
       This avoids an assertion failure, and possibly worse things, if
       someone tries to run these functions in parallel.
+-->
+誰かがこれらの関数を並列に実行しようとしたときの、アサート失敗あるいはもっと悪い事態を回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Disable transform that attempted to remove no-op <literal>AT TIME
       ZONE</> conversions (Tom Lane)
+-->
+何もしない<literal>AT TIME ZONE</>変換を取り除こうとする変換を無効にしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This resulted in wrong answers when the simplified expression was
       used in an index condition.
+-->
+これは単純化された式がインデックス条件で使われるときに誤った答えをもたらしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid discarding <type>interval</>-to-<type>interval</> casts
       that aren't really no-ops (Tom Lane)
+-->
+実際にはノーオペレーションではない<type>interval</>から<type>interval</>へのキャストを捨てないようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       In some cases, a cast that should result in zeroing out
       low-order <type>interval</> fields was mistakenly deemed to be a
       no-op and discarded.  An example is that casting from <type>INTERVAL
       MONTH</> to <type>INTERVAL YEAR</> failed to clear the months field.
+-->
+一部の場合に下位の<type>interval</>フィールドのゼロ埋めした結果になるべきキャストが誤って何もしない処理と認識され、捨てられていました。
+一例は<type>INTERVAL MONTH</>から<type>INTERVAL YEAR</>へのキャストが月フィールドをクリアしないことです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix bugs in transmitting GUC parameter values to parallel workers
       (Michael Paquier, Tom Lane)
+-->
+GUCパラメータ値をパラレルワーカに渡す際のバグを修正しました。
+(Michael Paquier, Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that cached plans are invalidated by changes in foreign-table
       options (Amit Langote, Etsuro Fujita, Ashutosh Bapat)
+-->
+キャッシュされたプランが外部テーブルオプションの変更により確実に無効化されるようにしました。
+(Amit Langote, Etsuro Fujita, Ashutosh Bapat)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_dump</> to dump user-defined casts and transforms
       that use built-in functions (Stephen Frost)
+-->
+組み込み関数を使うユーザ定義キャストと変換をダンプするように<application>pg_dump</>を修正しました。
+(Stephen Frost)
      </para>
     </listitem>
 
@@ -479,182 +733,278 @@ Branch: REL9_2_STABLE [60314e28e] 2016-12-13 19:08:09 -0600
      </para>
 
      <para>
+<!--
       This doesn't fix any live bug, but it may improve the behavior in
       future if <application>pg_restore</> is used with an archive
       generated by a later <application>pg_dump</> version.
+-->
+これは今あるバグを修正するわけではありませんが、将来<application>pg_restore</>が、後の<application>pg_dump</>バージョンで生成されたアーカイブに使用する場合の振る舞いを改善すると考えられます。 
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_basebackup</>'s rate limiting in the presence of
       slow I/O (Antonin Houska)
+-->
+遅いI/Oがある中での<application>pg_basebackup</>のレート制限を修正しました。
+(Antonin Houska)
      </para>
 
      <para>
+<!--
       If disk I/O was transiently much slower than the specified rate
       limit, the calculation overflowed, effectively disabling the rate
       limit for the rest of the run.
+-->
+ディスクI/Oが一時的に指定されたレート制限よりも非常に遅い場合、計算がオーバーフローして、残りの実行に対してレート制限が事実上使えませんでした。 
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_basebackup</>'s handling of
       symlinked <filename>pg_stat_tmp</> and <filename>pg_replslot</>
       subdirectories (Magnus Hagander, Michael Paquier)
+-->
+<application>pg_basebackup</>のシンボリックリンクされたサブディレクトリ<filename>pg_stat_tmp</>および<filename>pg_replslot</>の扱いが修正されました。
+(Magnus Hagander, Michael Paquier)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible <application>pg_basebackup</> failure on standby
       server when including WAL files (Amit Kapila, Robert Haas)
+-->
+WALファイルを含めたときスタンバイサーバで起こりうる<application>pg_basebackup</>の失敗を修正しました。
+(Amit Kapila, Robert Haas)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible mishandling of expanded arrays in domain check
       constraints and <literal>CASE</> execution (Tom Lane)
+-->
+ドメインのチェック制約と<literal>CASE</>実行にて、拡張された配列の誤操作を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       It was possible for a PL/pgSQL function invoked in these contexts to
       modify or even delete an array value that needs to be preserved for
       additional operations.
+-->
+これらのコンテキストで実行されたPL/pgSQL関数が続く操作のために保持される必要のある配列値を変更またはさらに削除する可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix nested uses of PL/pgSQL functions in contexts such as domain
       check constraints evaluated during assignment to a PL/pgSQL variable
       (Tom Lane)
+-->
+PL/pgSQL変数への割り当ての際に評価されたドメインのチェック制約のようなコンテキストでのPL/pgSQL関数の入れ子使用を修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that the Python exception objects we create for PL/Python are
       properly reference-counted (Rafa de la Torre, Tom Lane)
+-->
+PL/Pythonむけに作成したPython例外オブジェクトが確実に適切にリファレンスカウントされるようにしました。
+(Rafa de la Torre, Tom Lane)
      </para>
 
      <para>
+<!--
       This avoids failures if the objects are used after a Python garbage
       collection cycle has occurred.
+-->
+これはPythonのガーベージコレクションのサイクルが起きた後にオブジェクトが使われた場合の失敗を回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix PL/Tcl to support triggers on tables that have <literal>.tupno</>
       as a column name (Tom Lane)
+-->
+列名として<literal>.tupno</>を持つテーブルのトリガに対応するようにPL/Tclを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This matches the (previously undocumented) behavior of
       PL/Tcl's <command>spi_exec</> and <command>spi_execp</> commands,
       namely that a magic <literal>.tupno</> column is inserted only if
       there isn't a real column named that.
+-->
+これは（以前の文書化されていない）PL/Tclの<command>spi_exec</>および<command>spi_execp</>コマンドの振る舞いと調和させます。
+すなわち、<literal>.tupno</>マジック列はその名前の真の列が無い場合だけ挿入されます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Allow DOS-style line endings in <filename>~/.pgpass</> files,
       even on Unix (Vik Fearing)
+-->
+Unix上であってもDOS形式の改行文字が<filename>~/.pgpass</>ファイルで許されるようにしました。
+(Vik Fearing)
      </para>
 
      <para>
+<!--
       This change simplifies use of the same password file across Unix and
       Windows machines.
+-->
+この変更は同じパスワードファイルをUnixマシンとWindowsマシンとで使うのを簡単にします。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix one-byte buffer overrun if <application>ecpg</> is given a file
       name that ends with a dot (Takayuki Tsunakawa)
+-->
+<application>ecpg</>にドットで終わるファイル名が与えられた際の1バイトのバッファオーバランを修正しました。
+(Takayuki Tsunakawa)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>psql</>'s tab completion for <command>ALTER DEFAULT
       PRIVILEGES</> (Gilles Darold, Stephen Frost)
+-->
+<command>ALTER DEFAULT PRIVILEGES</>に対する<application>psql</>のタブ補完を修正しました。
+(Gilles Darold, Stephen Frost)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       In <application>psql</>, treat an empty or all-blank setting of
       the <envar>PAGER</> environment variable as meaning <quote>no
       pager</> (Tom Lane)
+-->
+<application>psql</>で、空または全てブランクの<envar>PAGER</>環境変数設定を<quote>ページャ無し</>という意味で扱うようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Previously, such a setting caused output intended for the pager to
       vanish entirely.
+-->
+これまでは、このような設定はページャにむけようとした出力を全く見えなくしていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Improve <filename>contrib/dblink</>'s reporting of
       low-level <application>libpq</> errors, such as out-of-memory
       (Joe Conway)
+-->
+<filename>contrib/dblink</>のメモリ不足などの低レベル<application>libpq</>エラーの報告を改善しました。
+(Joe Conway)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Teach <filename>contrib/dblink</> to ignore irrelevant server options
       when it uses a <filename>contrib/postgres_fdw</> foreign server as
       the source of connection options (Corey Huinker)
+-->
+接続オプションのソースとして<filename>contrib/postgres_fdw</>外部サーバを使うとき、<filename>contrib/dblink</>に無関係なサーバオプションを無視させました。
+(Corey Huinker)
      </para>
 
      <para>
+<!--
       Previously, if the foreign server object had options that were not
       also <application>libpq</> connection options, an error occurred.
+-->
+これまでは、外部サーバオブジェクトが<application>libpq</>接続オプションでは無いオプションを持っているなら、エラーが生じました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix portability problems in <filename>contrib/pageinspect</>'s
       functions for GIN indexes (Peter Eisentraut, Tom Lane)
+-->
+<filename>contrib/pageinspect</>のGINインデックスむけの関数で移植性の問題を修正しました。
+(Peter Eisentraut, Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       On Windows, ensure that environment variable changes are propagated
       to DLLs built with debug options (Christian Ullrich)
+-->
+Windowsで環境変数の変更がデバッグオプションを有効にしてビルドされたDLLに確実に伝播するようにしました。
+(Christian Ullrich)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Sync our copy of the timezone library with IANA release tzcode2016j
       (Tom Lane)
+-->
+タイムゾーンライブラリをIANA release tzcode2016jに同期しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fixes various issues, most notably that timezone data
       installation failed if the target directory didn't support hard
       links.
+-->
+多数の問題が修正されており、最も重要なものとしては対象ディレクトリがハードリンクをサポートしない場合はタイムゾーンデータ導入に失敗していたことがあります。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Update time zone data files to <application>tzdata</> release 2016j
       for DST law changes in northern Cyprus (adding a new zone
       Asia/Famagusta), Russia (adding a new zone Europe/Saratov), Tonga,
       and Antarctica/Casey.
       Historical corrections for Italy, Kazakhstan, Malta, and Palestine.
       Switch to preferring numeric zone abbreviations for Tonga.
+-->
+タイムゾーンデータを<application>tzdata</> release 2016jに更新しました。
+北キプロス（新タイムゾーン Asia/Famagusta 追加）、ロシア（新タイムゾーン Europe/Saratov 追加）、トンガ、Antarctica/Casey における夏時間法の変更と、イタリア、カザフスタン、マルタ、パレスチナにおける歴史的修正、トンガにおける数値によるゾーン略記法を選択する変更が含まれます。 
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.5.sgml
+++ b/doc/src/sgml/release-9.5.sgml
@@ -474,15 +474,18 @@ Branch: REL9_2_STABLE [60314e28e] 2016-12-13 19:08:09 -0600
       Prevent multicolumn expansion of <replaceable>foo</><literal>.*</> in
       an <command>UPDATE</> source expression (Tom Lane)
 -->
-
 <command>UPDATE</>のソース式での<replaceable>foo</><literal>.*</>の複数列の展開を防止しました。
 (Tom Lane)
      </para>
 
      <para>
-      This led to <quote>UPDATE target count mismatch --- internal
+<!--
+      This led to <quote>UPDATE target count mismatch -&#045;- internal
       error</>.  Now the syntax is understood as a whole-row variable,
       as it would be in other contexts.
+-->
+これは<quote>UPDATE target count mismatch --- internal error</>（UPDATE対象数が不一致です --- 内部エラー）をもたらしました。
+これからは、この構文は他のコンテキストと同様に行全体の変数として解釈されます。
      </para>
     </listitem>
 
@@ -727,9 +730,13 @@ GUCパラメータ値をパラレルワーカに渡す際のバグを修正し�
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_restore</> with <option>--create --if-exists</>
       to behave more sanely if an archive contains
       unrecognized <command>DROP</> commands (Tom Lane)
+-->
+アーカイブが認識できない<command>DROP</>コマンドを含む場合に<option>--create --if-exists</>を伴う<application>pg_restore</>をより分別のある振る舞いをするように修正しました。
+(Tom Lane)
      </para>
 
      <para>

--- a/doc/src/sgml/release-9.5.sgml
+++ b/doc/src/sgml/release-9.5.sgml
@@ -731,7 +731,7 @@ GUCパラメータ値をパラレルワーカに渡す際のバグを修正し�
     <listitem>
      <para>
 <!--
-      Fix <application>pg_restore</> with <option>--create --if-exists</>
+      Fix <application>pg_restore</> with <option>&#045;-create &#045;-if-exists</>
       to behave more sanely if an archive contains
       unrecognized <command>DROP</> commands (Tom Lane)
 -->


### PR DESCRIPTION
以下のファイルの9.6.2対応です。

- release-9.2.sgml
- release-9.3.sgml
- release-9.4.sgml
- release-9.5.sgml

すべて9.6.2由来で、こちらで新しく訳したところはありません。