### PR TITLE
fix typos in config

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -1566,7 +1566,7 @@ SSLサーバ証明書失効リスト（CRL）が入っているファイル名�
         In previous releases of PostgreSQL, the name of this file was
         hard-coded as <filename>root.crl</filename>.
 -->
-（以前のPostgreSQLリリースでは、このファイルは <filename>root.crt</filename> としてハードコードされていました。）
+（以前のPostgreSQLリリースでは、このファイルは <filename>root.crl</filename> としてハードコードされていました。）
        </para>
       </listitem>
      </varlistentry>
@@ -3466,7 +3466,7 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
         file system, or rebooting the server.
 -->
 <varname>fsync</varname>を無効(off)から有効(on）に変更したときの信頼できるリカバリのためには、カーネル内の全ての変更されたバッファを恒久的ストレージに強制的に吐き出させることが必要です。
-これは、クラスタがシャットダウンしている間、または<varname>fsync</varname>が有効のときに、<command>initdb --sync-only</command>を実行する、<command>sync</>を実行する、ファイルシステムをにアンマウントする、またはサーバを再起動することによって可能となります。
+これは、クラスタがシャットダウンしている間、または<varname>fsync</varname>が有効のときに、<command>initdb --sync-only</command>を実行する、<command>sync</>を実行する、ファイルシステムをアンマウントする、またはサーバを再起動することによって可能となります。
        </para>
 
        <para>


### PR DESCRIPTION
config.sgml に誤記を見つけました。
