### PR TITLE
update release-7.4 and 8.x for 9.6.4

### DIFF
--- a/doc/src/sgml/release-7.4.sgml
+++ b/doc/src/sgml/release-7.4.sgml
@@ -11,7 +11,7 @@
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-10-04</para>
   </formalpara>
 
@@ -214,7 +214,7 @@ PL/PerlおよびPL/Tclにおいて、呼び出し元のSQLユーザIDごとに�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-05-17</para>
   </formalpara>
 
@@ -431,7 +431,7 @@ pl/python内の雑多なメモリリークを修正しました。(Andreas Freun
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-03-15</para>
   </formalpara>
 
@@ -611,7 +611,7 @@ PL/Tclは確実にTclインタプリタを完全に初期化します。(Tom)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-12-14</para>
   </formalpara>
 
@@ -791,7 +791,7 @@ PAMスタックに渡される引数に関する正当ではない仮定を作�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-09-09</para>
   </formalpara>
 
@@ -986,7 +986,7 @@ readlineとeditlineライブラリの両方がインストールされている�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-03-16</para>
   </formalpara>
 
@@ -1108,7 +1108,7 @@ readlineとeditlineライブラリの両方がインストールされている�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-02-02</para>
   </formalpara>
 
@@ -1235,7 +1235,7 @@ readlineとeditlineライブラリの両方がインストールされている�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-11-03</para>
   </formalpara>
 
@@ -1363,7 +1363,7 @@ readlineとeditlineライブラリの両方がインストールされている�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-09-22</para>
   </formalpara>
 
@@ -1477,7 +1477,7 @@ readlineとeditlineライブラリの両方がインストールされている�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-06-12</para>
   </formalpara>
 
@@ -1561,10 +1561,12 @@ readlineとeditlineライブラリの両方がインストールされている�
   <formalpara>
 <!--
   <title>Release date:</title>
--->
-<title>リリース日</title>
   <para>never released</para>
+-->
+  <title>リリース日:</title>
+  <para>リリースされませんでした</para>
   </formalpara>
+
   <para>
 <!--
    This release contains a variety of fixes from 7.4.19.
@@ -1779,7 +1781,7 @@ COPY OUT時にNOTICEメッセージを正しく扱うよう<application>libpq</>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-01-07</para>
   </formalpara>
 
@@ -2007,7 +2009,7 @@ COPY OUT時にNOTICEメッセージを正しく扱うよう<application>libpq</>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-09-17</para>
   </formalpara>
 
@@ -2121,7 +2123,7 @@ COPY OUT時にNOTICEメッセージを正しく扱うよう<application>libpq</>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-04-23</para>
   </formalpara>
 
@@ -2230,7 +2232,7 @@ COPY OUT時にNOTICEメッセージを正しく扱うよう<application>libpq</>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-02-05</para>
   </formalpara>
 
@@ -2338,7 +2340,7 @@ COPY OUT時にNOTICEメッセージを正しく扱うよう<application>libpq</>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-01-08</para>
   </formalpara>
 
@@ -2474,7 +2476,7 @@ AIXにおける<function>getaddrinfo()</>の扱いを改良しました。(Tom)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2006-10-16</para>
   </formalpara>
 
@@ -2577,7 +2579,7 @@ ANYARRAY</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2006-05-23</para>
   </formalpara>
 
@@ -2786,7 +2788,7 @@ Intel MacでのBonjourを修正しました。(Ashley Clark)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2006-02-14</para>
   </formalpara>
 
@@ -2907,7 +2909,7 @@ configure時の<function>finite</>および<function>isinf</>の存在検査に�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2006-01-09</para>
   </formalpara>
 
@@ -3042,7 +3044,7 @@ what's actually returned by the query (Joe)</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2005-12-12</para>
   </formalpara>
 
@@ -3153,7 +3155,7 @@ table has been dropped</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2005-10-04</para>
   </formalpara>
 
@@ -3332,7 +3334,7 @@ code</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2005-05-09</para>
   </formalpara>
 
@@ -3707,7 +3709,7 @@ holder of the lock released it within a very narrow window.
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2005-01-31</para>
   </formalpara>
 
@@ -3821,7 +3823,7 @@ GMT</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2004-10-22</para>
   </formalpara>
 
@@ -3950,7 +3952,7 @@ ECPG prepare statement</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2004-08-18</para>
   </formalpara>
 
@@ -4016,7 +4018,7 @@ still worth a re-release.  The bug does not exist in pre-7.4 releases.
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2004-08-16</para>
   </formalpara>
 
@@ -4094,7 +4096,7 @@ aggregate plan</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2004-06-14</para>
   </formalpara>
 
@@ -4177,7 +4179,7 @@ names from outer query levels.
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2004-03-08</para>
   </formalpara>
 
@@ -4374,7 +4376,7 @@ inconveniences associated with the <literal>i/I</> problem.</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2003-12-22</para>
   </formalpara>
 
@@ -4540,7 +4542,7 @@ Informix互換用のECPGヘッダファイルの名前の一部がオペレー�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2003-11-17</para>
  </formalpara>
 

--- a/doc/src/sgml/release-8.0.sgml
+++ b/doc/src/sgml/release-8.0.sgml
@@ -11,7 +11,7 @@
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-10-04</para>
   </formalpara>
 
@@ -316,7 +316,7 @@ Pacific/ChuukはPacific/Trukより好まれるようになり（好まれる省�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-05-17</para>
   </formalpara>
 
@@ -556,7 +556,7 @@ pl/python内の雑多なメモリリークを修正しました。(Andreas Freun
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-03-15</para>
   </formalpara>
 
@@ -819,7 +819,7 @@ PL/Tclは確実にTclインタプリタを完全に初期化します。(Tom)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-12-14</para>
   </formalpara>
 
@@ -1050,7 +1050,7 @@ PL/Pythonの例外処理におけるまれなクラッシュを修正しまし�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-09-09</para>
   </formalpara>
 
@@ -1294,7 +1294,7 @@ readlineとeditlineライブラリの両方がインストールされている�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-03-16</para>
   </formalpara>
 
@@ -1416,7 +1416,7 @@ readlineとeditlineライブラリの両方がインストールされている�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-02-02</para>
   </formalpara>
 
@@ -1543,7 +1543,7 @@ readlineとeditlineライブラリの両方がインストールされている�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-11-03</para>
   </formalpara>
 
@@ -1710,7 +1710,7 @@ readlineとeditlineライブラリの両方がインストールされている�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-09-22</para>
   </formalpara>
 
@@ -1911,7 +1911,7 @@ Python 2.5で動作するようPL/Pythonを修正しました。
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-06-12</para>
   </formalpara>
 
@@ -1995,10 +1995,12 @@ Python 2.5で動作するようPL/Pythonを修正しました。
   <formalpara>
 <!--
   <title>Release date:</title>
--->
-<title>リリース日</title>
   <para>never released</para>
+-->
+  <title>リリース日:</title>
+  <para>リリースされませんでした</para>
   </formalpara>
+
   <para>
 <!--
    This release contains a variety of fixes from 8.0.15.
@@ -2347,7 +2349,7 @@ COPY OUT時にNOTICEメッセージを正しく扱うよう<application>libpq</>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-01-07</para>
   </formalpara>
 
@@ -2667,7 +2669,7 @@ COPY OUT時にNOTICEメッセージを正しく扱うよう<application>libpq</>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-09-17</para>
   </formalpara>
 
@@ -2828,7 +2830,7 @@ Windowsソケットを改良しました。(Magnus)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-04-23</para>
   </formalpara>
 
@@ -2946,7 +2948,7 @@ POSIX書式の時間帯指定が新しいUSA DST規則に従うよう修正し�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-02-07</para>
   </formalpara>
 
@@ -3011,7 +3013,7 @@ POSIX書式の時間帯指定が新しいUSA DST規則に従うよう修正し�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-02-05</para>
   </formalpara>
 
@@ -3119,7 +3121,7 @@ POSIX書式の時間帯指定が新しいUSA DST規則に従うよう修正し�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-01-08</para>
   </formalpara>
 
@@ -3300,7 +3302,7 @@ ECPGにおける接続時のメモリリークを修正しました。(Michael)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2006-10-16</para>
   </formalpara>
 
@@ -3436,7 +3438,7 @@ Win32における統計情報収集の不安定性を修正しました。(Tom, 
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2006-05-23</para>
   </formalpara>
 
@@ -3662,7 +3664,7 @@ Intel MacでのBonjourを修正しました。(Ashley Clark)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2006-02-14</para>
   </formalpara>
 
@@ -3873,7 +3875,7 @@ configure時の<function>finite</>および<function>isinf</>の存在検査に�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2006-01-09</para>
   </formalpara>
 
@@ -4058,7 +4060,7 @@ what's actually returned by the query (Joe)</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2005-12-12</para>
   </formalpara>
 
@@ -4238,7 +4240,7 @@ to subquery results</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2005-10-04</para>
   </formalpara>
 
@@ -4521,7 +4523,7 @@ code</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2005-05-09</para>
   </formalpara>
 
@@ -4787,7 +4789,7 @@ data types</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2005-04-07</para>
   </formalpara>
 
@@ -5131,7 +5133,7 @@ addresses in <type>INET</> data types (Tom)</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2005-01-31</para>
   </formalpara>
 
@@ -5281,7 +5283,7 @@ typedefs (Michael)</para></listitem>
 <!--
    <title>Release date:</title>
 -->
-<title>リリース日</title>
+   <title>リリース日:</title>
    <para>2005-01-19</para>
   </formalpara>
 

--- a/doc/src/sgml/release-8.1.sgml
+++ b/doc/src/sgml/release-8.1.sgml
@@ -11,7 +11,7 @@
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-12-16</para>
   </formalpara>
 
@@ -342,7 +342,7 @@ GiSTではこの状況の検知に失敗していました。
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-10-04</para>
   </formalpara>
 
@@ -667,7 +667,7 @@ Pacific/ChuukはPacific/Trukより好まれるようになり（好まれる省�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-05-17</para>
   </formalpara>
 
@@ -897,7 +897,7 @@ pl/python内の雑多なメモリリークを修正しました。(Andreas Freun
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-03-15</para>
   </formalpara>
 
@@ -1179,7 +1179,7 @@ PL/Tclは確実にTclインタプリタを完全に初期化します。(Tom)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-12-14</para>
   </formalpara>
 
@@ -1448,7 +1448,7 @@ PL/Pythonの例外処理におけるまれなクラッシュを修正しまし�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-09-09</para>
   </formalpara>
 
@@ -1692,7 +1692,7 @@ readlineとeditlineライブラリの両方がインストールされている�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-03-16</para>
   </formalpara>
 
@@ -1878,7 +1878,7 @@ TOASTの行型に対する権限は通常のデータベース操作ではまっ
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-02-02</para>
   </formalpara>
 
@@ -2057,7 +2057,7 @@ TOASTの行型に対する権限は通常のデータベース操作ではまっ
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-11-03</para>
   </formalpara>
 
@@ -2285,7 +2285,7 @@ TOASTの行型に対する権限は通常のデータベース操作ではまっ
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-09-22</para>
   </formalpara>
 
@@ -2548,7 +2548,7 @@ Python 2.5で動作するようPL/Pythonを修正しました。
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-06-12</para>
   </formalpara>
 
@@ -2651,9 +2651,10 @@ Python 2.5で動作するようPL/Pythonを修正しました。
   <formalpara>
 <!--
   <title>Release date:</title>
--->
-<title>リリース日</title>
   <para>never released</para>
+-->
+  <title>リリース日:</title>
+  <para>リリースされませんでした</para>
   </formalpara>
 
   <para>
@@ -3023,7 +3024,7 @@ COPY OUT時にNOTICEメッセージを正しく扱うよう<application>libpq</>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-01-07</para>
   </formalpara>
 
@@ -3395,7 +3396,7 @@ COPY OUT時にNOTICEメッセージを正しく扱うよう<application>libpq</>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-09-17</para>
   </formalpara>
 
@@ -3575,7 +3576,7 @@ Windowsソケットを改良しました。(Magnus)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-04-23</para>
   </formalpara>
 
@@ -3713,7 +3714,7 @@ POSIX書式の時間帯指定が新しいUSA DST規則に従うよう修正し�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-02-07</para>
   </formalpara>
 
@@ -3778,7 +3779,7 @@ POSIX書式の時間帯指定が新しいUSA DST規則に従うよう修正し�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-02-05</para>
   </formalpara>
 
@@ -3932,7 +3933,7 @@ POSIX書式の時間帯指定が新しいUSA DST規則に従うよう修正し�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-01-08</para>
   </formalpara>
 
@@ -4159,7 +4160,7 @@ Darwin (OS X)のコンパイルを修正しました。(Tom)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2006-10-16</para>
   </formalpara>
 
@@ -4362,7 +4363,7 @@ Fixes for <systemitem class="osname">AIX</> and
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2006-05-23</para>
   </formalpara>
 
@@ -4691,7 +4692,7 @@ documented (Tom)</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2006-02-14</para>
   </formalpara>
 
@@ -4958,7 +4959,7 @@ creation (Tom)</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2006-01-09</para>
   </formalpara>
 
@@ -5184,7 +5185,7 @@ what's actually returned by the query (Joe)</para></listitem>
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2005-12-12</para>
   </formalpara>
 
@@ -5381,7 +5382,7 @@ DISTINCT query</para></listitem>
 <!--
    <title>Release date:</title>
 -->
-<title>リリース日</title>
+   <title>リリース日:</title>
    <para>2005-11-08</para>
   </formalpara>
 

--- a/doc/src/sgml/release-8.2.sgml
+++ b/doc/src/sgml/release-8.2.sgml
@@ -11,7 +11,7 @@
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-12-05</para>
   </formalpara>
 
@@ -355,7 +355,7 @@ VPATH構築ですべてのサーバヘッダファイルが適切にインスト
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-09-26</para>
   </formalpara>
 
@@ -815,7 +815,7 @@ perl 5.14を用いたビルドを可能にしました。(Alex Hunsaker)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-04-18</para>
   </formalpara>
 
@@ -1013,7 +1013,7 @@ Cygwinにおいて<application>pg_regress</>で使用されるパス区切り文
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-01-31</para>
   </formalpara>
 
@@ -1213,7 +1213,7 @@ Cygwinにおいて<application>pg_regress</>で使用されるパス区切り文
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-12-16</para>
   </formalpara>
 
@@ -1580,7 +1580,7 @@ GiSTではこの状況の検知に失敗していました。
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-10-04</para>
   </formalpara>
 
@@ -2010,7 +2010,7 @@ Asia/Novosibirskはこの新しい振舞いにより合致しています。
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-05-17</para>
   </formalpara>
 
@@ -2311,7 +2311,7 @@ Windowsにおいて既知の時間帯名称の集合を更新しました。(Mag
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-03-15</para>
   </formalpara>
 
@@ -2712,7 +2712,7 @@ Widowsのシグナル処理における競合状態を修正しました。(Radu
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-12-14</para>
   </formalpara>
 
@@ -3076,7 +3076,7 @@ PL/Pythonの例外処理におけるまれなクラッシュを修正しまし�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-09-09</para>
   </formalpara>
 
@@ -3417,7 +3417,7 @@ readlineとeditlineライブラリの両方がインストールされている�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-03-16</para>
   </formalpara>
 
@@ -3667,7 +3667,7 @@ Windowsにおいて<function>CallNamedPipe()</>呼び出しが失敗した時に
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-02-02</para>
   </formalpara>
 
@@ -3932,7 +3932,7 @@ Windowsにおいて<function>CallNamedPipe()</>呼び出しが失敗した時に
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-11-03</para>
   </formalpara>
 
@@ -4209,7 +4209,7 @@ Windowsにおいて<function>CallNamedPipe()</>呼び出しが失敗した時に
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-09-22</para>
   </formalpara>
 
@@ -4555,7 +4555,7 @@ Windowsにおいて、<application>libpq</>がシステムコール当たり64kB
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-06-12</para>
   </formalpara>
 
@@ -4658,9 +4658,10 @@ Windowsにおいて、<application>libpq</>がシステムコール当たり64kB
   <formalpara>
 <!--
   <title>Release date:</title>
--->
-<title>リリース日</title>
   <para>never released</para>
+-->
+  <title>リリース日:</title>
+  <para>リリースされませんでした</para>
   </formalpara>
 
   <para>
@@ -4945,7 +4946,7 @@ SIGTERMがデータベースクラスタ全体を停止するために使用さ�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-03-17</para>
   </formalpara>
 
@@ -5351,7 +5352,7 @@ COPY OUT時にNOTICEメッセージを正しく扱うように<application>libpq
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-01-07</para>
   </formalpara>
 
@@ -5778,7 +5779,7 @@ GINインデックスに対するWAL再生における不具合を修正しま�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-09-17</para>
   </formalpara>
 
@@ -6040,7 +6041,7 @@ Windowsで<application>MIT Kerberos</>を使用する場合のメモリ割り当
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-04-23</para>
   </formalpara>
 
@@ -6254,7 +6255,7 @@ POSIX書式の時間帯指定が新しいUSA DST規則に従うよう修正し�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-02-07</para>
   </formalpara>
 
@@ -6325,7 +6326,7 @@ POSIX書式の時間帯指定が新しいUSA DST規則に従うよう修正し�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-02-05</para>
   </formalpara>
 
@@ -6563,7 +6564,7 @@ PL/pgSQL例外ブロックの処理でエラーが起きる可能性を修正し
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2007-01-08</para>
   </formalpara>
 
@@ -6768,7 +6769,7 @@ PLはすべてSPIを使用しますので、これはすべてのPL関数に影�
 <!--
    <title>Release date:</title>
 -->
-<title>リリース日</title>
+   <title>リリース日:</title>
    <para>2006-12-05</para>
   </formalpara>
 

--- a/doc/src/sgml/release-8.3.sgml
+++ b/doc/src/sgml/release-8.3.sgml
@@ -11,7 +11,7 @@
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2013-02-07</para>
   </formalpara>
 
@@ -268,7 +268,7 @@ Windows用にクロスコンパイルしたときに、<application>pgxs</>が�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-12-06</para>
   </formalpara>
 
@@ -711,7 +711,7 @@ AIX上でのロード可能モジュールのビルドについて<application>p
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-09-24</para>
   </formalpara>
 
@@ -880,7 +880,7 @@ PL/Perlで正しく最適化されない場合があるのを回避しました�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-08-17</para>
   </formalpara>
 
@@ -1219,7 +1219,7 @@ CVE-2012-3489に対する修正のためこの能力が壊れましたが、そ�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-06-04</para>
   </formalpara>
 
@@ -1561,7 +1561,7 @@ Windowsの<function>PGSemaphoreLock()</>の実装は、戻る前に<varname>Imme
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-02-27</para>
   </formalpara>
 
@@ -1994,7 +1994,7 @@ configureスクリプトはこれまで、この組み合わせは動作しな�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-12-05</para>
   </formalpara>
 
@@ -2395,7 +2395,7 @@ VPATH構築ですべてのサーバヘッダファイルが適切にインスト
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-09-26</para>
   </formalpara>
 
@@ -2949,7 +2949,7 @@ perl 5.14を用いたビルドを可能にしました。(Alex Hunsaker)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-04-18</para>
   </formalpara>
 
@@ -3194,7 +3194,7 @@ Cygwinにおいて<application>pg_regress</>で使用されるパス区切り文
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-01-31</para>
   </formalpara>
 
@@ -3394,7 +3394,7 @@ Cygwinにおいて<application>pg_regress</>で使用されるパス区切り文
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-12-16</para>
   </formalpara>
 
@@ -3811,7 +3811,7 @@ GSSAPIサポート付きでコンパイルされたpostmasterで、接続受け�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-10-04</para>
   </formalpara>
 
@@ -4355,7 +4355,7 @@ Asia/Novosibirskはこの新しい振舞いにより合致しています。
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-05-17</para>
   </formalpara>
 
@@ -4697,7 +4697,7 @@ Windowsにおいて既知の時間帯名称の集合を更新しました。(Mag
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-03-15</para>
   </formalpara>
 
@@ -5181,7 +5181,7 @@ Widowsのシグナル処理における競合状態を修正しました。(Radu
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-12-14</para>
   </formalpara>
 
@@ -5682,7 +5682,7 @@ WindowsではUnixのようなシグナルを持ちませんので、これはま
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-09-09</para>
   </formalpara>
 
@@ -6110,7 +6110,7 @@ readlineとeditlineライブラリの両方がインストールされている�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-03-16</para>
   </formalpara>
 
@@ -6450,7 +6450,7 @@ Windowsにおいて<function>CallNamedPipe()</>呼び出しが失敗した時に
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-02-02</para>
   </formalpara>
 
@@ -6889,7 +6889,7 @@ Windows 7 betaにおけるサービスとしての実行をサポートします
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-11-03</para>
   </formalpara>
 
@@ -7271,7 +7271,7 @@ PITR復旧中の前回完了したトランザクション時刻のログ処理�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-09-22</para>
   </formalpara>
 
@@ -7802,7 +7802,7 @@ Windowsにおいて、<application>libpq</>がシステムコール当たり64kB
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-06-12</para>
   </formalpara>
 
@@ -7905,9 +7905,10 @@ Windowsにおいて、<application>libpq</>がシステムコール当たり64kB
   <formalpara>
 <!--
   <title>Release date:</title>
--->
-<title>リリース日</title>
   <para>never released</para>
+-->
+  <title>リリース日:</title>
+  <para>リリースされませんでした</para>
   </formalpara>
 
   <para>
@@ -8439,7 +8440,7 @@ XID周回を防ぐために起動された自動バキュームのキャンセ�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2008-03-17</para>
   </formalpara>
 
@@ -8911,7 +8912,7 @@ MSVCを使用した<filename>contrib/uuid-ossp</>の構築が可能になりま�
 <!--
    <title>Release date:</title>
 -->
-<title>リリース日</title>
+   <title>リリース日:</title>
    <para>2008-02-04</para>
   </formalpara>
 

--- a/doc/src/sgml/release-8.4.sgml
+++ b/doc/src/sgml/release-8.4.sgml
@@ -11,7 +11,7 @@
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2014-07-24</para>
   </formalpara>
 
@@ -493,7 +493,7 @@ OS Xで<application>libpython</>のリンクを修正しました。(Tom Lane)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2014-03-20</para>
   </formalpara>
 
@@ -677,7 +677,7 @@ GINメタページのアクティブな部分は標準的なディスクセク�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2014-02-20</para>
   </formalpara>
 
@@ -1372,7 +1372,7 @@ MSVCビルドに於いて、このコピーは長らく行われてきました�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2013-12-05</para>
   </formalpara>
 
@@ -1678,7 +1678,7 @@ Windowsエラーコード変換のログ取得時に発生する可能性があ�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2013-10-10</para>
   </formalpara>
 
@@ -1975,7 +1975,7 @@ C99標準では、<literal>inf</>、<literal>+inf</>、 <literal>-inf</>、 <lit
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2013-04-04</para>
   </formalpara>
 
@@ -2319,7 +2319,7 @@ PL/Perlの<function>spi_prepare()</>関数のメモリリークを修正しま�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2013-02-07</para>
   </formalpara>
 
@@ -2634,7 +2634,7 @@ Windows用にクロスコンパイルしたときに、<application>pgxs</>が�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-12-06</para>
   </formalpara>
 
@@ -3086,7 +3086,7 @@ AIX上でのロード可能モジュールのビルドについて<application>p
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-09-24</para>
   </formalpara>
 
@@ -3264,7 +3264,7 @@ PL/Perlで正しく最適化されない場合があるのを回避しました�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-08-17</para>
   </formalpara>
 
@@ -3616,7 +3616,7 @@ CVE-2012-3489に対する修正のためこの能力が壊れましたが、そ�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-06-04</para>
   </formalpara>
 
@@ -4042,7 +4042,7 @@ PL/pgSQLの<command>RETURN NEXT</>コマンドにおけるメモリリークを�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-02-27</para>
   </formalpara>
 
@@ -4585,7 +4585,7 @@ configureスクリプトはこれまで、この組み合わせは動作しな�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-12-05</para>
   </formalpara>
 
@@ -5060,7 +5060,7 @@ VPATH構築ですべてのサーバヘッダファイルが適切にインスト
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-09-26</para>
   </formalpara>
 
@@ -5845,7 +5845,7 @@ perl 5.14を用いたビルドを可能にしました。(Alex Hunsaker)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-04-18</para>
   </formalpara>
 
@@ -6213,7 +6213,7 @@ Cygwinにおいて<application>pg_regress</>で使用されるパス区切り文
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-01-31</para>
   </formalpara>
 
@@ -6395,7 +6395,7 @@ Cygwinにおいて<application>pg_regress</>で使用されるパス区切り文
 これにより、<type>seg</>列上のGiSTインデックスにおいて実際に不正な結果になることはありませんが、非常に非効率的な結果になることがあり得ました。
 こうしたインデックスがある場合、この更新版をインストールした後に<command>REINDEX</>処理を行うことを検討してください。
 （これは過去の更新の<filename>contrib/cube</>で修正された不具合と同じです。）
-    </para>
+     </para>
     </listitem>
 
    </itemizedlist>
@@ -6413,7 +6413,7 @@ Cygwinにおいて<application>pg_regress</>で使用されるパス区切り文
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-12-16</para>
   </formalpara>
 
@@ -6880,7 +6880,7 @@ GSSAPIサポート付きでコンパイルされたpostmasterで、接続受け�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-10-04</para>
   </formalpara>
 
@@ -7662,7 +7662,7 @@ Asia/Novosibirskはこの新しい振舞いにより合致しています。
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-05-17</para>
   </formalpara>
 
@@ -8095,7 +8095,7 @@ Windowsにおいて既知の時間帯名称の集合を更新しました。(Mag
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-03-15</para>
   </formalpara>
 
@@ -8786,7 +8786,7 @@ Cコンパイラが64ビット整数データ型の動作を提供しない場�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-12-14</para>
   </formalpara>
 
@@ -9578,7 +9578,7 @@ WindowsではUnixのようなシグナルを持ちませんので、これはま
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2009-09-09</para>
   </formalpara>
 
@@ -10030,7 +10030,7 @@ readlineとeditlineライブラリの両方がインストールされている�
 <!--
    <title>Release date:</title>
 -->
-<title>リリース日</title>
+   <title>リリース日:</title>
    <para>2009-07-01</para>
   </formalpara>
 


### PR DESCRIPTION
release-7.4.sgml とrelease-8.*.sgml の 9.6.4対応です。
リリース日 → リリース日: だけです。基本的には。