### PR TITLE
update 9.1 relnote for 10.4

### DIFF
--- a/doc/src/sgml/release-9.1.sgml
+++ b/doc/src/sgml/release-9.1.sgml
@@ -14604,7 +14604,7 @@ Unixソケット接続をサポートしないプラットフォームにおい�
         which displays activity of <acronym>WAL</> sender processes (Itagaki
         Takahiro, Simon Riggs)
 -->
-<acronym>WAL</>送信プロセスの活動を表示する<link linkend="monitoring-stats-views-table"><structname>pg_stat_replication</></link>システムビューを追加しました。(Itagaki Takahiro、Simon Riggs)
+<acronym>WAL</>送信プロセスの活動を表示する<link linkend="pg-stat-replication-view"><structname>pg_stat_replication</></link>システムビューを追加しました。(Itagaki Takahiro、Simon Riggs)
        </para>
 
        <para>


### PR DESCRIPTION
release-9.1.sgmlの10.4対応です。

他のrelease-9.?.sgmlとは異質なようですので、これだけ単独で出します。