### PR TITLE
ref/create_table.sgmlの10.4対応

### DIFF
--- a/doc/src/sgml/ref/create_table.sgml
+++ b/doc/src/sgml/ref/create_table.sgml
@@ -783,8 +783,11 @@ Bツリー演算子クラスがない場合はエラーが報告されます。
 列制約とテーブル制約は区別されません。
      </para>
      <para>
+<!--
       Extended statistics are copied to the new table if
       <literal>INCLUDING STATISTICS</literal> is specified.
+-->
+<literal>INCLUDING STATISTICS</literal>を指定している場合、拡張統計情報は新しいテーブルにコピーされます。
      </para>
      <para>
 <!--
@@ -825,9 +828,10 @@ Bツリー演算子クラスがない場合はエラーが報告されます。
      </para>
      <para>
 <!--
+      <literal>INCLUDING ALL</literal> is an abbreviated form of
       <literal>INCLUDING COMMENTS INCLUDING CONSTRAINTS INCLUDING DEFAULTS INCLUDING IDENTITY INCLUDING INDEXES INCLUDING STATISTICS INCLUDING STORAGE</literal>.
 -->
-<literal>INCLUDING ALL</literal>は<literal>INCLUDING DEFAULTS INCLUDING IDENTITY INCLUDING CONSTRAINTS INCLUDING INDEXES INCLUDING STORAGE INCLUDING COMMENTS</literal>の省略形です。
+<literal>INCLUDING ALL</literal>は<literal>INCLUDING COMMENTS INCLUDING CONSTRAINTS INCLUDING DEFAULTS INCLUDING IDENTITY INCLUDING INDEXES INCLUDING STATISTICS INCLUDING STORAGE</literal>の省略形です。
      </para>
      <para>
 <!--


### PR DESCRIPTION
831行目の
```
      <literal>INCLUDING ALL</literal> is an abbreviated form of
```
が消えていたので復活させています。