### PR TITLE
create/alter/drop_publiction/subscriptionの翻訳

### DIFF
--- a/doc/src/sgml/ref/alter_publication.sgml
+++ b/doc/src/sgml/ref/alter_publication.sgml
@@ -200,7 +200,7 @@ ALTER PUBLICATION noinsert SET (publish = 'update, delete');
 <!--
    Add some tables to the publication:
 -->
-パブリケーションにいくつかのテールるを追加します。
+パブリケーションにいくつかのテーブルを追加します。
 <programlisting>
 ALTER PUBLICATION mypublication ADD TABLE users, departments;
 </programlisting></para>

--- a/doc/src/sgml/ref/alter_publication.sgml
+++ b/doc/src/sgml/ref/alter_publication.sgml
@@ -11,12 +11,18 @@ PostgreSQL documentation
  <refmeta>
   <refentrytitle>ALTER PUBLICATION</refentrytitle>
   <manvolnum>7</manvolnum>
+<!--
   <refmiscinfo>SQL - Language Statements</refmiscinfo>
+-->
+  <refmiscinfo>SQL - 言語</refmiscinfo>
  </refmeta>
 
  <refnamediv>
   <refname>ALTER PUBLICATION</refname>
+<!--
   <refpurpose>change the definition of a publication</refpurpose>
+-->
+  <refpurpose>パブリケーションの定義を変更する</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -31,14 +37,21 @@ ALTER PUBLICATION <replaceable class="PARAMETER">name</replaceable> RENAME TO <r
  </refsynopsisdiv>
 
  <refsect1>
+<!--
   <title>Description</title>
+-->
+  <title>説明</title>
 
   <para>
+<!--
    The command <command>ALTER PUBLICATION</command> can change the attributes
    of a publication.
+-->
+コマンド<command>ALTER PUBLICATION</command>はパブリケーションの属性を変更できます。
   </para>
 
   <para>
+<!--
    The first three variants change which tables are part of the publication.
    The <literal>SET TABLE</literal> clause will replace the list of tables in
    the publication with the specified one.  The <literal>ADD TABLE</literal>
@@ -47,38 +60,63 @@ ALTER PUBLICATION <replaceable class="PARAMETER">name</replaceable> RENAME TO <r
    is already subscribed to will require a <literal>ALTER SUBSCRIPTION
    ... REFRESH PUBLICATION</literal> action on the subscribing side in order
    to become effective.
+-->
+最初の3つの構文では、パブリケーションにどのテーブルが含まれるかを変更します。
+<literal>SET TABLE</literal>句は、パブリケーションのテーブルのリストを指定したもので置き換えます。
+<literal>ADD TABLE</literal>句と<literal>DROP TABLE</literal>句はパブリケーションに1つ以上のテーブルを追加または削除します。
+既にサブスクライブされているパブリケーションにテーブルを追加した場合、それを有効にするにはサブスクライブしている側で<literal>ALTER SUBSCRIPTION ... REFRESH PUBLICATION</literal>の操作を行う必要があることに注意してください。
   </para>
 
   <para>
+<!--
    The fourth variant of this command listed in the synopsis can change
    all of the publication properties specified in
    <xref linkend="sql-createpublication">.  Properties not mentioned in the
    command retain their previous settings.
+-->
+このコマンドの概要に挙げられている4番目の構文では、<xref linkend="sql-createpublication">で指定されたすべてのパブリケーションの属性を変更できます。
+このコマンドで属性を指定しなかったものについては、以前の設定が保持されます。
   </para>
 
   <para>
+<!--
    The remaining variants change the owner and the name of the publication.
+-->
+残りの構文では、パブリケーションの所有者および名前を変更します。
   </para>
 
   <para>
+<!--
    You must own the publication to use <command>ALTER PUBLICATION</command>.
    To alter the owner, you must also be a direct or indirect member of the new
    owning role. The new owner must have <literal>CREATE</literal> privilege on
    the database.  Also, the new owner of a <literal>FOR ALL TABLES</literal>
    publication must be a superuser.  However, a superuser can change the
    ownership of a publication while circumventing these restrictions.
+-->
+<command>ALTER PUBLICATION</command>を使用するには、そのパブリケーションを所有していなければなりません。
+所有者を変更するには、新しい所有ロールの直接的あるいは間接的なメンバーでもなければなりません。
+新しい所有者は、データベースに<literal>CREATE</literal>権限を持っていなければなりません。
+また、<literal>FOR ALL TABLES</literal>のパブリケーションの新しい所有者はスーパーユーザでなければなりません。
+しかし、スーパーユーザはこれらの制限を回避してパブリケーションの所有者を変更することができます。
   </para>
  </refsect1>
 
  <refsect1>
+<!--
   <title>Parameters</title>
+-->
+  <title>パラメータ</title>
 
   <variablelist>
    <varlistentry>
     <term><replaceable class="parameter">name</replaceable></term>
     <listitem>
      <para>
+<!--
       The name of an existing publication whose definition is to be altered.
+-->
+定義の変更の対象となる既存のパブリケーションの名前です。
      </para>
     </listitem>
    </varlistentry>
@@ -87,11 +125,17 @@ ALTER PUBLICATION <replaceable class="PARAMETER">name</replaceable> RENAME TO <r
     <term><replaceable class="parameter">table_name</replaceable></term>
     <listitem>
      <para>
+<!--
       Name of an existing table.  If <literal>ONLY</> is specified before the
       table name, only that table is affected.  If <literal>ONLY</> is not
       specified, the table and all its descendant tables (if any) are
       affected.  Optionally, <literal>*</> can be specified after the table
       name to explicitly indicate that descendant tables are included.
+-->
+既存のテーブルの名前です。
+テーブル名の前に<literal>ONLY</>が指定されたときは、そのテーブルだけが影響を受けます。
+テーブル名の前に<literal>ONLY</>が指定されていないときは、そのテーブルとそのすべての子テーブル（あれば）が影響を受けます。
+オプションでテーブル名の後に<literal>*</>を指定して、子テーブルが含まれることを明示的に示すことができます。
      </para>
     </listitem>
    </varlistentry>
@@ -100,8 +144,12 @@ ALTER PUBLICATION <replaceable class="PARAMETER">name</replaceable> RENAME TO <r
     <term><literal>SET ( <replaceable class="parameter">publication_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] )</literal></term>
     <listitem>
      <para>
+<!--
       This clause alters publication parameters originally set by
       <xref linkend="SQL-CREATEPUBLICATION">.  See there for more information.
+-->
+この句では、元は<xref linkend="SQL-CREATEPUBLICATION">により設定されたパブリケーションのパラメータを変更します。
+詳細な情報はそちらを参照してください。
      </para>
     </listitem>
    </varlistentry>
@@ -110,7 +158,10 @@ ALTER PUBLICATION <replaceable class="PARAMETER">name</replaceable> RENAME TO <r
     <term><replaceable class="parameter">new_owner</replaceable></term>
     <listitem>
      <para>
+<!--
       The user name of the new owner of the publication.
+-->
+パブリケーションの新しい所有者のユーザ名です。
      </para>
     </listitem>
    </varlistentry>
