### PR TITLE
update release-9.[2-5] for 9.6.5

### DIFF
--- a/doc/src/sgml/release-9.0.sgml
+++ b/doc/src/sgml/release-9.0.sgml
@@ -801,7 +801,7 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
    For information about new features in the 9.0 major release, see
    <xref linkend="release-9-0">.
 -->
-このリリースは9.0.21に対し、各種不具合を修正したものです。
+このリリースは9.0.21に対し、少数の不具合を修正したものです。
 9.0メジャーリリースにおける新機能については、<xref linkend="release-9-0">
 を参照してください。
   </para>
@@ -917,7 +917,7 @@ PostgreSQLコミュニティは2015年9月に9.0.Xシリーズの更新リリー
    For information about new features in the 9.0 major release, see
    <xref linkend="release-9-0">.
 -->
-このリリースは9.0.20に対し、各種不具合を修正したものです。
+このリリースは9.0.20に対し、少数の不具合を修正したものです。
 9.0メジャーリリースにおける新機能については、<xref linkend="release-9-0">
 を参照してください。
   </para>

--- a/doc/src/sgml/release-9.1.sgml
+++ b/doc/src/sgml/release-9.1.sgml
@@ -3111,7 +3111,7 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
    For information about new features in the 9.1 major release, see
    <xref linkend="release-9-1">.
 -->
-このリリースは9.1.17に対し、各種不具合を修正したものです。
+このリリースは9.1.17に対し、少数の不具合を修正したものです。
 9.1メジャーリリースにおける新機能については、<xref linkend="release-9-1">を参照してください。
   </para>
 
@@ -3217,7 +3217,7 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
    For information about new features in the 9.1 major release, see
    <xref linkend="release-9-1">.
 -->
-このリリースは9.1.16に対し、各種不具合を修正したものです。
+このリリースは9.1.16に対し、少数の不具合を修正したものです。
 9.1メジャーリリースにおける新機能については、<xref linkend="release-9-1">を参照してください。
   </para>
 
@@ -13226,7 +13226,7 @@ VPATH構築ですべてのサーバヘッダファイルが適切にインスト
    For information about new features in the 9.1 major release, see
    <xref linkend="release-9-1">.
 -->
-このリリースは9.1.0に対し、わずかな不具合を修正したものです。
+このリリースは9.1.0に対し、少数の不具合を修正したものです。
 9.1メジャーリリースにおける新機能については<xref linkend="release-9-1">を参照してください。
   </para>
 

--- a/doc/src/sgml/release-9.2.sgml
+++ b/doc/src/sgml/release-9.2.sgml
@@ -21,7 +21,7 @@
    For information about new features in the 9.2 major release, see
    <xref linkend="release-9-2">.
 -->
-このリリースは9.2.22に対し、各種不具合を修正したものです。
+このリリースは9.2.22に対し、少数の不具合を修正したものです。
 9.2メジャーリリースにおける新機能については、<xref linkend="release-9-2">を参照してください。
   </para>
 
@@ -5500,7 +5500,7 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
    For information about new features in the 9.2 major release, see
    <xref linkend="release-9-2">.
 -->
-このリリースは9.2.12に対し、各種不具合を修正したものです。
+このリリースは9.2.12に対し、少数の不具合を修正したものです。
 9.2メジャーリリースにおける新機能については、<xref linkend="release-9-2">を参照してください。
   </para>
 
@@ -5606,7 +5606,7 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
    For information about new features in the 9.2 major release, see
    <xref linkend="release-9-2">.
 -->
-このリリースは9.2.11に対し、各種不具合を修正したものです。
+このリリースは9.2.11に対し、少数の不具合を修正したものです。
 9.2メジャーリリースにおける新機能については、<xref linkend="release-9-2">を参照してください。
   </para>
 

--- a/doc/src/sgml/release-9.2.sgml
+++ b/doc/src/sgml/release-9.2.sgml
@@ -2,100 +2,158 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-2-23">
+<!--
   <title>Release 9.2.23</title>
+-->
+  <title>リリース9.2.23</title>
 
   <formalpara>
+<!--
   <title>Release date:</title>
+-->
+  <title>リリース日:</title>
   <para>2017-08-31</para>
   </formalpara>
 
   <para>
+<!--
    This release contains a small number of fixes from 9.2.22.
    For information about new features in the 9.2 major release, see
    <xref linkend="release-9-2">.
+-->
+このリリースは9.2.22に対し、各種不具合を修正したものです。
+9.2メジャーリリースにおける新機能については、<xref linkend="release-9-2">を参照してください。
   </para>
 
   <para>
