### PR TITLE
表9.69スナップショット構成要素の訳語修正です。

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -23572,8 +23572,8 @@ SELECT collation for ('foo' COLLATE "de_DE");
          transactions will either be committed and visible, or rolled
          back and dead.
 -->
-現在実行中で最も早いトランザクションID（txid）。
-これより早い全てのトランザクションはコミットされて可視となっているか、またはロールバックされて消滅している。
+現在実行中で最も小さいトランザクションID（txid）。
+これより小さい全てのトランザクションはコミットされて可視となっているか、またはロールバックされて消滅している。
        </entry>
       </row>
 

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -4100,8 +4100,8 @@ SELECT collation for ('foo' COLLATE "de_DE");
          transactions will either be committed and visible, or rolled
          back and dead.
 -->
-現在実行中で最も早いトランザクションID（txid）。
-これより早い全てのトランザクションはコミットされて可視となっているか、またはロールバックされて消滅している。
+現在実行中で最も小さいトランザクションID（txid）。
+これより小さい全てのトランザクションはコミットされて可視となっているか、またはロールバックされて消滅している。
        </entry>
       </row>
 


### PR DESCRIPTION
トランザクションIDの"earliest"に対して直訳の「早い」という訳語があてられていますが、
これは「小さい」か「若い」のどちらかにすべきと思います。
このPRでは、「小さい」としています。