### PR TITLE
tiny improvement of acronyms.sgml

### DIFF
--- a/doc/src/sgml/acronyms.sgml
+++ b/doc/src/sgml/acronyms.sgml
@@ -741,7 +741,7 @@
     <term><acronym>SPI</acronym></term>
     <listitem>
      <para>
-      <link linkend="spi">Server Programming Interface</link>
+      <link linkend="spi">Server Programming Interface（サーバプログラミングインタフェース）</link>
      </para>
     </listitem>
    </varlistentry>
@@ -774,7 +774,7 @@
     <term><acronym>SRF</acronym></term>
     <listitem>
      <para>
-      <link linkend="xfunc-c-return-set">Set-Returning Function</link>
+      <link linkend="xfunc-c-return-set">Set-Returning Function（集合を返す関数）</link>
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
頭文字のところで、本文中に対応する日本語訳があるものを（）に書いてみました。

（他にもあるかもしれませんがとりあえず私が気になったものだけ）