### PR TITLE
translate an untranslated sentence

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -9865,7 +9865,7 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
 積極的な走査は、無効タプルを含む可能性のあるページだけではなく、凍結されていないXIDあるいはMXIDを含むすべてのページを読む点で通常の<command>VACUUM</>とは異なります。
 デフォルトは1.5億トランザクションです。
 ユーザはこの値をゼロから20億までの任意の値に設定することができますが、<command>VACUUM</>は警告することなく、周回問題対策のautovacuumがテーブルに対して起動する前に定期的な手動<command>VACUUM</>が実行する機会を持つように、<xref linkend="guc-autovacuum-freeze-max-age">の95%に実効値を制限します。
-       <xref linkend="vacuum-for-wraparound">を参照してください。
+詳細は<xref linkend="vacuum-for-wraparound">を参照してください。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -9846,7 +9846,7 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         <command>VACUUM</> performs an aggressive scan if the table's
         <structname>pg_class</>.<structfield>relfrozenxid</> field has reached
         the age specified by this setting.  An aggressive scan differs from
@@ -9860,10 +9860,11 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
         anti-wraparound autovacuum is launched for the table. For more
         information see
         <xref linkend="vacuum-for-wraparound">.
-       -->
-       テーブルの<structname>pg_class</>.<structfield>relfrozenxid</>フィールドがこの設定で指定した時期に達すると、<command>VACUUM</>は積極的なテーブル走査を行います。
-       デフォルトは1.5億トランザクションです。
-       ユーザはこの値をゼロから20億までの任意の値に設定することができますが、<command>VACUUM</>は警告することなく、周回問題対策のautovacuumがテーブルに対して起動する前に定期的な手動<command>VACUUM</>が実行する機会を持つように、<xref linkend="guc-autovacuum-freeze-max-age">の95%に実効値を制限します。
+-->
+テーブルの<structname>pg_class</>.<structfield>relfrozenxid</>フィールドがこの設定で指定した時期に達すると、<command>VACUUM</>は積極的なテーブル走査を行います。
+積極的な走査は、無効タプルを含む可能性のあるページだけではなく、凍結されていないXIDあるいはMXIDを含むすべてのページを読む点で通常の<command>VACUUM</>とは異なります。
+デフォルトは1.5億トランザクションです。
+ユーザはこの値をゼロから20億までの任意の値に設定することができますが、<command>VACUUM</>は警告することなく、周回問題対策のautovacuumがテーブルに対して起動する前に定期的な手動<command>VACUUM</>が実行する機会を持つように、<xref linkend="guc-autovacuum-freeze-max-age">の95%に実効値を制限します。
        <xref linkend="vacuum-for-wraparound">を参照してください。
        </para>
       </listitem>


### PR DESCRIPTION
#1145 絡みでdead tupleをざっと見ていたら、訳が抜けているところを見つけました。
周辺の行頭の空白の削除も合わせてやっているので分かりにくくなっていますが、訳が漏れていたのは

> An aggressive scan differs from ...

で、対応する訳は

> 積極的な走査は、無効タプルを含む可能性のあるページだけではなく、 ...

です。