### PR TITLE
update pg_ctl-ref for 10.3

### DIFF
--- a/doc/src/sgml/ref/pg_ctl-ref.sgml
+++ b/doc/src/sgml/ref/pg_ctl-ref.sgml
@@ -14,7 +14,7 @@ PostgreSQL documentation
 <!--
   <refmiscinfo>Application</refmiscinfo>
 -->
-<refmiscinfo>アプリケーション</refmiscinfo>
+  <refmiscinfo>アプリケーション</refmiscinfo>
  </refmeta>
 
  <refnamediv>
@@ -22,7 +22,7 @@ PostgreSQL documentation
 <!--
   <refpurpose>initialize, start, stop, or control a <productname>PostgreSQL</productname> server</refpurpose>
 -->
-<refpurpose><productname>PostgreSQL</productname>サーバを初期化、起動、停止、制御する</refpurpose>
+  <refpurpose><productname>PostgreSQL</productname>サーバを初期化、起動、停止、制御する</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -147,7 +147,7 @@ PostgreSQL documentation
 <!--
   <title>Description</title>
 -->
-<title>説明</title>
+  <title>説明</title>
   <para>
 <!--
    <application>pg_ctl</application> is a utility for initializing a
@@ -273,8 +273,8 @@ Windowsではデフォルトで、サーバの標準出力と標準エラーは�
 -->
 <option>status</option>モードは指定したデータディレクトリでサーバが稼働しているかどうかを確認します。
 稼働している場合はサーバの<acronym>PID</acronym>と、サーバを起動する時に使われたコマンドラインオプションを表示します。
-サーバが稼働していない場合、<application>pg_ctl</application>は終了ステータス３を返します。
-アクセス可能なデータディレクトリが指定されていない場合、<application>pg_ctl</application>は終了ステータス４を返します。
+サーバが稼働していない場合、<application>pg_ctl</application>は終了ステータス3を返します。
+アクセス可能なデータディレクトリが指定されていない場合、<application>pg_ctl</application>は終了ステータス4を返します。
   </para>
 
   <para>
@@ -325,7 +325,7 @@ Windowsではデフォルトで、サーバの標準出力と標準エラーは�
 <!--
   <title>Options</title>
 -->
-<title>オプション</title>
+  <title>オプション</title>
 
     <variablelist>
 
@@ -545,8 +545,9 @@ Windowsではデフォルトで、サーバの標準出力と標準エラーは�
         <command>pg_ctl</command> returns an exit code based on the
         success of the startup or shutdown.
 -->
-起動処理を待機している場合、<command>pg_ctl</command>は繰り返しサーバへの接続を試行します。
-停止処理を待機している場合、<command>pg_ctl</command>はサーバが<acronym>PID</acronym>ファイルを削除するまで待機します。
+待機している場合、<command>pg_ctl</command>は繰り返しサーバの<acronym>PID</acronym>ファイルを確認し、確認と確認の間は少しの時間スリープします。
+起動は、サーバが接続を受け付ける準備ができたことを<acronym>PID</acronym>ファイルが示した時に、完了したとみなされます。
+停止は、サーバが<acronym>PID</acronym>ファイルを削除した時に、完了したとみなされます。
 <command>pg_ctl</command>は、起動もしくは停止が成功したかどうかに基づいて終了コードを返します。
        </para>
 
@@ -624,7 +625,7 @@ PostgreSQLの以前のリリースでは、<literal>stop</literal>モードを�
 <!--
    <title>Options for Windows</title>
 -->
-  <title>Windows用オプション</title>
+   <title>Windows用オプション</title>
 
    <variablelist>
     <varlistentry>
@@ -719,7 +720,7 @@ Windowsのサービスとして実行する際に、イベントログへの出�
 <!--
   <title>Environment</title>
 -->
-<title>環境</title>
+  <title>環境</title>
 
   <variablelist>
    <varlistentry>
@@ -785,7 +786,7 @@ Windowsのサービスとして実行する際に、イベントログへの出�
 <!--
   <title>Files</title>
 -->
-<title>ファイル</title>
+  <title>ファイル</title>
 
   <variablelist>
    <varlistentry>
@@ -829,13 +830,13 @@ Windowsのサービスとして実行する際に、イベントログへの出�
 <!--
   <title>Examples</title>
 -->
-<title>例</title>
+  <title>例</title>
 
   <refsect2 id="R2-APP-PGCTL-3">
 <!--
    <title>Starting the Server</title>
 -->
-<title>サーバの起動</title>
+   <title>サーバの起動</title>
 
    <para>
 <!--
@@ -947,7 +948,7 @@ pg_ctl: server is running (PID: 13718)
 <!--
   <title>See Also</title>
 -->
-<title>関連項目</title>
+  <title>関連項目</title>
 
   <simplelist type="inline">
    <member><xref linkend="app-initdb"></member>


### PR DESCRIPTION
pg_ctl-ref.sgml の 10.3 対応です。

厳密には10.3 対応は以下の部分だけで、それ以外はおまけです。
ー起動処理を待機している場合、
＋待機している場合