### PR TITLE
Issues #960 と #961 の修正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -94,9 +94,10 @@
        A decimal point is permitted only for floating-point parameters.
        Do not use thousands separators.  Quotes are not required.
 -->
-       <emphasis>数値型(整数型と浮動小数点型):</emphasis>
-       小数点は浮動小数点型のパラメータでのみ使用できます。
-       1000の位取りには使わないでください。引用符は必要ありません。
+<emphasis>数値型(整数型と浮動小数点型):</emphasis>
+小数点は浮動小数点型のパラメータでのみ使用できます。
+1000の位取りの区切り文字は使わないでください。
+引用符は必要ありません。
       </para>
      </listitem>
 
@@ -117,14 +118,16 @@
        The unit name is case-sensitive, and there can be whitespace between
        the numeric value and the unit.
 -->
-       <emphasis>単位付きの数値:</emphasis>
-       数値型のパラメータによっては暗黙的な単位を持つことがあります。
-       メモリの量や時間について記述するからです。
-       単位はキロバイト、ブロック（通常8キロバイト）、ミリ秒、秒、分などです。
-       修飾無しの数値によるこれらの設定においては、 <structname>pg_settings</>.<structfield>unit</> からデフォルト値が採用されます。
+<emphasis>単位付きの数値:</emphasis>
+数値型のパラメータによっては暗黙的な単位を持つことがあります。
+メモリの量や時間について記述するからです。
+単位はキロバイト、ブロック（通常8キロバイト）、ミリ秒、秒、分などです。
+修飾無しの数値によるこれらの設定においては、 <structname>pg_settings</>.<structfield>unit</> からデフォルト値が採用されます。
 使い勝手を考えて、たとえば<literal>'120 ms'</>のように単位を明示的に指定することもできます。
-この場合は、実際の単位に変換が行われます。なお、この機能を使う場合は、引用符付きの文字列として値を指定することに注意してください。
-単位の名称は大文字小文字を区別しません。また、数値と単位の間に空白があっても構いません。
+この場合は、実際の単位に変換が行われます。
+なお、この機能を使う場合は、引用符付きの文字列として値を指定しなければならないことに注意してください。
+単位の名称は大文字小文字を区別します。
+また、数値と単位の間に空白があっても構いません。
 
        <itemizedlist>
         <listitem>

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -94,10 +94,9 @@
        A decimal point is permitted only for floating-point parameters.
        Do not use thousands separators.  Quotes are not required.
 -->
-<emphasis>数値型(整数型と浮動小数点型):</emphasis>
-小数点は浮動小数点型のパラメータでのみ使用できます。
-1000の位取りの区切り文字は使わないでください。
-引用符は必要ありません。
+       <emphasis>数値型(整数型と浮動小数点型):</emphasis>
+       小数点は浮動小数点型のパラメータでのみ使用できます。
+       1000の位取りには使わないでください。引用符は必要ありません。
       </para>
      </listitem>
 
@@ -118,16 +117,14 @@
        The unit name is case-sensitive, and there can be whitespace between
        the numeric value and the unit.
 -->
-<emphasis>単位付きの数値:</emphasis>
-数値型のパラメータによっては暗黙的な単位を持つことがあります。
-メモリの量や時間について記述するからです。
-単位はキロバイト、ブロック（通常8キロバイト）、ミリ秒、秒、分などです。
-修飾無しの数値によるこれらの設定においては、 <structname>pg_settings</>.<structfield>unit</> からデフォルト値が採用されます。
+       <emphasis>単位付きの数値:</emphasis>
+       数値型のパラメータによっては暗黙的な単位を持つことがあります。
+       メモリの量や時間について記述するからです。
+       単位はキロバイト、ブロック（通常8キロバイト）、ミリ秒、秒、分などです。
+       修飾無しの数値によるこれらの設定においては、 <structname>pg_settings</>.<structfield>unit</> からデフォルト値が採用されます。
 使い勝手を考えて、たとえば<literal>'120 ms'</>のように単位を明示的に指定することもできます。
-この場合は、実際の単位に変換が行われます。
-なお、この機能を使う場合は、引用符付きの文字列として値を指定しなければならないことに注意してください。
-単位の名称は大文字小文字を区別します。
-また、数値と単位の間に空白があっても構いません。
+この場合は、実際の単位に変換が行われます。なお、この機能を使う場合は、引用符付きの文字列として値を指定することに注意してください。
+単位の名称は大文字小文字を区別しません。また、数値と単位の間に空白があっても構いません。
 
        <itemizedlist>
         <listitem>


### PR DESCRIPTION
重大な誤訳の #961 を修正するついでに #960 も修正しました。
また、これに関連した部分でmustを単に「する」と訳していたのを「しなければならない」に変更しました。
その他、インデントの削除、句点での改行を挿入しています。改行を入れたため、差分がハイライトされていませんが、訳の修正は上記の3箇所だけです。