### PR TITLE
http -> https (part 2)

### DIFF
--- a/doc/src/sgml/info.sgml
+++ b/doc/src/sgml/info.sgml
@@ -27,7 +27,7 @@
       url="https://wiki.postgresql.org/wiki/Todo">TODO</> list, and
       detailed information about many more topics.
 -->
-<productname>PostgreSQL</productname> <ulink url="http://wiki.postgresql.org">wiki</ulink>はプロジェクトの<ulink url="http://wiki.postgresql.org/wiki/Frequently_Asked_Questions">FAQ</>（よくある質問）リスト、<ulink url="http://wiki.postgresql.org/wiki/Todo">TODO</>リスト、およびさらに多くの話題の情報を収容しています。
+<productname>PostgreSQL</productname> <ulink url="https://wiki.postgresql.org">wiki</ulink>はプロジェクトの<ulink url="https://wiki.postgresql.org/wiki/Frequently_Asked_Questions">FAQ</>（よくある質問）リスト、<ulink url="https://wiki.postgresql.org/wiki/Todo">TODO</>リスト、およびさらに多くの話題の情報を収容しています。
      </para>
     </listitem>
    </varlistentry>
@@ -46,7 +46,7 @@
       information to make your work or play with
       <productname>PostgreSQL</productname> more productive.
 -->
-<productname>PostgreSQL</productname>の<ulink url="http://www.postgresql.org/">Webサイト</ulink>には、最新のリリースに関する詳細についてや、<productname>PostgreSQL</productname>の利用・操作をする上で生産性をより高める情報があります。
+<productname>PostgreSQL</productname>の<ulink url="https://www.postgresql.org/">Webサイト</ulink>には、最新のリリースに関する詳細についてや、<productname>PostgreSQL</productname>の利用・操作をする上で生産性をより高める情報があります。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/problems.sgml
+++ b/doc/src/sgml/problems.sgml
@@ -489,7 +489,7 @@ Git版に対するバグ報告の場合は、その旨も記載し、コミッ�
    Entering a bug report this way causes it to be mailed to the
    <email>pgsql-bugs@postgresql.org</email> mailing list.
 -->
-その他の方法として、プロジェクトの<ulink url="http://www.postgresql.org/">Webサイト</ulink>にあるバグ報告フォームの項目を埋める方法があります。
+その他の方法として、プロジェクトの<ulink url="https://www.postgresql.org/">Webサイト</ulink>にあるバグ報告フォームの項目を埋める方法があります。
 この方法で入力したバグ報告は、<email>pgsql-bugs@postgresql.org</email>メーリングリストに送信されます。
   </para>
 

--- a/doc/src/sgml/release.sgml
+++ b/doc/src/sgml/release.sgml
@@ -71,8 +71,8 @@ For new features, add links to the documentation sections.
    interface</ulink> that shows changes to specific files.
 -->
 各リリースにおける変更点の全一覧は、各リリースの<link linkend="git">Git</link>ログを参照することで入手できます。
-<ulink url="http://archives.postgresql.org/pgsql-committers/"><literal>pgsql-committers</literal>メーリングリスト</ulink>にもすべてのソースコードの変更点が記録されています。
-また、特定のファイルに対する変更点を表示する<ulink url="http://git.postgresql.org/gitweb?p=postgresql.git;a=summary">Webインタフェース</ulink>が存在します。
+<ulink url="https://archives.postgresql.org/pgsql-committers/"><literal>pgsql-committers</literal>メーリングリスト</ulink>にもすべてのソースコードの変更点が記録されています。
+また、特定のファイルに対する変更点を表示する<ulink url="https://git.postgresql.org/gitweb?p=postgresql.git;a=summary">Webインタフェース</ulink>が存在します。
   </para>
 
   <para>


### PR DESCRIPTION
以下のファイルの9.6.4対応です。

- info.sgml
- problems.sgml
- release.sgml

こちらも #967 同様、http -> https のみでした。