### PR TITLE
update sourcerepo.sgml to 9.6.4

### DIFF
--- a/doc/src/sgml/sourcerepo.sgml
+++ b/doc/src/sgml/sourcerepo.sgml
@@ -37,7 +37,7 @@ Wiki<ulink url="https://wiki.postgresql.org/wiki/Working_with_Git"></ulink>にGi
 -->
 ソースのリポジトリから<productname>PostgreSQL</productname>をビルドするには<application>bison</>、<application>flex</>そして<application>Perl</>の適度に新しいバージョンが必要であることに注意してください。
 配布されているtarballからビルドするためには、これらのツールは必要ではありません。なぜならこれらのツールを使ってビルドされるファイルはtarballに含まれているためです。
-他のツールの必要条件は、<xref linkend="installation">に示されているものと同様です。
+他のツールの必要条件は、<xref linkend="install-requirements">に示されているものと同様です。
   </para>
 
  <sect1 id="git">

--- a/doc/src/sgml/sourcerepo.sgml
+++ b/doc/src/sgml/sourcerepo.sgml
@@ -23,7 +23,7 @@
   url="https://wiki.postgresql.org/wiki/Working_with_Git"></ulink>,
   has some discussion on working with Git.
 -->
-Wiki<ulink url="http://wiki.postgresql.org/wiki/Working_with_Git"></ulink>にGitを使用する際の手順が掲載されています。
+Wiki<ulink url="https://wiki.postgresql.org/wiki/Working_with_Git"></ulink>にGitを使用する際の手順が掲載されています。
  </para>
 
   <para>
@@ -36,8 +36,8 @@ Wiki<ulink url="http://wiki.postgresql.org/wiki/Working_with_Git"></ulink>にGit
    are the same as shown in <xref linkend="install-requirements">.
 -->
 ソースのリポジトリから<productname>PostgreSQL</productname>をビルドするには<application>bison</>、<application>flex</>そして<application>Perl</>の適度に新しいバージョンが必要であることに注意してください。
-ビルドするために使われるファイルはtarballに含まれているため、配布されているtarballからビルドするためには、これらのツールは必要ではありません。
-他のツールの必要条件は、<xref linkend="installation">に示されているものと同様です。 ★変更あり
+配布されているtarballからビルドするためには、これらのツールは必要ではありません。なぜならこれらのツールを使ってビルドされるファイルはtarballに含まれているためです。
+他のツールの必要条件は、<xref linkend="installation">に示されているものと同様です。
   </para>
 
  <sect1 id="git">
@@ -103,7 +103,7 @@ git clone git://git.postgresql.org/git/postgresql.git
      prefix to <literal>https</>, as in:
 -->
 Gitミラーサイトは、例えばファイアウォールがGitプロトコルのアクセスをブロックしているような場合にもHTTPプロトコルでも到達できます。
-URLのプレフィックスを<literal>http</>に変更して以下のようにしてください。
+URLのプレフィックスを<literal>https</>に変更して以下のようにしてください。
 
 <programlisting>
 git clone https://git.postgresql.org/git/postgresql.git


### PR DESCRIPTION
sourcerepo.sgml の9.6.4対応です。

恒例のhttp -> https が主です。