### PR TITLE
remove zenkaku-star

### DIFF
--- a/doc/src/sgml/release-9.6.sgml
+++ b/doc/src/sgml/release-9.6.sgml
@@ -9441,7 +9441,7 @@ OpenSSL 1.1.0に対応しました。
        <para>
 <!--
         Transmit query cancellation requests to the remote server
-        (Michael Paquier, Etsuro Fujita) ★コンフリクト解消時に対応
+        (Michael Paquier, Etsuro Fujita)
 -->
 リモートサーバに問い合わせキャンセル要求を伝播するようにしました。
 (Michael Paquier, Etsuro Fujita)

--- a/doc/src/sgml/textsearch.sgml
+++ b/doc/src/sgml/textsearch.sgml
@@ -464,7 +464,7 @@ text @@ text
 -->
 <type>tsquery</>内において、演算子 <literal>&amp;</literal> (AND) は、マッチと見なされるには引数の両方がドキュメント内に現れる必要があるということを指定します。
 同様に、演算子 <literal>|</literal> (OR) では、引数の少なくとも一方が現れる必要があり、また演算子 <literal>!</> (NOT) は、マッチと見なされるには引数が現れては<emphasis>ならない</>ことを指定します。
-★追加翻訳が必要
+例えば、<literal>fat &amp; ! rat</>という問い合わせは、<literal>fat</>は含むが<literal>rat</>は含まないドキュメントとマッチします。
    </para>
 
    <para>
@@ -1782,7 +1782,7 @@ query.',
     <type>tsvector</type> summary, so it can be slow and should be used with
     care.
 -->
-<function>ts_headline</>は、<type>tsvector</type>の要約ではなく、元の文書を使います。ですので遅い可能性があり、注意深く使用する必要があります。よくある間違いは、たった10個の文書を表示しようとしているのに、<emphasis>すべての</emphasis>合致した文書に<function>ts_headline</function>を適用することです。<acronym>SQL</acronym>の副問い合わせがこのときに役に立ちます。例を示します。 ★変更あり
+<function>ts_headline</>は、<type>tsvector</type>の要約ではなく、元の文書を使います。ですので遅い可能性があり、注意深く使用する必要があります。
    </para>
 
   </sect2>


### PR DESCRIPTION
マージ時の目印である★が残っているのを見つけましたので、対応しました。
release-9.6.sgmlでは単に削除しただけです。