@@ -119,7 +170,10 @@ ALTER PUBLICATION <replaceable class="PARAMETER">name</replaceable> RENAME TO <r
     <term><replaceable class="parameter">new_name</replaceable></term>
     <listitem>
      <para>
+<!--
       The new name for the publication.
+-->
+パブリケーションの新しい名前です。
      </para>
     </listitem>
    </varlistentry>
@@ -127,33 +181,51 @@ ALTER PUBLICATION <replaceable class="PARAMETER">name</replaceable> RENAME TO <r
  </refsect1>
 
  <refsect1>
+<!--
   <title>Examples</title>
+-->
+  <title>例</title>
 
   <para>
+<!--
    Change the publication to publish only deletes and updates:
+-->
+deleteとupdateのみをパブリッシュするようにパブリケーションを変更します。
 <programlisting>
 ALTER PUBLICATION noinsert SET (publish = 'update, delete');
 </programlisting>
   </para>
 
   <para>
+<!--
    Add some tables to the publication:
+-->
+パブリケーションにいくつかのテールるを追加します。
 <programlisting>
 ALTER PUBLICATION mypublication ADD TABLE users, departments;
 </programlisting></para>
  </refsect1>
 
  <refsect1>
+<!--
   <title>Compatibility</title>
+-->
+  <title>互換性</title>
 
   <para>
+<!--
    <command>ALTER PUBLICATION</command> is a <productname>PostgreSQL</>
    extension.
+-->
+<command>ALTER PUBLICATION</command>は<productname>PostgreSQL</>の拡張です。
   </para>
  </refsect1>
 
  <refsect1>
+<!--
   <title>See Also</title>
+-->
+  <title>関連項目</title>
 
   <simplelist type="inline">
    <member><xref linkend="sql-createpublication"></member>

--- a/doc/src/sgml/ref/alter_subscription.sgml
+++ b/doc/src/sgml/ref/alter_subscription.sgml
@@ -11,12 +11,18 @@ PostgreSQL documentation
  <refmeta>
   <refentrytitle>ALTER SUBSCRIPTION</refentrytitle>
   <manvolnum>7</manvolnum>
+<!--
   <refmiscinfo>SQL - Language Statements</refmiscinfo>
+-->
+  <refmiscinfo>SQL - 言語</refmiscinfo>
  </refmeta>
 
  <refnamediv>
   <refname>ALTER SUBSCRIPTION</refname>
+<!--
   <refpurpose>change the definition of a subscription</refpurpose>
+-->
+  <refpurpose>サブスクリプションの定義を変更する</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -33,32 +39,51 @@ ALTER SUBSCRIPTION <replaceable class="PARAMETER">name</replaceable> RENAME TO <
  </refsynopsisdiv>
 
  <refsect1>
+<!--
   <title>Description</title>
+-->
+  <title>説明</title>
 
   <para>
+<!--
    <command>ALTER SUBSCRIPTION</command> can change most of the subscription
    properties that can be specified
    in <xref linkend="sql-createsubscription">.
+-->
+<command>ALTER SUBSCRIPTION</command>は<xref linkend="sql-createsubscription">で指定できるサブスクリプションの属性のほとんどを変更できます。
   </para>
 
   <para>
+<!--
    You must own the subscription to use <command>ALTER SUBSCRIPTION</>.
    To alter the owner, you must also be a direct or indirect member of the
    new owning role. The new owner has to be a superuser.
    (Currently, all subscription owners must be superusers, so the owner checks
    will be bypassed in practice.  But this might change in the future.)
+-->
+<command>ALTER SUBSCRIPTION</>を使用するには、そのサブスクリプションを所有していなければなりません。
+所有者を変更するには、新しい所有ロールの直接的あるいは間接的メンバーでもなければなりません。
+新しい所有者はスーパーユーザである必要があります。
+（現在は、すべてのサブスクリプションの所有者はスーパーユーザでなければならず、そのため所有者のチェックは実際には回避されます。
+しかしこれは将来、変更されるかもしれません。）
   </para>
  </refsect1>
 
  <refsect1>
+<!--
   <title>Parameters</title>
+-->
+  <title>パラメータ</title>
 
   <variablelist>
    <varlistentry>
     <term><replaceable class="parameter">name</replaceable></term>
     <listitem>
      <para>
+<!--
       The name of a subscription whose properties are to be altered.
+-->
+属性の変更の対象となるサブスクリプションの名前です。
      </para>
     </listitem>
    </varlistentry>
@@ -67,9 +92,13 @@ ALTER SUBSCRIPTION <replaceable class="PARAMETER">name</replaceable> RENAME TO <
     <term><literal>CONNECTION '<replaceable class="parameter">conninfo</replaceable>'</literal></term>
     <listitem>
      <para>
+<!--
       This clause alters the connection property originally set by
       <xref linkend="SQL-CREATESUBSCRIPTION">.  See there for more
       information.
+-->
+この句では、元は<xref linkend="SQL-CREATESUBSCRIPTION">により設定された接続の属性を変更します。
+詳細な情報はそちらを参照してください。
      </para>
     </listitem>
    </varlistentry>
@@ -78,31 +107,48 @@ ALTER SUBSCRIPTION <replaceable class="PARAMETER">name</replaceable> RENAME TO <
     <term><literal>SET PUBLICATION <replaceable class="parameter">publication_name</replaceable></literal></term>
     <listitem>
      <para>
+<!--
       Changes list of subscribed publications. See
       <xref linkend="SQL-CREATESUBSCRIPTION"> for more information.
       By default this command will also act like <literal>REFRESH
       PUBLICATION</literal>.
+-->
+サブスクライブするパブリケーションのリストを変更します。
+詳細は<xref linkend="SQL-CREATESUBSCRIPTION">を参照してください。
+デフォルトでは、このコマンドは<literal>REFRESH PUBLICATION</literal>のような動作もします。
      </para>
 
      <para>
+<!--
       <replaceable>set_publication_option</replaceable> specifies additional
       options for this operation.  The supported options are:
+-->
+<replaceable>set_publication_option</replaceable>は、この操作についての追加のオプションを指定します。
+以下のオプションがサポートされています。
 
       <variablelist>
        <varlistentry>
         <term><literal>refresh</literal> (<type>boolean</type>)</term>
         <listitem>
          <para>
+<!--
           When false, the command will not try to refresh table information.
           <literal>REFRESH PUBLICATION</literal> should then be executed separately.
           The default is <literal>true</literal>.
+-->
+falseにすると、このコマンドはテーブルを情報を更新しません。
+後で別に<literal>REFRESH PUBLICATION</literal>を実行することになります。
+デフォルトは<literal>true</literal>です。
          </para>
         </listitem>
        </varlistentry>
       </variablelist>
 
+<!--
       Additionally, refresh options as described
       under <literal>REFRESH PUBLICATION</literal> may be specified.
+-->
+さらに<literal>REFRESH PUBLICATION</literal>の項で説明されているrefreshオプションを指定できます。
      </para>
     </listitem>
    </varlistentry>
@@ -111,24 +157,36 @@ ALTER SUBSCRIPTION <replaceable class="PARAMETER">name</replaceable> RENAME TO <
     <term><literal>REFRESH PUBLICATION</literal></term>
     <listitem>
      <para>
