### PR TITLE
unify translation of 'interface'

### DIFF
--- a/doc/src/sgml/acronyms.sgml
+++ b/doc/src/sgml/acronyms.sgml
@@ -62,7 +62,7 @@
 <!--
       <link linkend="bki">Backend Interface</link>
 -->
-      <link linkend="bki">Backend Interface（バックエンドインターフェイス）</link>
+      <link linkend="bki">Backend Interface（バックエンドインタフェース）</link>
      </para>
     </listitem>
    </varlistentry>
@@ -186,7 +186,7 @@
 <!--
       <ulink url="http://dbi.perl.org/">Database Interface (Perl)</ulink>
 -->
-      <ulink url="http://dbi.perl.org/">Database Interface (Perl)（[Perlの]データベースインターフェイス）</ulink>
+      <ulink url="http://dbi.perl.org/">Database Interface (Perl)（[Perlの]データベースインタフェース）</ulink>
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/bgworker.sgml
+++ b/doc/src/sgml/bgworker.sgml
@@ -396,7 +396,7 @@ postmasterがバックグラウンドワーカを開始しようと試みたか�
    will log those notifications, but there is no programmatic way for the
    worker to intercept and respond to those notifications.
 -->
-バックグラウンドワーカは、サーバプログラミングインターフェイス(<acronym>SPI</acronym>)経由で<command>NOTIFY</command>コマンドにより非同期に通知を送る場合、囲んでいるトランザクションをコミットした後、通知を配信することができるように明示的に<function>ProcessCompletedNotifies</function>を呼ぶ必要があります。
+バックグラウンドワーカは、サーバプログラミングインタフェース(<acronym>SPI</acronym>)経由で<command>NOTIFY</command>コマンドにより非同期に通知を送る場合、囲んでいるトランザクションをコミットした後、通知を配信することができるように明示的に<function>ProcessCompletedNotifies</function>を呼ぶ必要があります。
 バックグラウンドワーカは、<acronym>SPI</acronym>を通じて<command>LISTEN</command>による非同期通知の受信を登録した場合、ワーカがこれらの通知をログに記録しますが、ワーカが傍受し、それらの通知に応答するためのプログラム的な方法はありません。
   </para>
 

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -939,7 +939,7 @@ include_dir 'conf.d'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
          Specifies the TCP/IP address(es) on which the server is
          to listen for connections from client applications.
          The value takes the form of a comma-separated list of host names
@@ -959,16 +959,16 @@ include_dir 'conf.d'
          can help prevent repeated malicious connection requests on
          insecure network interfaces.  This parameter can only be set
          at server start.
-        -->
-        クライアントアプリケーションからの接続をサーバが監視する TCP/IP アドレスを指定します。
-        この値は、ホスト名をコンマで区切ったリスト、そして/もしくは、数値によるIPアドレスです。
-        <literal>*</>という特別なエントリは利用可能な全てのIPインタフェースに対応します。
-        エントリ<literal>0.0.0.0</>は全てのIPv4アドレスの監視を、そしてエントリ<literal>::</>は全てのIPv6アドレスの監視を許容します。
-        リストが空の場合、サーバはいかなるIPインターフェイスも全く監視しないで、Unixドメインソケットのみを使用して接続が行われます。
-        デフォルトの値は<systemitem class="systemname">localhost</>で、ローカルなTCP/IP <quote>loopback</>接続のみ許可します。
-        クライアント認証 (<xref
-         linkend="client-authentication">)は誰がサーバにアクセス可能かをきめ細かく制御するのに対し、<varname>listen_addresses</varname>はどのインターフェイスが接続を試みるかを制御します。
-        これにより、安全でないネットワークインターフェイス上において繰り返して行われる悪意のある接続要求の防止に役立ちます。このパラメータはサーバ起動時のみ設定可能です。
+-->
+クライアントアプリケーションからの接続をサーバが監視する TCP/IP アドレスを指定します。
+この値は、ホスト名をコンマで区切ったリスト、そして/もしくは、数値によるIPアドレスです。
+<literal>*</>という特別なエントリは利用可能な全てのIPインタフェースに対応します。
+エントリ<literal>0.0.0.0</>は全てのIPv4アドレスの監視を、そしてエントリ<literal>::</>は全てのIPv6アドレスの監視を許容します。
+リストが空の場合、サーバはいかなるIPインタフェースも全く監視しないで、Unixドメインソケットのみを使用して接続が行われます。
+デフォルトの値は<systemitem class="systemname">localhost</>で、ローカルなTCP/IP <quote>loopback</>接続のみ許可します。
+クライアント認証 (<xref linkend="client-authentication">)は誰がサーバにアクセス可能かをきめ細かく制御するのに対し、<varname>listen_addresses</varname>はどのインタフェースが接続を試みるかを制御します。
+これにより、安全でないネットワークインタフェース上において繰り返して行われる悪意のある接続要求の防止に役立ちます。
+このパラメータはサーバ起動時のみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -11539,7 +11539,7 @@ onの場合、演算子の優先順位の変更の結果、<productname>PostgreS
        </para>
 
        <para>
