### PR TITLE
Translate about generic message callback in logicaldecoding.sgml

### DIFF
--- a/doc/src/sgml/logicaldecoding.sgml
+++ b/doc/src/sgml/logicaldecoding.sgml
@@ -908,11 +908,17 @@ typedef bool (*LogicalDecodeFilterByOriginCB) (
      </sect3>
 
     <sect3 id="logicaldecoding-output-plugin-message">
+<!--
      <title>Generic Message Callback</title>
+-->
+     <title>汎用メッセージコールバック</title>
 
      <para>
+<!--
       The optional <function>message_cb</function> callback is called whenever
       a logical decoding message has been decoded.
+-->
+オプションの<function>message_cb</function>コールバックは、ロジカルデコーディングメッセージがデコードされる度に呼び出されます。
 <programlisting>
 typedef void (*LogicalDecodeMessageCB) (
     struct LogicalDecodingContext *,


### PR DESCRIPTION
Generic Message Callbackの訳についてはおまかせします。