+<!--
       Fetch missing table information from publisher.  This will start
       replication of tables that were added to the subscribed-to publications
       since the last invocation of <command>REFRESH PUBLICATION</command> or
       since <command>CREATE SUBSCRIPTION</command>.
+-->
+不足しているテーブル情報をパブリッシャーから取得します。
+最後の<command>REFRESH PUBLICATION</command>、あるいは<command>CREATE SUBSCRIPTION</command>の実行の後でサブスクライブ対象のパブリケーションに追加されたテーブルの複製が、これにより開始されます。
      </para>
 
      <para>
+<!--
       <replaceable>refresh_option</replaceable> specifies additional options for the
       refresh operation.  The supported options are:
+-->
+<replaceable>refresh_option</replaceable>は更新(refresh)の操作について追加のオプションを指定します。
+以下のオプションがサポートされています。
 
       <variablelist>
        <varlistentry>
         <term><literal>copy_data</literal> (<type>boolean</type>)</term>
         <listitem>
          <para>
+<!--
           Specifies whether the existing data in the publications that are
           being subscribed to should be copied once the replication starts.
           The default is <literal>true</literal>.
+-->
+サブスクライブ対象のパブリケーションにある既存のデータが、レプリケーションの開始時にコピーされるかどうかを指定します。
+デフォルトは<literal>true</literal>です。
          </para>
         </listitem>
        </varlistentry>
@@ -141,8 +199,11 @@ ALTER SUBSCRIPTION <replaceable class="PARAMETER">name</replaceable> RENAME TO <
     <term><literal>ENABLE</literal></term>
     <listitem>
      <para>
+<!--
       Enables the previously disabled subscription, starting the logical
       replication worker at the end of transaction.
+-->
+以前に無効化されたサブスクリプションを有効化し、トランザクションの終了時に論理レプリケーションワーカを起動します。
      </para>
     </listitem>
    </varlistentry>
@@ -151,8 +212,11 @@ ALTER SUBSCRIPTION <replaceable class="PARAMETER">name</replaceable> RENAME TO <
     <term><literal>DISABLE</literal></term>
     <listitem>
      <para>
+<!--
       Disables the running subscription, stopping the logical replication
       worker at the end of transaction.
+-->
+実行中のサブスクリプションを無効化し、トランザクションの終了時に論理レプリケーションワーカを停止します。
      </para>
     </listitem>
    </varlistentry>
@@ -161,10 +225,15 @@ ALTER SUBSCRIPTION <replaceable class="PARAMETER">name</replaceable> RENAME TO <
     <term><literal>SET ( <replaceable class="parameter">subscription_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] )</literal></term>
     <listitem>
      <para>
+<!--
       This clause alters parameters originally set by
       <xref linkend="SQL-CREATESUBSCRIPTION">.  See there for more
       information.  The allowed options are <literal>slot_name</literal> and
       <literal>synchronous_commit</literal>
+-->
+この句では、元は<xref linkend="SQL-CREATESUBSCRIPTION">により設定されたパラメータを変更します。
+詳細な情報はそちらを参照してください。
+使用できるオプションは<literal>slot_name</literal>と<literal>synchronous_commit</literal>です。
      </para>
     </listitem>
    </varlistentry>
@@ -173,7 +242,10 @@ ALTER SUBSCRIPTION <replaceable class="PARAMETER">name</replaceable> RENAME TO <
     <term><replaceable class="parameter">new_owner</replaceable></term>
     <listitem>
      <para>
+<!--
       The user name of the new owner of the subscription.
+-->
+サブスクリプションの新しい所有者のユーザ名です。
      </para>
     </listitem>
    </varlistentry>
@@ -182,7 +254,10 @@ ALTER SUBSCRIPTION <replaceable class="PARAMETER">name</replaceable> RENAME TO <
     <term><replaceable class="parameter">new_name</replaceable></term>
     <listitem>
      <para>
+<!--
       The new name for the subscription.
+-->
+サブスクリプションの新しい名前です。
      </para>
     </listitem>
    </varlistentry>
@@ -190,34 +265,52 @@ ALTER SUBSCRIPTION <replaceable class="PARAMETER">name</replaceable> RENAME TO <
  </refsect1>
 
  <refsect1>
+<!--
   <title>Examples</title>
+-->
+  <title>例</title>
 
   <para>
+<!--
    Change the publication subscribed by a subscription to
    <literal>insert_only</literal>:
+-->
+サブスクリプションがサブスクライブするパブリケーションを<literal>insert_only</literal>に変更します。
 <programlisting>
 ALTER SUBSCRIPTION mysub SET PUBLICATION insert_only;
 </programlisting>
   </para>
 
   <para>
+<!--
    Disable (stop) the subscription:
+-->
+サブスクリプションを無効化（停止）します。
 <programlisting>
 ALTER SUBSCRIPTION mysub DISABLE;
 </programlisting></para>
  </refsect1>
 
  <refsect1>
+<!--
   <title>Compatibility</title>
+-->
+  <title>互換性</title>
 
   <para>
+<!--
    <command>ALTER SUBSCRIPTION</command> is a <productname>PostgreSQL</>
    extension.
+-->
+<command>ALTER SUBSCRIPTION</command>は<productname>PostgreSQL</>の拡張です。
   </para>
  </refsect1>
 
  <refsect1>
+<!--
   <title>See Also</title>
+-->
+  <title>関連項目</title>
 
   <simplelist type="inline">
    <member><xref linkend="sql-createsubscription"></member>

--- a/doc/src/sgml/ref/create_publication.sgml
+++ b/doc/src/sgml/ref/create_publication.sgml
@@ -11,12 +11,18 @@ PostgreSQL documentation
  <refmeta>
   <refentrytitle>CREATE PUBLICATION</refentrytitle>
   <manvolnum>7</manvolnum>
+<!--
   <refmiscinfo>SQL - Language Statements</refmiscinfo>
+-->
+  <refmiscinfo>SQL - 言語</refmiscinfo>
  </refmeta>
 
  <refnamediv>
   <refname>CREATE PUBLICATION</refname>
+<!--
   <refpurpose>define a new publication</refpurpose>
+-->
+  <refpurpose>新しいパブリケーションを定義する</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -30,31 +36,48 @@ CREATE PUBLICATION <replaceable class="parameter">name</replaceable>
  </refsynopsisdiv>
 
  <refsect1>
+<!--
   <title>Description</title>
+-->
+  <title>説明</title>
 
   <para>
+<!--
    <command>CREATE PUBLICATION</command> adds a new publication
    into the current database.  The publication name must be distinct from
    the name of any existing publication in the current database.
+-->
+<command>CREATE PUBLICATION</command>は現在のデータベースに新しいパブリケーションを追加します。
+パブリケーションの名前は現在のデータベースに存在するどのパブリケーションの名前とも異なるものでなければなりません。
   </para>
 
   <para>
+<!--
    A publication is essentially a group of tables whose data changes are
    intended to be replicated through logical replication.  See
    <xref linkend="logical-replication-publication"> for details about how
    publications fit into the logical replication setup.
