### PR TITLE
update rel9.[01] for 10.0

### DIFF
--- a/doc/src/sgml/release-9.0.sgml
+++ b/doc/src/sgml/release-9.0.sgml
@@ -4603,7 +4603,7 @@ GINインデックスがツリーページを削除する際の競合条件を�
 <!--
       Fix possible read past end of memory in rule printing (Peter Eisentraut)
 -->
-ルールの出力時にメモリの最後を超えて読もうとする可能性があることを修正ました。(Peter Eisentraut)
+ルールの出力時にメモリの最後を超えて読もうとする可能性があることを修正しました。(Peter Eisentraut)
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.1.sgml
+++ b/doc/src/sgml/release-9.1.sgml
@@ -4871,7 +4871,7 @@ LOGレベルに下げ、また、言い回しに幾分の努力を払い、<quot
       Warn if macOS's <function>setlocale()</> starts an unwanted extra
       thread inside the postmaster (Noah Misch)
 -->
-macmacOSの<function>setlocale()</>が不必要な余計なスレッドをpostmasterの中に作成した際に警告するようにしました。
+macOS Xの<function>setlocale()</>が不必要な余計なスレッドをpostmasterの中に作成した際に警告するようにしました。
 (Noah Misch)
      </para>
     </listitem>
@@ -5840,7 +5840,7 @@ Windowsで<application>initdb</>や<application>pg_upgrade</>がエラーにな�
 <!--
       Fix linking of <application>libpython</> on macOS (Tom Lane)
 -->
-macmacOSで<application>libpython</>のリンクを修正しました。(Tom Lane)
+macOS Xで<application>libpython</>のリンクを修正しました。(Tom Lane)
      </para>
 
      <para>
@@ -7295,7 +7295,7 @@ MIN()/MAX()の引数に単純な値ではなく、式を与えると、プラン
 <!--
       Fix possible read past end of memory in rule printing (Peter Eisentraut)
 -->
-ルールの出力時にメモリの最後を超えて読もうとする可能性があることを修正ました。(Peter Eisentraut)
+ルールの出力時にメモリの最後を超えて読もうとする可能性があることを修正しました。(Peter Eisentraut)
      </para>
     </listitem>
 


### PR DESCRIPTION
以下のファイルの10.0対応です。

- release-9.0.sgml
- release-9.1.sgml

基本的には9.6の差分の取り込みですが、一括置換に失敗したらしいところも直しています。