### PR TITLE
update release-old to 9.6.4

### DIFF
--- a/doc/src/sgml/release-old.sgml
+++ b/doc/src/sgml/release-old.sgml
@@ -11,7 +11,7 @@
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-01-07</para>
   </formalpara>
 
@@ -179,7 +179,7 @@
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-09-17</para>
   </formalpara>
 
@@ -271,7 +271,7 @@
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-04-23</para>
   </formalpara>
 
@@ -358,7 +358,7 @@
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-02-05</para>
   </formalpara>
 
@@ -453,7 +453,7 @@
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-01-08</para>
   </formalpara>
 
@@ -540,7 +540,7 @@
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2006-10-16</para>
   </formalpara>
 
@@ -631,7 +631,7 @@ libpqにおけるSSLに関したメモリリークを修正しました。
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2006-05-23</para>
   </formalpara>
 
@@ -805,7 +805,7 @@ Fuhr)</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2006-02-14</para>
   </formalpara>
 
@@ -915,7 +915,7 @@ configure時の<function>finite</>および<function>isinf</>の存在検査に�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2006-01-09</para>
   </formalpara>
 
@@ -1039,7 +1039,7 @@ what's actually returned by the query (Joe)</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2005-12-12</para>
   </formalpara>
 
@@ -1133,7 +1133,7 @@ table has been dropped</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2005-10-04</para>
   </formalpara>
 
@@ -1254,7 +1254,7 @@ PL/pgSQLにおいて、変数が参照渡し型の場合の<literal>var := var</
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2005-05-09</para>
   </formalpara>
 
@@ -1510,7 +1510,7 @@ month-related formats</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2005-01-31</para>
   </formalpara>
 
@@ -1584,7 +1584,7 @@ datestyles</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2004-10-22</para>
   </formalpara>
 
@@ -1678,7 +1678,7 @@ concern since there is no reason for non-developers to use this script anyway.
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2004-08-16</para>
   </formalpara>
 
@@ -1743,7 +1743,7 @@ since <productname>PostgreSQL</productname> 7.1.
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2004-03-02</para>
   </formalpara>
 
@@ -1826,7 +1826,7 @@ operations on bytea columns (Joe)</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2003-12-03</para>
   </formalpara>
 
@@ -1895,7 +1895,7 @@ operations on bytea columns (Joe)</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2003-07-24</para>
   </formalpara>
 
@@ -1953,7 +1953,7 @@ operations on bytea columns (Joe)</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2003-05-22</para>
  </formalpara>
 
@@ -2081,7 +2081,7 @@ operations on bytea columns (Joe)</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2003-02-04</para>
  </formalpara>
 
@@ -2160,7 +2160,7 @@ operations on bytea columns (Joe)</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2002-12-18</para>
  </formalpara>
 
@@ -2229,7 +2229,7 @@ operations on bytea columns (Joe)</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2002-11-27</para>
  </formalpara>
 
@@ -3030,7 +3030,7 @@ PostgreSQL 7.3 にロードされた、7.3 よりも前のデータベースは�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2005-05-09</para>
   </formalpara>
 
@@ -3144,7 +3144,7 @@ month-related formats</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2005-01-31</para>
   </formalpara>
 
@@ -3210,7 +3210,7 @@ datestyles</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2004-10-22</para>
   </formalpara>
 
@@ -3308,7 +3308,7 @@ concern since there is no reason for non-developers to use this script anyway.
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2004-08-16</para>
   </formalpara>
 
@@ -3376,7 +3376,7 @@ since <productname>PostgreSQL</productname> 7.1.
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2003-01-30</para>
  </formalpara>
 
@@ -3433,7 +3433,7 @@ since <productname>PostgreSQL</productname> 7.1.
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2002-10-01</para>
  </formalpara>
 
@@ -3488,7 +3488,7 @@ since <productname>PostgreSQL</productname> 7.1.
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2002-08-23</para>
  </formalpara>
 
@@ -3549,7 +3549,7 @@ since <productname>PostgreSQL</productname> 7.1.
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2002-03-21</para>
  </formalpara>
 
@@ -3613,7 +3613,7 @@ since <productname>PostgreSQL</productname> 7.1.
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2002-02-04</para>
  </formalpara>
 
@@ -4302,7 +4302,7 @@ OID は省略できるようになりました。ユーザは OID の使用が�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2001-08-15</para>
   </formalpara>
 
@@ -4355,7 +4355,7 @@ Cygwin build (Jason Tishler)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2001-05-11</para>
   </formalpara>
 
@@ -4411,7 +4411,7 @@ pg_dump cleanups
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2001-05-05</para>
   </formalpara>
 
