### PR TITLE
func.sgmlの9.4節&9.7節の10.0対応

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -2798,9 +2798,13 @@ NULLの引数は無視されます。
        </entry>
        <entry><type>text[]</type></entry>
        <entry>
+<!--
         Return captured substring(s) resulting from the first match of a POSIX
         regular expression to the <parameter>string</parameter>. See
         <xref linkend="functions-posix-regexp"> for more information.
+-->
+<parameter>string</parameter>に対してPOSIX正規表現でマッチし、捕捉された最初の部分文字列を返します。
+より詳細は<xref linkend="functions-posix-regexp">を参照してください。
        </entry>
        <entry><literal>regexp_match('foobarbequebaz', '(bar)(beque)')</literal></entry>
        <entry><literal>{bar,beque}</literal></entry>
@@ -2820,7 +2824,7 @@ NULLの引数は無視されます。
         expression to the <parameter>string</parameter>. See
         <xref linkend="functions-posix-regexp"> for more information.
 -->
-<parameter>string</parameter>に対してPOSIX正規表現でマッチし、捕捉されたすべての部分文字列を返します。
+<parameter>string</parameter>に対してPOSIX正規表現でマッチし、捕捉された部分文字列を返します。
 より詳細は<xref linkend="functions-posix-regexp">を参照してください。
        </entry>
        <entry><literal>regexp_matches('foobarbequebaz', 'ba.', 'g')</literal></entry>
@@ -5605,22 +5609,20 @@ regexp_replace('foobarbaz', 'b(..)', E'X\\1Y', 'g')
      behavior.  Supported flags are described
      in <xref linkend="posix-embedded-options-table">.
 -->
-<function>regexp_matches</>関数はPOSIX正規表現パターンマッチの結果捕捉された全ての部分文字列のテキスト配列を返します。
-<function>regexp_matches</function>(<replaceable>string</>, <replaceable>pattern</> <optional>, <replaceable>flags</> </optional>)の構文になります。
-この関数は何も行を返さない、1行を返す、複数行を返す（下記の<literal>g</>フラグを参照）といったことができます。
-もし<replaceable>pattern</>に対してマッチしない場合、関数は行を返しません。
-もし、パターンが丸括弧に括られた部分文字列を含まない場合、結果はパターン全体にマッチする部分文字列を含む単一要素のテキスト配列となります。
-もし、パターンが丸括弧に括られた部分文字列を含む場合、関数はテキスト配列を返し、その<replaceable>n</>番目の要素は、パターンの<replaceable>n</>番目に丸括弧で括られた部分文字列にマッチする部分文字列となります（<quote>捕捉されない</>丸括弧は数えません。詳細は下を見てください。）。
+<function>regexp_match</>関数はPOSIX正規表現パターンを文字列にマッチさせた結果、捕捉された最初の部分文字列のテキスト配列を返します。
+<function>regexp_match</function>(<replaceable>string</>, <replaceable>pattern</> <optional>, <replaceable>flags</> </optional>)の構文になります。
+マッチするものがなければ、結果は<literal>NULL</>となります。
+マッチする部分があり、かつ<replaceable>pattern</>が丸括弧で括られた部分文字列を含まない場合、結果はパターン全体にマッチする部分文字列を含む単一要素のテキスト配列となります。
+マッチする部分があり、かつ<replaceable>pattern</>が丸括弧で括られた部分文字列を含む場合、結果はテキスト配列で、その<replaceable>n</>番目の要素は<replaceable>pattern</>の<replaceable>n</>番目に丸括弧で括られた部分文字列にマッチする部分文字列となります（<quote>捕捉されない</>丸括弧は数えません。詳細は以下を参照してください）。
 <replaceable>flags</>パラメータは、関数の動作を変更するゼロもしくは複数の単一文字フラグを含むオプションのテキスト文字列です。
-フラグ<literal>g</>を指定すると、関数は最初のマッチだけでなく文字列の中で全てのマッチを検出し、それぞれのマッチについて1行を返します。
-有効なフラグは(<literal>g</>を除く)<xref linkend="posix-embedded-options-table">に記載されています。
+有効なフラグは<xref linkend="posix-embedded-options-table">に記載されています。
     </para>
 
    <para>
 <!--
     Some examples:
 -->
-例：
+例を示します。
 <programlisting>
 SELECT regexp_match('foobarbequebaz', 'bar.*que');
  regexp_match
@@ -5634,8 +5636,11 @@ SELECT regexp_match('foobarbequebaz', '(bar)(beque)');
  {bar,beque}
 (1 row)
 </programlisting>
+<!--
     In the common case where you just want the whole matching substring
     or <literal>NULL</> for no match, write something like
