### PR TITLE
update installation to 10.0

### DIFF
--- a/doc/src/sgml/installation.sgml
+++ b/doc/src/sgml/installation.sgml
@@ -275,8 +275,7 @@ su - postgres
       when using Python 3.
 -->
 <application>PL/Python</>サーバプログラム言語を構築するには、ヘッダファイルと<application>distutils</application>モジュールを含む<productname>Python</productname>のインストレーションが必要です。
-<productname>Python</productname>バージョン2.3が最低でも必要です。
-(<type>numeric</>型の関数引数を扱うためには、2.3.xのインストレーションが別途入手できる<filename>cdecimal</>モジュールを含んでいないといけません。それがなければ<application>PL/Python</>リグレッションテストに通らないことに注意してください。)
+<productname>Python</productname>バージョン2.4が最低でも必要です。
 バージョン3.1以降であれば<productname>Python 3</productname>もサポートされます。しかしPython 3を使用する場合は<![%standalone-include[the <application>PL/Python</>文書]]><![%standalone-ignore[<xref linkend="plpython-python23">]]>を参照してください。
      </para>
 
@@ -345,9 +344,13 @@ su - postgres
 
     <listitem>
      <para>
+<!--
       You need <productname>OpenSSL</>, if you want to support
       encrypted client connections. The minimum required version is
       0.9.8.
+-->
+暗号化されたクライアント接続をサポートする場合には<productname>OpenSSL</>が必要です。
+要求される最小のバージョンは0.9.8です。
      </para>
     </listitem>
 
@@ -358,7 +361,7 @@ su - postgres
       and/or <application>PAM</>, if you want to support authentication
       using those services.
 -->
-<application>Kerberos</>、<productname>OpenSSL</>、<productname>OpenLDAP</>、<application>PAM</>が、そのサービスを使用した認証や暗号化をサポートする場合には必要となります。
+<application>Kerberos</>、<productname>OpenLDAP</>、<application>PAM</>が、そのサービスを使用した認証をサポートする場合には必要です。
      </para>
     </listitem>
 
@@ -1069,14 +1072,20 @@ Windows環境がある場合は大文字の<literal>POSTGRES</literal>に設定�
        <term><option>--with-icu</option></term>
        <listitem>
         <para>
+<!--
          Build with support for
          the <productname>ICU</productname><indexterm><primary>ICU</></>
          library.  This requires the <productname>ICU4C</productname> package
          to be installed.  The minimum required version
          of <productname>ICU4C</productname> is currently 4.2.
+-->
+<productname>ICU</productname><indexterm><primary>ICU</></>ライブラリのサポートを有効にして構築します。
+これには<productname>ICU4C</productname>パッケージがインストールされていなければなりません。
+<productname>ICU4C</productname>の要求される最小のバージョンは現在4.2です。
         </para>
 
         <para>
+<!--
          By default,
          <productname>pkg-config</productname><indexterm><primary>pkg-config</></>
          will be used to find the required compilation options.  This is
@@ -1085,13 +1094,20 @@ Windows環境がある場合は大文字の<literal>POSTGRES</literal>に設定�
          not available, the variables <envar>ICU_CFLAGS</envar>
          and <envar>ICU_LIBS</envar> can be specified
          to <filename>configure</filename>, like in this example:
+-->
+デフォルトでは、<productname>pkg-config</productname><indexterm><primary>pkg-config</></>が必要なコンパイルオプションを見つけるのに使われます。
+これは<productname>ICU4C</productname>バージョン4.6またはそれ以降でサポートされています。
+より古いバージョンの場合や<productname>pkg-config</productname>が使えない場合には、以下の例のように、変数<envar>ICU_CFLAGS</envar>と<envar>ICU_LIBS</envar>を<filename>configure</filename>に指定できます。
 <programlisting>
 ./configure ... --with-icu ICU_CFLAGS='-I/some/where/include' ICU_LIBS='-L/some/where/lib -licui18n -licuuc -licudata'
 </programlisting>
+<!--
          (If <productname>ICU4C</productname> is in the default search path
          for the compiler, then you still need to specify a nonempty string in
          order to avoid use of <productname>pkg-config</productname>, for
          example, <literal>ICU_CFLAGS=' '</literal>.)
+-->
+(<productname>ICU4C</productname>がコンパイラのデフォルトの検索パスにあるのなら、<productname>pkg-config</productname>の使用を避けるため、例えば<literal>ICU_CFLAGS=' '</literal>のような空でない文字列を指定することも必要です。)
         </para>
        </listitem>
       </varlistentry>
@@ -1467,7 +1483,12 @@ float8値の<quote>値</>渡しを無効にし、<quote>参照</>渡しで渡す
          The value must be a power of 2 between 1 and 1024 (megabytes).
          Note that changing this value requires an initdb.
 -->