-       <!--
+<!--
         However, filtered forms in <productname>Microsoft
         Access</productname> generate queries that appear to use
         <literal><replaceable>expr</> = NULL</literal> to test for
@@ -11551,8 +11551,8 @@ onの場合、演算子の優先順位の変更の結果、<productname>PostgreS
         this option does little harm in practice.  But new users are
         frequently confused about the semantics of expressions
         involving null values, so this option is off by default.
-       -->
-       しかし、<productname>Microsoft Access</productname>のフィルタ形式はNULL値を検査するために<literal><replaceable>expr</> = NULL</literal>を使用する問い合わせを生成しますので、そのインタフェースを使用してデータベースにアクセスする場合は、このオプションを有効にする方が良いでしょう。
+-->
+しかし、<productname>Microsoft Access</productname>のフィルタ形式はNULL値を検査するために<literal><replaceable>expr</> = NULL</literal>を使用する問い合わせを生成しますので、そのインタフェースを使用してデータベースにアクセスする場合は、このオプションを有効にする方が良いでしょう。
 <literal><replaceable>expr</> = NULL</literal>という形の式は（SQL標準解釈を使用した結果）常にNULL値を返しますので、通常のアプリケーションでは意味がほとんどなく、滅多に使用されません。
 ですので、このオプションは実際は害はありません。
 しかし、慣れていないユーザはしばしばNULL値に関する式の意味に戸惑いますので、デフォルトでこのオプションはoffです。

--- a/doc/src/sgml/release-9.6.sgml
+++ b/doc/src/sgml/release-9.6.sgml
@@ -10907,7 +10907,7 @@ PL/Pythonでのセッション有効期間のメモリリークを修正しま�
 <!--
     <title>Client Interfaces</title>
 -->
-    <title>クライアントインターフェイス</title>
+    <title>クライアントインタフェース</title>
 
     <itemizedlist>
 
@@ -12122,7 +12122,7 @@ This commit is also listed under libpq and PL/pgSQL
         Add a generic interface for writing <acronym>WAL</acronym> records
         (Alexander Korotkov, Petr Jel&iacute;nek, Markus Nullmeier)
 -->
-<acronym>WAL</acronym>レコード書き込みの一般インターフェイスを追加しました。
+<acronym>WAL</acronym>レコード書き込みの一般インタフェースを追加しました。
 (Alexander Korotkov, Petr Jel&iacute;nek, Markus Nullmeier)
        </para>
 

--- a/doc/src/sgml/release-old.sgml
+++ b/doc/src/sgml/release-old.sgml
@@ -2914,7 +2914,7 @@ PostgreSQL 7.3 にロードされた、7.3 よりも前のデータベースは�
 <!--
    <title>Miscellaneous Interfaces</title>
 -->
-   <title>種々のインターフェイス</title>
+   <title>種々のインタフェース</title>
 <itemizedlist>
 <listitem><para>Fixed ECPG bug concerning octal numbers in single quotes (Michael)</para></listitem>
 <listitem><para>Move src/interfaces/libpgeasy to http://gborg.postgresql.org (Marc, Bruce)</para></listitem>

--- a/doc/src/sgml/sepgsql.sgml
+++ b/doc/src/sgml/sepgsql.sgml
@@ -595,11 +595,8 @@ UPDATE t1 SET x = 2, y = md5sum(y) WHERE z = 100;
     <literal>db_procedure:{entrypoint}</> permission to check whether it
     can perform as entry point of trusted procedure.
 -->
-利用者がクエリの一部として、あるいは近道インターフェースを用いた呼び出しによって
-関数を実行しようとするとき、<literal>db_procedure:{execute}</>権限がチェックされ
-ます。
-関数がトラステッドプロシージャである場合、関数がトラステッドプロシージャのエントリー
-ポイントとして振る舞う事ができるかどうかを検査するために<literal>db_procedure:{entrypoint}</>権限がチェックされます。
+利用者がクエリの一部として、あるいは近道インタフェースを用いた呼び出しによって関数を実行しようとするとき、<literal>db_procedure:{execute}</>権限がチェックされます。
+関数がトラステッドプロシージャである場合、関数がトラステッドプロシージャのエントリーポイントとして振る舞う事ができるかどうかを検査するために<literal>db_procedure:{entrypoint}</>権限がチェックされます。
    </para>
 
    <para>


### PR DESCRIPTION
#953 で提案されていたinterfaceの訳語の統一です。

それなりに自信のあるところだけしかやってませんので、全部ではありません。