### PR TITLE
pg_receivewal,sgml, pg_reset_wal.sgml, pg_waldump.sgmlの10.0対応

### DIFF
--- a/doc/src/sgml/ref/pg_receivewal.sgml
+++ b/doc/src/sgml/ref/pg_receivewal.sgml
@@ -19,7 +19,10 @@ PostgreSQL documentation
 
  <refnamediv>
   <refname>pg_receivewal</refname>
+<!--
   <refpurpose>stream write-ahead logs from a <productname>PostgreSQL</productname> server</refpurpose>
+-->
+  <refpurpose><productname>PostgreSQL</productname>サーバから先行書き込みログをストリームする</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -45,8 +48,8 @@ PostgreSQL documentation
    location for doing a restore using point-in-time recovery (see
    <xref linkend="continuous-archiving">).
 -->
-<application>pg_receivexlog</application>は実行中の<productname>PostgreSQL</productname>クラスタからトランザクションログをストリームするために使用されます。
-トランザクションログはストリーミングレプリケーションプロトコルを使用してストリームされ、ローカルディレクトリのファイルとして書き出されます。
+<application>pg_receivewal</application>は実行中の<productname>PostgreSQL</productname>クラスタから先行書き込みログをストリームするために使用されます。
+先行書き込みログはストリーミングレプリケーションプロトコルを使用してストリームされ、ローカルディレクトリのファイルとして書き出されます。
 このディレクトリはポイントインタイムリカバリ（<xref linkend="continuous-archiving">参照）を用いてリストアする際のアーカイブ場所として使用することができます。
   </para>
 
@@ -58,15 +61,19 @@ PostgreSQL documentation
    For this reason, it is not necessary to set
    <xref linkend="guc-archive-timeout"> when using
     <application>pg_receivewal</application>.
+-->
+<application>pg_receivewal</application>は先行書き込みログをサーバで生成に合わせてリアルタイムでストリームし、<xref linkend="guc-archive-command">とは異なり、セグメントが完了するまで待機することはありません。
+このため、<application>pg_receivewal</application>を使用する場合には<xref linkend="guc-archive-timeout">を設定する必要はありません。
   </para>
 
   <para>
+<!--
    Unlike the WAL receiver of a PostgreSQL standby server, <application>pg_receivewal</>
    by default flushes WAL data only when a WAL file is closed.
    The option <option>&#045;-synchronous</> must be specified to flush WAL data
    in real time.
 -->
-PostgreSQLのスタンバイサーバのWALレシーバと異なり、<application>pg_receivexlog</>はデフォルトでは、WALファイルがクローズされた時にのみ、WALデータをフラッシュします。
+PostgreSQLのスタンバイサーバのWALレシーバと異なり、<application>pg_receivewal</>はデフォルトでは、WALファイルがクローズされた時にのみ、WALデータをフラッシュします。
 WALデータをリアルタイムでフラッシュするには<option>--synchronous</>オプションを指定する必要があります。
   </para>
 
@@ -81,7 +88,7 @@ WALデータをリアルタイムでフラッシュするには<option>--synchro
    configured with <xref linkend="guc-max-wal-senders"> set high enough to
    leave at least one session available for the stream.
 -->
-トランザクションログは通常の<productname>PostgreSQL</productname>接続を経由して、そしてレプリケーションプロトコルを使用して、ストリームされます。
+先行書き込みログは通常の<productname>PostgreSQL</productname>接続を経由して、そしてレプリケーションプロトコルを使用して、ストリームされます。
 この接続はスーパーユーザまたは<literal>REPLICATION</literal>権限（<xref linkend="role-attributes">参照）を持つユーザで確立されなければなりません。
 そして<filename>pg_hba.conf</filename>でレプリケーション用の接続を許可しなければなりません。
 またサーバではストリーム用に利用できるセッションが少なくとも１つ存在できるために<xref linkend="guc-max-wal-senders">を十分大きく設定しなければなりません。
@@ -95,7 +102,7 @@ WALデータをリアルタイムでフラッシュするには<option>--synchro
    as possible. To avoid this behavior, use the <literal>-n</literal>
    parameter.
 -->