+-->
+パブリケーションは本質的にはテーブルの集合で、それらのテーブルのデータの変更が、論理レプリケーションを通じて複製されることが意図されているものです。
+論理レプリケーションの設定で、パブリケーションがどのように位置づけられるかの詳細については、<xref linkend="logical-replication-publication">を参照してください。
    </para>
  </refsect1>
 
  <refsect1>
+<!--
   <title>Parameters</title>
+-->
+  <title>パラメータ</title>
 
   <variablelist>
    <varlistentry>
     <term><replaceable class="parameter">name</replaceable></term>
     <listitem>
      <para>
+<!--
       The name of the new publication.
+-->
+新しいパブリケーションの名前です。
      </para>
     </listitem>
    </varlistentry>
@@ -63,20 +86,31 @@ CREATE PUBLICATION <replaceable class="parameter">name</replaceable>
     <term><literal>FOR TABLE</literal></term>
     <listitem>
      <para>
+<!--
       Specifies a list of tables to add to the publication.  If
       <literal>ONLY</> is specified before the table name, only
       that table is added to the publication.  If <literal>ONLY</> is not
       specified, the table and all its descendant tables (if any) are added.
       Optionally, <literal>*</> can be specified after the table name to
       explicitly indicate that descendant tables are included.
+-->
+パブリケーションに追加するテーブルのリストを指定します。
+テーブル名の前に<literal>ONLY</>が指定されているときは、そのテーブルだけがパブリケーションに追加されます。
+<literal>ONLY</>が指定されていないときは、そのテーブルと、そのすべての子テーブル（あれば）が追加されます。
+オプションで、テーブル名の後に<literal>*</>を指定して、子テーブルが含まれることを明示的に示すことができます。
      </para>
 
      <para>
+<!--
       Only persistent base tables can be part of a publication.  Temporary
       tables, unlogged tables, foreign tables, materialized views, regular
       views, and partitioned tables cannot be part of a publication.  To
       replicate a partitioned table, add the individual partitions to the
       publication.
+-->
+パブリケーションに含めることができるのは、永続的なベーステーブルだけです。
+一時テーブル、ログを取らないテーブル、外部テーブル、マテリアライズドビュー、通常のビュー、パーティションテーブルはパブリケーションに含めることはできません。
+パーティションテーブルを複製するには、個々のパーティションをパブリケーションに追加してください。
      </para>
     </listitem>
    </varlistentry>
@@ -85,8 +119,11 @@ CREATE PUBLICATION <replaceable class="parameter">name</replaceable>
     <term><literal>FOR ALL TABLES</literal></term>
     <listitem>
      <para>
+<!--
       Marks the publication as one that replicates changes for all tables in
       the database, including tables created in the future.
+-->
+そのパブリケーションでは、将来作成されるテーブルも含め、そのデータベース内の全テーブルについての変更を複製するものとして印をつけます。
      </para>
     </listitem>
    </varlistentry>
@@ -95,14 +132,19 @@ CREATE PUBLICATION <replaceable class="parameter">name</replaceable>
     <term><literal>WITH ( <replaceable class="parameter">publication_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] )</literal></term>
     <listitem>
      <para>
+<!--
       This clause specifies optional parameters for a publication.  The
       following parameters are supported:
+-->
+この句ではパブリケーションのオプションパラメータを指定します。
+以下のパラメータがサポートされています。
 
       <variablelist>
        <varlistentry>
         <term><literal>publish</literal> (<type>string</type>)</term>
         <listitem>
          <para>
+<!--
           This parameter determines which DML operations will be published by
           the new publication to the subscribers.  The value is
           comma-separated list of operations.  The allowed operations are
@@ -110,6 +152,11 @@ CREATE PUBLICATION <replaceable class="parameter">name</replaceable>
           <literal>delete</literal>.  The default is to publish all actions,
           and so the default value for this option is
           <literal>'insert, update, delete'</literal>.
+-->
+このパラメータは、新しいパブリケーションがどのDML操作をサブスクライバにパブリッシュするかを指定します。
+値はカンマで区切られた操作のリストです。
+使用できる操作は<literal>insert</literal>、<literal>update</literal>、<literal>delete</literal>です。
+デフォルトではすべての動作をパブリッシュするので、このオプションのデフォルト値は<literal>'insert, update, delete'</literal>です。
          </para>
         </listitem>
        </varlistentry>
@@ -123,76 +170,121 @@ CREATE PUBLICATION <replaceable class="parameter">name</replaceable>
  </refsect1>
 
  <refsect1>
+<!--
   <title>Notes</title>
+-->
+  <title>注釈</title>
 
   <para>
+<!--
    If neither <literal>FOR TABLE</literal> nor <literal>FOR ALL
    TABLES</literal> is specified, then the publication starts out with an
    empty set of tables.  That is useful if tables are to be added later.
+-->
+<literal>FOR TABLE</literal>と<literal>FOR ALL TABLES</literal>のどちらも指定されていない場合、パブリケーションは空のテーブルの集合で作られます。
+これは後でテーブルを追加したい場合に便利です。
   </para>
 
   <para>
+<!--
    The creation of a publication does not start replication.  It only defines
    a grouping and filtering logic for future subscribers.
+-->
+パブリケーションを作るだけでは、レプリケーションは開始されません。
+これは単に将来のサブスクライバのためにグループとフィルタの論理を定義するだけです。
   </para>
 
   <para>
+<!--
    To create a publication, the invoking user must have the
    <literal>CREATE</> privilege for the current database.
    (Of course, superusers bypass this check.)
+-->
+パブリケーションを作成するには、それを実行するユーザは現在のデータベースに<literal>CREATE</>権限を持っていなければなりません。
+（もちろん、スーパーユーザにはこの検査は適用されません。）
   </para>
 
   <para>
+<!--
    To add a table to a publication, the invoking user must have ownership
    rights on the table.  The <command>FOR ALL TABLES</command> clause requires
    the invoking user to be a superuser.
+-->
+パブリケーションにテーブルを追加するには、それを実行するユーザがそのテーブルの所有権を持っていなければなりません。
+<command>FOR ALL TABLES</command>句は、それを実行するユーザがスーパーユーザである必要があります。
   </para>
 
   <para>
+<!--
    The tables added to a publication that publishes <command>UPDATE</command>
    and/or <command>DELETE</command> operations must have
    <literal>REPLICA IDENTITY</> defined.  Otherwise those operations will be
    disallowed on those tables.
+-->
+<command>UPDATE</command>または<command>DELETE</command>をパブリッシュするパブリケーションに追加されるテーブルには<literal>REPLICA IDENTITY</>が定義されていなければなりません。
+そうでなければ、それらのテーブルに対して、それらの操作は禁止されることになります。
   </para>
 
   <para>
+<!--
    For an <command>INSERT ... ON CONFLICT</> command, the publication will
    publish the operation that actually results from the command.  So depending
    of the outcome, it may be published as either <command>INSERT</command> or
    <command>UPDATE</command>, or it may not be published at all.
+-->
+<command>INSERT ... ON CONFLICT</>コマンドに対しては、パブリケーションはコマンドの結果として実際に起こった操作をパブリッシュします。
+従って、その結果に応じて<command>INSERT</command>あるいは<command>UPDATE</command>のいずれかとしてパブリッシュするか、あるいは何もパブリッシュしないかもしれません。
   </para>
 
   <para>
