### PR TITLE
fix typos in config

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -9927,8 +9927,8 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
         anti-wraparound is launched for the table.
         For more information see <xref linkend="vacuum-for-multixact-wraparound">.
 -->
-        <structname>pg_class</>.<structfield>relminmxid</>フィールドがこの設定値で指定した年代に達すると<command>VACUUM</>はテーブルの積極的なスキャンを行います。
-積極的なスキャンは、不要タプルを含む可能性のあるページだけではなく、凍結XIDあるいはMXIDを含むすべてのページを読む通常の<command>VACUUM</>とは異なります。
+<structname>pg_class</>.<structfield>relminmxid</>フィールドがこの設定値で指定した年代に達すると<command>VACUUM</>はテーブルの積極的なスキャンを行います。
+積極的なスキャンは、無効タプルを含む可能性のあるページだけではなく、凍結XIDあるいはMXIDを含むすべてのページを読む点で通常の<command>VACUUM</>とは異なります。
 デフォルトは1億5千万トランザクションです。
 ユーザは0から20億まで任意の値を設定できますが、テーブルに対してラップアラウンド防止処理が起動される前に定期的な手動<command>VACUUM</>が走ることができるように、<command>VACUUM</>は<xref linkend="guc-autovacuum-multixact-freeze-max-age">の95%に暗黙的に制限します。
 詳細は<xref linkend="vacuum-for-multixact-wraparound">をご覧ください。


### PR DESCRIPTION
#1172 の dead tuple 対策で漏れていたのを見つけました。あとinの意味を読み違えているように思います。
ついでに行頭の空白の削除もしています。