-接続が失われた場合、または、致命的ではないエラーで初期確立ができなかった場合、<application>pg_receivexlog</application>は無期限に接続を再試行しできるだけ早くストリーミングを再確立します。
+接続が失われた場合、または、致命的ではないエラーで初期確立ができなかった場合、<application>pg_receivewal</application>は無期限に接続を再試行しできるだけ早くストリーミングを再確立します。
 この動作を止めるためには<literal>-n</literal>パラメータを使用してください。
   </para>
  </refsect1>
@@ -188,8 +195,8 @@ WALデータをリアルタイムでフラッシュするには<option>--synchro
          synchronized to disk so that the server can remove that segment if it
          is not otherwise needed.
 -->
-<application>pg_receivexlog</application>が既存のレプリケーションスロットを使うようにします(<xref linkend="streaming-replication-slots">を参照してください)。
-このオプションが使われると、<application>pg_receivexlog</>はフラッシュ位置をサーバに報告します。
+<application>pg_receivewal</application>が既存のレプリケーションスロットを使うようにします(<xref linkend="streaming-replication-slots">を参照してください)。
+このオプションが使われると、<application>pg_receivewal</>はフラッシュ位置をサーバに報告します。
 これは、各セグメントがいつディスクに同期されたかを示し、それによりサーバが必要のなくなったセグメントを削除できるようになります。
         </para>
 
@@ -204,7 +211,7 @@ WALデータをリアルタイムでフラッシュするには<option>--synchro
          satisfactorily.  The option <literal>&#045;-synchronous</literal> (see
          below) must be specified in addition to make this work correctly.
 -->
-<application>pg_receivexlog</application>のレプリケーションクライアントが同期スタンバイとしてサーバ上で構成されている場合、レプリケーションスロットを利用するとフラッシュ位置がサーバに報告されますが、それはWALファイルがクローズされる時のみです。
+<application>pg_receivewal</application>のレプリケーションクライアントが同期スタンバイとしてサーバ上で構成されている場合、レプリケーションスロットを利用するとフラッシュ位置がサーバに報告されますが、それはWALファイルがクローズされる時のみです。
 したがって、その構成ではプライマリ上のトランザクションが長時間待たされることになり、結果的に満足する動作を得られません。
 これを正しく動作させるには、追加で<literal>--synchronous</literal>オプション（以下を参照）を指定する必要があります。
         </para>
@@ -231,7 +238,7 @@ WALデータを受け取ると即座にディスクにフラッシュします�
         server as a synchronous standby, to ensure that timely feedback is
         sent to the server.
 -->
-<application>pg_receivexlog</application>のレプリケーションクライアントが同期スタンバイとしてサーバ上で構成されている場合、フィードバックが遅延なくサーバに送り返されることを確実にするため、このオプションを指定すべきです。
+<application>pg_receivewal</application>のレプリケーションクライアントが同期スタンバイとしてサーバ上で構成されている場合、フィードバックが遅延なくサーバに送り返されることを確実にするため、このオプションを指定すべきです。
        </para>
       </listitem>
      </varlistentry>
@@ -254,10 +261,14 @@ WALデータを受け取ると即座にディスクにフラッシュします�
       <term><option>--compress=<replaceable class="parameter">level</replaceable></option></term>
       <listitem>
        <para>
+<!--
         Enables gzip compression of write-ahead logs, and specifies the
         compression level (0 through 9, 0 being no compression and 9 being best
         compression).  The suffix <filename>.gz</filename> will
         automatically be added to all filenames.
+-->
+先行書き込みログのgzip圧縮を有効にし、圧縮レベルを指定します（0から9まで、0は圧縮なし、9が最大圧縮）。
+すべてのファイル名に、拡張子<filename>.gz</filename>が自動的に追加されます。
        </para>
       </listitem>
      </varlistentry>
@@ -290,7 +301,7 @@ WALデータを受け取ると即座にディスクにフラッシュします�
         name in the connection string will be ignored.
 -->
 このオプションは他のクライアントアプリケーションとの整合性のために<literal>--dbname</>と呼ばれます。
-しかし、<application>pg_receivexlog</application>はクラスタ内のどの特定のデータベースにも接続しませんので、接続文字列内のデータベース名は無視されます。
+しかし、<application>pg_receivewal</application>はクラスタ内のどの特定のデータベースにも接続しませんので、接続文字列内のデータベース名は無視されます。
        </para>
       </listitem>
      </varlistentry>
@@ -373,7 +384,7 @@ WALデータを受け取ると即座にディスクにフラッシュします�
         Force <application>pg_receivewal</application> to prompt for a
         password before connecting to a database.
 -->