+<!--
    <command>COPY ... FROM</command> commands are published
    as <command>INSERT</command> operations.
+-->
+<command>COPY ... FROM</command>コマンドは<command>INSERT</command>の操作としてパブリッシュされます。
   </para>
 
   <para>
+<!--
    <command>TRUNCATE</command> and <acronym>DDL</acronym> operations
    are not published.
+-->
+<command>TRUNCATE</command>および<acronym>DDL</acronym>の操作はパブリッシュされません。
   </para>
  </refsect1>
 
  <refsect1>
+<!--
   <title>Examples</title>
+-->
+  <title>例</title>
 
   <para>
+<!--
    Create a publication that publishes all changes in two tables:
+-->
+2つのテーブルのすべての変更をパブリッシュするパブリケーションを作成します。
 <programlisting>
 CREATE PUBLICATION mypublication FOR TABLE users, departments;
 </programlisting>
   </para>
 
   <para>
+<!--
    Create a publication that publishes all changes in all tables:
+-->
+すべてのテーブルのすべての変更をパブリッシュするパブリケーションを作成します。
 <programlisting>
 CREATE PUBLICATION alltables FOR ALL TABLES;
 </programlisting>
   </para>
 
   <para>
+<!--
    Create a publication that only publishes <command>INSERT</command>
    operations in one table:
+-->
+１つのテーブルの<command>INSERT</command>の操作のみをパブリッシュするパブリケーションを作成します。
 <programlisting>
 CREATE PUBLICATION insert_only FOR TABLE mydata
     WITH (publish = 'insert');
@@ -200,16 +292,25 @@ CREATE PUBLICATION insert_only FOR TABLE mydata
  </refsect1>
 
  <refsect1>
+<!--
   <title>Compatibility</title>
+-->
+  <title>互換性</title>
 
   <para>
+<!--
    <command>CREATE PUBLICATION</command> is a <productname>PostgreSQL</>
    extension.
+-->
+<command>CREATE PUBLICATION</command>は<productname>PostgreSQL</>の拡張です。
   </para>
  </refsect1>
 
  <refsect1>
+<!--
   <title>See Also</title>
+-->
+  <title>関連項目</title>
 
   <simplelist type="inline">
    <member><xref linkend="sql-alterpublication"></member>

--- a/doc/src/sgml/ref/create_subscription.sgml
+++ b/doc/src/sgml/ref/create_subscription.sgml
@@ -203,7 +203,7 @@ CREATE SUBSCRIPTION <replaceable class="PARAMETER">subscription_name</replaceabl
 -->
 <literal>slot_name</literal>を<literal>NONE</literal>に設定すると、サブスクリプションに紐付けられたレプリケーションスロットがなくなります。
 これはレプリケーションスロットを後で手作業で作成する場合に使用できます。
-そのようなサブスクリプションは、<literal>enabled</literal>と<iteral>create_slot</literal>の両方を<literal>false</literal>に設定しなければなりません。
+そのようなサブスクリプションは、<literal>enabled</literal>と<literal>create_slot</literal>の両方を<literal>false</literal>に設定しなければなりません。
          </para>
         </listitem>
        </varlistentry>

--- a/doc/src/sgml/ref/create_subscription.sgml
+++ b/doc/src/sgml/ref/create_subscription.sgml
@@ -11,12 +11,18 @@ PostgreSQL documentation
  <refmeta>
   <refentrytitle>CREATE SUBSCRIPTION</refentrytitle>
   <manvolnum>7</manvolnum>
+<!--
   <refmiscinfo>SQL - Language Statements</refmiscinfo>
+-->
+  <refmiscinfo>SQL - 言語</refmiscinfo>
  </refmeta>
 
  <refnamediv>
   <refname>CREATE SUBSCRIPTION</refname>
+<!--
   <refpurpose>define a new subscription</refpurpose>
+-->
+  <refpurpose>新しいサブスクリプションを定義する</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -29,42 +35,65 @@ CREATE SUBSCRIPTION <replaceable class="PARAMETER">subscription_name</replaceabl
  </refsynopsisdiv>
 
  <refsect1>
+<!--
   <title>Description</title>
+-->
+  <title>説明</title>
 
   <para>
+<!--
    <command>CREATE SUBSCRIPTION</command> adds a new subscription for the
    current database.  The subscription name must be distinct from the name of
    any existing subscription in the database.
+-->
+<command>CREATE SUBSCRIPTION</command>は現在のデータベースに新しいサブスクリプションを追加します。
+サブスクリプションの名前は現在のデータベースに存在するどのサブスクリプションの名前とも異なるものでなければなりません。
   </para>
 
   <para>
+<!--
    The subscription represents a replication connection to the publisher.  As
    such this command does not only add definitions in the local catalogs but
    also creates a replication slot on the publisher.
+-->
+サブスクリプションはパブリッシャーへのレプリケーション接続を表します。
+そのためこのコマンドはローカルのカタログに定義を追加するだけでなく、パブリッシャーのレプリケーションスロットも作成します。
   </para>
 
   <para>
+<!--
    A logical replication worker will be started to replicate data for the new
    subscription at the commit of the transaction where this command is run.
+-->
+このコマンドが実行されるトランザクションがコミットされた時点で、新しいサブスクリプションに対してデータを複製する論理レプリケーションワーカが開始されます。
   </para>
 
   <para>
+<!--
    Additional info about subscriptions and logical replication as a whole
    can is available at <xref linkend="logical-replication-subscription"> and
    <xref linkend="logical-replication">.
+-->
+サブスクリプションおよび論理レプリケーションの全体像についての追加情報は<xref linkend="logical-replication-subscription">および<xref linkend="logical-replication">に記述されています。
   </para>
 
  </refsect1>
 
  <refsect1>
+<!--
   <title>Parameters</title>
+-->
+  <title>パラメータ</title>
 
   <variablelist>
    <varlistentry>
     <term><replaceable class="parameter">subscription_name</replaceable></term>
     <listitem>
      <para>
+<!--
       The name of the new subscription.
+-->
+新しいサブスクリプションの名前です。
      </para>
     </listitem>
    </varlistentry>
@@ -73,8 +102,12 @@ CREATE SUBSCRIPTION <replaceable class="PARAMETER">subscription_name</replaceabl
     <term><literal>CONNECTION '<replaceable class="parameter">conninfo</replaceable>'</literal></term>
     <listitem>
      <para>
+<!--
       The connection string to the publisher.  For details
       see <xref linkend="libpq-connstring">.
+-->
+パブリッシャーへの接続文字列です。
+詳細は<xref linkend="libpq-connstring">を参照してください。
      </para>
     </listitem>
    </varlistentry>
@@ -83,7 +116,10 @@ CREATE SUBSCRIPTION <replaceable class="PARAMETER">subscription_name</replaceabl
     <term><literal>PUBLICATION <replaceable class="parameter">publication_name</replaceable></literal></term>
     <listitem>
      <para>
+<!--
       Names of the publications on the publisher to subscribe to.
+-->
+パブリッシャー上のパブリケーションで、サブスクリプションの対象となるものの名前です。
      </para>
     </listitem>
    </varlistentry>