+-->
+マッチするときはマッチする部分文字列全体、マッチしないときは<literal>NULL</>を返したいというよくあるケースは、以下のように書くことができます。
 <programlisting>
 SELECT (regexp_match('foobarbequebaz', 'bar.*que'))[1];
  regexp_match
@@ -5646,6 +5651,7 @@ SELECT (regexp_match('foobarbequebaz', 'bar.*que'))[1];
    </para>
 
     <para>
+<!--
      The <function>regexp_matches</> function returns a set of text arrays
      of captured substring(s) resulting from matching a POSIX regular
      expression pattern to a string.  It has the same syntax as
@@ -5661,10 +5667,19 @@ SELECT (regexp_match('foobarbequebaz', 'bar.*que'))[1];
      in <xref linkend="posix-embedded-options-table">, plus
      the <literal>g</> flag which commands it to return all matches, not
      just the first one.
+-->
+<function>regexp_matches</>関数はPOSIX正規表現パターンを文字列にマッチさせた結果、捕捉された部分文字列のテキスト配列の集合を返します。
+構文は<function>regexp_match</function>と同じです。
+この関数は、マッチするものがないときは行を返しませんが、マッチするものがあり、<literal>g</>フラグが指定されていないときは1行だけ、マッチするものが<replaceable>N</>個あり、<literal>g</>フラグが指定されているときは<replaceable>N</>行を返します。
+返される各行は上で<function>regexp_match</function>について説明したのと全く同じで、マッチする部分文字列全体、または丸括弧で括られた部分文字列にマッチする部分文字列を含むテキスト配列です。
+<function>regexp_matches</>は<xref linkend="posix-embedded-options-table">に示すすべてのフラグに加え、最初のマッチだけでなくすべてのマッチを返す<literal>g</>を受け付けます。
     </para>
 
    <para>
+<!--
     Some examples:
+-->
+例を示します。
 <programlisting>
 SELECT regexp_matches('foo', 'not there');
  regexp_matches
@@ -5691,15 +5706,20 @@ SELECT regexp_matches('foobarbequebazilbarfbonk', '(b[^b]+)(b[^b]+)', 'g');
      versions, a common trick is to place a <function>regexp_matches()</>
      call in a sub-select, for example:
 -->
-副問い合わせを使用することで、<function>regexp_matches()</>が常に1行を返すように強制することが可能です。
-これは、<literal>SELECT</>の対象リスト内で、マッチするものが無い行も含めて全ての行を返して欲しい場合に特に有用です。
+最初にマッチするものだけが必要なときは<function>regexp_match()</>を使う方がより簡単で効率的ですから、<function>regexp_matches()</>はほとんどの場合<literal>g</>フラグを指定して使われるでしょう。
+しかし、<function>regexp_match()</>は<productname>PostgreSQL</>のバージョン10以上でのみ利用できます。
+古いバージョンを使う時によくある手法は、以下の例のように、副SELECTの中に<function>regexp_matches()</>の呼び出しを入れることです。
 <programlisting>
 SELECT col1, (SELECT regexp_matches(col2, '(bar)(beque)')) FROM tab;
 </programlisting>
+<!--
      This produces a text array if there's a match, or <literal>NULL</> if
      not, the same as <function>regexp_match()</> would do.  Without the
      sub-select, this query would produce no output at all for table rows
      without a match, which is typically not the desired behavior.
+-->
+これは<function>regexp_match()</>と同じく、マッチするものがあればテキスト配列を生成し、マッチしなければ<literal>NULL</>となります。
+副SELECTを使わなければ、マッチするものがないテーブル行については問い合わせの出力が生成されず、多くの場合に期待される動作と異なります。
     </para>
    </tip>
 
@@ -5802,7 +5822,7 @@ SELECT foo FROM regexp_split_to_table('the quick brown fox', E'\\s*') AS foo;
     in practice.  Other software systems such as Perl use similar definitions.
 -->
 最後の例が明らかにしているように、regexp分割関数は文字列の最初あるいは終わり、もしくは前のマッチの直後に発生する長さを持たないマッチを無視します。
-<function>regexp_matches</>で実装されたregexpマッチの厳格な定義にこれは相容れませんが、実務上は最も使い勝手の良い動作です。
+<function>regexp_match</>および<function>regexp_matches</>で実装されたregexpマッチの厳格な定義にこれは相容れませんが、実務上は最も使い勝手の良い動作です。
 Perlのような他のソフトウェアシステムも似たような定義を使用します。
    </para>
 

--- a/doc/src/sgml/func1.sgml
+++ b/doc/src/sgml/func1.sgml
@@ -2750,9 +2750,13 @@ NULLの引数は無視されます。
        </entry>
        <entry><type>text[]</type></entry>
        <entry>
