### PR TITLE
create/alter_tableの10.0対応です。

### DIFF
--- a/doc/src/sgml/ref/alter_table.sgml
+++ b/doc/src/sgml/ref/alter_table.sgml
@@ -162,6 +162,7 @@ ALTER TABLE [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable>
 -->
 この構文を使用すると、テーブルから列を削除できます。
 削除する列を含んでいるインデックスおよびテーブル制約も自動的に削除されます。
+削除する列を参照する多変量統計がある場合、列の削除の結果、その統計が1つの列のデータしか含まないようになるなら、それも削除されます。
 また、削除する列にテーブル以外が依存（例えば、外部キー制約、ビューなど）している場合、<literal>CASCADE</>を付ける必要があります。
 <literal>IF EXISTS</literal>が指定されている場合、もしその列がなかったとしてもエラーにはなりません。
 この場合は代わりに注意が出力されます。
@@ -231,6 +232,7 @@ ALTER TABLE [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable>
      </para>
 
      <para>
+<!--
       If this table is a partition, one cannot perform <literal>DROP NOT NULL</literal>
       on a column if it is marked <literal>NOT NULL</literal> in the parent
       table.  To drop the <literal>NOT NULL</literal> constraint from all the
@@ -239,6 +241,11 @@ ALTER TABLE [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable>
       parent, such a constraint can still be added to individual partitions,
       if desired; that is, the children can disallow nulls even if the parent
       allows them, but not the other way around.
+-->
+このテーブルがパーティションの場合、親テーブルで<literal>NOT NULL</literal>の印がつけられている列について<literal>DROP NOT NULL</literal>を実行することはできません。
+すべてのパーティションから<literal>NOT NULL</literal>制約を削除するには、親テーブルで<literal>DROP NOT NULL</literal>を実行してください。
+親テーブルに<literal>NOT NULL</>制約がない場合でも、望むなら各パーティションにそのような制約を追加することができます。
+つまり、親テーブルがNULLを許していても子テーブルでNULLを禁止することができますが、その逆はできません。
      </para>
     </listitem>
    </varlistentry>
@@ -249,15 +256,23 @@ ALTER TABLE [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable>
     <term><literal>DROP IDENTITY [ IF EXISTS ]</literal></term>
     <listitem>
      <para>
+<!--
       These forms change whether a column is an identity column or change the
       generation attribute of an existing identity column.
       See <xref linkend="sql-createtable"> for details.
+-->
+この構文では、列がIDENTITY列であるかどうか、または既存のIDENTITY列の生成属性を変更することができます。
+詳細は<xref linkend="sql-createtable">を参照してください。
      </para>
 
      <para>
+<!--
       If <literal>DROP IDENTITY IF EXISTS</literal> is specified and the
       column is not an identity column, no error is thrown.  In this case a
       notice is issued instead.
+-->
+<literal>DROP IDENTITY IF EXISTS</literal>が指定され、その列がIDENTITY列でない場合は、エラーを発生させません。
+この場合、注意メッセージが発行されます。
      </para>
     </listitem>
    </varlistentry>
@@ -267,10 +282,14 @@ ALTER TABLE [ IF EXISTS ] <replaceable class="PARAMETER">name</replaceable>
     <term><literal>RESTART</literal></term>
     <listitem>
      <para>
+<!--
       These forms alter the sequence that underlies an existing identity
       column.  <replaceable>sequence_option</replaceable> is an option
       supported by <xref linkend="sql-altersequence"> such
       as <literal>INCREMENT BY</literal>.
+-->
+この構文では、既存のIDENTITY列に紐付けられているシーケンスを変更します。
+<replaceable>sequence_option</replaceable>は<literal>INCREMENT BY</literal>など<xref linkend="sql-altersequence">がサポートするオプションです。
      </para>
     </listitem>
    </varlistentry>
@@ -848,14 +867,18 @@ clusterオプションの変更は<literal>SHARE UPDATE EXCLUSIVE</literal>ロ�
 このコマンドによってテーブルの内容が即座に変更されない点に注意してください。
 パラメータによりますが、期待する効果を得るためにテーブルを書き換える必要がある場合があります。
 このためには、<link linkend="SQL-VACUUM">VACUUM FULL</>、<xref linkend="SQL-CLUSTER">またはテーブルを強制的に書き換える<command>ALTER TABLE</>の構文のいずれかを使用してください。
+プランナに関連するパラメータについては、次にテーブルがロックされた時に変更が有効になるため、現在実行中の問い合わせは影響を受けません。
      </para>
 
      <para>
+<!--
       <literal>SHARE UPDATE EXCLUSIVE</literal> lock will be taken for
       fillfactor and autovacuum storage parameters, as well as the
       following planner related parameters:
       <varname>effective_io_concurrency</>, <varname>parallel_workers</>, <varname>seq_page_cost</>,
       <varname>random_page_cost</>, <varname>n_distinct</> and <varname>n_distinct_inherited</>.
+-->
+fillfactorおよびautovacuumのストレージパラメータおよびプランナに関連するパラメータ<varname>effective_io_concurrency</>、<varname>parallel_workers</>、<varname>seq_page_cost</>、<varname>random_page_cost</>、<varname>n_distinct</>、<varname>n_distinct_inherited</>については<literal>SHARE UPDATE EXCLUSIVE</literal>ロックが獲得されます。
      </para>
 
      <note>
@@ -1059,6 +1082,7 @@ OIDの状態を変更するためには代わりに<literal>SET WITH OIDS</>お�
     <term><literal>ATTACH PARTITION <replaceable class="PARAMETER">partition_name</replaceable> FOR VALUES <replaceable class="PARAMETER">partition_bound_spec</replaceable></literal></term>
     <listitem>
      <para>
+<!--
       This form attaches an existing table (which might itself be partitioned)
       as a partition of the target table using the same syntax for
       <replaceable class="PARAMETER">partition_bound_spec</replaceable> as
@@ -1074,9 +1098,18 @@ OIDの状態を変更するためには代わりに<literal>SET WITH OIDS</>お�
       attached is marked <literal>NO INHERIT</literal>, the command will fail;
       such a constraint must be recreated without the <literal>NO INHERIT</literal>
       clause.
+-->
+この構文では、既存のテーブル（それ自体がパーティションテーブルのこともあります）を対象テーブルのパーティションとして、<xref linkend="sql-createtable">の<replaceable class="PARAMETER">partition_bound_spec</replaceable>と同じ形式を使って追加します。
+パーティション境界の指定は、対象テーブルのパーティション戦略とパーティションキーに対応していなければなりません。
+パーティションとして追加されるテーブルは、対象テーブルと同じ列を持っており、余分な列があってはならず、さらに列の型も一致しなければなりません。
+また、対象テーブルの<literal>NOT NULL</literal>制約と<literal>CHECK</literal>をすべて持っていなければなりません。
+現在のところ、<literal>UNIQUE</literal>、<literal>PRIMARY KEY</literal>、<literal>FOREIGN KEY</literal>の制約については考慮されていません。
+追加されるテーブルの<literal>CHECK</literal>制約に<literal>NO INHERIT</literal>の印がつけられているものがあれば、コマンドは失敗します。
+そのような制約は<literal>NO INHERIT</literal>句なしに再作成しなければなりません。
      </para>
 
      <para>
+<!--
       If the new partition is a regular table, a full table scan is performed
       to check that no existing row in the table violates the partition
       constraint.  It is possible to avoid this scan by adding a valid
@@ -1089,13 +1122,23 @@ OIDの状態を変更するためには代わりに<literal>SET WITH OIDS</>お�
       a list partition that will not accept <literal>NULL</literal> values,
       also add <literal>NOT NULL</literal> constraint to the partition key
       column, unless it's an expression.
+-->
+新しいパーティションが通常のテーブルの場合、パーティションの制約に違反する行がテーブルに存在しないことを確認するため、テーブルの全件走査が行われます。
+このコマンドを実行するより前に、望まれるパーティションの制約を満たす行だけしか許さないような有効な<literal>CHECK</literal>制約をテーブルに追加すれば、この全件走査を避けることができます。
+パーティションの制約を確認するためにテーブルをスキャンしなくても良いことは、そのような制約を使って決定されます。
+しかし、パーティションキーに式が一つでもあり、それが<literal>NULL</literal>値を受け付けないときは、この仕組みは機能しません。
+<literal>NULL</literal>値を受け付けないリストパーティションに追加するときも、それが式でないなら、パーティションキーの列に<literal>NOT NULL</literal>制約を追加してください。
      </para>
 
      <para>
+<!--
       If the new partition is a foreign table, nothing is done to verify
       that all the rows in the foreign table obey the partition constraint.
       (See the discussion in <xref linkend="SQL-CREATEFOREIGNTABLE"> about
       constraints on the foreign table.)
+-->
+新しいパーティションが外部テーブルの場合、外部テーブルのすべての行がパーティションの制約に従うかどうかの確認は何も行われません。
+（外部テーブルの制約については<xref linkend="SQL-CREATEFOREIGNTABLE">の議論を参照してください。）
      </para>
     </listitem>
    </varlistentry>
@@ -1104,9 +1147,13 @@ OIDの状態を変更するためには代わりに<literal>SET WITH OIDS</>お�
     <term><literal>DETACH PARTITION</literal> <replaceable class="PARAMETER">partition_name</replaceable></term>
     <listitem>
      <para>
+<!--
       This form detaches specified partition of the target table.  The detached
       partition continues to exist as a standalone table, but no longer has any
       ties to the table from which it was detached.
+-->
+この構文は、指定したパーティションを対象のテーブルから切り離します。
+切り離されたパーティションは単独のテーブルとして存在し続けますが、切り離される前のテーブルとの紐付けはなくなります。
      </para>
     </listitem>
    </varlistentry>
@@ -1125,7 +1172,7 @@ OIDの状態を変更するためには代わりに<literal>SET WITH OIDS</>お�
    columns in a single command.  This is particularly useful with large
    tables, since only one pass over the table need be made.
 -->
-<literal>RENAME</literal>および<literal>SET SCHEMA</>は、複数の変更リストに結合して、まとめて処理することができますが、それらを除き、ALTER TABLEのすべての構文は１つだけのテーブルに対して作用します。
+<literal>RENAME</literal>、<literal>SET SCHEMA</>、<literal>ATTACH PARTITION</literal>、<literal>DETACH PARTITION</literal>は、複数の変更リストに結合して、まとめて処理することができますが、それらを除き、ALTER TABLEのすべての構文は１つだけのテーブルに対して作用します。
 例えば、複数の列の追加、型の変更を単一のコマンドで実行することができます。
 これは特に巨大なテーブルでは便利です。変更のために必要なテーブル全体の走査が1回で済むからです。
   </para>
@@ -1150,6 +1197,7 @@ OIDの状態を変更するためには代わりに<literal>SET WITH OIDS</>お�
 <command>ALTER TABLE</>コマンドを使用するには、変更するテーブルを所有している必要があります。
 テーブルのスキーマあるいはテーブル空間を変更するには、新しいスキーマあるいはテーブル空間における<literal>CREATE</literal>権限も持っていなければなりません。
 テーブルを親テーブルの新しい子テーブルとして追加するには、親テーブルも所有している必要があります。
+またテーブルをテーブルのパーティションとして追加する場合、追加されるテーブルを所有している必要があります。
 また、所有者を変更するには、新しい所有ロールの直接あるいは間接的なメンバでなければならず、かつ、そのロールがテーブルのスキーマにおける<literal>CREATE</literal>権限を持たなければなりません
 （この制限により、テーブルの削除と再作成を行ってもできないことが、所有者の変更によってもできないようにしています。
 ただし、スーパーユーザはすべてのテーブルの所有者を変更することができます）。
@@ -1436,7 +1484,10 @@ OIDの状態を変更するためには代わりに<literal>SET WITH OIDS</>お�
       <term><replaceable class="PARAMETER">partition_name</replaceable></term>
       <listitem>
        <para>
+<!--
         The name of the table to attach as a new partition or to detach from this table.
+-->
+新しいパーティションとして追加する、またはテーブルから切り離すテーブルの名前です。
        </para>
       </listitem>
      </varlistentry>
@@ -1445,8 +1496,12 @@ OIDの状態を変更するためには代わりに<literal>SET WITH OIDS</>お�
       <term><replaceable class="PARAMETER">partition_bound_spec</replaceable></term>
       <listitem>
        <para>
+<!--
         The partition bound specification for a new partition.  Refer to
         <xref linkend="sql-createtable"> for more details on the syntax of the same.
+-->
+新しいパーティションのパーティション境界の指定です。
+その構文の詳細については<xref linkend="sql-createtable">を参照してください。
        </para>
       </listitem>
      </varlistentry>
@@ -1515,6 +1570,8 @@ OIDの状態を変更するためには代わりに<literal>SET WITH OIDS</>お�
    <para>
     Similarly, when attaching a new partition it may be scanned to verify that
     existing rows meet the partition constraint.
+-->
+同様に、新しいパーティションを追加するときは、既存の行がパーティションの制約を満たすかどうかを確認するため、テーブルが操作されるかもしれません。
    </para>
 
    <para>
@@ -1610,9 +1667,11 @@ OIDの状態を変更するためには代わりに<literal>SET WITH OIDS</>お�
     valid for those descendants.  In all of these cases, <command>ALTER TABLE
     ONLY</command> will be rejected.
 -->
-そのテーブルを継承するテーブルがある場合、子テーブルに同じ処理を実行しなければ、親テーブルに対する列の追加、列の名前、列の型、継承された制約の名前の変更を実行することはできません。
-つまり、<command>ALTER TABLE ONLY</command>コマンドは受け付けられません。
+そのテーブルを継承するテーブルがある場合、子テーブルに同じ処理を実行しなければ、親テーブルに対する列の追加、列の名前、列の型の変更を実行することはできません。
 この制限により、子テーブルの列が常に親テーブルと一致していることが保証されます。
+同様に、すべての子テーブルで制約の名前を変更し、それが親と子の間で一致するようにしなければ、親テーブルの制約の名前を変更することはできません。
+また、親テーブルからSELECTすると、その子テーブルからもSELECTすることになるため、親テーブルの制約は、それが子テーブルでも有効であると印を付けられるまで、有効であると印を付けられません
+これらのすべての場合において、<command>ALTER TABLE ONLY</command>は受け付けられません。
    </para>
 
    <para>
@@ -1631,6 +1690,8 @@ OIDの状態を変更するためには代わりに<literal>SET WITH OIDS</>お�
 再帰的な<literal>DROP COLUMN</literal>操作では、子テーブルが他の親テーブルからその列を継承しておらず、かつ、その列について独立した定義を持っていない場合のみ、その子テーブルの列を削除します。
 再帰的でない<literal>DROP COLUMN</literal>（つまり、<command>ALTER TABLE ONLY ... DROP COLUMN</command>）操作では、継承された列は削除されません。
 削除する代わりに、その列は継承されておらず独立して定義されているという印を付けます。
+再帰的でない<literal>DROP COLUMN</literal>コマンドは、パーティションテーブルでは失敗します。
+テーブルのすべてのパーティションは、パーティションの最上位と同じ列を持っていなければならないからです。
    </para>
 
    <para>
@@ -1640,16 +1701,13 @@ OIDの状態を変更するためには代わりに<literal>SET WITH OIDS</>お�
     IDENTITY</literal>), as well as the actions
     <literal>TRIGGER</>, <literal>CLUSTER</>, <literal>OWNER</>,
     and <literal>TABLESPACE</> never recurse to descendant tables;
--->
-<literal>TRIGGER</>、<literal>CLUSTER</>、<literal>OWNER</>および<literal>TABLESPACE</>は子テーブルに再帰的に伝わりません。
-つまり、常に<literal>ONLY</>が指定されているかのように動作します。
-制約の追加は、<literal>NO INHERIT</>印がない<literal>CHECK</>制約に関してのみ再帰的に伝わります。
-   </para>
-
-   <para>
     that is, they always act as though <literal>ONLY</> were specified.
     Adding a constraint recurses only for <literal>CHECK</> constraints
     that are not marked <literal>NO INHERIT</>.
+-->
+IDENTITY列についての操作（<literal>ADD GENERATED</literal>、<literal>SET</literal>、<literal>DROP IDENTITY</literal>など）および<literal>TRIGGER</>、<literal>CLUSTER</>、<literal>OWNER</>および<literal>TABLESPACE</>の操作は子テーブルに再帰的に伝わりません。
+つまり、常に<literal>ONLY</>が指定されているかのように動作します。
+制約の追加は、<literal>NO INHERIT</>印がない<literal>CHECK</>制約に関してのみ再帰的に伝わります。
    </para>
 
    <para>
@@ -1911,21 +1969,30 @@ ALTER TABLE distributors DROP CONSTRAINT distributors_pkey,
 </programlisting></para>
 
   <para>
+<!--
    Attach a partition to range partitioned table:
+-->
+範囲パーティションテーブルにパーティションを追加します。
 <programlisting>
 ALTER TABLE measurement
     ATTACH PARTITION measurement_y2016m07 FOR VALUES FROM ('2016-07-01') TO ('2016-08-01');
 </programlisting></para>
 
   <para>
+<!--
    Attach a partition to list partitioned table:
+-->
+リストパーティションテーブルにパーティションを追加します。
 <programlisting>
 ALTER TABLE cities
     ATTACH PARTITION cities_ab FOR VALUES IN ('a', 'b');
 </programlisting></para>
 
   <para>
+<!--
    Detach a partition from partitioned table:
+-->
+パーティションテーブルからパーティションを切り離します。
 <programlisting>
 ALTER TABLE measurement
     DETACH PARTITION measurement_y2015m12;
@@ -1950,7 +2017,7 @@ ALTER TABLE measurement
    Also, the ability to specify more than one manipulation in a single
    <command>ALTER TABLE</> command is an extension.
 -->
-（<literal>USING INDEX</literal>がない）<literal>ADD</literal>、<literal>DROP</>、<literal>SET DEFAULT</>、（<literal>USING</literal>がない）<literal>SET DATA TYPE</literal>構文は標準SQLに従います。
+（<literal>USING INDEX</literal>がない）<literal>ADD</literal>、<literal>DROP [COLUMN]</>、<literal>DROP IDENTITY</literal>、<literal>RESTART</literal>、<literal>SET DEFAULT</>、（<literal>USING</literal>のない）<literal>SET DATA TYPE</literal>、<literal>SET GENERATED</literal>、<literal>SET <replaceable>sequence_option</replaceable></literal>構文は標準SQLに従います。
 他の構文は標準SQLに対する<productname>PostgreSQL</productname>の拡張です。
 また、単一の<command>ALTER TABLE</>コマンド内に複数の操作を指定する機能も<productname>PostgreSQL</productname>の拡張です。
   </para>

--- a/doc/src/sgml/ref/alter_table.sgml
+++ b/doc/src/sgml/ref/alter_table.sgml
@@ -863,7 +863,7 @@ clusterオプションの変更は<literal>SHARE UPDATE EXCLUSIVE</literal>ロ�
       affected.
 -->
 この構文は、1つ以上のテーブルの格納パラメータを変更します。
-設定可能なパラメータに関しては<xref linkend="SQL-CREATETABLE-storage-parameters" endterm="SQL-CREATETABLE-storage-parameters-title">を参照してください。
+設定可能なパラメータの詳細に関しては<xref linkend="SQL-CREATETABLE-storage-parameters" endterm="SQL-CREATETABLE-storage-parameters-title">を参照してください。
 このコマンドによってテーブルの内容が即座に変更されない点に注意してください。
 パラメータによりますが、期待する効果を得るためにテーブルを書き換える必要がある場合があります。
 このためには、<link linkend="SQL-VACUUM">VACUUM FULL</>、<xref linkend="SQL-CLUSTER">またはテーブルを強制的に書き換える<command>ALTER TABLE</>の構文のいずれかを使用してください。
@@ -1571,7 +1571,7 @@ OIDの状態を変更するためには代わりに<literal>SET WITH OIDS</>お�
     Similarly, when attaching a new partition it may be scanned to verify that
     existing rows meet the partition constraint.
 -->
-同様に、新しいパーティションを追加するときは、既存の行がパーティションの制約を満たすかどうかを確認するため、テーブルが操作されるかもしれません。
+同様に、新しいパーティションを追加するときは、既存の行がパーティションの制約を満たすかどうかを確認するため、テーブルが走査されるかもしれません。
    </para>
 
    <para>

--- a/doc/src/sgml/ref/create_table.sgml
+++ b/doc/src/sgml/ref/create_table.sgml
@@ -99,7 +99,10 @@ CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXI
 
 { INCLUDING | EXCLUDING } { DEFAULTS | CONSTRAINTS | IDENTITY | INDEXES | STORAGE | COMMENTS | ALL }
 
+<!--
 <phrase>and <replaceable class="PARAMETER">partition_bound_spec</replaceable> is:</phrase>
+-->
+<phrase>また<replaceable class="PARAMETER">partition_bound_spec</replaceable>は、以下の通りです。</phrase>
 
 IN ( { <replaceable class="PARAMETER">numeric_literal</replaceable> | <replaceable class="PARAMETER">string_literal</replaceable> | NULL } [, ...] ) |
 FROM ( { <replaceable class="PARAMETER">numeric_literal</replaceable> | <replaceable class="PARAMETER">string_literal</replaceable> | MINVALUE | MAXVALUE } [, ...] )
@@ -355,37 +358,54 @@ FROM ( { <replaceable class="PARAMETER">numeric_literal</replaceable> | <replace
     <term><literal>PARTITION OF <replaceable class="PARAMETER">parent_table</replaceable> FOR VALUES <replaceable class="PARAMETER">partition_bound_spec</replaceable></literal></term>
     <listitem>
      <para>
+<!--
       Creates the table as a <firstterm>partition</firstterm> of the specified
       parent table.
+-->
+指定した親テーブルの<firstterm>パーティション</firstterm>としてテーブルを作成します。
      </para>
 
      <para>
+<!--
       The <replaceable class="PARAMETER">partition_bound_spec</replaceable>
       must correspond to the partitioning method and partition key of the
       parent table, and must not overlap with any existing partition of that
       parent.  The form with <literal>IN</> is used for list partitioning,
       while the form with <literal>FROM</> and <literal>TO</> is used for
       range partitioning.
+-->
+<replaceable class="PARAMETER">partition_bound_spec</replaceable>は親テーブルのパーティショニング方法とパーティションキーに対応していなければならず、またそのテーブルのどの既存のパーティションとも重なり合ってはいけません。
+<literal>IN</>の構文はリストパーティショニングで使用され、<literal>FROM</>と<literal>TO</>の構文は範囲パーティショニングで使用されます。
      </para>
 
      <para>
+<!--
       Each of the values specified in
       the <replaceable class="PARAMETER">partition_bound_spec</> is
       a literal, <literal>NULL</literal>, <literal>MINVALUE</literal>, or
       <literal>MAXVALUE</literal>.  Each literal value must be either a
       numeric constant that is coercible to the corresponding partition key
       column's type, or a string literal that is valid input for that type.
+-->
+<replaceable class="PARAMETER">partition_bound_spec</>で指定される各値はリテラル、<literal>NULL</literal>、<literal>MINVALUE</literal>あるいは<literal>MAXVALUE</literal>です。
+各リテラル値はパーティションキー列の型に変換可能な数値定数か、その列の型として有効な入力である文字列リテラルのいずれかです。
      </para>
 
      <para>
+<!--
       When creating a list partition, <literal>NULL</literal> can be
       specified to signify that the partition allows the partition key
       column to be null.  However, there cannot be more than one such
       list partition for a given parent table.  <literal>NULL</literal>
       cannot be specified for range partitions.
+-->
+リストパーティションを作るときは、<literal>NULL</literal>を指定することができて、それはそのパーティションではパーティションキーの列をNULLにすることができるということを意味します。
+しかし、1つの親テーブルで2つ以上、そのようなリストパーティションを作ることはできません。
+範囲パーティションでは<literal>NULL</literal>を指定することはできません。
      </para>
 
      <para>
+<!--
       When creating a range partition, the lower bound specified with
       <literal>FROM</literal> is an inclusive bound, whereas the upper
       bound specified with <literal>TO</literal> is an exclusive bound.
@@ -399,9 +419,15 @@ FROM ( { <replaceable class="PARAMETER">numeric_literal</replaceable> | <replace
       allows <literal>x=1</> with any <literal>y&gt;=2</>,
       <literal>x=2</> with any non-null <literal>y</>,
       and <literal>x=3</> with any <literal>y&lt;4</>.
+-->
+範囲パーティションを作るとき、<literal>FROM</literal>で指定する下限はそれを含む境界、<literal>TO</literal>で指定する上限はそれを含まない境界になります。
+つまり、<literal>FROM</literal>リストで指定される値は、そのパーティションの対応するパーティションキー列において有効な値ですが、<literal>TO</literal>リストで指定される値はそうではない、ということです。
+この文の意味は行単位の比較の規則（<xref linkend="row-wise-comparison">）に従って理解しなければならないことに注意してください。
+例えば、<literal>PARTITION BY RANGE (x,y)</>について、パーティション境界<literal>FROM (1, 2) TO (3, 4)</literal>には、<literal>x=1</>で<literal>y&gt;=2</>の任意の値のもの、<literal>x=2</>でNULLでない任意の<literal>y</>のもの、<literal>x=3</>で<literal>y&lt;4</>の任意の値のものが入ります。
      </para>
 
      <para>
+<!--
       The special values <literal>MINVALUE</> and <literal>MAXVALUE</>
       may be used when creating a range partition to indicate that there
       is no lower or upper bound on the column's value. For example, a
@@ -409,9 +435,13 @@ FROM ( { <replaceable class="PARAMETER">numeric_literal</replaceable> | <replace
       any values less than 10, and a partition defined using
       <literal>FROM (10) TO (MAXVALUE)</> allows any values greater than
       or equal to 10.
+-->
+範囲パーティションを作るとき、<literal>MINVALUE</>および<literal>MAXVALUE</>という特別な値を使用することができて、これらはそれぞれ列の値に下限と上限がないことを示します。
+例えば、<literal>FROM (MINVALUE) TO (10)</>で定義されたパーティションには10より小さいすべての値が入り、<literal>FROM (10) TO (MAXVALUE)</>で定義されたパーティションには10以上のすべての値が入ります。
      </para>
 
      <para>
+<!--
       When creating a range partition involving more than one column, it
       can also make sense to use <literal>MAXVALUE</> as part of the lower
       bound, and <literal>MINVALUE</> as part of the upper bound. For
@@ -421,16 +451,26 @@ FROM ( { <replaceable class="PARAMETER">numeric_literal</replaceable> | <replace
       or equal to 10. Similarly, a partition defined using
       <literal>FROM ('a', MINVALUE) TO ('b', MINVALUE)</> allows any rows
       where the first partition key column starts with "a".
+-->
+2つ以上の列を含む範囲パーティションを作るとき、<literal>MAXVALUE</>を下限の一部として使うことや、<literal>MINVALUE</>を上限の一部として使うことも意味を持ちえます。
+例えば、<literal>FROM (0, MAXVALUE) TO (10, MAXVALUE)</>で定義されたパーティションには、パーティションキーの第1列が0より大きく、かつ10以下であるものが入ります。
+同様に、<literal>FROM ('a', MINVALUE) TO ('b', MINVALUE)</>で定義されたパーティションには、パーティションキーの第1列が"a"で始まるすべての行が入ります。
      </para>
 
      <para>
+<!--
       Note that if <literal>MINVALUE</> or <literal>MAXVALUE</> is used for
       one column of a partitioning bound, the same value must be used for all
       subsequent columns.  For example, <literal>(10, MINVALUE, 0)</> is not
       a valid bound; you should write <literal>(10, MINVALUE, MINVALUE)</>.
+-->
+<literal>MINVALUE</>または<literal>MAXVALUE</>をパーティション境界の1つの列で使用する場合、それより後の列では同じ値を使用しなければならないことに注意してください。
+例えば、<literal>(10, MINVALUE, 0)</>は有効な境界ではありません。
+<literal>(10, MINVALUE, MINVALUE)</>とします。
      </para>
 
      <para>
+<!--
       Also note that some element types, such as <literal>timestamp</>,
       have a notion of "infinity", which is just another value that can
       be stored. This is different from <literal>MINVALUE</> and
@@ -441,10 +481,16 @@ FROM ( { <replaceable class="PARAMETER">numeric_literal</replaceable> | <replace
       less than any other value, including "minus infinity". Thus the range
       <literal>FROM ('infinity') TO (MAXVALUE)</> is not an empty range; it
       allows precisely one value to be stored &mdash; "infinity".
+-->
+<literal>timestamp</>,など一部の要素型では、"infinity"（無限）の概念があり、それも保存できる値であることにも注意してください。
+<literal>MINVALUE</>と<literal>MAXVALUE</>は保存できる真の値ではなく、値に境界がないということを表現するための方法に過ぎないため、これとは違います。
+<literal>MAXVALUE</>は"infinity"も含め、他のすべての値より大きいものと考えることができ、また<literal>MINVALUE</>は"minus infinity"も含め、他のすべての値より小さいものと考えることができます。
+従って、境界<literal>FROM ('infinity') TO (MAXVALUE)</>は空の範囲ではなく、たった1つの値、つまり"infinity"だけを保存します。
      </para>
 
      <para>
       A partition must have the same column names and types as the partitioned
+<!--
       table to which it belongs.  If the parent is specified <literal>WITH
       OIDS</literal> then all partitions must have OIDs; the parent's OID
       column will be inherited by all partitions just like any other column.
@@ -456,22 +502,39 @@ FROM ( { <replaceable class="PARAMETER">numeric_literal</replaceable> | <replace
       the same name and condition as in the parent will be merged with the
       parent constraint.  Defaults may be specified separately for each
       partition.
+-->
+パーティションは、それが属するパーティションテーブルと同じ列名および型を持っていなければなりません。
+親が<literal>WITH OIDS</literal>を指定している場合は、すべてのパーティションがOIDを持っていなければならず、親のOIDは他の列と同様にすべてのパーティションに継承されます。
+パーティションテーブルの列名や型の変更や、OID列の追加や削除は自動的にすべてのパーティションに反映されます。
+<literal>CHECK</>制約はすべてのパーティションで自動的に継承されますが、個々のパーティションで追加の<literal>CHECK</>制約を指定することができます。
+親の制約と同じ名前と条件を持つ追加制約は親の制約と統合されます。
+デフォルト制約は各パーティションで別々に指定できます。
      </para>
 
      <para>
+<!--
       Rows inserted into a partitioned table will be automatically routed to
       the correct partition.  If no suitable partition exists, an error will
       occur.  Also, if updating a row in a given partition would require it
       to move to another partition due to new partition key values, an error
       will occur.
+-->
+パーティションテーブルに挿入された行は、自動的に正しいパーティションに回されます。
+適当なパーティションが存在しないときは、エラーが発生します。
+また、パーティション内の行の更新で、パーティションキーの値が新しくなることにより他のパーティションに移動する必要がある場合も、エラーが発生します。
+      will occur.
      </para>
 
      <para>
+<!--
       Operations such as TRUNCATE which normally affect a table and all of its
       inheritance children will cascade to all partitions, but may also be
       performed on an individual partition.  Note that dropping a partition
       with <literal>DROP TABLE</literal> requires taking an <literal>ACCESS
       EXCLUSIVE</literal> lock on the parent table.
+-->
+TRUNCATEのように通常はテーブルとそれを継承するすべての子テーブルに影響を及ぼす操作は、すべてのパーティションに対しても適用されますが、個別のパーティションに対して操作することも可能です。
+<literal>DROP TABLE</literal>でパーティションを削除するには、親テーブルについて<literal>ACCESS EXCLUSIVE</literal>のロックを取得する必要があることに注意してください。
      </para>
     </listitem>
    </varlistentry>
@@ -597,9 +660,13 @@ FROM ( { <replaceable class="PARAMETER">numeric_literal</replaceable> | <replace
      </para>
 
      <para>
+<!--
       If a column in the parent table is an identity column, that property is
       not inherited.  A column in the child table can be declared identity
       column if desired.
+-->
+親テーブルのある列がIDENTITY列の場合、その属性は継承されません。
+望むなら子テーブルの列をIDENTY列と宣言することができます。
      </para>
     </listitem>
    </varlistentry>
@@ -608,6 +675,7 @@ FROM ( { <replaceable class="PARAMETER">numeric_literal</replaceable> | <replace
     <term><literal>PARTITION BY { RANGE | LIST } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ <replaceable class="parameter">opclass</replaceable> ] [, ...] ) </literal></term>
     <listitem>
      <para>
+<!--
       The optional <literal>PARTITION BY</literal> clause specifies a strategy
       of partitioning the table.  The table thus created is called a
       <firstterm>partitioned</firstterm> table.  The parenthesized list of
@@ -619,22 +687,38 @@ FROM ( { <replaceable class="PARAMETER">numeric_literal</replaceable> | <replace
       expression.  If no B-tree operator class is specified when creating a
       partitioned table, the default B-tree operator class for the datatype will
       be used.  If there is none, an error will be reported.
+-->
+オプションの<literal>PARTITION BY</literal>句により、テーブルのパーティショニングの戦略を指定できます。
+このようにして作られたテーブルを<firstterm>パーティション</firstterm>テーブルと呼びます。
+括弧に囲まれた列や式のリストはテーブルの<firstterm>パーティションキー</firstterm>を構成します。
+範囲パーティションを使うときは、パーティションキーは複数の列または式にまたがることができます（最大で32ですが、この制限は<productname>PostgreSQL</productname>をビルドする時に変更できます）が、リストパーティションでは、パーティションキーは1つだけの列または式で構成されなければなりません。
+パーティションテーブルの作成時にBツリー演算子クラスを指定しない場合は、そのデータ型のデフォルトのBツリー演算子クラスが使用されます。
+Bツリー演算子クラスがない場合はエラーが報告されます。
      </para>
 
      <para>
+<!--
       A partitioned table is divided into sub-tables (called partitions),
       which are created using separate <literal>CREATE TABLE</> commands.
       The partitioned table is itself empty.  A data row inserted into the
       table is routed to a partition based on the value of columns or
       expressions in the partition key.  If no existing partition matches
       the values in the new row, an error will be reported.
+-->
+パーティションテーブルは（パーティションと呼ばれる）副テーブルに分割され、それらは別の<literal>CREATE TABLE</>コマンドにより作成されます。
+パーティションテーブルそれ自体は空になります。
+テーブルに挿入されるデータ行は、パーティションキーの列あるいは式の値に基づいて、1つのパーティションに回されます。
+新しい行の値に適合するパーティションが存在しないときは、エラーが報告されます。
      </para>
 
      <para>
+<!--
       Partitioned tables do not support <literal>UNIQUE</literal>,
       <literal>PRIMARY KEY</literal>, <literal>EXCLUDE</literal>, or
       <literal>FOREIGN KEY</literal> constraints; however, you can define
       these constraints on individual partitions.
+-->
+パーティションテーブルは<literal>UNIQUE</literal>、<literal>PRIMARY KEY</literal>、<literal>EXCLUDE</literal>、<literal>FOREIGN KEY</literal>の各制約をサポートしませんが、個々のパーティションでこれらの制約を定義することはできます。
      </para>
 
     </listitem>
@@ -683,16 +767,20 @@ FROM ( { <replaceable class="PARAMETER">numeric_literal</replaceable> | <replace
       sequence is created for each identity column of the new table, separate
       from the sequences associated with the old table.
 -->
-非NULL制約は常に新しいテーブルにコピーされます。
-<literal>CHECK</literal>制約は、<literal>INCLUDING CONSTRAINTS</literal>が指定された場合にのみコピーされます。
-列制約とテーブル制約は区別されません。
+コピーされる列定義のIDENTITYの指定は、<literal>INCLUDING IDENTITY</literal>が指定された場合にのみコピーされます。
+新しいテーブルの各IDENTITY列には新しいシーケンスが作られ、古いテーブルに紐付けられたシーケンスとは別になります。
      </para>
      <para>
+<!--
       Not-null constraints are always copied to the new table.
       <literal>CHECK</literal> constraints will be copied only if
       <literal>INCLUDING CONSTRAINTS</literal> is specified.
       No distinction is made between column constraints and table
       constraints.
+-->
+非NULL制約は常に新しいテーブルにコピーされます。
+<literal>CHECK</literal>制約は、<literal>INCLUDING CONSTRAINTS</literal>が指定された場合にのみコピーされます。
+列制約とテーブル制約は区別されません。
      </para>
      <para>
 <!--
@@ -736,7 +824,7 @@ FROM ( { <replaceable class="PARAMETER">numeric_literal</replaceable> | <replace
       <literal>INCLUDING ALL</literal> is an abbreviated form of
       <literal>INCLUDING DEFAULTS INCLUDING IDENTITY INCLUDING CONSTRAINTS INCLUDING INDEXES INCLUDING STORAGE INCLUDING COMMENTS</literal>.
 -->
-<literal>INCLUDING ALL</literal>は<literal>INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES INCLUDING STORAGE INCLUDING COMMENTS</literal>の省略形です。
+<literal>INCLUDING ALL</literal>は<literal>INCLUDING DEFAULTS INCLUDING IDENTITY INCLUDING CONSTRAINTS INCLUDING INDEXES INCLUDING STORAGE INCLUDING COMMENTS</literal>の省略形です。
      </para>
      <para>
 <!--
@@ -907,13 +995,18 @@ TRUEまたはUNKNOWNと評価される式は成功します。
     <term><literal>GENERATED { ALWAYS | BY DEFAULT } AS IDENTITY [ ( <replaceable>sequence_options</replaceable> ) ]</literal></term>
     <listitem>
      <para>
+<!--
       This clause creates the column as an <firstterm>identity
       column</firstterm>.  It will have an implicit sequence attached to it
       and the column in new rows will automatically have values from the
       sequence assigned to it.
+-->
+この句は列を<firstterm>IDENTITY列</firstterm>として作成します。
+それには暗示的なシーケンスが紐付けられ、新しい行のその列には紐付けられたシーケンスから取られた値が自動的に入ります。
      </para>
 
      <para>
+<!--
       The clauses <literal>ALWAYS</literal> and <literal>BY DEFAULT</literal>
       determine how the sequence value is given precedence over a
       user-specified value in an <command>INSERT</command> statement.
@@ -924,12 +1017,22 @@ TRUEまたはUNKNOWNと評価される式は成功します。
       precedence.  See <xref linkend="sql-insert"> for details.  (In
       the <command>COPY</command> command, user-specified values are always
       used regardless of this setting.)
+-->
+<literal>ALWAYS</literal>と<literal>BY DEFAULT</literal>の句は、ユーザが<command>INSERT</command>文で指定した値に対するシーケンスの値の優先度がどうなるかを決定します。
+<literal>ALWAYS</literal>が指定された場合、ユーザが指定した値は<command>INSERT</command>文で<literal>OVERRIDING SYSTEM VALUE</literal>を指定した場合にのみ受け付けられます。
+<literal>BY DEFAULT</literal>が指定された場合は、ユーザが指定した値が優先します。
+詳細は<xref linkend="sql-insert">を参照してください。
+（<command>COPY</command>コマンドでは、この設定と関係なく、ユーザが指定した値が常に使用されます。）
      </para>
 
      <para>
+<!--
       The optional <replaceable>sequence_options</replaceable> clause can be
       used to override the options of the sequence.
       See <xref linkend="sql-createsequence"> for details.
+-->
+オプションで<replaceable>sequence_options</replaceable>句を指定することにより、シーケンスのオプションを変更できます。
+詳しくは<xref linkend="sql-createsequence">を参照してください。
      </para>
     </listitem>
    </varlistentry>
@@ -1136,6 +1239,7 @@ predicateの前後に括弧が必要であることに注意して下さい。
 外部キー制約は、新しいテーブルの1つまたは複数の列の集合が、被参照テーブルの一部の行の被参照列に一致する値を持たなければならないことを指定するものです。
 <replaceable class="parameter">refcolumn</replaceable>リストが省略された場合、<replaceable class="parameter">reftable</replaceable>の主キーが使用されます。
 被参照列は、被参照テーブルにおいて遅延不可の一意性制約もしくは主キー制約を持った列でなければなりません。
+ユーザは被参照テーブル（テーブル全体または特定の被参照列）について<literal>REFERENCES</>権限を持っていなければなりません。
 一時テーブルと永続テーブルとの間で外部キー制約を定義できないことに注意してください。
      </para>
 
@@ -1541,6 +1645,7 @@ predicateの前後に括弧が必要であることに注意して下さい。
 これはもしあれば、テーブルの補助<acronym>TOAST</>テーブルの動作を制御します。
 (TOASTに関する詳細については<xref linkend="storage-toast">を参照してください。)
 テーブルのパラメータ値が設定され、それと同等の<literal>toast.</literal>パラメータが設定されていない場合、TOASTテーブルはテーブルのパラメータ値を利用します。
+これらのパラメータをパーティションテーブルについて指定することはサポートされませんが、個々の末端のパーティションについて指定することはできます。
    </para>
 
    <variablelist>
@@ -1852,7 +1957,7 @@ falseの場合、トランザクションIDの周回問題を回避するため�
      purpose.
 -->
 新規のアプリケーションでOIDを使用するのはお勧めしません。
-可能であれば、テーブルの主キーとして<literal>SERIAL</literal>や他のシーケンスジェネレータを使用する方が望ましいです。
+可能であれば、テーブルの主キーとしてIDENTITY列や他のシーケンスジェネレータを使用する方が望ましいです。
 しかし、アプリケーションがテーブルの特定の行を識別するためにOIDを使用する場合は、そのテーブルの<structfield>oid</>列に一意性制約を作成することを推奨します。
 これにより、カウンタが一周してしまった場合でも、テーブル内のOIDで一意に行を識別できることが保証されるからです。
 OIDがテーブルをまたがって一意であると考えるのは止めてください。
@@ -2171,7 +2276,10 @@ CREATE TABLE employees OF employee_type (
 </programlisting></para>
 
   <para>
+<!--
    Create a range partitioned table:
+-->
+範囲パーティションテーブルを作成します。
 <programlisting>
 CREATE TABLE measurement (
     logdate         date not null,
@@ -2181,7 +2289,10 @@ CREATE TABLE measurement (
 </programlisting></para>
 
   <para>
+<!--
    Create a range partitioned table with multiple columns in the partition key:
+-->
+パーティションキーに複数の列がある範囲パーティションテーブルを作成します。
 <programlisting>
 CREATE TABLE measurement_year_month (
     logdate         date not null,
@@ -2191,7 +2302,10 @@ CREATE TABLE measurement_year_month (
 </programlisting></para>
 
   <para>
+<!--
    Create a list partitioned table:
+-->
+リストパーティションテーブルを作成します。
 <programlisting>
 CREATE TABLE cities (
     city_id      bigserial not null,
@@ -2201,7 +2315,10 @@ CREATE TABLE cities (
 </programlisting></para>
 
   <para>
+<!--
    Create partition of a range partitioned table:
+-->
+範囲パーティションテーブルのパーティションを作成します。
 <programlisting>
 CREATE TABLE measurement_y2016m07
     PARTITION OF measurement (
@@ -2212,6 +2329,7 @@ CREATE TABLE measurement_y2016m07
   <para>
    Create a few partitions of a range partitioned table with multiple
    columns in the partition key:
+パーティションキーに複数の列がある範囲パーティションテーブルに、パーティションをいくつか作成します。
 <programlisting>
 CREATE TABLE measurement_ym_older
     PARTITION OF measurement_year_month
@@ -2231,7 +2349,10 @@ CREATE TABLE measurement_ym_y2017m01
 </programlisting></para>
 
   <para>
+<!--
    Create partition of a list partitioned table:
+-->
+リストパーティションテーブルのパーティションを作成します。
 <programlisting>
 CREATE TABLE cities_ab
     PARTITION OF cities (
@@ -2242,6 +2363,7 @@ CREATE TABLE cities_ab
   <para>
    Create partition of a list partitioned table that is itself further
    partitioned and then add a partition to it:
+リストパーティションテーブルにパーティションを作成しますが、それ自体がさらにパーティションになり、それにパーティションを追加します。
 <programlisting>
 CREATE TABLE cities_ab
     PARTITION OF cities (
@@ -2476,9 +2598,13 @@ SQL:1999以降では、異なる構文と意味体系による単一継承を定
   </refsect2>
 
   <refsect2>
+<!--
    <title>Multiple Identity Columns</title>
+-->
+   <title>複数のIDENTITY列</title>
 
    <para>
+<!--
     <productname>PostgreSQL</productname> allows a table to have more than one
     identity column.  The standard specifies that a table can have at most one
     identity column.  This is relaxed mainly to give more flexibility for
@@ -2486,6 +2612,11 @@ SQL:1999以降では、異なる構文と意味体系による単一継承を定
     the <command>INSERT</command> command supports only one override clause
     that applies to the entire statement, so having multiple identity columns
     with different behaviors is not well supported.
+-->
+<productname>PostgreSQL</productname>ではテーブルに2つ以上のIDENTITY列を持つことを許しています。
+標準SQLでは、1つのテーブルは最大で1つのIDENTITY列を持つことができると規定しています。
+主にスキーマの変更や移行でより柔軟性を持たせるために、この制約を緩和しています。
+<command>INSERT</command>コマンドはOVERRIDING句を1つだけしかサポートせず、これが文全体に適用されるため、複数のIDENTITY列があり、これらの動作が異なる場合は正しくサポートされないことに注意してください。
    </para>
   </refsect2>
 
@@ -2562,20 +2693,32 @@ PostgreSQLはこうした自己参照列を明示的にサポートしません�
   </refsect2>
 
   <refsect2>
+<!--
    <title><literal>PARTITION BY</> Clause</title>
+-->
+   <title><literal>PARTITION BY</>句</title>
 
    <para>
+<!--
     The <literal>PARTITION BY</> clause is a
     <productname>PostgreSQL</productname> extension.
+-->
+<literal>PARTITION BY</>は<productname>PostgreSQL</productname>の拡張です。
    </para>
   </refsect2>
 
   <refsect2>
+<!--
    <title><literal>PARTITION OF</> Clause</title>
+-->
+   <title><literal>PARTITION OF</>句</title>
 
    <para>
+<!--
     The <literal>PARTITION OF</> clause is a
     <productname>PostgreSQL</productname> extension.
+-->
+<literal>PARTITION OF</>句は<productname>PostgreSQL</productname>の拡張です。
    </para>
   </refsect2>
 

--- a/doc/src/sgml/ref/create_table.sgml
+++ b/doc/src/sgml/ref/create_table.sgml
@@ -489,8 +489,8 @@ FROM ( { <replaceable class="PARAMETER">numeric_literal</replaceable> | <replace
      </para>
 
      <para>
-      A partition must have the same column names and types as the partitioned
 <!--
+      A partition must have the same column names and types as the partitioned
       table to which it belongs.  If the parent is specified <literal>WITH
       OIDS</literal> then all partitions must have OIDs; the parent's OID
       column will be inherited by all partitions just like any other column.


### PR DESCRIPTION
いずれも大半の変更はpartitioningに関するものなので、１つのPRにまとめました。
特に迷ったのは"range partition"の訳語ですが、「範囲パーティション」としました。耳障りは「レンジパーティション」の方が良いのですが、文字で読むと何のことかわかりにくいと思ったので。
もう一つ、ちょっと迷ったのは、「（既存の）テーブルをパーティションテーブルに（パーティションとして）attachする」というケースで、「付加する」「所属させる」なども考えましたが「追加する」としました。反対の「detachする」ケースは「分離する」も良いかと思いましたが「切り離す」としました。
partitioningは、他のファイルで既に使われていたので「パーティショニング」を基本にしましたが、「パーティション」としたところもあります。partitionedは"「ド」は付けずに「パーティション」としました。
新機能のidentity column（serial型と同等だが、identityは標準SQL準拠）ですが、検索してみると「IDENTITY列」が多く使われているようだったので、（不本意ながら）そのように訳しました。