### PR TITLE
fix see and seealso

### DIFF
--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -5490,7 +5490,7 @@ IPv6ではアドレス長は128ビットですので、128ビットが一意な�
 <!--
      <primary>macaddr (data type)</primary>
 -->
-     <primary>macaddr（データ型）</primary>
+     <primary>macaddr (データ型)</primary>
     </indexterm>
 
     <indexterm>
@@ -5572,7 +5572,7 @@ PostgreSQLではビット反転に関する準備をしていません。
 <!--
      <primary>MAC address (EUI-64 format)</primary>
 -->
-     <primary>MAC アドレス (EUI-64 形式)</primary>
+     <primary>MACアドレス (EUI-64 形式)</primary>
      <see>macaddr</see>
     </indexterm>
 

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -79,7 +79,7 @@
 -->
     <primary>論理値</primary>
     <secondary>演算子</secondary>
-    <see>演算子、論理</see>
+    <see>演算子, 論理</see>
    </indexterm>
 
    <para>
@@ -2009,7 +2009,7 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
 -->
          <primary>長さ</primary>
          <secondary sortas="character string">文字列の</secondary>
-         <see>文字列、長さ</see>
+         <see>文字列, 長さ</see>
         </indexterm>
        </entry>
        <entry><literal>char_length('jose')</literal></entry>
@@ -4634,7 +4634,7 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
 -->
         <primary>長さ</primary>
         <secondary sortas="binary string">バイナリ文字列の</secondary>
-        <see>バイナリ文字列、長さ</see>
+        <see>バイナリ文字列, 長さ</see>
        </indexterm>
       </entry>
       <entry><literal>length(E'jo\\000se'::bytea)</literal></entry>

--- a/doc/src/sgml/func1.sgml
+++ b/doc/src/sgml/func1.sgml
@@ -31,7 +31,7 @@
 -->
     <primary>論理値</primary>
     <secondary>演算子</secondary>
-    <see>演算子、論理</see>
+    <see>演算子, 論理</see>
    </indexterm>
 
    <para>
@@ -1961,7 +1961,7 @@ NULL値が入力されると、<quote>不明</>という論理値として扱わ
 -->
          <primary>長さ</primary>
          <secondary sortas="character string">文字列の</secondary>
-         <see>文字列、長さ</see>
+         <see>文字列, 長さ</see>
         </indexterm>
        </entry>
        <entry><literal>char_length('jose')</literal></entry>
@@ -4586,7 +4586,7 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
 -->
         <primary>長さ</primary>
         <secondary sortas="binary string">バイナリ文字列の</secondary>
-        <see>バイナリ文字列、長さ</see>
+        <see>バイナリ文字列, 長さ</see>
        </indexterm>
       </entry>
       <entry><literal>length(E'jo\\000se'::bytea)</literal></entry>

--- a/doc/src/sgml/ref/create_trigger.sgml
+++ b/doc/src/sgml/ref/create_trigger.sgml
@@ -14,7 +14,7 @@ PostgreSQL documentation
   <seealso>ephemeral named relation</seealso>
 -->
   <primary>遷移テーブル</primary>
-  <seealso>一時的な名前がついたリレーション</seealso>
+  <seealso>短命の名前付きリレーション</seealso>
  </indexterm>
 
  <refmeta>


### PR DESCRIPTION
索引の参照がリンクになっていない所を見つけました。
たとえば
> 論理値
>    演算子 (参照 演算子、論理)

です。原因となっていると思われる所を修正してみました。
（が、それで直っているかどうかは未確認です。）