### PR TITLE
前へ(prev)がAppendix L,Kとばしてしまう問題の修正

### DIFF
--- a/doc/src/sgml/Makefile
+++ b/doc/src/sgml/Makefile
@@ -254,6 +254,7 @@ postgres.xml: $(srcdir)/postgres.sgml $(ALMOSTALLSGML)
 	SP_CHARSET_FIXED=1 SP_ENCODING=UTF-8 \
 	$(OSX) -D. -x comment -x lower -i include-xslt-index $< >postgres.xmltmp
 	$(PERL) -p -e 's/\[(aacute|acirc|aelig|agrave|amp|aring|atilde|auml|bull|copy|eacute|egrave|gt|iacute|lt|mdash|nbsp|ntilde|oacute|ocirc|oslash|ouml|pi|quot|scaron|uuml) *\]/\&\1;/gi;' \
+                   -e 's/\<!-- doc\/src\/sgml\/.*\.sgml --\>//;' \
 	           -e '$$_ .= qq{<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN" "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">\n} if $$. == 1;' \
 	  <postgres.xmltmp > $@
 	rm postgres.xmltmp


### PR DESCRIPTION
原因は不明ですが、osx -x comment によりコメントを残してbuildすると
一部（Appendix L,K)がprevのリンクからとばされてしまう。
とりあえず最初の doc/src/sgml/〜.sgml は不要なので削除するスクリプト
を追加しました。