### PR TITLE
PDF用スタイルシートの10.0対応＆整理

### DIFF
--- a/doc/src/sgml/stylesheet-fo.xsl
+++ b/doc/src/sgml/stylesheet-fo.xsl
@@ -12,133 +12,11 @@
 <xsl:param name="ulink.footnotes" select="1"></xsl:param>
 <xsl:param name="use.extensions" select="1"></xsl:param>
 <xsl:param name="variablelist.as.blocks" select="1"></xsl:param>
-<xsl:param name="hyphenate">false</xsl:param>
-
-<!-- <xsl:param name="title.color">#EC5800</xsl:param> -->
-<xsl:param name="title.color">black</xsl:param>
-
-<!-- header settings -->
-<xsl:param name="header.column.widths">2 5 2</xsl:param>
-
-<xsl:attribute-set name="component.title.properties">
-  <xsl:attribute name="line-height">30pt</xsl:attribute>
-  <xsl:attribute name="color"><xsl:value-of select="$title.color"/></xsl:attribute>
-  <xsl:attribute name="space-after.minimum">0.5em</xsl:attribute>
-  <xsl:attribute name="space-after.optimum">0.5em</xsl:attribute>
-  <xsl:attribute name="space-after.maximum">0.5em</xsl:attribute>
-</xsl:attribute-set>
-
-<xsl:attribute-set name="section.title.properties">
-  <xsl:attribute name="line-height">30pt</xsl:attribute>
-  <xsl:attribute name="color"><xsl:value-of select="$title.color"/></xsl:attribute>
-  <xsl:attribute name="space-before.minimum">0.5em</xsl:attribute>
-  <xsl:attribute name="space-before.optimum">1.2em</xsl:attribute>
-  <xsl:attribute name="space-before.maximum">1.4em</xsl:attribute>
-  <xsl:attribute name="space-after.minimum">0.1em</xsl:attribute>
-  <xsl:attribute name="space-after.optimum">0.1em</xsl:attribute>
-  <xsl:attribute name="space-after.maximum">0.1em</xsl:attribute>
-</xsl:attribute-set>
-
-<xsl:attribute-set name="section.title.level1.properties">
-  <xsl:attribute name="space-before.minimum">1.0em</xsl:attribute>
-  <xsl:attribute name="space-before.optimum">1.2em</xsl:attribute>
-  <xsl:attribute name="space-before.maximum">1.4em</xsl:attribute>
-</xsl:attribute-set>
-
-<xsl:attribute-set name="part.titlepage.recto.style">
-  <xsl:attribute name="line-height">30pt</xsl:attribute>
-  <xsl:attribute name="color"><xsl:value-of select="$title.color"/></xsl:attribute>
-  <xsl:attribute name="space-after.minimum">1.0em</xsl:attribute>
-  <xsl:attribute name="space-after.optimum">1.0em</xsl:attribute>
-  <xsl:attribute name="space-after.maximum">1.0em</xsl:attribute>
-</xsl:attribute-set>
-
-<xsl:attribute-set name="reference.titlepage.recto.style">
-  <xsl:attribute name="line-height">30pt</xsl:attribute>
-  <xsl:attribute name="color"><xsl:value-of select="$title.color"/></xsl:attribute>
-  <xsl:attribute name="space-before.minimum">1.0em</xsl:attribute>
-  <xsl:attribute name="space-before.optimum">1.0em</xsl:attribute>
-  <xsl:attribute name="space-before.maximum">1.0em</xsl:attribute>
-  <xsl:attribute name="space-after.minimum">0.1em</xsl:attribute>
-  <xsl:attribute name="space-after.optimum">0.1em</xsl:attribute>
-  <xsl:attribute name="space-after.maximum">0.1em</xsl:attribute>
-</xsl:attribute-set>
-
-<xsl:attribute-set name="normal.para.spacing">
-  <xsl:attribute name="space-before.minimum">0.4em</xsl:attribute>
-  <xsl:attribute name="space-before.optimum">0.6em</xsl:attribute>
-  <xsl:attribute name="space-before.maximum">0.8em</xsl:attribute>
-  <xsl:attribute name="text-align">left</xsl:attribute>
-</xsl:attribute-set>
 
 <xsl:attribute-set name="monospace.verbatim.properties"
                    use-attribute-sets="verbatim.properties monospace.properties">
   <xsl:attribute name="wrap-option">wrap</xsl:attribute>
   <xsl:attribute name="font-size">90%</xsl:attribute>
