### PR TITLE
update advanced.sgml and docguide.sgml to 9.6.4 (http -> https (part 1))

### DIFF
--- a/doc/src/sgml/advanced.sgml
+++ b/doc/src/sgml/advanced.sgml
@@ -1006,7 +1006,7 @@ SELECT name, altitude
     <ulink url="https://www.postgresql.org">web site</ulink>
     for links to more resources.
 -->
-もっと多くの入門資料がお望みであれば、PostgreSQLの<ulink url="http://www.postgresql.org/">Webサイト</ulink>により多くのリソースがリンクされています。
+もっと多くの入門資料がお望みであれば、PostgreSQLの<ulink url="https://www.postgresql.org/">Webサイト</ulink>により多くのリソースがリンクされています。
    </para>
   </sect1>
  </chapter>

--- a/doc/src/sgml/docguide.sgml
+++ b/doc/src/sgml/docguide.sgml
@@ -848,7 +848,7 @@ DocBookスタイルシートはいくつか比較的標準となっている場�
     url="https://www.postgresql.org/docs/current">postgresql.org</> instead of the
     default simple style use:
 -->
-デフォルトの簡単なスタイルではなく<ulink url="http://postgresql.org/docs/current">postgresql.org</>で使われているスタイルシートのHTMLの文書を作成するには、次のようにします。
+デフォルトの簡単なスタイルではなく<ulink url="https://postgresql.org/docs/current">postgresql.org</>で使われているスタイルシートのHTMLの文書を作成するには、次のようにします。
 <screen>
 <prompt>doc/src/sgml$ </prompt><userinput>make STYLE=website html</userinput>
 </screen>


### PR DESCRIPTION
advanced.sgmlとdocguide.sgmlの9.6.4対応です。
http -> https だけでした。