### PR TITLE
update release-8.[01] for 10.0

### DIFF
--- a/doc/src/sgml/release-8.0.sgml
+++ b/doc/src/sgml/release-8.0.sgml
@@ -7969,7 +7969,7 @@ PL/pgSQLで<command>ELSEIF</>を受け付けるようになりました。(Neil)
        Prevent <application>psql</> <command>\dn</command> from showing
        temporary schemas (Bruce)
 -->
-<application>psql</>の<command>\dn</command>による一時スキーマを表示を防止(Bruce)
+<application>psql</>の<command>\dn</command>による一時スキーマの表示を防止(Bruce)
       </para>
      </listitem>
 

--- a/doc/src/sgml/release-8.1.sgml
+++ b/doc/src/sgml/release-8.1.sgml
@@ -515,7 +515,7 @@ PL/PerlおよびPL/Tclにおいて、呼び出し元のSQLユーザIDごとに�
       <filename>postmaster.pid</> and the socket lockfile) while writing them
       (Tom Lane)
 -->
-ロックファイル（<filename>postmaster.pid</>およびソケット用のロックファイル）を書き出す時に、注意してその内容のfsyncします。(Tom Lane)
+ロックファイル（<filename>postmaster.pid</>およびソケット用のロックファイル）を書き出す時に、注意してその内容をfsyncします。(Tom Lane)
      </para>
 
      <para>
@@ -4178,7 +4178,7 @@ macOS (Darwin)のコンパイルを修正しました。(Tom)
 <!--
    <title>Migration to Version 8.1.5</title>
 -->
-   <title>8.1.5バージョンへの移行</title>
+   <title>バージョン8.1.5への移行</title>
 
    <para>
 <!--
@@ -4310,20 +4310,20 @@ Wieland)</para></listitem>
 (Tom)</para></listitem>
 -->
 <listitem><para>
-ハッシュテーブルとビットマップインデックススキャンに効率的な改良が加えられました。
+ハッシュテーブルとビットマップインデックススキャンに効率的な改良が加えられました。(Tom)
 </para></listitem>
 <!--
 <listitem><para>Fix instability of statistics collection on Windows (Tom, Andrew)</para></listitem>
 -->
 <listitem><para>
-Windows上での統計情報収集の不安定性を修正しました。
+Windows上での統計情報収集の不安定性を修正しました。(Tom, Andrew)
 </para></listitem>
 <!--
 <listitem><para>Fix <varname>statement_timeout</> to use the proper
 units on Win32 (Bruce)</para>
 -->
 <listitem><para>
-Win32上で適切なユニットを使用する<varname>statement_timeout</>を修正しました。
+Win32上で適切なユニットを使用する<varname>statement_timeout</>を修正しました。(Bruce)
 </para>
 <!--
 <para>In previous Win32 8.1.X versions, the delay was off by a factor of
@@ -4337,14 +4337,14 @@ Win32上で適切なユニットを使用する<varname>statement_timeout</>を�
 compilers (Hiroshi Saito)</para></listitem>
 -->
 <listitem><para>
-<acronym>MSVC</>および<productname>Borland C++</>コンパイラ向けに修正しました。
+<acronym>MSVC</>および<productname>Borland C++</>コンパイラ向けに修正しました。(Hiroshi Saito)
 </para></listitem>
 <!--
 <listitem><para>Fixes for <systemitem class="osname">AIX</> and
 <productname>Intel</> compilers (Tom)</para></listitem>
 -->
 <listitem><para>
-<systemitem class="osname">AIX</>および<productname>Intel</>コンパイラ向けに修正しました。
+<systemitem class="osname">AIX</>および<productname>Intel</>コンパイラ向けに修正しました。(Tom)
 </para></listitem>
 <!--
 <listitem><para>Fix rare bug in continuous archiving (Tom)</para></listitem>


### PR DESCRIPTION
以下のファイルの10.0対応です。
- release-8.0.sgml
- release-8.1.sgml

前者は9.6の最近の変更を取り込んだだけですが、後者はそれにプラスαがあります。