### PR TITLE
fix 'PL/pgSQL'

### DIFF
--- a/doc/src/sgml/release-old.sgml
+++ b/doc/src/sgml/release-old.sgml
@@ -1237,7 +1237,7 @@ SSL有効時のシグナルの扱いに対する堅牢性を向上しました�
 the variable is of pass-by-reference type</para></listitem>
 -->
 <listitem><para>
-PL/PgSQLにおいて、変数が参照渡し型の場合の<literal>var := var</>の扱いを修正しました。
+PL/pgSQLにおいて、変数が参照渡し型の場合の<literal>var := var</>の扱いを修正しました。
 </para></listitem>
 </itemizedlist>
 


### PR DESCRIPTION
ちょっとした修正です。
PL/pgSQLと書くのが正しいようなので。