-</xsl:attribute-set>
-
-<xsl:attribute-set name="lit.shading.style">
-  <xsl:attribute name="background-color">#eef8e8</xsl:attribute>
-</xsl:attribute-set>
-
-<xsl:attribute-set name="nongraphical.admonition.properties">
-  <xsl:attribute name="border-style">solid</xsl:attribute>
-  <xsl:attribute name="border-width">1pt</xsl:attribute>
-  <xsl:attribute name="border-color">black</xsl:attribute>
-  <xsl:attribute name="padding-start">12pt</xsl:attribute>
-  <xsl:attribute name="padding-end">12pt</xsl:attribute>
-  <xsl:attribute name="padding-top">6pt</xsl:attribute>
-  <xsl:attribute name="padding-bottom">6pt</xsl:attribute>
-</xsl:attribute-set>
-
-<xsl:attribute-set name="admonition.title.properties">
-  <xsl:attribute name="text-align">center</xsl:attribute>
-</xsl:attribute-set>
-
-<!-- Change display of some elements -->
-
-<xsl:param name="l10n.gentext.default.language">ja</xsl:param>
-<xsl:param name="body.start.indent">0</xsl:param>
-<xsl:param name="line-height">150%</xsl:param>
-
-<xsl:param name="title.font.family" select="'YuGothic,Meiryo,MS-PGothic,Hiragino Kaku Gothic ProN,Gen Shin Gothic P,TakaoPGothic'"/>
-<xsl:param name="body.font.family" select="'YuMincho,Meiryo,MS-PMincho,Hiragino Mincho ProN,Serif,Gen Shin Gothic P,TakaoPMincho'"/>
-<xsl:param name="monospace.font.family" select="'Osaka-mono,MS-Gothic,Gen Shin Gothic Monospace,TakaoGothic'"/>
-<xsl:param name="symbol.font.family" select="'Osaka-mono,MS-Gothic,Gen Shin Gothic P,TakaoPGothic'"/>
-<xsl:param name="dingbat.font.family" select="'YuGothic,Meiryo,MS-PGothic,Hiragino Kaku Gothic ProN,Gen Shin Gothic P,TakaoPGothic'"/>
-
-<xsl:attribute-set name="table.properties" use-attribute-sets="normal.para.spacing">
-  <xsl:attribute name="font-size">80%</xsl:attribute>
-  <xsl:attribute name="wrap-option">wrap</xsl:attribute>
-  <xsl:attribute name="text-align">left</xsl:attribute>
-  <xsl:attribute name="white-space-treatment">ignore</xsl:attribute>
-</xsl:attribute-set>
-
-<xsl:template name="table.row.properties">
-  <xsl:if test="ancestor::thead">
-    <xsl:attribute name="font-size">100%</xsl:attribute>
-    <xsl:attribute name="background-color">#EFEFEF</xsl:attribute>
-  </xsl:if>
-</xsl:template>
-
-<xsl:param name="shade.verbatim">1</xsl:param>
-<xsl:attribute-set name="shade.verbatim.style">
-  <xsl:attribute name="border">1pt solid black</xsl:attribute>
-  <xsl:attribute name="margin-left">0</xsl:attribute>
-  <xsl:attribute name="margin-right">0</xsl:attribute>
-  <xsl:attribute name="padding">5pt</xsl:attribute>
-  <xsl:attribute name="background-color">#EFEFEF</xsl:attribute>
-</xsl:attribute-set>
-
-<xsl:attribute-set name="xref.properties">
-  <xsl:attribute name="color">blue</xsl:attribute>
-</xsl:attribute-set>
-<xsl:attribute-set name="simple.xlink.properties">
-  <xsl:attribute name="color">blue</xsl:attribute>
-</xsl:attribute-set>
-
-<xsl:attribute-set name="index.entry.properties">
-  <xsl:attribute name="background-color">#EFEFEF</xsl:attribute>
 </xsl:attribute-set>
 
 <xsl:attribute-set name="nongraphical.admonition.properties">
@@ -217,26 +95,115 @@
   </fo:bookmark>
 </xsl:template>
 
