### PR TITLE
datatype.sgmlのPostgreSQL10対応

### DIFF
--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -2467,7 +2467,7 @@ SELECT E'\\xDEADBEEF';
         <entry>1 microsecond</entry>
 -->
         <entry>12 バイト</entry>
-        <entry時刻（日付なし)、時間帯付き</entry>
+        <entry>時刻（日付なし)、時間帯付き</entry>
         <entry>00:00:00+1459</entry>
         <entry>24:00:00-1459</entry>
         <entry>1 マイクロ秒</entry>

--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -2459,11 +2459,18 @@ SELECT E'\\xDEADBEEF';
        </row>
        <row>
         <entry><type>time [ (<replaceable>p</replaceable>) ] with time zone</type></entry>
+<!--
         <entry>12 bytes</entry>
         <entry>time of day (no date), with time zone</entry>
         <entry>00:00:00+1459</entry>
         <entry>24:00:00-1459</entry>
         <entry>1 microsecond</entry>
+-->
+        <entry>12 バイト</entry>
+        <entry時刻（日付なし)、時間帯付き</entry>
+        <entry>00:00:00+1459</entry>
+        <entry>24:00:00-1459</entry>
+        <entry>1 マイクロ秒</entry>
        </row>
        <row>
         <entry><type>interval [ <replaceable>fields</replaceable> ] [ (<replaceable>p</replaceable>) ]</type></entry>

--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -262,7 +262,7 @@
 <!--
        <entry>MAC (Media Access Control) address (EUI-64 format)</entry>
 -->
-       <entry>MAC (Media Access Control) アドレス (EUI-64 フォーマット)</entry>
+       <entry>MAC (Media Access Control) アドレス (EUI-64 形式)</entry>
       </row>
 
       <row>
@@ -1267,7 +1267,7 @@ IEEE754では、<literal>NaN</>は（<literal>NaN</>を含む）他のすべて�
       identity column feature, described at <xref linkend="sql-createtable">.
 -->
 このセクションではPostgreSQL固有の自動増分列の作成方法について記述します。
-SQL標準のID列を作成する別の方法は、<xref linkend="sql-createtable">に記述されています。
+SQL標準の識別列を作成する方法は、<xref linkend="sql-createtable">に記述されています。
      </para>
     </note>
 
@@ -2410,7 +2410,7 @@ SELECT E'\\xDEADBEEF';
 <!--
         <entry>1 microsecond</entry>
 -->
-<entry>1マイクロ秒、14桁</entry>
+<entry>1マイクロ秒</entry>
        </row>
        <row>
         <entry><type>timestamp [ (<replaceable>p</replaceable>) ] with time zone</type></entry>
@@ -2425,7 +2425,7 @@ SELECT E'\\xDEADBEEF';
 <!--
         <entry>1 microsecond</entry>
 -->
-<entry>1マイクロ秒、14桁</entry>
+<entry>1マイクロ秒</entry>
        </row>
        <row>
         <entry><type>date</type></entry>
@@ -2455,7 +2455,7 @@ SELECT E'\\xDEADBEEF';
 <!--
         <entry>1 microsecond</entry>
 -->
-<entry>1マイクロ秒、14桁</entry>
+<entry>1マイクロ秒</entry>
        </row>
        <row>
         <entry><type>time [ (<replaceable>p</replaceable>) ] with time zone</type></entry>
@@ -2478,7 +2478,7 @@ SELECT E'\\xDEADBEEF';
         <entry>時間間隔</entry>
         <entry>-178000000年</entry>
         <entry>178000000年</entry>
-        <entry>1マイクロ秒、14桁</entry>
+        <entry>1マイクロ秒</entry>
        </row>
       </tbody>
      </tgroup>
@@ -2513,43 +2513,6 @@ SELECT E'\\xDEADBEEF';
 デフォルトでは、精度についての明示的な限界はありません。
 <replaceable>p</replaceable>の許容範囲は0から6です。
    </para>
