### PR TITLE
capitalize pic

### DIFF
--- a/doc/src/sgml/dfunc.sgml
+++ b/doc/src/sgml/dfunc.sgml
@@ -97,7 +97,7 @@ Cで書かれた<productname>PostgreSQL</productname>の拡張関数を使うた
       <option>-fPIC</option>.  To create shared libraries the compiler
       flag is <option>-shared</option>.
 -->
-<acronym>PIC</acronym>を作るためのコンパイラフラグは<option>-fpic</option>です。
+<acronym>PIC</acronym>を作るためのコンパイラフラグは<option>-fPIC</option>です。
 共有ライブラリを作るコンパイラフラグは<option>-shared</option>です。
 <programlisting>
 gcc -fPIC -c foo.c
@@ -129,7 +129,7 @@ gcc -shared -o foo.so foo.o
       linker flag for shared libraries is <option>-b</option>.  So:
 -->
 <acronym>PIC</acronym>を作るためのシステムコンパイラのコンパイラフラグは<option>+z</option>です。
-<application>GCC</application>を使う場合は<option>-fpic</option>です。
+<application>GCC</application>を使う場合は<option>-fPIC</option>です。
 共有ライブラリのためのリンカフラグは<option>-b</option>です。
 したがって、以下のようになります。
 <programlisting>
@@ -175,9 +175,7 @@ ld -b -o foo.sl foo.o
       The compiler flag to create a shared library is
       <option>-shared</option>.  A complete example looks like this:
 -->
-<acronym>PIC</acronym>を作るためのコンパイラフラグは<option>-fpic</option>です。
-いくつかのプラットフォームでは状況によって<option>-fpic</option>が動作しない場合は<option>-fPIC</option>を使わなければいけません。
-さらに詳しい情報についてはGCCのマニュアルを参照してください。
+<acronym>PIC</acronym>を作るためのコンパイラフラグは<option>-fPIC</option>です。
 共有ライブラリを作るコンパイラフラグは<option>-shared</option>です。
 完全な例は下記のようになります。
 <programlisting>
@@ -228,7 +226,7 @@ cc -bundle -flat_namespace -undefined suppress -o foo.so foo.o
       shared libraries.  On the older non-ELF systems, <literal>ld
       -Bshareable</literal> is used.
 -->
-<acronym>PIC</acronym>を作るためのコンパイラフラグは<option>-fpic</option>です。
+<acronym>PIC</acronym>を作るためのコンパイラフラグは<option>-fPIC</option>です。
 <acronym>ELF</acronym>システムでは<option>-shared</option>コンパイラフラグを使用して共有ライブラリをリンクします。
 より古い非ELFシステムでは<literal>ld -Bshareable</literal>が使われます。
 <programlisting>
@@ -254,7 +252,7 @@ gcc -shared -o foo.so foo.o
       <option>-fPIC</option>.  <literal>ld -Bshareable</literal> is
       used to link shared libraries.
 -->
-<acronym>PIC</acronym>を作成するためのコンパイラフラグは<option>-fpic</option>です。
+<acronym>PIC</acronym>を作成するためのコンパイラフラグは<option>-fPIC</option>です。
 共有ライブラリをリンクするには<literal>ld -Bshareable</literal>を使用します。
 <programlisting>
 gcc -fPIC -c foo.c
@@ -282,7 +280,7 @@ ld -Bshareable -o foo.so foo.o
       <option>-G</option> with either compiler or alternatively
       <option>-shared</option> with <application>GCC</>.
 -->
-<acronym>PIC</acronym>を作るためのコンパイラフラグはSunコンパイラでは<option>-KPIC</option>で、<application>GCC</>では<option>-fpic</option>です。
+<acronym>PIC</acronym>を作るためのコンパイラフラグはSunコンパイラでは<option>-KPIC</option>で、<application>GCC</>では<option>-fPIC</option>です。
 共有ライブラリをリンクするためには、どちらのコンパイラでもコンパイラオプションは<option>-G</option>で、<application>GCC</>の場合、代わりに<option>-shared</option>オプションを使うこともできます。
 <programlisting>
 cc -KPIC -c foo.c


### PR DESCRIPTION
dfunc.sgml の9.6.4対応です。

主な作業はpicを大文字にすることでした。