### PR TITLE
typeconv.sgml訳の改善提案です。

### DIFF
--- a/doc/src/sgml/typeconv.sgml
+++ b/doc/src/sgml/typeconv.sgml
@@ -1188,7 +1188,7 @@ are binary-compatible, meaning that one can be passed to a function that
 accepts the other without doing any physical conversion.  Therefore, no
 type conversion call is really inserted in this case.
 -->
-パーサは<structname>pg_cast</>カタログから<type>text</type>と<type>varchar</type>がバイナリ互換、つまり、何らかの物理的な変換を行うことなく片方を受け付ける関数にもう片方を渡すことができることを学習します。
+パーサは<structname>pg_cast</>カタログから<type>text</type>と<type>varchar</type>がバイナリ互換、つまり、何らかの物理的な変換を行うことなく片方を受け付ける関数にもう片方を渡すことができることを知ります。
 したがって、この場合実際に挿入される型変換呼び出しはありません。
 </para>
 </note>


### PR DESCRIPTION
"The parser learns from the pg_cast catalog that..."で"learn"を「パー
サはpg_castカタログから...を*学習*します」と訳していますが、単に「知る」
とした方がわかりやすいと思います。「学習」と直訳してしまうと、混乱して
しまいます。