+<!--
         Return captured substring(s) resulting from the first match of a POSIX
         regular expression to the <parameter>string</parameter>. See
         <xref linkend="functions-posix-regexp"> for more information.
+-->
+<parameter>string</parameter>に対してPOSIX正規表現でマッチし、捕捉された最初の部分文字列を返します。
+より詳細は<xref linkend="functions-posix-regexp">を参照してください。
        </entry>
        <entry><literal>regexp_match('foobarbequebaz', '(bar)(beque)')</literal></entry>
        <entry><literal>{bar,beque}</literal></entry>
@@ -2772,7 +2776,7 @@ NULLの引数は無視されます。
         expression to the <parameter>string</parameter>. See
         <xref linkend="functions-posix-regexp"> for more information.
 -->
-<parameter>string</parameter>に対してPOSIX正規表現でマッチし、捕捉されたすべての部分文字列を返します。
+<parameter>string</parameter>に対してPOSIX正規表現でマッチし、捕捉された部分文字列を返します。
 より詳細は<xref linkend="functions-posix-regexp">を参照してください。
        </entry>
        <entry><literal>regexp_matches('foobarbequebaz', 'ba.', 'g')</literal></entry>
@@ -5557,22 +5561,20 @@ regexp_replace('foobarbaz', 'b(..)', E'X\\1Y', 'g')
      behavior.  Supported flags are described
      in <xref linkend="posix-embedded-options-table">.
 -->
-<function>regexp_matches</>関数はPOSIX正規表現パターンマッチの結果捕捉された全ての部分文字列のテキスト配列を返します。
-<function>regexp_matches</function>(<replaceable>string</>, <replaceable>pattern</> <optional>, <replaceable>flags</> </optional>)の構文になります。
-この関数は何も行を返さない、1行を返す、複数行を返す（下記の<literal>g</>フラグを参照）といったことができます。
-もし<replaceable>pattern</>に対してマッチしない場合、関数は行を返しません。
-もし、パターンが丸括弧に括られた部分文字列を含まない場合、結果はパターン全体にマッチする部分文字列を含む単一要素のテキスト配列となります。
-もし、パターンが丸括弧に括られた部分文字列を含む場合、関数はテキスト配列を返し、その<replaceable>n</>番目の要素は、パターンの<replaceable>n</>番目に丸括弧で括られた部分文字列にマッチする部分文字列となります（<quote>捕捉されない</>丸括弧は数えません。詳細は下を見てください。）。
+<function>regexp_match</>関数はPOSIX正規表現パターンを文字列にマッチさせた結果、捕捉された最初の部分文字列のテキスト配列を返します。
+<function>regexp_match</function>(<replaceable>string</>, <replaceable>pattern</> <optional>, <replaceable>flags</> </optional>)の構文になります。
+マッチするものがなければ、結果は<literal>NULL</>となります。
+マッチする部分があり、かつ<replaceable>pattern</>が丸括弧で括られた部分文字列を含まない場合、結果はパターン全体にマッチする部分文字列を含む単一要素のテキスト配列となります。
+マッチする部分があり、かつ<replaceable>pattern</>が丸括弧で括られた部分文字列を含む場合、結果はテキスト配列で、その<replaceable>n</>番目の要素は<replaceable>pattern</>の<replaceable>n</>番目に丸括弧で括られた部分文字列にマッチする部分文字列となります（<quote>捕捉されない</>丸括弧は数えません。詳細は以下を参照してください）。
 <replaceable>flags</>パラメータは、関数の動作を変更するゼロもしくは複数の単一文字フラグを含むオプションのテキスト文字列です。
-フラグ<literal>g</>を指定すると、関数は最初のマッチだけでなく文字列の中で全てのマッチを検出し、それぞれのマッチについて1行を返します。
-有効なフラグは(<literal>g</>を除く)<xref linkend="posix-embedded-options-table">に記載されています。
+有効なフラグは<xref linkend="posix-embedded-options-table">に記載されています。
     </para>
 
    <para>
 <!--
     Some examples:
 -->
-例：
+例を示します。
 <programlisting>
 SELECT regexp_match('foobarbequebaz', 'bar.*que');
  regexp_match
@@ -5586,8 +5588,11 @@ SELECT regexp_match('foobarbequebaz', '(bar)(beque)');
  {bar,beque}
 (1 row)
 </programlisting>
+<!--
     In the common case where you just want the whole matching substring
     or <literal>NULL</> for no match, write something like