-メガバイト単位で<firstterm>WALセグメント容量</>を設定します。これはWALログ内のそれぞれ個別のファイルの容量です。この容量を調整することで、WALログ配送の粒度を制御するのに役立ちます。デフォルト容量は16メガバイトです。1から64（メガバイト）の範囲の２のべき乗でなければなりません。この値の変更はinitdbを必要とすることを覚えておいてください。
+メガバイト単位で<firstterm>WALセグメント容量</>を設定します。
+これはWALログ内のそれぞれ個別のファイルの容量です。
+この容量を調整することで、WALログ配送の粒度を制御するのに役立ちます。
+デフォルト容量は16メガバイトです。
+1から1024（メガバイト）の範囲の２のべき乗でなければなりません。
+この値の変更はinitdbを必要とすることを覚えておいてください。
         </para>
        </listitem>
       </varlistentry>
@@ -1519,17 +1540,23 @@ float8値の<quote>値</>渡しを無効にし、<quote>参照</>渡しで渡す
        <term><option>--disable-strong-random</option></term>
        <listitem>
         <para>
+<!--
          Allow the build to succeed even if <productname>PostgreSQL</>
          has no support for strong random numbers on the platform.
          A source of random numbers is needed for some authentication
          protocols, as well as some routines in the
          <![%standalone-include[pgcrypto]]>
          <![%standalone-ignore[<xref linkend="pgcrypto">]]>
-         module. <option>--disable-strong-random</option> disables functionality that
+         module. <option>&#045;-disable-strong-random</option> disables functionality that
          requires cryptographically strong random numbers, and substitutes
          a weak pseudo-random-number-generator for the generation of
          authentication salt values and query cancel keys. It may make
          authentication less secure.
+-->
+そのプラットフォーム上で<productname>PostgreSQL</>が強い乱数のサポートを受けられない場合でも、構築には成功するようにします。
+乱数源は、一部の認証プロトコルや<![%standalone-include[pgcrypto]]><![%standalone-ignore[<xref linkend="pgcrypto">]]>モジュール内の一部のルーチンで必要です。
+<option>--disable-strong-random</option>は暗号論的に強い乱数を必要とする機能を無効にして、認証のソルト値や問い合わせのキャンセル鍵の生成を弱い疑似乱数生成器で置き換えます。
+それにより認証はより安全ではなくなるでしょう。
         </para>
        </listitem>
       </varlistentry>
@@ -2077,7 +2104,6 @@ libxmlインストレーションの場所を特定するために使用する<c
 <screen>
 <userinput>make COPT='-Werror'</>
 </screen>
-     or
 <!--
      or
 -->
@@ -2128,14 +2154,6 @@ libxmlインストレーションの場所を特定するために使用する<c
 -->
 <envar>COPT</>と<envar>PROFILE</>の環境変数は、<productname>PostgreSQL</>のmakefileでは実際には全く同一に扱われます。
 どちらを使うかは好みの問題ですが、開発者の一般的な習慣では、一時的にフラグを調整するには<envar>PROFILE</>を使い、永続的に保持するものには<envar>COPT</>を使います。
-     </para>
-
-     <para>
-      The <envar>COPT</> and <envar>PROFILE</> environment variables are
-      actually handled identically by the <productname>PostgreSQL</>
-      makefiles.  Which to use is a matter of preference, but a common habit
-      among developers is to use <envar>PROFILE</> for one-time flag
-      adjustments, while <envar>COPT</> might be kept set all the time.
      </para>
     </note>
    </step>
@@ -2906,8 +2924,8 @@ kill `cat /usr/local/pgsql/data/postmaster.pid`
    <option>&#045;&#045;disable-spinlocks</option>, but performance will be poor.
 -->
 一般的に、<productname>PostgreSQL</>は、次のCPUアーキテクチャで動作することを期待できます。
-x86, x86_64, IA64, PowerPC, PowerPC 64, S/390, S/390x, Sparc, Sparc 64, ARM, MIPS, MIPSEL, M68K,PA-RISC。
-M32R、VAXをサポートするコードは存在しますが、これらのアーキテクチャで試験が行われたという報告は最近ありません。
+x86, x86_64, IA64, PowerPC, PowerPC 64, S/390, S/390x, Sparc, Sparc 64, ARM, MIPS, MIPSEL, PA-RISC。
+M68K、M32R、VAXをサポートするコードは存在しますが、これらのアーキテクチャで試験が行われたという報告は最近ありません。
 <option>--disable-spinlocks</option>を付けることで、未サポートの種類のCPUでも構築することがしばしばできますが、性能は低下します。
   </para>
 
@@ -2924,7 +2942,7 @@ M32R、VAXをサポートするコードは存在しますが、これらのア�
    specific to your operating system, particularly if using an older system.
 -->
 <productname>PostgreSQL</>は次のオペレーティングシステムで動作することを期待できます。
