### PR TITLE
update release-9.[01] for 9.6.4

### DIFF
--- a/doc/src/sgml/release-9.0.sgml
+++ b/doc/src/sgml/release-9.0.sgml
@@ -11,7 +11,7 @@
 <!--
   <title>Release date:</title>
 -->
-  <title>リリース日</title>
+  <title>リリース日:</title>
   <para>2015-10-08</para>
   </formalpara>
 
@@ -791,7 +791,7 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2015-06-12</para>
   </formalpara>
 
@@ -907,7 +907,7 @@ PostgreSQLコミュニティは2015年9月に9.0.Xシリーズの更新リリー
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2015-06-04</para>
   </formalpara>
 
@@ -1053,7 +1053,7 @@ PostgreSQLコミュニティは2015年9月に9.0.Xシリーズの更新リリー
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2015-05-22</para>
   </formalpara>
 
@@ -1745,7 +1745,7 @@ Sparc V8 マシンでのコンパイル失敗を修正しました。
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2015-02-05</para>
   </formalpara>
 
@@ -2871,7 +2871,7 @@ SRET(アジア/スレドネコリムスク)、XJT(アジア/ウルムチ)、西�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2014-07-24</para>
   </formalpara>
 
@@ -3391,7 +3391,7 @@ OS Xで<application>libpython</>のリンクを修正しました。(Tom Lane)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2014-03-20</para>
   </formalpara>
 
@@ -3623,7 +3623,7 @@ GINメタページのアクティブな部分は標準的なディスクセク�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2014-02-20</para>
   </formalpara>
 
@@ -4380,7 +4380,7 @@ Cygwin環境で廃止予定の<literal>dllwrap</>ツールの使用を止めま�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2013-12-05</para>
   </formalpara>
 
@@ -4741,7 +4741,7 @@ Windowsエラーコード変換のログ取得時に発生する可能性があ�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2013-10-10</para>
   </formalpara>
 
@@ -5137,7 +5137,7 @@ C99標準では、<literal>inf</>、<literal>+inf</>、 <literal>-inf</>、 <lit
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2013-04-04</para>
   </formalpara>
 
@@ -5582,7 +5582,7 @@ PL/Perlの<function>spi_prepare()</>関数のメモリリークを修正しま�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2013-02-07</para>
   </formalpara>
 
@@ -5973,7 +5973,7 @@ Windows用にクロスコンパイルしたときに、<application>pgxs</>が�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-12-06</para>
   </formalpara>
 
@@ -6538,7 +6538,7 @@ AIX上でのロード可能モジュールのビルドについて<application>p
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-09-24</para>
   </formalpara>
 
@@ -6754,7 +6754,7 @@ Windows上で<application>pg_upgrade</>が生成するスクリプトで、パ�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-08-17</para>
   </formalpara>
 
@@ -7214,7 +7214,7 @@ PL/PythonにおいてPostgreSQL符号化方式とPython符号化方式との間�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-06-04</para>
   </formalpara>
 
@@ -7692,7 +7692,7 @@ PL/pgSQLの<command>RETURN NEXT</>コマンドにおけるメモリリークを�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-02-27</para>
   </formalpara>
 
@@ -8464,7 +8464,7 @@ configureスクリプトはこれまで、この組み合わせは動作しな�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-12-05</para>
   </formalpara>
 
@@ -9044,7 +9044,7 @@ VPATH構築ですべてのサーバヘッダファイルが適切にインスト
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-09-26</para>
   </formalpara>
 
@@ -10012,7 +10012,7 @@ perl 5.14を用いたビルドを可能にしました。(Alex Hunsaker)
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-04-18</para>
   </formalpara>
 
@@ -10523,7 +10523,7 @@ Cygwinにおいて<application>pg_regress</>で使用されるパス区切り文
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-01-31</para>
   </formalpara>
 
@@ -10789,7 +10789,7 @@ EvalPlanQualは同一行に対する同時更新の間だけ実行されます�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-12-16</para>
   </formalpara>
 
@@ -11458,7 +11458,7 @@ RADIUS認証サーバからの無効な応答パケットを受け取った後�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2010-10-04</para>
   </formalpara>
 
@@ -11673,7 +11673,7 @@ PL/PerlおよびPL/Tclにおいて、呼び出し元のSQLユーザIDごとに�
 <!--
    <title>Release date:</title>
 -->
-<title>リリース日</title>
+   <title>リリース日:</title>
    <para>2010-09-20</para>
   </formalpara>
 

--- a/doc/src/sgml/release-9.1.sgml
+++ b/doc/src/sgml/release-9.1.sgml
@@ -11,7 +11,7 @@
 <!--
   <title>Release date:</title>
 -->