-<application>pg_receivexlog</application>はデータベースに接続する前にパスワード入力を強制的に促します。
+<application>pg_receivewal</application>はデータベースに接続する前にパスワード入力を強制的に促します。
        </para>
 
        <para>
@@ -387,8 +398,8 @@ WALデータを受け取ると即座にディスクにフラッシュします�
         connection attempt.
 -->
 このオプションは重要ではありません。
-<application>pg_receivexlog</application>は、サーバがパスワード認証を要求した場合に自動的にパスワードを促すためです。
-しかし<application>pg_receivexlog</application>は、サーバがパスワードを要求するかどうかを確認するために接続試行を浪費します。
+<application>pg_receivewal</application>は、サーバがパスワード認証を要求した場合に自動的にパスワードを促すためです。
+しかし<application>pg_receivewal</application>は、サーバがパスワードを要求するかどうかを確認するために接続試行を浪費します。
 <option>-W</>と入力して無駄な接続試行を防止することが有意である場合があります。
        </para>
       </listitem>
@@ -401,7 +412,7 @@ WALデータを受け取ると即座にディスクにフラッシュします�
     <application>pg_receivewal</application> can perform one of the two
     following actions in order to control physical replication slots:
 -->
-<application>pg_receivexlog</application>は物理的なレプリケーションスロットを制御するため、以下の2つの動作のうちの1つを実行できます。
+<application>pg_receivewal</application>は物理的なレプリケーションスロットを制御するため、以下の2つの動作のうちの1つを実行できます。
 
     <variablelist>
      <varlistentry>
@@ -447,7 +458,7 @@ WALデータを受け取ると即座にディスクにフラッシュします�
 <!--
        Print the <application>pg_receivewal</application> version and exit.
 -->
-<application>pg_receivexlog</application>のバージョンを表示し、終了します。
+<application>pg_receivewal</application>のバージョンを表示し、終了します。
        </para>
        </listitem>
      </varlistentry>
@@ -461,7 +472,7 @@ WALデータを受け取ると即座にディスクにフラッシュします�
        Show help about <application>pg_receivewal</application> command line
        arguments, and exit.
 -->
-<application>pg_receivexlog</application>コマンドライン引数についてのヘルプを表示し、終了します。
+<application>pg_receivewal</application>コマンドライン引数についてのヘルプを表示し、終了します。
        </para>
        </listitem>
      </varlistentry>
@@ -506,8 +517,8 @@ WALデータを受け取ると即座にディスクにフラッシュします�
    replication slot will fill up the server's disk space if the receiver does
    not keep up with fetching the WAL data.
 -->
-<xref linkend="guc-archive-command">の代わりに<application>pg_receivexlog</application>をWALのバックアップのメインの方法として使用する場合、レプリケーションスロットを使用することを強く推奨します。
-そうしなければ、サーバは<xref linkend="guc-archive-command">とレプリケーションスロットのいずれからもWALのストリームがどこまでアーカイブされているかの情報を得られないため、トランザクションログファイルがバックアップされる前にそれを再利用または削除するかもしれないのです。
+<xref linkend="guc-archive-command">の代わりに<application>pg_receivewal</application>をWALのバックアップのメインの方法として使用する場合、レプリケーションスロットを使用することを強く推奨します。
+そうしなければ、サーバは<xref linkend="guc-archive-command">とレプリケーションスロットのいずれからもWALのストリームがどこまでアーカイブされているかの情報を得られないため、先行書き込みログファイルがバックアップされる前にそれを再利用または削除するかもしれないのです。
 しかし、WALデータを受け取る側がそのフェッチに追いつけない場合、レプリケーションスロットがサーバのディスクスペースを一杯にしてしまうかもしれないことに注意してください。
   </para>
 
@@ -525,7 +536,7 @@ WALデータを受け取ると即座にディスクにフラッシュします�
    <literal>mydbserver</literal> and store it in the local directory
    <filename>/usr/local/pgsql/archive</filename>:
 -->
-トランザクションログを<literal>mydbserver</literal>にあるサーバからストリームし、それをローカルディレクトリ<filename>/usr/local/pgsql/archive</filename>に格納します。
+先行書き込みログを<literal>mydbserver</literal>にあるサーバからストリームし、それをローカルディレクトリ<filename>/usr/local/pgsql/archive</filename>に格納します。
 <screen>
 <prompt>$</prompt> <userinput>pg_receivewal -h mydbserver -D /usr/local/pgsql/archive</userinput>
 </screen></para>