-
-   <note>
-   <para>
-<!--
-    When <type>timestamp</> values are stored as eight-byte integers
-    (currently the default), microsecond precision is available over
-    the full range of values. When <type>timestamp</> values are
-    stored as double precision floating-point numbers instead (a
-    deprecated compile-time option), the effective limit of precision
-    might be less than 6. <type>timestamp</type> values are stored as
-    seconds before or after midnight 2000-01-01.  When
-    <type>timestamp</type> values are implemented using floating-point
-    numbers, microsecond precision is achieved for dates within a few
-    years of 2000-01-01, but the precision degrades for dates further
-    away. Note that using floating-point datetimes allows a larger
-    range of <type>timestamp</type> values to be represented than
-    shown above: from 4713 BC up to 5874897 AD.
-    -->
-<type>timestamp</>の値が8バイト整数（現在のデフォルト）で格納されていれば、すべての値についてマイクロ秒精度が有効です。
-<type>timestamp</>の値が倍精度浮動小数点数（将来のサポートが保証されないコンパイル時のオプション）で格納されていると、有効な精度は6より小さいかもしれません。
-<type>timestamp</>の値は2000-01-01深夜を基準にした経過秒数として格納されます。
-<type>timestamp</type>の値が浮動小数点数として格納されていれば、2000-01-01から数年の範囲でマイクロ秒精度が得られますが、それより離脱すると精度は劣化します。
-浮動小数点の日付時刻を使用すると、上で示した範囲より広い<type>timestamp</type>の値（4713 BCから5874897 ADまで）を利用できます。
-   </para>
-
-   <para>
-   <!--
-    The same compile-time option also determines whether
-    <type>time</type> and <type>interval</type> values are stored as
-    floating-point numbers or eight-byte integers.  In the
-    floating-point case, large <type>interval</type> values degrade in
-    precision as the size of the interval increases.
-    -->
-同じコンパイル時オプションは<type>time</type>および<type>interval</type>の値が浮動小数点数か、8バイト整数のいずれかによって格納されるかを決定します。
-浮動小数点の場合、大きな<type>interval</type>では間隔が増加する際に精度が落ちます。
-   </para>
-   </note>
 
    <para>
 <!--
@@ -2682,7 +2645,7 @@ MINUTE TO SECOND
 ここで、<replaceable>p</replaceable>は秒フィールドの小数点以下の桁数を与えるオプションの精度の指定です。
 精度は<type>time</type>、<type>timestamp</type>および<type>interval</type>型に対して0から6の範囲で設定できます。
 値の許容範囲は既に説明しています。
-定数指定において精度指定がない場合は、リテラル値の精度がデフォルトとして使われます(ただし、６桁を超えることはできません)。
+定数指定において精度指定がない場合は、リテラル値の精度がデフォルトとして使われます(ただし、６桁を超えることはありません)。
     </para>
 
     <sect3>
@@ -5271,7 +5234,7 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry>MAC addresses (EUI-64 format)</entry>
 -->
         <entry>8 バイト</entry>
-        <entry>MAC アドレス (EUI-64 フォーマット)</entry>
+        <entry>MAC アドレス (EUI-64 形式)</entry>
        </row>
 
       </tbody>
@@ -5602,7 +5565,7 @@ PostgreSQLではビット反転に関する準備をしていません。
 <!--
      <primary>MAC address (EUI-64 format)</primary>
 -->
-     <primary>MAC アドレス (EUI-64 フォーマット)</primary>
+     <primary>MAC アドレス (EUI-64 形式)</primary>
      <see>macaddr</see>
     </indexterm>
 
@@ -5629,18 +5592,18 @@ PostgreSQLではビット反転に関する準備をしていません。
 
      The following are examples of input formats that are accepted:
 -->
-<type>macaddr8</>データ型はイーサーネットカードのハードウェアアドレスで知られるEUI-64フォーマットでデータを格納します。（MACアドレスは他の目的にもよく使用されます。）
-このデータ型は６バイトと８バイトの両方の長さのMACアドレスを受け入れることがき、８バイトのフォーマットで格納します。
-6バイト形式で与えられたMACアドレスは8バイト型のフォーマットでは、それぞれ、４番目と５番目のバイトをFFとFEとして格納されます。
+<type>macaddr8</>データ型はイーサーネットカードのハードウェアアドレスなどで知られるEUI-64形式でデータを格納します（MACアドレスは他の目的にもよく使用されます。）。
+このデータ型は６バイト長と８バイト長の両方の長さのMACアドレスを受け入れることがき、８バイト長の形式で格納します。
+6バイト形式で与えられたMACアドレスは8バイト長の形式では、それぞれ、４番目と５番目のバイトをFFとFEとして格納されます。
 