@@ -4476,7 +4476,7 @@ Python fixes (Darcy)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2001-04-13</para>
   </formalpara>
 
@@ -4832,7 +4832,7 @@ New FreeBSD tools ipc_check, start-scripts/freebsd
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2000-11-11</para>
   </formalpara>
 
@@ -4923,7 +4923,7 @@ Fix for crash of backend, on abort (Tom)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2000-06-05</para>
   </formalpara>
 
@@ -4978,7 +4978,7 @@ tarballに文書を追加した。
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2000-06-01</para>
   </formalpara>
 
@@ -5051,7 +5051,7 @@ ecpg changes (Michael)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2000-05-08</para>
   </formalpara>
 
@@ -5591,7 +5591,7 @@ New multibyte encodings
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>1999-10-13</para>
   </formalpara>
 
@@ -5645,7 +5645,7 @@ Fix dumping rules on inherited tables
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>1999-09-15</para>
   </formalpara>
 
@@ -5720,7 +5720,7 @@ Updated version of pgaccess 0.98
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>1999-07-15</para>
   </formalpara>
 
@@ -5793,7 +5793,7 @@ Add Win1250 (Czech) support (Pavel Behal)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>1999-06-09</para>
   </formalpara>
 
@@ -6301,7 +6301,7 @@ New install commands for plpgsql(Jan)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>1998-12-20</para>
   </formalpara>
 
@@ -6355,7 +6355,7 @@ Fix for datetime constant problem on some platforms(Thomas)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>1998-12-18</para>
   </formalpara>
 
@@ -6438,7 +6438,7 @@ Upgrade to PyGreSQL 2.2(D'Arcy)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>1998-10-30</para>
   </formalpara>
 
@@ -6782,7 +6782,7 @@ new Makefile.shlib for shared library configuration(Tom)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>1998-04-07</para>
   </formalpara>
 
@@ -6883,7 +6883,7 @@ ASSERT fixes(Bruce)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>1998-03-23</para>
   </formalpara>
 
@@ -7002,7 +7002,7 @@ Better identify tcl and tk libs and includes(Bruce)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>1998-03-01</para>
   </formalpara>
 
@@ -7399,7 +7399,7 @@ Remove un-needed malloc() calls and replace with palloc()(Bruce)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>1997-10-17</para>
   </formalpara>
 
@@ -7522,7 +7522,7 @@ Trigger function for inserting user names for INSERT/UPDATE(Brook Milligan)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>1997-10-02</para>
   </formalpara>
 
@@ -7703,7 +7703,7 @@ SPI and Trigger programming guides (Vadim &amp; D'Arcy)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>1997-07-22</para>
   </formalpara>
 
@@ -7765,7 +7765,7 @@ pg_dumpall now returns proper status, portability fix(Bruce)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>1997-06-08</para>
   </formalpara>
 
@@ -7981,7 +7981,7 @@ DG/UX, Ultrix, IRIX, AIX portability fixes
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>1997-01-29</para>
   </formalpara>
 
@@ -8149,7 +8149,7 @@ Unused/uninitialized variables corrected
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>1996-11-04</para>
   </formalpara>
 
@@ -8174,7 +8174,7 @@ releases.
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>1996-08-01</para>
   </formalpara>
 
@@ -8373,7 +8373,7 @@ Contributors (apologies to any missed)
 <!--
    <title>Release date:</title>
 -->
-<title>リリース日</title>
+   <title>リリース日:</title>
    <para>1996-02-23</para>
    </formalpara>
 
@@ -8628,7 +8628,7 @@ Bug fixes:
 <!--
    <title>Release date:</title>
 -->
-<title>リリース日</title>
+   <title>リリース日:</title>
    <para>1995-09-05</para>
    </formalpara>
 
@@ -8694,7 +8694,7 @@ Bug fixes:
 <!--
    <title>Release date:</title>
 -->
-<title>リリース日</title>
+   <title>リリース日:</title>
    <para>1995-07-21</para>
    </formalpara>
 
@@ -8825,7 +8825,7 @@ New documentation:
 <!--
    <title>Release date:</title>
 -->
-<title>リリース日</title>
+   <title>リリース日:</title>
    <para>1995-05-25</para>
    </formalpara>
 
@@ -8885,7 +8885,7 @@ The following bugs have been fixed in postgres95-beta-0.02:
 <!--
    <title>Release date:</title>
 -->
-<title>リリース日</title>
+   <title>リリース日:</title>
    <para>1995-05-01</para>
    </formalpara>
 


### PR DESCRIPTION
release-old.sgml の 9.6.4 対応です。

と言っても、（英文に合わせて）リリース日 → リリース日: なだけです。