### PR TITLE
fix typos in 'release version'

### DIFF
--- a/doc/src/sgml/release-7.4.sgml
+++ b/doc/src/sgml/release-7.4.sgml
@@ -3971,7 +3971,7 @@ ECPG prepare statement</para></listitem>
 <!--
    <title>Migration to Version 7.4.5</title>
 -->
-   <title>7.4.4バージョンへの移行</title>
+   <title>バージョン7.4.5への移行</title>
 
 
    <para>
@@ -4037,7 +4037,7 @@ still worth a re-release.  The bug does not exist in pre-7.4 releases.
 <!--
    <title>Migration to Version 7.4.4</title>
 -->
-   <title>7.4.4バージョンへの移行</title>
+   <title>バージョン7.4.4への移行</title>
 
    <para>
 <!--
@@ -4115,7 +4115,7 @@ aggregate plan</para></listitem>
 <!--
    <title>Migration to Version 7.4.3</title>
 -->
-   <title>7.4.3バージョンへの移行</title>
+   <title>バージョン7.4.3への移行</title>
 
    <para>
 <!--
@@ -4198,7 +4198,7 @@ names from outer query levels.
 <!--
    <title>Migration to Version 7.4.2</title>
 -->
-   <title>7.4.2バージョンへの移行</title>
+   <title>バージョン7.4.2への移行</title>
 
    <para>
 <!--
@@ -4395,7 +4395,7 @@ inconveniences associated with the <literal>i/I</> problem.</para></listitem>
 <!--
    <title>Migration to Version 7.4.1</title>
 -->
-   <title>7.4.1バージョンへの移行</title>
+   <title>バージョン7.4.1への移行</title>
 
    <para>
 <!--

--- a/doc/src/sgml/release-8.1.sgml
+++ b/doc/src/sgml/release-8.1.sgml
@@ -4178,7 +4178,7 @@ Darwin (OS X)のコンパイルを修正しました。(Tom)
 <!--
    <title>Migration to Version 8.1.5</title>
 -->
-   <title>8.1.5バージョンへの移行</title>
+   <title>バージョン8.1.5への移行</title>
 
    <para>
 <!--

--- a/doc/src/sgml/release-9.5.sgml
+++ b/doc/src/sgml/release-9.5.sgml
@@ -29,7 +29,7 @@
 <!--
    <title>Migration to Version 9.5.9</title>
 -->
-   <title>バージョン9.5.8への移行</title>
+   <title>バージョン9.5.9への移行</title>
 
    <para>
 <!--

--- a/doc/src/sgml/release-9.6.sgml
+++ b/doc/src/sgml/release-9.6.sgml
@@ -2061,7 +2061,7 @@ MSVCビルドで、<filename>vcregress.pl</>のコマンドライン上の<liter
 <!--
    <title>Migration to Version 9.6.3</title>
 -->
-   <title>バージョン9.6.2への移行</title>
+   <title>バージョン9.6.3への移行</title>
 
    <para>
 <!--

--- a/doc/src/sgml/release-old.sgml
+++ b/doc/src/sgml/release-old.sgml
@@ -4310,7 +4310,7 @@ OID は省略できるようになりました。ユーザは OID の使用が�
 <!--
    <title>Migration to Version 7.1.3</title>
 -->
-   <title>7.1.3への移行</title>
+   <title>バージョン7.1.3への移行</title>
 
    <para>
 <!--


### PR DESCRIPTION
バージョンの書き方でいろいろありましたので、纏めて修正しました。