-IPv6はEUI-48から変換後に７番目のビットに1を設定する修正されるべきEUI-64フォーマットを使用する点に注意してください。
+IPv6はEUI-48から変換後に７番目のビットに1となるべき設定がなされた修正EUI-64形式を使用する点に注意してください。
  <function>macaddr8_set7bit</>関数がこの変換生成を提供します。
 
 一般的には(バイト境界上での)16進数の対で構成され、任意に<literal>':'</>、<literal>'-'</> もしくは <literal>'.'</>のいずれかの一貫した記号で分割された入力を受け付けます。
 16進数の桁数は16桁(8 バイト)か12桁(6バイト)のいずれかである必要があります。
 前後の空白は無視されます。
 
-以下の入力フォーマットの例は受け付けられます。
+以下の入力形式の例は受け付けられます。
      <simplelist>
       <member><literal>'08:00:2b:01:02:03:04:05'</></member>
       <member><literal>'08-00-2b-01-02-03-04-05'</></member>
@@ -5666,12 +5629,12 @@ IPv6はEUI-48から変換後に７番目のビットに1を設定する修正さ
      IPv6 address, use <function>macaddr8_set7bit</> as shown:
 -->
 これらの例は全て同じアドレスを指します。
-桁には大文字、小文字の<literal>a</> から<literal>f</>も受付けられます。
+桁には大文字の<literal>A</> から<literal>F</>、小文字の<literal>a</> から<literal>f</>も受付けられます。
 出力は常に１番目の形式です。
 
-下から6つのフォーマットは標準ではありません。
+下から6つの形式は標準ではありません。
 
-従来のEUI-48形式の48ビットのMACアドレスからIPv6のホスト部を含む修正がなされたEUI-64形式のフォーマットへ変更するためには、以下に示すように<function>macaddr8_set7bit</>を使用します。
+従来のEUI-48形式の48ビットのMACアドレスからIPv6のホスト部を含む修正がなされたEUI-64形式へ変更するためには、以下に示すように<function>macaddr8_set7bit</>を使用します。
 
 <programlisting>
 SELECT macaddr8_set7bit('08:00:2b:01:02:03');

--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -253,13 +253,16 @@
 <!--
        <entry>MAC (Media Access Control) address</entry>
 -->
-<entry>MAC（メディアアクセスコントロール）アドレス</entry>
+<entry>MAC（Media Access Control）アドレス</entry>
       </row>
 
       <row>
        <entry><type>macaddr8</type></entry>
        <entry></entry>
+<!--
        <entry>MAC (Media Access Control) address (EUI-64 format)</entry>
+-->
+       <entry>MAC (Media Access Control) アドレス (EUI-64 フォーマット)</entry>
       </row>
 
       <row>
@@ -1150,7 +1153,7 @@ FROM generate_series(-3.5, 3.5, 1) as x;
 -->
 これらはそれぞれ、IEEE 754の特殊な値、<quote>無限大</quote>、<quote>負の無限大</quote>、<quote>非数値</quote>を表します。
 （浮動小数点計算がIEEE 754に従わないマシンでは、これらの値はおそらく正しく動作しません。）
-これらの値をSQLコマンドの定数として記述する場合、例えば<literal>UPDATE table SET x = 'Infinity'</>のように引用符でくくる必要があります。
+これらの値をSQLコマンドの定数として記述する場合、例えば<literal>UPDATE table SET x = '-Infinity'</>のように引用符でくくる必要があります。
 入力の際、これらの文字列は大文字小文字の区別なく認識されます。
     </para>
 
@@ -1258,9 +1261,13 @@ IEEE754では、<literal>NaN</>は（<literal>NaN</>を含む）他のすべて�
 
     <note>
      <para>
+<!--
       This section describes a PostgreSQL-specific way to create an
       autoincrementing column.  Another way is to use the SQL-standard
       identity column feature, described at <xref linkend="sql-createtable">.
+-->
+このセクションではPostgreSQL固有の自動増分列の作成方法について記述します。
+SQL標準のID列を作成する別の方法は、<xref linkend="sql-createtable">に記述されています。
      </para>
     </note>
 