@@ -92,17 +128,25 @@ CREATE SUBSCRIPTION <replaceable class="PARAMETER">subscription_name</replaceabl
     <term><literal>WITH ( <replaceable class="parameter">subscription_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] )</literal></term>
     <listitem>
      <para>
+<!--
       This clause specifies optional parameters for a subscription.  The
       following parameters are supported:
+-->
+この句ではサブスクリプションのオプションパラメータを指定します。
+以下のパラメータがサポートされています。
 
       <variablelist>
        <varlistentry>
         <term><literal>copy_data</literal> (<type>boolean</type>)</term>
         <listitem>
          <para>
+<!--
           Specifies whether the existing data in the publications that are
           being subscribed to should be copied once the replication starts.
           The default is <literal>true</literal>.
+-->
+サブスクリプションの対象となるパブリケーションの既存データが、レプリケーションの開始時にコピーされるかどうかを指定します。
+デフォルトは<literal>true</literal>です。
          </para>
         </listitem>
        </varlistentry>
@@ -111,8 +155,12 @@ CREATE SUBSCRIPTION <replaceable class="PARAMETER">subscription_name</replaceabl
         <term><literal>create_slot</literal> (<type>boolean</type>)</term>
         <listitem>
          <para>
+<!--
           Specifies whether the command should create the replication slot on
           the publisher.  The default is <literal>true</literal>.
+-->
+このコマンドがパブリッシャー上にレプリケーションスロットを作るかどうかを指定します。
+デフォルトは<literal>true</literal>です。
          </para>
         </listitem>
        </varlistentry>
@@ -121,9 +169,13 @@ CREATE SUBSCRIPTION <replaceable class="PARAMETER">subscription_name</replaceabl
         <term><literal>enabled</literal> (<type>boolean</type>)</term>
         <listitem>
          <para>
+<!--
           Specifies whether the subscription should be actively replicating,
           or whether it should be just setup but not started yet.  The default
           is <literal>true</literal>.
+-->
+サブスクリプションが複製の動作をすぐに行うか、あるいは単に設定をするだけでまだ開始しないかを指定します。
+デフォルトは<literal>true</literal>です。
          </para>
         </listitem>
        </varlistentry>
@@ -132,17 +184,26 @@ CREATE SUBSCRIPTION <replaceable class="PARAMETER">subscription_name</replaceabl
         <term><literal>slot_name</literal> (<type>string</type>)</term>
         <listitem>
          <para>
+<!--
           Name of the replication slot to use.  The default behavior is to
           use the name of the subscription for the slot name.
+-->
+使用するレプリケーションスロットの名前です。
+デフォルトの挙動では、サブスクリプションの名前をスロット名として使用します。
          </para>
 
          <para>
+<!--
           When <literal>slot_name</literal> is set to
           <literal>NONE</literal>, there will be no replication slot
           associated with the subscription.  This can be used if the
           replication slot will be created later manually.  Such
           subscriptions must also have both <literal>enabled</literal> and
           <literal>create_slot</literal> set to <literal>false</literal>.
+-->
+<literal>slot_name</literal>を<literal>NONE</literal>に設定すると、サブスクリプションに紐付けられたレプリケーションスロットがなくなります。
+これはレプリケーションスロットを後で手作業で作成する場合に使用できます。
+そのようなサブスクリプションは、<literal>enabled</literal>と<iteral>create_slot</literal>の両方を<literal>false</literal>に設定しなければなりません。
          </para>
         </listitem>
        </varlistentry>
@@ -151,18 +212,27 @@ CREATE SUBSCRIPTION <replaceable class="PARAMETER">subscription_name</replaceabl
         <term><literal>synchronous_commit</literal> (<type>enum</type>)</term>
         <listitem>
          <para>
+<!--
           The value of this parameter overrides the
           <xref linkend="guc-synchronous-commit"> setting.  The default
           value is <literal>off</literal>.
+-->
+このパラメータの値は<xref linkend="guc-synchronous-commit">の設定をオーバーライドします。
+デフォルト値は<literal>off</literal>です。
          </para>
 
          <para>
+<!--
           It is safe to use <literal>off</literal> for logical replication:
           If the subscriber loses transactions because of missing
           synchronization, the data will be resent from the publisher.
+-->
+論理レプリケーションでは<literal>off</literal>を使用するのが安全です。
+そうすることで、同期の失敗によりサブスクライバがトランザクションを失った場合でも、パブリッシャーからデータが再送されます。
          </para>
 
          <para>
+<!--
           A different setting might be appropriate when doing synchronous
           logical replication.  The logical replication workers report the
           positions of writes and flushes to the publisher, and when using
@@ -174,6 +244,11 @@ CREATE SUBSCRIPTION <replaceable class="PARAMETER">subscription_name</replaceabl
           <command>COMMIT</command> on the publisher.  In this scenario, it
           can be advantageous to set <literal>synchronous_commit</literal>
           to <literal>local</literal> or higher.
+-->
+同期論理レプリケーションを行う場合は別の設定が適切かもしれません。
+論理レプリケーションのワーカは書き込みおよび吐き出しの位置をパブリッシャーに報告しますが、同期レプリケーションを行っているときは、パブリッシャは実際に吐き出しがされるのを待ちます。
+これはつまり、サブスクリプションが同期レプリケーションで使われている時に、サブスクライバの<literal>synchronous_commit</literal>を<literal>off</literal>に設定すると、パブリッシャーでの<command>COMMIT</command>の遅延が増大するかもしれない、ということを意味します。
+この場合、<literal>synchronous_commit</literal>を<literal>local</literal>またはそれ以上に設定することが有利になりえます。
          </para>
         </listitem>
        </varlistentry>
@@ -182,27 +257,39 @@ CREATE SUBSCRIPTION <replaceable class="PARAMETER">subscription_name</replaceabl
         <term><literal>connect</literal> (<type>boolean</type>)</term>
         <listitem>
          <para>
+<!--
           Specifies whether the <command>CREATE SUBSCRIPTION</command>
           should connect to the publisher at all.  Setting this to
           <literal>false</literal> will change default values of
           <literal>enabled</literal>, <literal>create_slot</literal> and
           <literal>copy_data</literal> to <literal>false</literal>.
+-->
+<command>CREATE SUBSCRIPTION</command>がパブリッシャーに接続するかどうかを指定します。
+これを<literal>false</literal>に設定すると、<literal>enabled</literal>、<literal>create_slot</literal>、<literal>copy_data</literal>のデフォルト値を<literal>false</literal>に変更します。
          </para>
 
          <para>
+<!--
           It is not allowed to combine <literal>connect</literal> set to
           <literal>false</literal> and <literal>enabled</literal>,
           <literal>create_slot</literal>, or <literal>copy_data</literal>
           set to <literal>true</literal>.
+-->
+<literal>connect</literal>を<literal>false</literal>に設定し、<literal>enabled</literal>、<literal>create_slot</literal>または<literal>copy_data</literal>を<literal>true</literal>に設定することは許されません。
          </para>
 
          <para>
+<!--
           Since no connection is made when this option is set
           to <literal>false</literal>, the tables are not subscribed, and so
           after you enable the subscription nothing will be replicated.
           It is required to run
           <literal>ALTER SUBSCRIPTION ... REFRESH PUBLICATION</> in order
           for tables to be subscribed.
