### PR TITLE
fix typo in release-old

### DIFF
--- a/doc/src/sgml/release-old.sgml
+++ b/doc/src/sgml/release-old.sgml
@@ -7786,7 +7786,7 @@ pg_dumpall now returns proper status, portability fix(Bruce)
  relative to the original regression output.
 -->
 新しい3個のデータ型(<type>datetime</type>、<type>timespan</type>、<type>circle</type>) が<productname>PostgreSQL</productname> 固有の型セットとして追加されました。
-point、boxe、path、polygon の出力書式において、これら型の間で一貫性を持たせました。
+point、box、path、polygon の出力書式において、これら型の間で一貫性を持たせました。
 misc.out における polygon 出力は元のリグレッション出力からの相対値の正確さをチェックする部分的なものになりました。
 </para>
 


### PR DESCRIPTION
release-oldに10.0対応の必要はなかったのですが、その確認の過程で誤記をみつけました。