--- a/doc/src/sgml/ref/pg_resetwal.sgml
+++ b/doc/src/sgml/ref/pg_resetwal.sgml
@@ -48,7 +48,7 @@ PostgreSQL documentation
    if these files have become corrupted.  It should be used only as a
    last resort, when the server will not start due to such corruption.
 -->
-<command>pg_resetxlog</command>は、先行書き込みログ（WAL）を消去し、さらにオプションで<filename>pg_control</>ファイル内に保存された制御情報の一部を初期化します。
+<command>pg_resetwal</command>は、先行書き込みログ（WAL）を消去し、さらにオプションで<filename>pg_control</>ファイル内に保存された制御情報の一部を初期化します。
 この機能は、これらのファイルが破損した場合に必要になることがあります。
 このような破損などが原因でサーバを起動できない場合の最後の手段としてのみ、この機能を使用してください。
   </para>
@@ -77,7 +77,7 @@ PostgreSQL documentation
 -->
 このユーティリティの実行にはデータディレクトリへの読み込み/書き込みアクセス権限が必要となるため、サーバをインストールしたユーザのみが実行できます。
 安全のため、データディレクトリをコマンドラインで指定する必要があります。
-<command>pg_resetxlog</command>は、環境変数<envar>PGDATA</>を使用しません。
+<command>pg_resetwal</command>は、環境変数<envar>PGDATA</>を使用しません。
   </para>
 
   <para>
@@ -96,7 +96,7 @@ PostgreSQL documentation
    execute any data-modifying operations in the database before you dump,
    as any such action is likely to make the corruption worse.
 -->
-<command>pg_resetxlog</command>が<filename>pg_control</>に対する有効なデータを判別できない場合、<option>-f</>（force,強制）オプションを指定すれば強制的に処理を進めることができます。
+<command>pg_resetwal</command>が<filename>pg_control</>に対する有効なデータを判別できない場合、<option>-f</>（force,強制）オプションを指定すれば強制的に処理を進めることができます。
 その場合、欠落したデータは無難な値で代用されます。
 ほとんどフィールドでは適切な値が使用されますが、次のOID、次のトランザクションIDとエポック時間、マルチトランザクションIDとそのオフセット、WAL開始アドレスの値については、手動の操作が必要な場合があります。
 これらの値は下記で説明するオプションを使用して設定することができます。
@@ -122,7 +122,7 @@ PostgreSQL documentation
       Force <command>pg_resetwal</command> to proceed even if it cannot determine
       valid data for <filename>pg_control</>, as explained above.
 -->
-上で説明したように、<filename>pg_control</>に有効なデータが確認できない場合でも、強制的に<command>pg_resetxlog</command>の処理を実行します。
+上で説明したように、<filename>pg_control</>に有効なデータが確認できない場合でも、強制的に<command>pg_resetwal</command>の処理を実行します。
      </para>
     </listitem>
    </varlistentry>
@@ -139,8 +139,8 @@ PostgreSQL documentation
       useful as a sanity check before allowing <command>pg_resetwal</command>
       to proceed for real.
 -->
-<option>-n</>（no operation,操作なし）オプションを指定すると、<command>pg_resetxlog</command>は<filename>pg_control</>から再構築した値、および変更される値を出力して、何も変更せずに終了します。
-これは主にデバッグと目的としたツールですが、<command>pg_resetxlog</command>を実際に進める前の検査としても有用な場合があります。
+<option>-n</>（no operation,操作なし）オプションを指定すると、<command>pg_resetwal</command>は<filename>pg_control</>から再構築した値、および変更される値を出力して、何も変更せずに終了します。
+これは主にデバッグと目的としたツールですが、<command>pg_resetwal</command>を実際に進める前の検査としても有用な場合があります。
      </para>
     </listitem>
    </varlistentry>
@@ -172,7 +172,7 @@ PostgreSQL documentation
    described below.  For values that take numeric arguments, hexadecimal
    values can be specified by using the prefix <literal>0x</literal>.
 -->