+<!--
    The <productname>PostgreSQL</> community will stop releasing updates
    for the 9.2.X release series in September 2017.
    Users are encouraged to update to a newer release branch soon.
+-->
+<productname>PostgreSQL</>コミュニティは9.2.Xリリースシリーズに対するアップデートのリリースを2017年9月に停止する予定です。
+早めに新しいリリースのブランチに更新することを推奨します。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.2.23</title>
+-->
+   <title>バージョン9.2.23への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.2.X.
+-->
+9.2.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if you are upgrading from a version earlier than 9.2.22,
     see <xref linkend="release-9-2-22">.
+-->
+しかしながら、9.2.22よりも前のリリースからアップグレードする場合は、<xref linkend="release-9-2-22">を参照して下さい。
    </para>
 
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Show foreign tables
       in <structname>information_schema</>.<structname>table_privileges</>
       view (Peter Eisentraut)
+-->
+<structname>information_schema</>.<structname>table_privileges</>ビューで外部テーブルを表示するようになりました。
+(Peter Eisentraut)
      </para>
 
      <para>
+<!--
       All other relevant <structname>information_schema</> views include
       foreign tables, but this one ignored them.
+-->
+全ての他の関連する<structname>information_schema</>ビューは外部テーブルを含んでいますが、このビューは外部テーブルを無視していました。
      </para>
 
      <para>
+<!--
       Since this view definition is installed by <application>initdb</>,
       merely upgrading will not fix the problem.  If you need to fix this
       in an existing installation, you can, as a superuser, do this
       in <application>psql</>:
+-->
+このビュー定義は<application>initdb</>で導入されるため、アップグレードするだけでは問題は修正されません。
+既存のインストレーションで修正する必要がある場合、スーパーユーザーとして<application>psql</>で以下を実行してください。
 <programlisting>
 BEGIN;
 DROP SCHEMA information_schema CASCADE;
 \i <replaceable>SHAREDIR</>/information_schema.sql
 COMMIT;
 </programlisting>