@@ -2504,7 +2511,7 @@ SELECT E'\\xDEADBEEF';
 -->
 <type>time</type>、<type>timestamp</type>および<type>interval</type>は秒フィールドに保有されている小数点以下の桁数を指定する精度値<replaceable>p</replaceable>をオプションで受け付けます。
 デフォルトでは、精度についての明示的な限界はありません。
-<replaceable>p</replaceable>の許容範囲は<type>timestamp</type>型と<type>interval</type>型の場合は0から6です。
+<replaceable>p</replaceable>の許容範囲は0から6です。
    </para>
 
    <note>
@@ -2673,9 +2680,9 @@ MINUTE TO SECOND
      more than 6 digits).
 -->
 ここで、<replaceable>p</replaceable>は秒フィールドの小数点以下の桁数を与えるオプションの精度の指定です。
-精度は<type>time</type>、<type>timestamp</type>および<type>interval</type>型に対して設定できます。
+精度は<type>time</type>、<type>timestamp</type>および<type>interval</type>型に対して0から6の範囲で設定できます。
 値の許容範囲は既に説明しています。
-定数指定において精度指定がない場合は、リテラル値の精度がデフォルトとして使われます。
+定数指定において精度指定がない場合は、リテラル値の精度がデフォルトとして使われます(ただし、６桁を超えることはできません)。
     </para>
 
     <sect3>
@@ -5259,8 +5266,12 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
 
        <row>
         <entry><type>macaddr8</type></entry>
+<!--
         <entry>8 bytes</entry>
         <entry>MAC addresses (EUI-64 format)</entry>
+-->
+        <entry>8 バイト</entry>
+        <entry>MAC アドレス (EUI-64 フォーマット)</entry>
        </row>
 
       </tbody>
@@ -5487,6 +5498,7 @@ IPv6ではアドレス長は128ビットですので、128ビットが一意な�
     but not for <type>cidr</type>.
 -->
 <type>inet</type>データ型と<type>cidr</type>データ型との基本的な相違は、<type>inet</type>ではネットマスクの右側に0でないビット値を受け付けますが、<type>cidr</type>では受け付けないことです。
+例えば、<literal>192.168.0.1/24</literal> は<type>inet</type>では有効ですが、<type>cidr</type>では有効ではありません。
     </para>
 
       <tip>
@@ -5580,15 +5592,22 @@ PostgreSQLではビット反転に関する準備をしていません。
     <title><type>macaddr8</type></title>
 
     <indexterm>
+<!--
      <primary>macaddr8 (data type)</primary>
+-->
+     <primary>macaddr8 (データ型)</primary>
     </indexterm>
 
     <indexterm>
+<!--
      <primary>MAC address (EUI-64 format)</primary>
+-->
+     <primary>MAC アドレス (EUI-64 フォーマット)</primary>
      <see>macaddr</see>
     </indexterm>
 
     <para>
+<!--
      The <type>macaddr8</> type stores MAC addresses in EUI-64
      format, known for example from Ethernet card hardware addresses
      (although MAC addresses are used for other purposes as well).
@@ -5609,7 +5628,19 @@ PostgreSQLではビット反転に関する準備をしていません。
      12 (6 bytes).  Leading and trailing whitespace is ignored.
 
      The following are examples of input formats that are accepted:
+-->
+<type>macaddr8</>データ型はイーサーネットカードのハードウェアアドレスで知られるEUI-64フォーマットでデータを格納します。（MACアドレスは他の目的にもよく使用されます。）
+このデータ型は６バイトと８バイトの両方の長さのMACアドレスを受け入れることがき、８バイトのフォーマットで格納します。
+6バイト形式で与えられたMACアドレスは8バイト型のフォーマットでは、それぞれ、４番目と５番目のバイトをFFとFEとして格納されます。
 