+-->
+マッチするときはマッチする部分文字列全体、マッチしないときは<literal>NULL</>を返したいというよくあるケースは、以下のように書くことができます。
 <programlisting>
 SELECT (regexp_match('foobarbequebaz', 'bar.*que'))[1];
  regexp_match
@@ -5598,6 +5603,7 @@ SELECT (regexp_match('foobarbequebaz', 'bar.*que'))[1];
    </para>
 
     <para>
+<!--
      The <function>regexp_matches</> function returns a set of text arrays
      of captured substring(s) resulting from matching a POSIX regular
      expression pattern to a string.  It has the same syntax as
@@ -5613,10 +5619,19 @@ SELECT (regexp_match('foobarbequebaz', 'bar.*que'))[1];
      in <xref linkend="posix-embedded-options-table">, plus
      the <literal>g</> flag which commands it to return all matches, not
      just the first one.
+-->
+<function>regexp_matches</>関数はPOSIX正規表現パターンを文字列にマッチさせた結果、捕捉された部分文字列のテキスト配列の集合を返します。
+構文は<function>regexp_match</function>と同じです。
+この関数は、マッチするものがないときは行を返しませんが、マッチするものがあり、<literal>g</>フラグが指定されていないときは1行だけ、マッチするものが<replaceable>N</>個あり、<literal>g</>フラグが指定されているときは<replaceable>N</>行を返します。
+返される各行は上で<function>regexp_match</function>について説明したのと全く同じで、マッチする部分文字列全体、または丸括弧で括られた部分文字列にマッチする部分文字列を含むテキスト配列です。
+<function>regexp_matches</>は<xref linkend="posix-embedded-options-table">に示すすべてのフラグに加え、最初のマッチだけでなくすべてのマッチを返す<literal>g</>を受け付けます。
     </para>
 
    <para>
+<!--
     Some examples:
+-->
+例を示します。
 <programlisting>
 SELECT regexp_matches('foo', 'not there');
  regexp_matches
@@ -5643,15 +5658,20 @@ SELECT regexp_matches('foobarbequebazilbarfbonk', '(b[^b]+)(b[^b]+)', 'g');
      versions, a common trick is to place a <function>regexp_matches()</>
      call in a sub-select, for example:
 -->
-副問い合わせを使用することで、<function>regexp_matches()</>が常に1行を返すように強制することが可能です。
-これは、<literal>SELECT</>の対象リスト内で、マッチするものが無い行も含めて全ての行を返して欲しい場合に特に有用です。
+最初にマッチするものだけが必要なときは<function>regexp_match()</>を使う方がより簡単で効率的ですから、<function>regexp_matches()</>はほとんどの場合<literal>g</>フラグを指定して使われるでしょう。
+しかし、<function>regexp_match()</>は<productname>PostgreSQL</>のバージョン10以上でのみ利用できます。
+古いバージョンを使う時によくある手法は、以下の例のように、副SELECTの中に<function>regexp_matches()</>の呼び出しを入れることです。
 <programlisting>
 SELECT col1, (SELECT regexp_matches(col2, '(bar)(beque)')) FROM tab;
 </programlisting>
+<!--
      This produces a text array if there's a match, or <literal>NULL</> if
      not, the same as <function>regexp_match()</> would do.  Without the
      sub-select, this query would produce no output at all for table rows
      without a match, which is typically not the desired behavior.
+-->
+これは<function>regexp_match()</>と同じく、マッチするものがあればテキスト配列を生成し、マッチしなければ<literal>NULL</>となります。
+副SELECTを使わなければ、マッチするものがないテーブル行については問い合わせの出力が生成されず、多くの場合に期待される動作と異なります。
     </para>
    </tip>
 
@@ -5754,7 +5774,7 @@ SELECT foo FROM regexp_split_to_table('the quick brown fox', E'\\s*') AS foo;
     in practice.  Other software systems such as Perl use similar definitions.
 -->
 最後の例が明らかにしているように、regexp分割関数は文字列の最初あるいは終わり、もしくは前のマッチの直後に発生する長さを持たないマッチを無視します。
-<function>regexp_matches</>で実装されたregexpマッチの厳格な定義にこれは相容れませんが、実務上は最も使い勝手の良い動作です。
+<function>regexp_match</>および<function>regexp_matches</>で実装されたregexpマッチの厳格な定義にこれは相容れませんが、実務上は最も使い勝手の良い動作です。
 Perlのような他のソフトウェアシステムも似たような定義を使用します。
    </para>
 


### PR DESCRIPTION
func.sgmlは変更部分が多いので、節ごとに分割してPRを出します。
本PRは9.4（文字列関数）および9.7.3（POSIX正規表現）に関するもので、新規に追加されたregexp_matchに関する記述と、従来からあるregexp_matchesに関する記述の変更です。