-  <title>リリース日</title>
+  <title>リリース日:</title>
   <para>2016-10-27</para>
   </formalpara>
 
@@ -330,7 +330,7 @@ IANAは英語の省略形が現実に使われている形跡がないゾーン�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2016-08-11</para>
   </formalpara>
 
@@ -854,7 +854,7 @@ AIXの共有ライブラリをビルドするMakefileのルールをパラレル
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2016-05-12</para>
   </formalpara>
 
@@ -1109,7 +1109,7 @@ Windowsの<function>FormatMessage()</>関数の安全でない可能性のある
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2016-03-31</para>
   </formalpara>
 
@@ -1427,7 +1427,7 @@ Perl本体からもはや提供されなくなったため、MSVCビルドで<li
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2016-02-11</para>
   </formalpara>
 
@@ -2226,7 +2226,7 @@ MSVCビルドにてインストールされるヘッダファイル群に<filena
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2015-10-08</para>
   </formalpara>
 
@@ -3101,7 +3101,7 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2015-06-12</para>
   </formalpara>
 
@@ -3207,7 +3207,7 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+<title>リリース日:</title>
   <para>2015-06-04</para>
   </formalpara>
 
@@ -3342,7 +3342,7 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2015-05-22</para>
   </formalpara>
 
@@ -4157,7 +4157,7 @@ Sparc V8 マシンでのコンパイル失敗を修正しました。
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2015-02-05</para>
   </formalpara>
 
@@ -5404,7 +5404,7 @@ SRET(アジア/スレドネコリムスク)、XJT(アジア/ウルムチ)、西�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2014-07-24</para>
   </formalpara>
 
@@ -5977,7 +5977,7 @@ macOS Xで<application>libpython</>のリンクを修正しました。(Tom Lane
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2014-03-20</para>
   </formalpara>
 
@@ -6229,7 +6229,7 @@ GINメタページのアクティブな部分は標準的なディスクセク�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2014-02-20</para>
   </formalpara>
 
@@ -7055,7 +7055,7 @@ Cygwin環境で廃止予定の<literal>dllwrap</>ツールの使用を止めま�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2013-12-05</para>
   </formalpara>
 
@@ -7443,7 +7443,7 @@ Windowsエラーコード変換のログ取得時に発生する可能性があ�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2013-10-10</para>
   </formalpara>
 
@@ -7941,7 +7941,7 @@ C99標準では、<literal>inf</>、<literal>+inf</>、 <literal>-inf</>、 <lit
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2013-04-04</para>
   </formalpara>
 
@@ -8439,7 +8439,7 @@ PL/Perlの<function>spi_prepare()</>関数のメモリリークを修正しま�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2013-02-07</para>
   </formalpara>
 
@@ -8920,7 +8920,7 @@ Windows用にクロスコンパイルしたときに、<application>pgxs</>が�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-12-06</para>
   </formalpara>
 
@@ -9610,7 +9610,7 @@ AIX上でのロード可能モジュールのビルドについて<application>p
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-09-24</para>
   </formalpara>
 
@@ -9991,7 +9991,7 @@ Windows上で<application>pg_upgrade</>が生成するスクリプトで、パ�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-08-17</para>
   </formalpara>
 
@@ -10569,7 +10569,7 @@ PL/PythonにおいてPostgreSQL符号化方式とPython符号化方式との間�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-06-04</para>
   </formalpara>
 
@@ -11297,7 +11297,7 @@ PL/Perlは確実に<varname>_TD</>変数をパッケージで修飾します。(
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2012-02-27</para>
   </formalpara>
 
@@ -12248,7 +12248,7 @@ MinGWが標準的な名前のOpenSSLライブラリを使用して構築でき�
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-12-05</para>
   </formalpara>
 
@@ -13216,7 +13216,7 @@ VPATH構築ですべてのサーバヘッダファイルが適切にインスト
 <!--
   <title>Release date:</title>
 -->
-<title>リリース日</title>
+  <title>リリース日:</title>
   <para>2011-09-26</para>
   </formalpara>
 
@@ -13321,7 +13321,7 @@ GiSTインデックススキャン終了時のメモリリークを修正しま�
 <!--
    <title>Release date:</title>
 -->
-<title>リリース日</title>
+   <title>リリース日:</title>
    <para>2011-09-12</para>
   </formalpara>
 


### PR DESCRIPTION
release-9.[01].sgml の 9.6.4 対応です。
ここまでは新しいバージョンが出た訳ではありませんので
リリース日 → リリース日:
だけです。