### PR TITLE
update rel8.[2-4] for 10.0

### DIFF
--- a/doc/src/sgml/release-8.2.sgml
+++ b/doc/src/sgml/release-8.2.sgml
@@ -1814,7 +1814,7 @@ Windowsにおいて終了コード128（<literal>ERROR_WAIT_NO_CHILDREN</>）を
       <filename>postmaster.pid</> and the socket lockfile) while writing them
       (Tom Lane)
 -->
-ロックファイル（<filename>postmaster.pid</>およびソケット用のロックファイル）を書き出す時に、注意してその内容のfsyncします。(Tom Lane)
+ロックファイル（<filename>postmaster.pid</>およびソケット用のロックファイル）を書き出す時に、注意してその内容をfsyncします。(Tom Lane)
      </para>
 
      <para>

--- a/doc/src/sgml/release-8.3.sgml
+++ b/doc/src/sgml/release-8.3.sgml
@@ -4083,7 +4083,7 @@ NULLがソートで先になるようなソート順の場合、最初のNULLに
       <filename>postmaster.pid</> and the socket lockfile) while writing them
       (Tom Lane)
 -->
-ロックファイル（<filename>postmaster.pid</>およびソケット用のロックファイル）を書き出す時に、注意してその内容のfsyncします。(Tom Lane)
+ロックファイル（<filename>postmaster.pid</>およびソケット用のロックファイル）を書き出す時に、注意してその内容をfsyncします。(Tom Lane)
      </para>
 
      <para>

--- a/doc/src/sgml/release-8.4.sgml
+++ b/doc/src/sgml/release-8.4.sgml
@@ -1540,7 +1540,7 @@ GINインデックスがツリーページを削除する際の競合条件を�
 <!--
       Fix possible read past end of memory in rule printing (Peter Eisentraut)
 -->
-ルールの出力時にメモリの最後を超えて読もうとする可能性があることを修正ました。(Peter Eisentraut)
+ルールの出力時にメモリの最後を超えて読もうとする可能性があることを修正しました。(Peter Eisentraut)
      </para>
     </listitem>
 
@@ -7250,7 +7250,7 @@ NULLがソートで先になるようなソート順の場合、最初のNULLに
       <filename>postmaster.pid</> and the socket lockfile) while writing them
       (Tom Lane)
 -->
-ロックファイル（<filename>postmaster.pid</>およびソケット用のロックファイル）を書き出す時に、注意してその内容のfsyncします。(Tom Lane)
+ロックファイル（<filename>postmaster.pid</>およびソケット用のロックファイル）を書き出す時に、注意してその内容をfsyncします。(Tom Lane)
      </para>
 
      <para>
@@ -7918,7 +7918,7 @@ relcache項目の再構築中にキャッシュ再設定メッセージを受け
       Fix PL/pgSQL's <literal>CASE</> statement to not fail when the
       case expression is a query that returns no rows (Tom)
 -->
-case式が行を返さない問い合わせであった場合に失敗しないように、pl/pgSQLの<literal>CASE</>文を修正しました。(Tom)
+case式が行を返さない問い合わせであった場合に失敗しないように、PL/pgSQLの<literal>CASE</>文を修正しました。(Tom)
      </para>
     </listitem>
 


### PR DESCRIPTION
以下のファイルの10.0対応です。

- release-8.2.sgml
- release-8.3.sgml
- release-8.4.sgml

9.6の差分の取り込みだけだと思います。