-Linux (最近のディストリビューションすべて), Windows (Win2000 SP4以降), FreeBSD, OpenBSD, NetBSD, OS X, AIX, HP/UX, Solaris, UnixWare。
+Linux (最近のディストリビューションすべて), Windows (Win2000 SP4以降), FreeBSD, OpenBSD, NetBSD, OS X, AIX, HP/UX, Solaris。
 他のUnixに似たシステムでも動作するかもしれませんが、最近試験されていません。
 ほとんどの場合、指定されたオペレーティングシステムでサポートされるCPUアーキテクチャはすべて動作するでしょう。
 特に古めのシステムを使用している場合、以下の<xref linkend="installation-platform-notes">を参照し、使用するオペレーティングシステム固有の情報がないか確認してください。
@@ -3140,7 +3158,6 @@ Unixドメインソケットを除くTCP/IP接続の動作は正常です。
 メンテナンスレベル5300-03以降に更新していれば、この修正が含まれています。
 すぐに解決させたければ、<filename>/usr/include/sys/socket.h</filename>内で<symbol>_SS_MAXSIZE</symbol>を1025に変更してください。
 どちらの場合でも、ヘッダファイルを修正した後でPostgreSQLを再コンパイルしてください。
-     
     </para>
    </sect3>
 
@@ -3272,7 +3289,7 @@ AIX6.1ではIPv6サポートがさらに改善されたため、この対策は�
 -->
 AIXはメモリ管理手法の観点から見ると多少独特です。
 ギガバイト単位のRAMが空いているサーバがあっても、アプリケーションを実行している時にメモリ不足やアドレス空間エラーが発生することがあります。
-こうした例の1つが、見慣れないエラーによる<command>createlang</command>の失敗です。
+こうした例の1つが、見慣れないエラーによる拡張のロードの失敗です。
 例えば、PostgreSQLインストレーションの所有者として実行してみます。
 <screen>
 =# CREATE EXTENSION plperl;
@@ -3324,7 +3341,7 @@ ERROR:  could not load library "/opt/dbs/pgsql/lib/plperl.so": Bad address
      heap instead of the shared library segments where it would
      otherwise be placed.
 -->
-上記、<command>createlang</command>の例の場合において、PostgreSQLインストレーションにおけるバイナリのumaskとパーミッションをチェックしてください。
+上記、<literal>plperl</literal>の例の場合において、PostgreSQLインストレーションにおけるバイナリのumaskとパーミッションをチェックしてください。
 例に関与したバイナリは32-ビットであり、755ではなく750モードでインストールされました。
 このような形式で設定されたパーミッションのため、所有者もしくはグループ所有のメンバーのみライブラリを読み込めます。
 それは誰もが読み取り可能ではないため、ローダは、そうでない場合に配置される共有ライブラリセグメントにではなく、オブジェクトをプロセスのヒープに配置します。
@@ -3660,7 +3677,7 @@ PHSS_30966  s700_800 ld(1) and linker tools cumulative patch
     copies of their latest patches.
 -->
 一般原則として、HPのCコンパイラを使用する場合、libcとld/dldパッチとコンパイラパッチが最新版でなければなりません。
-それらの最新パッチの無償コピーについては、<ulink url="http://itrc.hp.com"></ulink>および<ulink url="ftp://us-ffs.external.hp.com/"></ulink>のHPサポートサイトを見てください。
+それらの最新パッチの無償コピーについては、<ulink url="ftp://us-ffs.external.hp.com/"></ulink>のHPサポートサイトを見てください。
    </para>
 
    <para>
@@ -3669,8 +3686,6 @@ PHSS_30966  s700_800 ld(1) and linker tools cumulative patch
     64-bit binaries using GCC, you must use a GCC 64-bit version.
 -->
 PA-RISC 2.0マシン上でGCCを使用して64-ビットバイナリを構築したい場合、GCC 64-ビット版を使用しなければなりません。
-HP-UX PA-RISCとItanium用のバイナリは<ulink url="http://www.hp.com/go/gcc"></ulink>から入手できます。
-同時にbinutilsも入手しインストールすることを忘れないでください。
    </para>
 
    <para>
@@ -3838,7 +3853,6 @@ MSYSコンソールはバッファリングに問題があるので、すべて�
     </para>
    </sect3>
   </sect2>
-
 
   <sect2 id="installation-notes-solaris">
    <title>Solaris</title>
@@ -4024,7 +4038,6 @@ SPARCで64ビットバイナリを使用する理由がないのであれば、3
      information.
 -->
 そのとおりです。DTraceを使うことができます。より詳細な情報は<![%standalone-include[文書]]><![%standalone-ignore[<xref linkend="dynamic-trace">]]>を参照してください。
-より多くの情報が<ulink url="https://blogs.oracle.com/robertlor/entry/user_level_dtrace_probes_in"></ulink>文書にあります。
     </para>
 
     <para>


### PR DESCRIPTION
installation.sgml の10.0対応です。

The ＜envar＞COPT</> and ＜envar＞PROFILE</>云々やorを削除していますが、マージのときに誤って多重に取り込まれたものを削除しただけです。あるべきものは残っているはずです。