+<!-- Setting for jpug-doc -->
+<xsl:param name="l10n.gentext.default.language">ja</xsl:param>
+<xsl:param name="alignment">left</xsl:param>
+<xsl:param name="body.start.indent">0</xsl:param>
+<xsl:param name="line-height">150%</xsl:param>
+<xsl:param name="hyphenate">false</xsl:param>
+
+<xsl:param name="title.font.family" select="'YuGothic,Meiryo,MS-PGothic,Hiragino Kaku Gothic ProN,Gen Shin Gothic P,TakaoPGothic'"/>
+<xsl:param name="body.font.family" select="'YuMincho,Meiryo,MS-PMincho,Hiragino Mincho ProN,Serif,Gen Shin Gothic P,TakaoPMincho'"/>
+<xsl:param name="monospace.font.family" select="'Osaka-mono,MS-Gothic,Gen Shin Gothic Monospace,TakaoGothic'"/>
+<xsl:param name="symbol.font.family" select="'Osaka-mono,MS-Gothic,Gen Shin Gothic P,TakaoPGothic'"/>
+<xsl:param name="dingbat.font.family" select="'YuGothic,Meiryo,MS-PGothic,Hiragino Kaku Gothic ProN,Gen Shin Gothic P,TakaoPGothic'"/>
+
+<!-- crop margin -->
+<!--
+<xsl:param name="page.margin.top">0.1in</xsl:param>
+<xsl:param name="page.margin.bottom">0.1in</xsl:param>
+<xsl:param name="page.margin.inner">0.1in</xsl:param>
+<xsl:param name="page.margin.outer">0.1in</xsl:param>
+-->
+
+<!-- <xsl:param name="title.color">#EC5800</xsl:param> -->
+<xsl:param name="title.color">black</xsl:param>
+<xsl:attribute-set name="component.title.properties">
+  <xsl:attribute name="line-height">30pt</xsl:attribute>
+  <xsl:attribute name="color"><xsl:value-of select="$title.color"/></xsl:attribute>
+  <xsl:attribute name="space-before.minimum">1.5em</xsl:attribute>
+  <xsl:attribute name="space-before.optimum">1.5em</xsl:attribute>
+  <xsl:attribute name="space-before.maximum">3.0em</xsl:attribute>
+</xsl:attribute-set>
+
+<xsl:attribute-set name="section.title.properties">
+  <xsl:attribute name="line-height">30pt</xsl:attribute>
+  <xsl:attribute name="color"><xsl:value-of select="$title.color"/></xsl:attribute>
+  <xsl:attribute name="space-before.minimum">0.5em</xsl:attribute>
+  <xsl:attribute name="space-before.optimum">1.5em</xsl:attribute>
+  <xsl:attribute name="space-before.maximum">3.0em</xsl:attribute>
+</xsl:attribute-set>
+
+<xsl:attribute-set name="section.title.level1.properties">
+  <xsl:attribute name="space-before.minimum">1.0em</xsl:attribute>
+  <xsl:attribute name="space-before.optimum">1.2em</xsl:attribute>
+  <xsl:attribute name="space-before.maximum">1.4em</xsl:attribute>
+</xsl:attribute-set>
+
+<xsl:attribute-set name="part.titlepage.recto.style">
+  <xsl:attribute name="line-height">30pt</xsl:attribute>
+  <xsl:attribute name="color"><xsl:value-of select="$title.color"/></xsl:attribute>
+</xsl:attribute-set>
+
+<xsl:attribute-set name="reference.titlepage.recto.style">
+  <xsl:attribute name="line-height">30pt</xsl:attribute>
+  <xsl:attribute name="color"><xsl:value-of select="$title.color"/></xsl:attribute>
+  <xsl:attribute name="space-before.minimum">1.0em</xsl:attribute>
+  <xsl:attribute name="space-before.optimum">1.0em</xsl:attribute>
+  <xsl:attribute name="space-before.maximum">1.0em</xsl:attribute>
+</xsl:attribute-set>
+
+<xsl:attribute-set name="table.properties" use-attribute-sets="normal.para.spacing">
+  <xsl:attribute name="font-size">80%</xsl:attribute>
+</xsl:attribute-set>
+
+<xsl:template name="table.row.properties">
+  <xsl:if test="ancestor::thead">
+    <xsl:attribute name="font-size">100%</xsl:attribute>
+    <xsl:attribute name="background-color">#EFEFEF</xsl:attribute>
+  </xsl:if>
+</xsl:template>
+
+<xsl:param name="shade.verbatim">1</xsl:param>
+<xsl:attribute-set name="shade.verbatim.style">
+  <xsl:attribute name="border">1pt solid black</xsl:attribute>
+  <xsl:attribute name="margin-left">0</xsl:attribute>
+  <xsl:attribute name="margin-right">0</xsl:attribute>
+  <xsl:attribute name="padding">5pt</xsl:attribute>
+  <xsl:attribute name="background-color">#EFEFEF</xsl:attribute>
+</xsl:attribute-set>
+
+<xsl:attribute-set name="xref.properties">
+  <xsl:attribute name="color">blue</xsl:attribute>
+</xsl:attribute-set>
+<xsl:attribute-set name="simple.xlink.properties">
+  <xsl:attribute name="color">blue</xsl:attribute>
+</xsl:attribute-set>
+
+<xsl:attribute-set name="index.entry.properties">
+  <xsl:attribute name="background-color">#EFEFEF</xsl:attribute>
+</xsl:attribute-set>
+
 <xsl:template match="text()">
