### PR TITLE
Add missing authors of an item in release note 9.6.

### DIFF
--- a/doc/src/sgml/release-9.6.sgml
+++ b/doc/src/sgml/release-9.6.sgml
@@ -8219,6 +8219,7 @@ XXX this is pending backpatch, may need to remove
         index's pending list concurrently (Teodor Sigaev, Jeff Janes)
 -->
 複数プロセスが<acronym>GIN</>インデックスのペンディングリストを同時にクリーンアップしようとするのを防ぎます。
+(Teodor Sigaev, Jeff Janes)
        </para>
 
        <para>


### PR DESCRIPTION
少し気になったので。古いリリースノートに対する修正なので、無視していただいても構いません。