### PR TITLE
fix exposed English sentences - 2

### DIFF
--- a/doc/src/sgml/ref/pg_ctl-ref.sgml
+++ b/doc/src/sgml/ref/pg_ctl-ref.sgml
@@ -902,6 +902,7 @@ Windowsのサービスとして実行する際に、イベントログへの出�
    </para>
 
    <para>
+<!--
     But if <option>-o</> is specified, that replaces any previous options.
     To restart using port 5433, disabling <function>fsync</> upon restart:
 -->


### PR DESCRIPTION
pg_ctl-ref.sgml で原文が見えてしまう（であろう）ところを見つけました。