-      (Run <literal>pg_config --sharedir</> if you're uncertain
+<!--
+      (Run <literal>pg_config -&#045;sharedir</> if you're uncertain
       where <replaceable>SHAREDIR</> is.)  This must be repeated in each
       database to be fixed.
+-->
+（<replaceable>SHAREDIR</>がどこににあるか確証がもてない場合、<literal>pg_config --sharedir</>を実行してください。）
+これは修正すべき各データベースで繰り返さなくてはなりません。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Clean up handling of a fatal exit (e.g., due to receipt
       of <systemitem>SIGTERM</>) that occurs while trying to execute
       a <command>ROLLBACK</> of a failed transaction (Tom Lane)
+-->
+失敗したトランザクションの<command>ROLLBACK</>実行を試みている間に生じた、致命的な（例えば<systemitem>SIGTERM</>を受けとったことによる）終了の処理を整理しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This situation could result in an assertion failure.  In production
       builds, the exit would still occur, but it would log an unexpected
       message about <quote>cannot drop active portal</>.
+-->
+この状況はアサート失敗に至るかもしれません。
+実運用ビルドでもこのような終了は起きますが、この場合は<quote>cannot drop active portal(アクティブポータルを削除できません)</>といった予期せぬメッセージがログ出力されます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Remove assertion that could trigger during a fatal exit (Tom Lane)
+-->
+致命的な終了の間に駆動するかもしれないアサートを削除しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Correctly identify columns that are of a range type or domain type over
       a composite type or domain type being searched for (Tom Lane)
+-->
+検索されている、複合型またはドメイン型の上の、範囲型またはドメイン型の列を正確に識別するようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Certain <command>ALTER</> commands that change the definition of a
       composite type or domain type are supposed to fail if there are any
       stored values of that type in the database, because they lack the
@@ -103,28 +161,43 @@ COMMIT;
       these checks could miss relevant values that are wrapped inside range
       types or sub-domains, possibly allowing the database to become
       inconsistent.
+-->
+複合型またはドメイン型の定義を変更する、ある種の<command>ALTER</>コマンドはデータベース中にその型の格納された値が1つでもあるときはエラーになるはずでした。なぜなら、そのような値を更新または検査するのに必要な基盤が欠けているためです。
+これまでは、これらの検査は範囲型またはドメイン型の内側にラップされた関連する値を見過ごすかもしれず、データベースが不整合になるのを許すおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Change <application>ecpg</>'s parser to allow <literal>RETURNING</>
       clauses without attached C variables (Michael Meskes)
+-->
+<application>ecpg</>のパーサを、C変数の割り当て無しの<literal>RETURNING</>句が使えるように変更しました。
+(Michael Meskes)
      </para>
 
      <para>
+<!--
       This allows <application>ecpg</> programs to contain SQL constructs
       that use <literal>RETURNING</> internally (for example, inside a CTE)
       rather than using it to define values to be returned to the client.
+-->
+これにより<literal>RETURNING</>をクライアントに返される値を定義するためではなく内部的に（例えばCTE内に）使ったSQL構文を<application>ecpg</>プログラムに含むことができます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Improve selection of compiler flags for PL/Perl on Windows (Tom Lane)
+-->
+Windows上のPL/Perlに対するコンパイラフラグの選択を改善しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fix avoids possible crashes of PL/Perl due to inconsistent
       assumptions about the width of <type>time_t</> values.
       A side-effect that may be visible to extension developers is
@@ -132,6 +205,10 @@ COMMIT;
       in <productname>PostgreSQL</> Windows builds.  This is not expected
       to cause problems, because type <type>time_t</> is not used
       in any <productname>PostgreSQL</> API definitions.
+-->
+本修正は<type>time_t</>値の幅についての一貫性のない仮定のために起こりうるPL/Perlのクラッシュを回避します。
+拡張の開発者に見えるかもしれない副作用は、<literal>_USE_32BIT_TIME_T</>が<productname>PostgreSQL</>のWindowsビルドではもはやグローバルに定義されないことです。
+<type>time_t</>はいかなる<productname>PostgreSQL</> API定義でも使われないため、これは問題をひき起こさないと予想されます。
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.3.sgml
+++ b/doc/src/sgml/release-9.3.sgml
@@ -2,94 +2,148 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-3-19">
+<!--
   <title>Release 9.3.19</title>
+-->
+  <title>リリース9.3.19</title>
 
   <formalpara>
+<!--
   <title>Release date:</title>
+-->
+  <title>リリース日:</title>
   <para>2017-08-31</para>
   </formalpara>
 
   <para>
+<!--
    This release contains a small number of fixes from 9.3.18.
    For information about new features in the 9.3 major release, see
    <xref linkend="release-9-3">.
+-->
+このリリースは9.3.18に対し、各種不具合を修正したものです。
+9.3メジャーリリースにおける新機能については、<xref linkend="release-9-3">を参照してください。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.3.19</title>
+-->
+   <title>バージョン9.3.19への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.3.X.
+-->
+9.3.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if you are upgrading from a version earlier than 9.3.18,
     see <xref linkend="release-9-3-18">.
+-->
+しかしながら、9.3.18よりも前のバージョンからアップグレードする場合には、<xref linkend="release-9-3-18">を参照してください。
    </para>
 
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Show foreign tables
       in <structname>information_schema</>.<structname>table_privileges</>
       view (Peter Eisentraut)
+-->
+<structname>information_schema</>.<structname>table_privileges</>ビューで外部テーブルを表示するようになりました。
+(Peter Eisentraut)
      </para>
 
      <para>
+<!--
       All other relevant <structname>information_schema</> views include
       foreign tables, but this one ignored them.
+-->
+全ての他の関連する<structname>information_schema</>ビューは外部テーブルを含んでいますが、このビューは外部テーブルを無視していました。
      </para>
 
      <para>
+<!--
       Since this view definition is installed by <application>initdb</>,
       merely upgrading will not fix the problem.  If you need to fix this
       in an existing installation, you can, as a superuser, do this
       in <application>psql</>:
+-->
+このビュー定義は<application>initdb</>で導入されるため、アップグレードするだけでは問題は修正されません。
+既存のインストレーションで修正する必要がある場合、スーパーユーザーとして<application>psql</>で以下を実行してください。
 <programlisting>
 BEGIN;
 DROP SCHEMA information_schema CASCADE;
 \i <replaceable>SHAREDIR</>/information_schema.sql
 COMMIT;
 </programlisting>
-      (Run <literal>pg_config --sharedir</> if you're uncertain
+<!--
+      (Run <literal>pg_config -&#045;sharedir</> if you're uncertain
       where <replaceable>SHAREDIR</> is.)  This must be repeated in each
       database to be fixed.
+-->
+（<replaceable>SHAREDIR</>がどこににあるか確証がもてない場合、<literal>pg_config --sharedir</>を実行してください。）
+これは修正すべき各データベースで繰り返さなくてはなりません。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Clean up handling of a fatal exit (e.g., due to receipt
       of <systemitem>SIGTERM</>) that occurs while trying to execute
       a <command>ROLLBACK</> of a failed transaction (Tom Lane)
+-->
+失敗したトランザクションの<command>ROLLBACK</>実行を試みている間に生じた、致命的な（例えば<systemitem>SIGTERM</>を受けとったことによる）終了の処理を整理しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This situation could result in an assertion failure.  In production
       builds, the exit would still occur, but it would log an unexpected
       message about <quote>cannot drop active portal</>.
+-->
+この状況はアサート失敗に至るかもしれません。
+実運用ビルドでもこのような終了は起きますが、この場合は<quote>cannot drop active portal(アクティブポータルを削除できません)</>といった予期せぬメッセージがログ出力されます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Remove assertion that could trigger during a fatal exit (Tom Lane)
+-->
+致命的な終了の間に駆動するかもしれないアサートを削除しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Correctly identify columns that are of a range type or domain type over
       a composite type or domain type being searched for (Tom Lane)
+-->
+検索されている、複合型またはドメイン型の上の、範囲型またはドメイン型の列を正確に識別するようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Certain <command>ALTER</> commands that change the definition of a
       composite type or domain type are supposed to fail if there are any
       stored values of that type in the database, because they lack the
@@ -97,36 +151,55 @@ COMMIT;
       these checks could miss relevant values that are wrapped inside range
       types or sub-domains, possibly allowing the database to become
       inconsistent.
+-->
+複合型またはドメイン型の定義を変更する、ある種の<command>ALTER</>コマンドはデータベース中にその型の格納された値が1つでもあるときはエラーになるはずでした。なぜなら、そのような値を更新または検査するのに必要な基盤が欠けているためです。
+これまでは、これらの検査は範囲型またはドメイン型の内側にラップされた関連する値を見過ごすかもしれず、データベースが不整合になるのを許すおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix crash in <application>pg_restore</> when using parallel mode and
       using a list file to select a subset of items to restore
       (Fabr&iacute;zio de Royes Mello)
+-->
+<application>pg_restore</>における、パラレルモードを使っていてリストアする部分要素を選択するのにリストファイルを使っているときのクラッシュを修正しました。
+(Fabr&iacute;zio de Royes Mello)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Change <application>ecpg</>'s parser to allow <literal>RETURNING</>
       clauses without attached C variables (Michael Meskes)
+-->
+<application>ecpg</>のパーサを、C変数の割り当て無しの<literal>RETURNING</>句が使えるように変更しました。
+(Michael Meskes)
      </para>
 
      <para>
+<!--
       This allows <application>ecpg</> programs to contain SQL constructs
       that use <literal>RETURNING</> internally (for example, inside a CTE)
       rather than using it to define values to be returned to the client.
+-->
+これにより<literal>RETURNING</>をクライアントに返される値を定義するためではなく内部的に（例えばCTE内に）使ったSQL構文を<application>ecpg</>プログラムに含むことができます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Improve selection of compiler flags for PL/Perl on Windows (Tom Lane)
+-->
+Windows上のPL/Perlに対するコンパイラフラグの選択を改善しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fix avoids possible crashes of PL/Perl due to inconsistent
       assumptions about the width of <type>time_t</> values.
       A side-effect that may be visible to extension developers is
@@ -134,6 +207,10 @@ COMMIT;
       in <productname>PostgreSQL</> Windows builds.  This is not expected
       to cause problems, because type <type>time_t</> is not used
       in any <productname>PostgreSQL</> API definitions.
+-->
+本修正は<type>time_t</>値の幅についての一貫性のない仮定のために起こりうるPL/Perlのクラッシュを回避します。
+拡張の開発者に見えるかもしれない副作用は、<literal>_USE_32BIT_TIME_T</>が<productname>PostgreSQL</>のWindowsビルドではもはやグローバルに定義されないことです。
+<type>time_t</>はいかなる<productname>PostgreSQL</> API定義でも使われないため、これは問題をひき起こさないと予想されます。
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.3.sgml
+++ b/doc/src/sgml/release-9.3.sgml
@@ -21,7 +21,7 @@
    For information about new features in the 9.3 major release, see
    <xref linkend="release-9-3">.
 -->
-このリリースは9.3.18に対し、各種不具合を修正したものです。
+このリリースは9.3.18に対し、少数の不具合を修正したものです。
 9.3メジャーリリースにおける新機能については、<xref linkend="release-9-3">を参照してください。
   </para>
 
@@ -6343,7 +6343,7 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
    For information about new features in the 9.3 major release, see
    <xref linkend="release-9-3">.
 -->
-このリリースは9.3.8に対し、各種不具合を修正したものです。
+このリリースは9.3.8に対し、少数の不具合を修正したものです。
 9.3メジャーリリースにおける新機能については、<xref linkend="release-9-3">を参照してください。
   </para>
 
@@ -6568,7 +6568,7 @@ Windowsの<filename>install.bat</>スクリプトが空白文字を含む対象�
    For information about new features in the 9.3 major release, see
    <xref linkend="release-9-3">.
 -->
-このリリースは9.3.7に対し、各種不具合を修正したものです。
+このリリースは9.3.7に対し、少数の不具合を修正したものです。
 9.3メジャーリリースにおける新機能については、<xref linkend="release-9-3">を参照してください。
   </para>
 

--- a/doc/src/sgml/release-9.4.sgml
+++ b/doc/src/sgml/release-9.4.sgml
@@ -21,7 +21,7 @@
    For information about new features in the 9.4 major release, see
    <xref linkend="release-9-4">.
 -->
-このリリースは9.4.13に対し、各種不具合を修正したものです。
+このリリースは9.4.13に対し、少数の不具合を修正したものです。
 9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">を参照してください。
   </para>
 
@@ -8616,7 +8616,7 @@ Branch: REL9_0_STABLE [47ac95f37] 2015-10-02 19:16:37 -0400
    For information about new features in the 9.4 major release, see
    <xref linkend="release-9-4">.
 -->
-このリリースは9.4.3に対し、各種不具合を修正したものです。
+このリリースは9.4.3に対し、少数の不具合を修正したものです。
 9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">を参照してください。
   </para>
 
@@ -8873,7 +8873,7 @@ Branch: REL9_3_STABLE [d3fdec6ae] 2015-06-03 11:58:47 -0400
    For information about new features in the 9.4 major release, see
    <xref linkend="release-9-4">.
 -->
-このリリースは9.4.2に対し、各種不具合を修正したものです。
+このリリースは9.4.2に対し、少数の不具合を修正したものです。
 9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">を参照してください。
   </para>
 

--- a/doc/src/sgml/release-9.4.sgml
+++ b/doc/src/sgml/release-9.4.sgml
@@ -2,34 +2,56 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-4-14">
+<!--
   <title>Release 9.4.14</title>
+-->
+  <title>リリース9.4.14</title>
 
   <formalpara>
+<!--
   <title>Release date:</title>
+-->
+  <title>リリース日:</title>
   <para>2017-08-31</para>
   </formalpara>
 
   <para>
+<!--
    This release contains a small number of fixes from 9.4.13.
    For information about new features in the 9.4 major release, see
    <xref linkend="release-9-4">.
+-->
+このリリースは9.4.13に対し、各種不具合を修正したものです。
+9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">を参照してください。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.4.14</title>
+-->
+   <title>バージョン9.4.14への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.4.X.
+-->
+9.4.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if you are upgrading from a version earlier than 9.4.13,
     see <xref linkend="release-9-4-13">.
+-->
+しかしながら、9.4.13よりも前のリリースからアップグレードする場合は、<xref linkend="release-9-4-13">を参照して下さい。
    </para>
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
@@ -39,73 +61,112 @@ Author: Andres Freund <andres@anarazel.de>
 Branch: REL9_4_STABLE [b51c8efc6] 2017-08-24 15:21:32 -0700
 -->
      <para>
+<!--
       Fix failure of walsender processes to respond to shutdown signals
       (Marco Nenciarini)
+-->
+walsenderプロセスがシャットダウンシグナルに反応するのに失敗するのを修正しました。
+(Marco Nenciarini)
      </para>
 
      <para>
+<!--
       A missed flag update resulted in walsenders continuing to run as long
       as they had a standby server connected, preventing primary-server
       shutdown unless immediate shutdown mode is used.
+-->
+フラグの更新忘れのため、即時シャットダウンモード以外では、walsenderはスタンバイサーバが接続されている限り動作し続け、プライマリサーバがシャットダウンできませんでした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Show foreign tables
       in <structname>information_schema</>.<structname>table_privileges</>
       view (Peter Eisentraut)
+-->
+<structname>information_schema</>.<structname>table_privileges</>ビューで外部テーブルを表示するようになりました。
+(Peter Eisentraut)
      </para>
 
      <para>
+<!--
       All other relevant <structname>information_schema</> views include
       foreign tables, but this one ignored them.
+-->
+全ての他の関連する<structname>information_schema</>ビューは外部テーブルを含んでいますが、このビューは外部テーブルを無視していました。
      </para>
 
      <para>
+<!--
       Since this view definition is installed by <application>initdb</>,
       merely upgrading will not fix the problem.  If you need to fix this
       in an existing installation, you can, as a superuser, do this
       in <application>psql</>:
+-->
+このビュー定義は<application>initdb</>で導入されるため、アップグレードするだけでは問題は修正されません。
+既存のインストレーションで修正する必要がある場合、スーパーユーザーとして<application>psql</>で以下を実行してください。
 <programlisting>
 BEGIN;
 DROP SCHEMA information_schema CASCADE;
 \i <replaceable>SHAREDIR</>/information_schema.sql
 COMMIT;
 </programlisting>
-      (Run <literal>pg_config --sharedir</> if you're uncertain
+<!--
+      (Run <literal>pg_config -&#045;sharedir</> if you're uncertain
       where <replaceable>SHAREDIR</> is.)  This must be repeated in each
       database to be fixed.
+-->
+（<replaceable>SHAREDIR</>がどこににあるか確証がもてない場合、<literal>pg_config --sharedir</>を実行してください。）
+これは修正すべき各データベースで繰り返さなくてはなりません。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Clean up handling of a fatal exit (e.g., due to receipt
       of <systemitem>SIGTERM</>) that occurs while trying to execute
       a <command>ROLLBACK</> of a failed transaction (Tom Lane)
+-->
+失敗したトランザクションの<command>ROLLBACK</>実行を試みている間に生じた、致命的な（例えば<systemitem>SIGTERM</>を受けとったことによる）終了の処理を整理しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This situation could result in an assertion failure.  In production
       builds, the exit would still occur, but it would log an unexpected
       message about <quote>cannot drop active portal</>.
+-->
+この状況はアサート失敗に至るかもしれません。
+実運用ビルドでもこのような終了は起きますが、この場合は<quote>cannot drop active portal(アクティブポータルを削除できません)</>といった予期せぬメッセージがログ出力されます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Remove assertion that could trigger during a fatal exit (Tom Lane)
+-->
+致命的な終了の間に駆動するかもしれないアサートを削除しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Correctly identify columns that are of a range type or domain type over
       a composite type or domain type being searched for (Tom Lane)
+-->
+検索されている、複合型またはドメイン型の上の、範囲型またはドメイン型の列を正確に識別するようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Certain <command>ALTER</> commands that change the definition of a
       composite type or domain type are supposed to fail if there are any
       stored values of that type in the database, because they lack the
@@ -113,36 +174,55 @@ COMMIT;
       these checks could miss relevant values that are wrapped inside range
       types or sub-domains, possibly allowing the database to become
       inconsistent.
+-->
+複合型またはドメイン型の定義を変更する、ある種の<command>ALTER</>コマンドはデータベース中にその型の格納された値が1つでもあるときはエラーになるはずでした。なぜなら、そのような値を更新または検査するのに必要な基盤が欠けているためです。
+これまでは、これらの検査は範囲型またはドメイン型の内側にラップされた関連する値を見過ごすかもしれず、データベースが不整合になるのを許すおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix crash in <application>pg_restore</> when using parallel mode and
       using a list file to select a subset of items to restore
       (Fabr&iacute;zio de Royes Mello)
+-->
+<application>pg_restore</>における、パラレルモードを使っていてリストアする部分要素を選択するのにリストファイルを使っているときのクラッシュを修正しました。
+(Fabr&iacute;zio de Royes Mello)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Change <application>ecpg</>'s parser to allow <literal>RETURNING</>
       clauses without attached C variables (Michael Meskes)
+-->
+<application>ecpg</>のパーサを、C変数の割り当て無しの<literal>RETURNING</>句が使えるように変更しました。
+(Michael Meskes)
      </para>
 
      <para>
+<!--
       This allows <application>ecpg</> programs to contain SQL constructs
       that use <literal>RETURNING</> internally (for example, inside a CTE)
       rather than using it to define values to be returned to the client.
+-->
+これにより<literal>RETURNING</>をクライアントに返される値を定義するためではなく内部的に（例えばCTE内に）使ったSQL構文を<application>ecpg</>プログラムに含むことができます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Improve selection of compiler flags for PL/Perl on Windows (Tom Lane)
+-->
+Windows上のPL/Perlに対するコンパイラフラグの選択を改善しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fix avoids possible crashes of PL/Perl due to inconsistent
       assumptions about the width of <type>time_t</> values.
       A side-effect that may be visible to extension developers is
@@ -150,6 +230,10 @@ COMMIT;
       in <productname>PostgreSQL</> Windows builds.  This is not expected
       to cause problems, because type <type>time_t</> is not used
       in any <productname>PostgreSQL</> API definitions.
+-->
+本修正は<type>time_t</>値の幅についての一貫性のない仮定のために起こりうるPL/Perlのクラッシュを回避します。
+拡張の開発者に見えるかもしれない副作用は、<literal>_USE_32BIT_TIME_T</>が<productname>PostgreSQL</>のWindowsビルドではもはやグローバルに定義されないことです。
+<type>time_t</>はいかなる<productname>PostgreSQL</> API定義でも使われないため、これは問題をひき起こさないと予想されます。
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.5.sgml
+++ b/doc/src/sgml/release-9.5.sgml
@@ -21,7 +21,7 @@
    For information about new features in the 9.5 major release, see
    <xref linkend="release-9-5">.
 -->
-このリリースは9.5.8に対し、各種不具合を修正したものです。
+このリリースは9.5.8に対し、少数の不具合を修正したものです。
 9.5メジャーリリースにおける新機能については、<xref linkend="release-9-5">を参照してください。
   </para>
 

--- a/doc/src/sgml/release-9.5.sgml
+++ b/doc/src/sgml/release-9.5.sgml
@@ -2,93 +2,147 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-5-9">
+<!--
   <title>Release 9.5.9</title>
+-->
+  <title>リリース9.5.9</title>
 
   <formalpara>
+<!--
   <title>Release date:</title>
+-->
+  <title>リリース日:</title>
   <para>2017-08-31</para>
   </formalpara>
 
   <para>
+<!--
    This release contains a small number of fixes from 9.5.8.
    For information about new features in the 9.5 major release, see
    <xref linkend="release-9-5">.
+-->
+このリリースは9.5.8に対し、各種不具合を修正したものです。
+9.5メジャーリリースにおける新機能については、<xref linkend="release-9-5">を参照してください。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.5.9</title>
+-->
+   <title>バージョン9.5.8への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.5.X.
+-->
+9.5.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if you are upgrading from a version earlier than 9.5.8,
     see <xref linkend="release-9-5-8">.
+-->
+しかしながら、また、9.5.8よりも前のリリースからアップグレードする場合は、<xref linkend="release-9-5-8">を参照して下さい。
    </para>
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Show foreign tables
       in <structname>information_schema</>.<structname>table_privileges</>
       view (Peter Eisentraut)
+-->
+<structname>information_schema</>.<structname>table_privileges</>ビューで外部テーブルを表示するようになりました。
+(Peter Eisentraut)
      </para>
 
      <para>
+<!--
       All other relevant <structname>information_schema</> views include
       foreign tables, but this one ignored them.
+-->
+全ての他の関連する<structname>information_schema</>ビューは外部テーブルを含んでいますが、このビューは外部テーブルを無視していました。
      </para>
 
      <para>
+<!--
       Since this view definition is installed by <application>initdb</>,
       merely upgrading will not fix the problem.  If you need to fix this
       in an existing installation, you can, as a superuser, do this
       in <application>psql</>:
+-->
+このビュー定義は<application>initdb</>で導入されるため、アップグレードするだけでは問題は修正されません。
+既存のインストレーションで修正する必要がある場合、スーパーユーザーとして<application>psql</>で以下を実行してください。
 <programlisting>
 BEGIN;
 DROP SCHEMA information_schema CASCADE;
 \i <replaceable>SHAREDIR</>/information_schema.sql
 COMMIT;
 </programlisting>
-      (Run <literal>pg_config --sharedir</> if you're uncertain
+<!--
+      (Run <literal>pg_config -&#045;sharedir</> if you're uncertain
       where <replaceable>SHAREDIR</> is.)  This must be repeated in each
       database to be fixed.
+-->
+（<replaceable>SHAREDIR</>がどこににあるか確証がもてない場合、<literal>pg_config --sharedir</>を実行してください。）
+これは修正すべき各データベースで繰り返さなくてはなりません。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Clean up handling of a fatal exit (e.g., due to receipt
       of <systemitem>SIGTERM</>) that occurs while trying to execute
       a <command>ROLLBACK</> of a failed transaction (Tom Lane)
+-->
+失敗したトランザクションの<command>ROLLBACK</>実行を試みている間に生じた、致命的な（例えば<systemitem>SIGTERM</>を受けとったことによる）終了の処理を整理しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This situation could result in an assertion failure.  In production
       builds, the exit would still occur, but it would log an unexpected
       message about <quote>cannot drop active portal</>.
+-->
+この状況はアサート失敗に至るかもしれません。
+実運用ビルドでもこのような終了は起きますが、この場合は<quote>cannot drop active portal(アクティブポータルを削除できません)</>といった予期せぬメッセージがログ出力されます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Remove assertion that could trigger during a fatal exit (Tom Lane)
+-->
+致命的な終了の間に駆動するかもしれないアサートを削除しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Correctly identify columns that are of a range type or domain type over
       a composite type or domain type being searched for (Tom Lane)
+-->
+検索されている、複合型またはドメイン型の上の、範囲型またはドメイン型の列を正確に識別するようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Certain <command>ALTER</> commands that change the definition of a
       composite type or domain type are supposed to fail if there are any
       stored values of that type in the database, because they lack the
@@ -96,36 +150,55 @@ COMMIT;
       these checks could miss relevant values that are wrapped inside range
       types or sub-domains, possibly allowing the database to become
       inconsistent.
+-->
+複合型またはドメイン型の定義を変更する、ある種の<command>ALTER</>コマンドはデータベース中にその型の格納された値が1つでもあるときはエラーになるはずでした。なぜなら、そのような値を更新または検査するのに必要な基盤が欠けているためです。
+これまでは、これらの検査は範囲型またはドメイン型の内側にラップされた関連する値を見過ごすかもしれず、データベースが不整合になるのを許すおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix crash in <application>pg_restore</> when using parallel mode and
       using a list file to select a subset of items to restore
       (Fabr&iacute;zio de Royes Mello)
+-->
+<application>pg_restore</>における、パラレルモードを使っていてリストアする部分要素を選択するのにリストファイルを使っているときのクラッシュを修正しました。
+(Fabr&iacute;zio de Royes Mello)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Change <application>ecpg</>'s parser to allow <literal>RETURNING</>
       clauses without attached C variables (Michael Meskes)
+-->
+<application>ecpg</>のパーサを、C変数の割り当て無しの<literal>RETURNING</>句が使えるように変更しました。
+(Michael Meskes)
      </para>
 
      <para>
+<!--
       This allows <application>ecpg</> programs to contain SQL constructs
       that use <literal>RETURNING</> internally (for example, inside a CTE)
       rather than using it to define values to be returned to the client.
+-->
+これにより<literal>RETURNING</>をクライアントに返される値を定義するためではなく内部的に（例えばCTE内に）使ったSQL構文を<application>ecpg</>プログラムに含むことができます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Improve selection of compiler flags for PL/Perl on Windows (Tom Lane)
+-->
+Windows上のPL/Perlに対するコンパイラフラグの選択を改善しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fix avoids possible crashes of PL/Perl due to inconsistent
       assumptions about the width of <type>time_t</> values.
       A side-effect that may be visible to extension developers is
@@ -133,13 +206,21 @@ COMMIT;
       in <productname>PostgreSQL</> Windows builds.  This is not expected
       to cause problems, because type <type>time_t</> is not used
       in any <productname>PostgreSQL</> API definitions.
+-->
+本修正は<type>time_t</>値の幅についての一貫性のない仮定のために起こりうるPL/Perlのクラッシュを回避します。
+拡張の開発者に見えるかもしれない副作用は、<literal>_USE_32BIT_TIME_T</>が<productname>PostgreSQL</>のWindowsビルドではもはやグローバルに定義されないことです。
+<type>time_t</>はいかなる<productname>PostgreSQL</> API定義でも使われないため、これは問題をひき起こさないと予想されます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <literal>make check</> to behave correctly when invoked via a
       non-GNU make program (Thomas Munro)
+-->
+非GNUのmakeプログラムから起動されたときに正しく動作するように<literal>make check</>を修正しました。
+(Thomas Munro)
      </para>
     </listitem>
 
@@ -149,10 +230,10 @@ COMMIT;
  </sect1>
 
  <sect1 id="release-9-5-8">
-  <title>Release 9.5.8</title>
 <!--
-  <title>リリース9.5.8</title>
+  <title>Release 9.5.8</title>
 -->
+  <title>リリース9.5.8</title>
 
   <formalpara>
 <!--


### PR DESCRIPTION
release-9.[2-5]の9.6.5対応です。

```
<!--
Author: Andres Freund <andres@anarazel.de>
Branch: REL9_4_STABLE [b51c8efc6] 2017-08-24 15:21:32 -0700
-->
```

以外はrelease-9.6からスクリプトで持ってきました。
あと、どさくさにまぎれてRelease 9.5.8の間違いを直しています。