-<xsl:choose>
-  <xsl:when test="ancestor::table">
-    <xsl:call-template name="intersperse-with-zero-spaces">
-      <xsl:with-param name="str" select="translate(., '&#x2014;', '&#x2015;')"/>
-    </xsl:call-template>
-  </xsl:when>
-  <xsl:otherwise>
-    <xsl:value-of select="translate(., '&#x2014;', '&#x2015;')"/>
-  </xsl:otherwise>
-</xsl:choose>
+  <xsl:choose>
+    <xsl:when test="ancestor::table">
+      <xsl:call-template name="intersperse-with-zero-spaces">
+        <xsl:with-param name="str" select="."/>
+      </xsl:call-template>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:value-of select="."/>
+    </xsl:otherwise>
+  </xsl:choose>
 </xsl:template>
 
 <!-- Actual intercalation: recursive -->
 <xsl:template name="intersperse-with-zero-spaces">
   <xsl:param name="str"/>
   <xsl:variable name="spacechars">
-        &#x9;&#xA;
-        &#x2000;&#x2001;&#x2002;&#x2003;&#x2004;&#x2005;
-        &#x2006;&#x2007;&#x2008;&#x2009;&#x200A;&#x200B;
+    &#x9;&#xA;
+    &#x2000;&#x2001;&#x2002;&#x2003;&#x2004;&#x2005;
+    &#x2006;&#x2007;&#x2008;&#x2009;&#x200A;&#x200B;
   </xsl:variable>
   <xsl:if test="string-length($str) > 0">
     <xsl:variable name="c1"
@@ -253,6 +220,51 @@
       <xsl:with-param name="str" select="substring($str, 2)"/>
     </xsl:call-template>
   </xsl:if>
+</xsl:template>
+
+<!-- header settings -->
+<xsl:param name="header.column.widths">2 5 2</xsl:param>
+<xsl:template name="header.content">
+  <xsl:param name="position" select="''"/>
+  <xsl:choose>
+<!-- Book Title -->
+<!--
+    <xsl:when test="$position='left'">
+      <xsl:variable name="home" select="/*[1]"/>
+      <xsl:apply-templates select="$home" mode="object.title.markup"/>
+    </xsl:when>
+-->
+<!-- Chapter title -->
+   <xsl:when test="$position='center'">
+      <xsl:apply-templates select="." mode="object.title.markup"/>
+    </xsl:when>
+<!-- Logo image -->
+<!--
+    <xsl:when test="$position='right'">
+      <fo:external-graphic src="PgKameAoiSen.svg" display-align="before" scaling="uniform" content-height="8%" content-width="8%"/>
+      </xsl:when>
+-->
+  </xsl:choose>
+</xsl:template>
+
+<!-- footer settings -->
+<xsl:param name="footer.column.widths">5 1 5</xsl:param>
+<xsl:template name="footer.content">
+  <xsl:param name="position" select="''"/>
+  <xsl:choose>
+<!-- Book title -->
+<!--
+    <xsl:when test="$position='left'">
+      <xsl:attribute name="font-size">9pt</xsl:attribute>
+      <xsl:variable name="home" select="/*[1]"/>
+      <xsl:apply-templates select="$home" mode="object.title.markup"/>
+    </xsl:when>
+-->
+<!-- Page Number -->
+    <xsl:when test="$position='center'">
+      <fo:page-number/>
+    </xsl:when>
+  </xsl:choose>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/doc/src/sgml/stylesheet-fo.xsl
+++ b/doc/src/sgml/stylesheet-fo.xsl
@@ -192,7 +192,9 @@
       </xsl:call-template>
     </xsl:when>
     <xsl:otherwise>
-      <xsl:value-of select="."/>
+      <xsl:call-template name="ideographic-comma">
+        <xsl:with-param name="str" select="."/>
+      </xsl:call-template>
     </xsl:otherwise>
   </xsl:choose>
 </xsl:template>
@@ -220,6 +222,21 @@
       <xsl:with-param name="str" select="substring($str, 2)"/>
     </xsl:call-template>
   </xsl:if>
+</xsl:template>
+
+<xsl:template name="ideographic-comma">
+  <xsl:param name="str"/>
+  <xsl:choose>
+    <xsl:when test="contains($str, '&#x3001;')">
+      <xsl:value-of select="substring-before($str, '&#x3001;')" />&#x3001;&#x200B;
+      <xsl:call-template name="ideographic-comma">
+        <xsl:with-param name="str" select="substring-after($str, '&#x3001;')"/>
+      </xsl:call-template>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:value-of select="$str" />
+    </xsl:otherwise>
+  </xsl:choose>
 </xsl:template>
 
 <!-- header settings -->


### PR DESCRIPTION
REL_10_0との差分を後半に集約
ヘッダに章番号を表示
ヘッダ、フッタのカスタマイズ用にコメントを追加
ページマージン削除用設定をコメントとして残す
タイトル表示位置調整