+-->
+このオプションが<literal>false</literal>に設定されると接続が行われないため、テーブルはサブスクライブされません。
+そのため、サブスクリプションを有効にしても、何も複製されません。
+テーブルをサブスクライブするには、<literal>ALTER SUBSCRIPTION ... REFRESH PUBLICATION</>を実行する必要があります。
          </para>
         </listitem>
        </varlistentry>
@@ -214,20 +301,30 @@ CREATE SUBSCRIPTION <replaceable class="PARAMETER">subscription_name</replaceabl
  </refsect1>
 
  <refsect1>
+<!--
   <title>Notes</title>
+-->
+  <title>注釈</title>
 
   <para>
+<!--
    See <xref linkend="logical-replication-security"> for details on
    how to configure access control between the subscription and the
    publication instance.
+-->
+サブスクリプションとパブリケーションのインスタンスの間のアクセス制御をどのように設定するかの詳細については、<xref linkend="logical-replication-security">を参照してください。
   </para>
 
   <para>
+<!--
    When creating a replication slot (the default behavior), <command>CREATE
    SUBSCRIPTION</command> cannot be executed inside a transaction block.
+-->
+レプリケーションスロットを作成する（デフォルトの動作です）場合、<command>CREATE SUBSCRIPTION</command>をトランザクションブロックの内側で実行することはできません。
   </para>
 
   <para>
+<!--
    Creating a subscription that connects to the same database cluster (for
    example, to replicate between databases in the same cluster or to replicate
    within the same database) will only succeed if the replication slot is not
@@ -238,17 +335,28 @@ CREATE SUBSCRIPTION <replaceable class="PARAMETER">subscription_name</replaceabl
    plugin name <literal>pgoutput</literal>) and create the subscription using
    the parameter <literal>create_slot = false</literal>.  This is an
    implementation restriction that might be lifted in a future release.
+-->
+同じデータベースクラスタに接続するサブスクリプション（例えば、同一のクラスタ内のデータベース間で複製を行う、あるいは同一のデータベース内で複製を行う）の作成は、同じコマンド内でレプリケーションスロットが作成されない場合にのみ成功します。
+そうでない場合、<command>CREATE SUBSCRIPTION</command>の呼び出しはハングアップします。
+これを動作させるには、（関数<function>pg_create_logical_replication_slot</function>をプラグイン名<literal>pgoutput</literal>で使って）レプリケーションスロットを別に作り、パラメータ<literal>create_slot = false</literal>を使ってサブスクリプションを作成してください。
+これは実装上の制限で、将来のリリースでは解決されるかもしれません。
   </para>
  </refsect1>
 
  <refsect1>
+<!--
   <title>Examples</title>
+-->
+  <title>例</title>
 
   <para>
+<!--
    Create a subscription to a remote server that replicates tables in
    the publications <literal>mypublication</literal> and
    <literal>insert_only</literal> and starts replicating immediately on
    commit:
+-->
+パブリケーション<literal>mypublication</literal>および<literal>insert_only</literal>のテーブルを複製する、リモートサーバへのサブスクリプションを作成し、コミット後、すぐにレプリケーションを開始します。
 <programlisting>
 CREATE SUBSCRIPTION mysub
          CONNECTION 'host=192.168.1.50 port=5432 user=foo dbname=foodb'
@@ -257,9 +365,12 @@ CREATE SUBSCRIPTION mysub
   </para>
 
   <para>
+<!--
    Create a subscription to a remote server that replicates tables in
    the <literal>insert_only</literal> publication and does not start replicating
    until enabled at a later time.
+-->
+パブリケーション<literal>insert_only</literal>のテーブルを複製するリモートサーバへのサブスクリプションを作成しますが、後に有効化するまではレプリケーションを開始しません。
 <programlisting>
 CREATE SUBSCRIPTION mysub
          CONNECTION 'host=192.168.1.50 port=5432 user=foo dbname=foodb'
@@ -269,16 +380,25 @@ CREATE SUBSCRIPTION mysub
  </refsect1>
 
  <refsect1>
+<!--
   <title>Compatibility</title>
+-->
+  <title>互換性</title>
 
   <para>
+<!--
    <command>CREATE SUBSCRIPTION</command> is a <productname>PostgreSQL</>
    extension.
+-->
+<command>CREATE SUBSCRIPTION</command>は<productname>PostgreSQL</>の拡張です。
   </para>
  </refsect1>
 
  <refsect1>
+<!--
   <title>See Also</title>
+-->
+  <title>関連項目</title>
 
   <simplelist type="inline">
    <member><xref linkend="sql-altersubscription"></member>

--- a/doc/src/sgml/ref/drop_publication.sgml
+++ b/doc/src/sgml/ref/drop_publication.sgml
@@ -11,12 +11,18 @@ PostgreSQL documentation
  <refmeta>
   <refentrytitle>DROP PUBLICATION</refentrytitle>
   <manvolnum>7</manvolnum>
+<!--
   <refmiscinfo>SQL - Language Statements</refmiscinfo>
+-->
+  <refmiscinfo>SQL - 言語</refmiscinfo>
  </refmeta>
 
  <refnamediv>
   <refname>DROP PUBLICATION</refname>
+<!--
   <refpurpose>remove a publication</refpurpose>