-以下のオプションは<command>pg_resetxlog</command>が<filename>pg_control</>を四でも適切な値を決定できない場合にのみ必要になります。
+以下のオプションは<command>pg_resetwal</command>が<filename>pg_control</>を四でも適切な値を決定できない場合にのみ必要になります。
 安全な値は以下で説明するようにして決定できます。
 数値を引数として取る値については、<literal>0x</literal>の接頭辞をつけることで16進数の値を指定できます。
   </para>
@@ -228,7 +228,7 @@ PostgreSQL documentation
       if so, an appropriate value should be obtainable from the state of
       the downstream replicated database.
 -->
-<command>pg_resetxlog</command>で設定されるフィールドを除き、トランザクションIDのエポック時間は実際にはデータベース内のどこにも格納されません。
+<command>pg_resetwal</command>で設定されるフィールドを除き、トランザクションIDのエポック時間は実際にはデータベース内のどこにも格納されません。
 そのため、データベース自体だけを考えるのであれば、任意の値で動作するでしょう。
 <application>Slony-I</>や<application>Skytools</>などのレプリケーションシステムが確実に正しく動作するように、この値を調整しなければならない可能性があります。
 その場合、適切な値は下流で複製されたデータベースの状態から得られるはずです。
@@ -256,10 +256,10 @@ WALの開始アドレスを手作業で設定します。
       For example, if <filename>00000001000000320000004A</> is the
       largest entry in <filename>pg_wal</>, use <literal>-l 00000001000000320000004B</> or higher.
 -->
-WAL開始アドレスは、データディレクトリ以下の<filename>pg_xlog</>に現在存在するどのWALセグメントファイル名よりも大きくならなければなりません。
+WAL開始アドレスは、データディレクトリ以下の<filename>pg_wal</>に現在存在するどのWALセグメントファイル名よりも大きくならなければなりません。
 この名前も16進数で、3つの部分に分かれています。
 最初の部分は<quote>時系列ID</>で、通常、この値は変更すべきではありません。
-例えば、<filename>pg_xlog</>内で最大のエントリが<filename>00000001000000320000004A</>である場合は、<literal>-l 00000001000000320000004B</>以上を使用してください。
+例えば、<filename>pg_wal</>内で最大のエントリが<filename>00000001000000320000004A</>である場合は、<literal>-l 00000001000000320000004B</>以上を使用してください。
      </para>
 
      <note>
@@ -273,8 +273,8 @@ WAL開始アドレスは、データディレクトリ以下の<filename>pg_xlog
        entries in an offline archive; or if the contents of
        <filename>pg_wal</> have been lost entirely.
 -->
-<command>pg_resetxlog</command>自体は<filename>pg_xlog</>内のファイルを参照し、最後の既存のファイル名より大きな値をデフォルトの<option>-l</>設定として選択します。
-したがって、手作業による<option>-l</>の調整は、オフラインアーカイブ内の項目など<filename>pg_xlog</>に現存しないWALセグメントファイルがあることに気づいた場合、または、<filename>pg_xlog</>の内容が完全に失われている場合にのみ必要とされます。
+<command>pg_resetwal</command>自体は<filename>pg_wal</>内のファイルを参照し、最後の既存のファイル名より大きな値をデフォルトの<option>-l</>設定として選択します。
+したがって、手作業による<option>-l</>の調整は、オフラインアーカイブ内の項目など<filename>pg_wal</>に現存しないWALセグメントファイルがあることに気づいた場合、または、<filename>pg_wal</>の内容が完全に失われている場合にのみ必要とされます。
       </para>
      </note>
     </listitem>
@@ -404,18 +404,18 @@ WAL開始アドレスは、データディレクトリ以下の<filename>pg_xlog
    so, make doubly certain that there is no server process still alive.
 -->
 このコマンドは、サーバの稼動中に使用してはいけません。
-<command>pg_resetxlog</command>は、データディレクトリにサーバのロックファイルがあると、実行されません。
+<command>pg_resetwal</command>は、データディレクトリにサーバのロックファイルがあると、実行されません。
 サーバがクラッシュした場合、ロックファイルがそのまま残される場合があります。
-その場合は、ロックファイルを削除すれば<command>pg_resetxlog</command>を実行することができます。
+その場合は、ロックファイルを削除すれば<command>pg_resetwal</command>を実行することができます。
 しかし、そのようなことをする前に、まだ稼働中のサーバプロセスが一切ないことを慎重に確認してください。
   </para>
 
   <para>
 <!--
