### PR TITLE
CSSの10.0対応です。

### DIFF
--- a/doc/src/sgml/stylesheet.css
+++ b/doc/src/sgml/stylesheet.css
@@ -28,6 +28,10 @@ p i, pre i, .emphasis em {
 	font-weight: bold;
 	color: #440000;
 }
+not([href]) code {
+	font-weight: bold;
+	color: #440000;
+}
 
 .replaceable code {
 	font-style: italic;
@@ -72,6 +76,10 @@ h3 {
 	margin: 1.2em 0em 1.2em 0em;
 	font-weight: bold;
 	color: #EC5800;
+}
+
+.tip h3, .note h3, .caution h3, .warning h3 {
+        text-align: center;
 }
 
 h4 {
@@ -124,8 +132,11 @@ div.example {
 .important,
 .caution,
 .warning {
-	margin-left: 0.5in;
-	margin-right: 0.5in;
+	margin: 4ex auto;
+	margin-top: 4ex;
+	margin-right: auto;
+	margin-bottom: 4ex;
+	margin-left: auto;
 	border-color: #DBDBCC;
 	background-color: #EEEEDD;
 	padding: 14px;
@@ -149,81 +160,32 @@ pre.literallayout, .screen, .synopsis, .programlisting {
 
 /* shadow */
 
-PRE.LITERALLAYOUT, PRE.SCREEN, PRE.SYNOPSIS, PRE.PROGRAMLISTING, BLOCKQUOTE.NOTE, BLOCKQUOTE.TIP, table.CAUTION, table.CALSTABLE, table.WARNING, pre.literallayout, pre.screen, pre.synopsis, pre.programlisting, div.note, div.tip, table.caution, table.calstable, table.warning, div.blockquote, .informaltable table, .table-contents table {
+pre.literallayout, pre.screen, pre.synopsis, pre.programlisting, div.note, div.tip, table.caution, table.calstable, table.warning, div.blockquote, .informaltable table, .table-contents table {
 	box-shadow: 3px 3px 5px #DFDFDF;
 }
 
 /* Table Styles */
 
 .table-contents table,
-.informaltable table,
-table.CALSTABLE,
-table.CAUTION,
-table.WARNING {
+.informaltable table {
 	border-spacing: 0;
 	border-collapse: collapse;
 }
 
 .table-contents table,
-.informaltable table,
-table.CALSTABLE {
+.informaltable table {
 	margin: 2ex 0 2ex 2ex;
 	background-color: #E0ECEF;
 	border: 2px solid #A7C6DF;
 }
 
-table.CAUTION,
-table.WARNING {
-	border-collapse: separate;
-	display: block;
-	padding: 0;
-}
-
-table.CAUTION {
-	background-color: #F5F5DC;
-	border-color: #DEDFA7;
-}
-
-table.WARNING, div.warning {
+div.warning {
 	background-color: #FFD7D7;
 	border-color: #DF421E;
 }
 
-table.CALSTABLE td,
-table.CALSTABLE th,
-table.CAUTION td,
-table.CAUTION th,
-table.WARNING td,
-table.WARNING th {
-	border-style: solid;
-}
-
-table.CAUTION td,
-table.CAUTION th,
-table.WARNING td,
-table.WARNING th {
-	border-width: 0;
-	padding-left: 2ex;
-	padding-right: 2ex;
-}
-
-table.WARNING td {
-	padding-top: 7px;
-}
-
-.table-contents table td,
-table.CALSTABLE td {
+.table-contents table td {
 	background-color: #FFF;
-}
-
-table.CAUTION td,
-table.CAUTION th {
-	border-color: #f3e4d5;
-}
-
-table.WARNING td,
-table.WARNING th {
-	border-color: #ffd7d7;
 }
 
 .table-contents table, .table-contents td, .table-contents th{
@@ -246,8 +208,7 @@ table.CALSTABLE th {
 }
 
 .table-contents table tr:hover td,
-.informaltable table tr:hover td,
-table.CALSTABLE tr:hover td {
+.informaltable table tr:hover td tr:hover td {
 	background-color: #EFEFEF;
 }
 


### PR DESCRIPTION
HTML4版対応だった部分の削除
消えていた強調部分を再度対応
目次等リンクで強調部分が入っていたのを無効化