+-->
+  <refpurpose>パブリケーションを削除する</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -26,28 +32,44 @@ DROP PUBLICATION [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable>
  </refsynopsisdiv>
 
  <refsect1>
+<!--
   <title>Description</title>
+-->
+  <title>説明</title>
 
   <para>
+<!--
    <command>DROP PUBLICATION</command> removes an existing publication from
    the database.
+-->
+<command>DROP PUBLICATION</command>は既存のパブリケーションをデータベースから削除します。
   </para>
 
   <para>
+<!--
    A publication can only be dropped by its owner or a superuser.
+-->
+パブリケーションはその所有者またはスーパーユーザによってのみ削除することができます。
   </para>
  </refsect1>
 
  <refsect1>
+<!--
   <title>Parameters</title>
+-->
+  <title>パラメータ</title>
 
   <variablelist>
    <varlistentry>
     <term><literal>IF EXISTS</literal></term>
     <listitem>
      <para>
+<!--
       Do not throw an error if the publication does not exist. A notice is
       issued in this case.
+-->
+パブリケーションが存在しない場合でもエラーになりません。
+この場合、注意メッセージが発行されます。
      </para>
     </listitem>
    </varlistentry>
@@ -56,7 +78,10 @@ DROP PUBLICATION [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable>
     <term><replaceable class="parameter">name</replaceable></term>
     <listitem>
      <para>
+<!--
       The name of an existing publication.
+-->
+既存のパブリケーションの名前です。
      </para>
     </listitem>
    </varlistentry>
@@ -67,8 +92,11 @@ DROP PUBLICATION [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable>
 
     <listitem>
      <para>
+<!--
       These key words do not have any effect, since there are no dependencies
       on publications.
+-->
+パブリケーションに依存するものはないので、これらのキーワードは何も効果がありません。
      </para>
     </listitem>
    </varlistentry>
@@ -76,26 +104,41 @@ DROP PUBLICATION [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable>
  </refsect1>
 
  <refsect1>
+<!--
   <title>Examples</title>
+-->
+  <title>例</title>
 
   <para>
+<!--
    Drop a publication:
+-->
+パブリケーションを削除します。
 <programlisting>
 DROP PUBLICATION mypublication;
 </programlisting></para>
  </refsect1>
 
  <refsect1>
+<!--
   <title>Compatibility</title>
+-->
+  <title>互換性</title>
 
   <para>
+<!--
    <command>DROP PUBLICATION</command> is a <productname>PostgreSQL</>
    extension.
+-->
+<command>DROP PUBLICATION</command>は<productname>PostgreSQL</>の拡張です。
   </para>
  </refsect1>
 
  <refsect1>
+<!--
   <title>See Also</title>
+-->
+  <title>関連項目</title>
 
   <simplelist type="inline">
    <member><xref linkend="sql-createpublication"></member>

--- a/doc/src/sgml/ref/drop_subscription.sgml
+++ b/doc/src/sgml/ref/drop_subscription.sgml
@@ -11,12 +11,18 @@ PostgreSQL documentation
  <refmeta>
   <refentrytitle>DROP SUBSCRIPTION</refentrytitle>
   <manvolnum>7</manvolnum>
+<!--
   <refmiscinfo>SQL - Language Statements</refmiscinfo>
+-->
+  <refmiscinfo>SQL - 言語</refmiscinfo>
  </refmeta>
 
  <refnamediv>
   <refname>DROP SUBSCRIPTION</refname>
+<!--
   <refpurpose>remove a subscription</refpurpose>
+-->
+  <refpurpose>サブスクリプションを削除する</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -26,34 +32,53 @@ DROP SUBSCRIPTION [ IF EXISTS ] <replaceable class="parameter">name</replaceable
  </refsynopsisdiv>
 
  <refsect1>
+<!--
   <title>Description</title>
+-->
+  <title>説明</title>
 
   <para>
+<!--
    <command>DROP SUBSCRIPTION</command> removes a subscription from the
    database cluster.
+-->
+<command>DROP SUBSCRIPTION</command>はデータベースクラスタからサブスクリプションを削除します。
   </para>
 
   <para>
+<!--
    A subscription can only be dropped by a superuser.
+-->
+スーパーユーザのみがサブスクリプションを削除できます。
   </para>
 
   <para>
+<!--
    <command>DROP SUBSCRIPTION</command> cannot be executed inside a
    transaction block if the subscription is associated with a replication
    slot.  (You can use <command>ALTER SUBSCRIPTION</command> to unset the
    slot.)
+-->
+サブスクリプションがレプリケーションスロットに紐付けられている場合、<command>DROP SUBSCRIPTION</command>をトランザクショングロックの内側で実行することはできません。
+（スロットの設定を解除するには<command>ALTER SUBSCRIPTION</command>を使うことができます。）
   </para>
  </refsect1>
 
  <refsect1>
+<!--
   <title>Parameters</title>
+-->
+  <title>パラメータ</title>
 
   <variablelist>
    <varlistentry>
     <term><replaceable class="parameter">name</replaceable></term>
     <listitem>
      <para>
+<!--
       The name of a subscription to be dropped.
+-->
+削除対象のサブスクリプションの名前です。
      </para>
     </listitem>
    </varlistentry>
@@ -64,8 +89,11 @@ DROP SUBSCRIPTION [ IF EXISTS ] <replaceable class="parameter">name</replaceable
 
     <listitem>
      <para>
+<!--
       These key words do not have any effect, since there are no dependencies
       on subscriptions.
+-->
+サブスクリプションに依存するものはないので、これらのキーワードは何も効果がありません。
      </para>
     </listitem>
    </varlistentry>
@@ -74,9 +102,13 @@ DROP SUBSCRIPTION [ IF EXISTS ] <replaceable class="parameter">name</replaceable
  </refsect1>
 
  <refsect1>
+<!--
   <title>Notes</title>
+-->
+  <title>注釈</title>
 
   <para>
+<!--
    When dropping a subscription that is associated with a replication slot on
    the remote host (the normal state), <command>DROP SUBSCRIPTION</command>
    will connect to the remote host and try to drop the replication slot as
@@ -92,35 +124,62 @@ DROP SUBSCRIPTION [ IF EXISTS ] <replaceable class="parameter">name</replaceable
    exists, it should then be dropped manually; otherwise it will continue to
    reserve WAL and might eventually cause the disk to fill up.  See
    also <xref linkend="logical-replication-subscription-slot">.
+-->
+リモートホストのレプリケーションスロットに紐付けられているサブスクリプション（これが通常の状態です）を削除するとき、<command>DROP SUBSCRIPTION</command>はその操作の一部として、リモートホストに接続し、レプリケーションスロットを削除しようとします。
+リモートホスト上でサブスクリプションに割り当てられたリソースを解放するために、これが必要となります。
+リモートホストに到達できない、あるいはリモートのレプリケーションスロットが削除できない、存在しない、存在したことがない、という理由で削除に失敗した場合、<command>DROP SUBSCRIPTION</command>コマンドは失敗します。
+この状況において先へ進むためには、<literal>ALTER SUBSCRIPTION ... SET (slot_name = NONE)</literal>を実行してサブスクリプションとレプリケーションスロットの紐付けを解除してください。
+その後なら<command>DROP SUBSCRIPTION</command>はリモートホスト上で何のアクションも起こそうとしません。
+リモートのレプリケーションスロットがそれでも存在する場合、それを手作業で削除すべきであることに注意してください。
+そうしなければ、WALを保存し続け、最終的にはディスクを一杯にしてしまうかもしれません。
+<xref linkend="logical-replication-subscription-slot">も参照してください。
   </para>
 
   <para>
+<!--
    If a subscription is associated with a replication slot, then <command>DROP
    SUBSCRIPTION</command> cannot be executed inside a transaction block.
+-->
+サブスクリプションがレプリケーションスロットと紐付けられている場合、<command>DROP SUBSCRIPTION</command>をトランザクションブロックの内側で実行することはできません。
   </para>
  </refsect1>
 
  <refsect1>
+<!--
   <title>Examples</title>
+-->
+  <title>例</title>
 
   <para>
+<!--
    Drop a subscription:
+-->
+サブスクリプションを削除します。
 <programlisting>
 DROP SUBSCRIPTION mysub;
 </programlisting></para>
  </refsect1>
 
  <refsect1>
+<!--
   <title>Compatibility</title>
+-->
+  <title>互換性</title>
 
   <para>
+<!--
    <command>DROP SUBSCRIPTION</command> is a <productname>PostgreSQL</>
    extension.
+-->
+<command>DROP SUBSCRIPTION</command>は<productname>PostgreSQL</>の拡張です。
   </para>
  </refsect1>
 
  <refsect1>
-  <title>See Also</title>
+<!--
+  <title>See Also</title> 
+-->
+  <title>関連項目</title> 
 
   <simplelist type="inline">
    <member><xref linkend="sql-createsubscription"></member>


### PR DESCRIPTION
logical replicationに関連するref以下の6個の新規ファイルの翻訳です。
logical replicationは「論理レプリケーション」、publication/publish/publisher, subscription/subscribe/subscriberはそのままカタカナにしています。