-   <command>pg_resetxlog</command> works only with servers of the same
+   <command>pg_resetwal</command> works only with servers of the same
    major version.
 -->
-<command>pg_resetxlog</command>は同一のメジャーバージョンのサーバに対してのみ動作します。
+<command>pg_resetwal</command>は同一のメジャーバージョンのサーバに対してのみ動作します。
   </para>
 
   <para>

--- a/doc/src/sgml/ref/pg_waldump.sgml
+++ b/doc/src/sgml/ref/pg_waldump.sgml
@@ -41,11 +41,11 @@ PostgreSQL documentation
 -->
   <title>説明</title>
   <para>
-   <command>pg_waldump</command> displays the write-ahead log (WAL) and is mainly
 <!--
+   <command>pg_waldump</command> displays the write-ahead log (WAL) and is mainly
    useful for debugging or educational purposes.
 -->
-<command>pg_xlogdump</command>は先行書き出しログ（WAL）を表示します。
+<command>pg_waldump</command>は先行書き出しログ（WAL）を表示します。
 主にデバッグや学習目的に有用です。
   </para>
 
@@ -121,7 +121,7 @@ PostgreSQL documentation
         Stop reading at the specified WAL location, instead of reading to the
         end of the log stream.
 -->
-ログストリームの終了点まで読み取る代わりに、指定したログ位置で読み取りを終了します。
+ログストリームの終了点まで読み取る代わりに、指定したWAL位置で読み取りを終了します。
        </para>
       </listitem>
      </varlistentry>
@@ -166,8 +166,8 @@ PostgreSQL documentation
         current directory, and the <literal>pg_wal</literal> subdirectory
         of <envar>PGDATA</envar>.
 -->
-ログセグメントファイルを見つけ出すディレクトリ、あるいはログセグメントファイルが含まれる<literal>pg_xlog</literal>サブディレクトリが含まれるディレクトリを指定します。
-デフォルトではカレントディレクトリ、カレントディレクトリ内の<literal>pg_xlog</literal>サブディレクトリ、<envar>PGDATA</envar>の<literal>pg_xlog</literal>サブディレクトリから検索されます。
+ログセグメントファイルを見つけ出すディレクトリ、あるいはログセグメントファイルが含まれる<literal>pg_wal</literal>サブディレクトリが含まれるディレクトリを指定します。
+デフォルトではカレントディレクトリ、カレントディレクトリ内の<literal>pg_wal</literal>サブディレクトリ、<envar>PGDATA</envar>の<literal>pg_wal</literal>サブディレクトリから検索されます。
        </para>
       </listitem>
      </varlistentry>
@@ -197,7 +197,7 @@ PostgreSQL documentation
         WAL location at which to start reading. The default is to start reading
         the first valid log record found in the earliest file found.
 -->
-読み取りを始めるログ位置です。
+読み取りを始めるWAL位置です。
 デフォルトでは、最も過去のファイルの中で見つかった最初の有効なログレコードから読み取りを始めます。
        </para>
       </listitem>
@@ -228,7 +228,7 @@ PostgreSQL documentation
 <!--
        Print the <application>pg_waldump</application> version and exit.
 -->
-<application>pg_xlogdump</application>のバージョンを表示し終了します。
+<application>pg_waldump</application>のバージョンを表示し終了します。
        </para>
        </listitem>
      </varlistentry>
@@ -271,7 +271,7 @@ PostgreSQL documentation
          Show help about <application>pg_waldump</application> command line
          arguments, and exit.
 -->
-<application>pg_xlogdump</application>のコマンドライン引数に関する説明を表示し、終了します。
+<application>pg_waldump</application>のコマンドライン引数に関する説明を表示し、終了します。
         </para>
        </listitem>
       </varlistentry>
@@ -306,7 +306,7 @@ PostgreSQL documentation
     <literal>.partial</>. If those files need to be read, <literal>.partial</>
     suffix needs to be removed from the file name.
 -->
-<application>pg_xlogdump</>は拡張子<literal>.partial</>のWALファイルを読むことはできません。
+<application>pg_waldump</>は拡張子<literal>.partial</>のWALファイルを読むことはできません。
 読む必要がある場合は、ファイル名から拡張子<literal>.partial</>を削除してください。
   </para>
 


### PR DESCRIPTION
xlog->walに名前が変わった3つのファイルです。
大半は、xlog→wal、トランザクションログ→先行書き込みログ、の機械的置換です。