+IPv6はEUI-48から変換後に７番目のビットに1を設定する修正されるべきEUI-64フォーマットを使用する点に注意してください。
+ <function>macaddr8_set7bit</>関数がこの変換生成を提供します。
+
+一般的には(バイト境界上での)16進数の対で構成され、任意に<literal>':'</>、<literal>'-'</> もしくは <literal>'.'</>のいずれかの一貫した記号で分割された入力を受け付けます。
+16進数の桁数は16桁(8 バイト)か12桁(6バイト)のいずれかである必要があります。
+前後の空白は無視されます。
+
+以下の入力フォーマットの例は受け付けられます。
      <simplelist>
       <member><literal>'08:00:2b:01:02:03:04:05'</></member>
       <member><literal>'08-00-2b-01-02-03-04-05'</></member>
@@ -5621,6 +5652,7 @@ PostgreSQLではビット反転に関する準備をしていません。
       <member><literal>'08002b0102030405'</></member>
      </simplelist>
 
+<!--
      These examples would all specify the same address.  Upper and
      lower case is accepted for the digits
      <literal>a</> through <literal>f</>.  Output is always in the
@@ -5632,6 +5664,14 @@ PostgreSQLではビット反転に関する準備をしていません。
      To convert a traditional 48 bit MAC address in EUI-48 format to
      modified EUI-64 format to be included as the host portion of an
      IPv6 address, use <function>macaddr8_set7bit</> as shown:
+-->
+これらの例は全て同じアドレスを指します。
+桁には大文字、小文字の<literal>a</> から<literal>f</>も受付けられます。
+出力は常に１番目の形式です。
+
+下から6つのフォーマットは標準ではありません。
+
+従来のEUI-48形式の48ビットのMACアドレスからIPv6のホスト部を含む修正がなされたEUI-64形式のフォーマットへ変更するためには、以下に示すように<function>macaddr8_set7bit</>を使用します。
 
 <programlisting>
 SELECT macaddr8_set7bit('08:00:2b:01:02:03');
@@ -6454,7 +6494,7 @@ XMLデータは内部的にUTF-8として処理されますので、サーバの
      issue for <function>xmltable()</> and <function>xpath()</> in particular.
      -->
 サーバ符号化方式がUTF-8でない場合、いくつかのXMLに関係した関数は非ASCIIデータに対して全く機能しないことがあります。
-特に<function>xpath()</>に対する問題として知られています。
+これは特に<function>xmltable()</>と<function>xpath()</>に対する問題として知られています。
     </para>
    </caution>
    </sect2>
@@ -6928,7 +6968,7 @@ OID別名型はトランザクション隔離規則に完全には従いませ�
     representation of <type>XLogRecPtr</type> and an internal system type of
     <productname>PostgreSQL</productname>.
 -->
-<type>pg_lsn</type>型はXLOGの位置を示すLSN(Log Sequence Number)データを格納するために使用します。
+<type>pg_lsn</type>型はWALの位置を示すLSN(Log Sequence Number)データを格納するために使用します。
 この型は<type>XLogRecPtr</type>を示す<productname>PostgreSQL</productname>の内部的なシステムの型です。
    </para>
 
@@ -7222,8 +7262,11 @@ LSNは例えば、<literal>16/B374D848</>のように２つのスラッシュで
 
        <row>
         <entry><type>unknown</></entry>
+<!--
         <entry>Identifies a not-yet-resolved type, e.g. of an undecorated
          string literal.</entry>
+-->
+        <entry>未解決の型を特定します。例えば、修飾されていない文字列リテラルのような型です。</entry>
        </row>
 
        <row>
@@ -7233,7 +7276,7 @@ LSNは例えば、<literal>16/B374D848</>のように２つのスラッシュで
          purposes.</entry>
 -->
         <entry>
-過去に上記の目的すべてを果たしていた古いデータ型の名前です。
+過去に上記の目的の多数を果たしていた使われなくなったデータ型の名前です。
         </entry>
        </row>
       </tbody>

--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -300,7 +300,7 @@
 <!--
        <entry><productname>PostgreSQL</productname> Log Sequence Number</entry>
 -->
-       <entry><productname>PostgreSQL</productname>ログ順序番号</entry>
+       <entry><productname>PostgreSQL</productname>ログシーケンス番号</entry>
       </row>
 
       <row>


### PR DESCRIPTION
MAC (Media Access Control) はMAC (メディアアクセスコントロール)と訳されていましたが
頭文字が表記されており理解しやすいため、英文のままとしました。

また、6497行目は少し分かりにくく感じたので、This isの箇所を明示的に訳出しました。