### PR TITLE
psql-ref.sgmlの9.6.4対応

### DIFF
--- a/doc/src/sgml/ref/psql-ref.sgml
+++ b/doc/src/sgml/ref/psql-ref.sgml
@@ -1527,7 +1527,7 @@ Cの形式のブロックコメントは、サーバに送信され、サーバ�
         <xref linkend="APP-PSQL-patterns" endterm="APP-PSQL-patterns-title">
         below.)
 -->
-<replaceable class="parameter">pattern</replaceable>にマッチする各リレーション（テーブル、ビュー、インデックス、シーケンス、外部テーブル）または複合型について、全ての列、列の型、テーブル空間（デフォルト以外を使用している場合）、<literal>NOT NULL</literal>やデフォルトなどの特別な属性を表示します。
+<replaceable class="parameter">pattern</replaceable>にマッチする各リレーション（テーブル、ビュー、マテリアライズドビュー、インデックス、シーケンス、外部テーブル）または複合型について、全ての列、列の型、テーブル空間（デフォルト以外を使用している場合）、<literal>NOT NULL</literal>やデフォルトなどの特別な属性を表示します。
 関連付けられているインデックス、制約、ルールおよびトリガも表示されます。
 外部テーブルでは関連する外部サーバも表示されます。
 （<quote>パターンのマッチング</>については後述の<xref linkend="APP-PSQL-patterns" endterm="APP-PSQL-patterns-title">で定義されています。）
@@ -1576,8 +1576,8 @@ Cの形式のブロックコメントは、サーバに送信され、サーバ�
         foreign tables.
         This is purely a convenience measure.
 -->
-<command>\d</command>が<replaceable class="parameter">pattern</replaceable>引数なしで使用された場合は、<command>\dtvsE</command>と同じ意味となり、可視である全てのテーブル、ビュー、シーケンス、外部テーブルの一覧が表示されます。
-これは単に便宜上のものです。
+<command>\d</command>が<replaceable class="parameter">pattern</replaceable>引数なしで使用された場合は、<command>\dtvmsE</command>と同じ意味となり、可視である全てのテーブル、ビュー、マテリアライズドビュー、シーケンス、外部テーブルの一覧が表示されます。
+これは純粋に利便性のためです。
         </para>
         </note>
         </listitem>


### PR DESCRIPTION
原文に変更があった部分の直後の"This is purely a convenience measure"の訳の違和感が強かったので、ついでに修正しました。