### PR TITLE
fix typos in 10.0

### DIFF
--- a/doc/src/sgml/release-9.6.sgml
+++ b/doc/src/sgml/release-9.6.sgml
@@ -5,7 +5,7 @@
 <!--
   <title>Release 9.6.5</title>
 -->
-  <title>リリース 9.6.5</title>
+  <title>リリース9.6.5</title>
 
   <formalpara>
 <!--
@@ -370,7 +370,7 @@ Branch: REL9_5_STABLE [a784d5f21] 2017-08-09 12:06:14 -0400
 <!--
   <title>Release 9.6.4</title>
 -->
-  <title>リリース 9.6.4</title>
+  <title>リリース9.6.4</title>
 
   <formalpara>
 <!--
@@ -2062,7 +2062,10 @@ MSVCビルドで、<filename>vcregress.pl</>のコマンドライン上の<liter
  </sect1>
 
  <sect1 id="release-9-6-3">
+<!--
   <title>Release 9.6.3</title>
+-->
+  <title>リリース9.6.3</title>
 
   <formalpara>
 <!--

--- a/doc/src/sgml/spi.sgml
+++ b/doc/src/sgml/spi.sgml
@@ -4809,7 +4809,7 @@ char * SPI_getrelname(Relation <parameter>rel</parameter>)
 <!--
   <refpurpose>return the namespace of the specified relation</refpurpose>
 -->
-  <refpurpose>指定されたリレーションの名前空間を返す。</refpurpose>
+  <refpurpose>指定されたリレーションの名前空間を返す</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>


### PR DESCRIPTION
pgsql-jp.github.ioの10.0を眺めていたら、いくつかおかしいところを見つけたので修正です。

