### PR TITLE
update relnote 9.3-9.6 for 10.4

### DIFF
--- a/doc/src/sgml/release-9.3.sgml
+++ b/doc/src/sgml/release-9.3.sgml
@@ -2,50 +2,80 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-3-23">
+<!--
   <title>Release 9.3.23</title>
+-->
+  <title>リリース9.3.23</title>
 
   <formalpara>
+<!--
   <title>Release date:</title>
+-->
+  <title>リリース日:</title>
   <para>2018-05-10</para>
   </formalpara>
 
   <para>
+<!--
    This release contains a variety of fixes from 9.3.22.
    For information about new features in the 9.3 major release, see
    <xref linkend="release-9-3">.
+-->
+このリリースは9.3.22に対し、各種不具合を修正したものです。
+9.3メジャーリリースにおける新機能については、<xref linkend="release-9-3">を参照してください。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.3.23</title>
+-->
+   <title>バージョン9.3.23への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.3.X.
+-->
+9.3.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if the function marking mistakes mentioned in the first
     changelog entry below affect you, you will want to take steps to
     correct your database catalogs.
+-->
+しかしながら、1番目の変更履歴項目で言及されている誤った印付けの関数の影響があるなら、データベースカタログを補正する手順を行うのが望ましいです。
    </para>
 
    <para>
+<!--
     Also, if you are upgrading from a version earlier than 9.3.22,
     see <xref linkend="release-9-3-22">.
+-->
+また、9.3.22より前のバージョンからアップグレードする場合には<xref linkend="release-9-3-22">を参照してください。
    </para>
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Fix incorrect volatility markings on a few built-in functions
       (Thomas Munro, Tom Lane)
+-->
+いくつかの組み込み関数での誤った変動性区分を修正しました。
+(Thomas Munro, Tom Lane)
      </para>
 
      <para>
+<!--
       The functions
       <function>query_to_xml</function>,
       <function>cursor_to_xml</function>,
@@ -65,16 +95,29 @@
       done in each database of the installation.)  Another option is
       to <application>pg_upgrade</application> the database to a version
       containing the corrected initial data.
+-->
+関数<function>query_to_xml</function>、<function>cursor_to_xml</function>、<function>cursor_to_xmlschema</function>、<function>query_to_xmlschema</function>、および<function>query_to_xml_and_xmlschema</function>は、ユーザから供給される不安定な操作を含むかもしれない問い合わせを実行するため、揮発性(volatile)と印付けすべきです。
+これらはそうなっておらず、誤った問い合わせ最適化が行われる危険をもたらしました。
+これは新たなインストレーションでは補正された初期カタログデータにより修正されますが、既存のインストレーションは誤った印付けを含んだ状態のままとなります。
+これら関数の実際の使用ではほとんど害は生じないと見られますが、用心のため、手動でこれら関数の<structname>pg_proc</structname>エントリを更新することで修正できます。
+例えば<literal>ALTER FUNCTION pg_catalog.query_to_xml(text, boolean, boolean, text) VOLATILE</literal>と実行します。
+（インストレーションの各データベース上で行う必要があることに注意してください。）
+他の選択肢はそのデータベースを正しい初期データを持つバージョンに<application>pg_upgrade</application>することです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid re-using TOAST value OIDs that match dead-but-not-yet-vacuumed
       TOAST entries (Pavan Deolasee)
+-->
+無効になったものの未バキュームのTOASTエントリと一致するTOAST値のOIDの再使用を回避しました。
+(Pavan Deolasee)
      </para>
 
      <para>
+<!--
       Once the OID counter has wrapped around, it's possible to assign a
       TOAST value whose OID matches a previously deleted entry in the same
       TOAST table.  If that entry were not yet vacuumed away, this resulted
@@ -83,17 +126,27 @@
       persist until the dead entry was removed
       by <command>VACUUM</command>.  Fix by not selecting such OIDs when
       creating a new TOAST entry.
+-->
+一度OIDカウンタが周回すると、同じTOASTテーブルで以前に削除済みのエントリとOIDが一致するTOAST値を割り当てする可能性があります。
+そのエントリが未だバキュームされていないと、<quote>unexpected chunk number 0 (expected 1) for toast value <replaceable>nnnnn</replaceable>（TOAST値nnnnnに対する予期せぬチャンク番号0、(1が期待された)）</quote>というエラーをひき起こします。
+これは無効なエントリが<command>VACUUM</command>で除去されるまで持続します。
+新たなTOASTエントリを作るときにそのようなOIDを選択しないようにして修正しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Change <command>ANALYZE</command>'s algorithm for updating
       <structname>pg_class</structname>.<structfield>reltuples</structfield>
       (David Gould)
+-->
+<command>ANALYZE</command>の<structname>pg_class</structname>.<structfield>reltuples</structfield>を更新するアルゴリズムを変更しました。
+(David Gould)
      </para>
 
      <para>
+<!--
       Previously, pages not actually scanned by <command>ANALYZE</command>
       were assumed to retain their old tuple density.  In a large table
       where <command>ANALYZE</command> samples only a small fraction of the
@@ -107,193 +160,299 @@
       that <command>ANALYZE</command>'s sample is a statistically unbiased
       sample of the table (as it should be), and just extrapolate the
       density observed within those pages to the whole table.
+-->
+これまでは、<command>ANALYZE</command>で実際にはスキャンされないページは、以前のタプル密度を維持していると見做されました。
+<command>ANALYZE</command>のサンプル取得が全体のごく一部分となる大きなテーブルにおいては、これは全体のタプル密度見積が決して大きくは変更されないことを意味し、そのため、実際にテーブルに起きていることは無視されて、<structfield>reltuples</structfield>はテーブルの物理サイズ（<structfield>relpages</structfield>）の変化にほぼ比例して変化していました。
+これは、事実上自動バキュームを遮断するほどに<structfield>reltuples</structfield>が実際より大きくなる結果としてあらわれました。
+<command>ANALYZE</command>のサンプルがテーブルの統計的に偏りがないサンプルと見做し（そうであるべきなので）、観測されたページ内の密度を単にテーブル全体に外挿することで、修正しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <literal>UPDATE/DELETE ... WHERE CURRENT OF</literal> to not fail
       when the referenced cursor uses an index-only-scan plan (Yugo Nagata,
       Tom Lane)
+-->
+参照されるカーソルがインデックスオンリースキャンプランを使うときに<literal>UPDATE/DELETE ... WHERE CURRENT OF</literal>が失敗しないように修正しました。
+(Yugo Nagata, Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect planning of join clauses pushed into parameterized
       paths (Andrew Gierth, Tom Lane)
+-->
+パラメタライズドパスにプッシュされたJOIN句の誤ったプラン作成を修正しました。
+(Andrew Gierth, Tom Lane)
      </para>
 
      <para>
+<!--
       This error could result in misclassifying a condition as
       a <quote>join filter</quote> for an outer join when it should be a
       plain <quote>filter</quote> condition, leading to incorrect join
       output.
+-->
+この障害により、<quote>filter</quote>条件のプランであるべきときに、条件が外部結合に対する<quote>join filter</quote>であると誤った分別がされ、間違った結合結果をもたらす可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix misoptimization of <literal>CHECK</literal> constraints having
       provably-NULL subclauses of
       top-level <literal>AND</literal>/<literal>OR</literal> conditions
       (Tom Lane, Dean Rasheed)
+-->
+NULLであると証明可能なトップレベル<literal>AND</literal>/<literal>OR</literal>条件の副句を持つ、<literal>CHECK</literal>制約の誤った最適化が修正されました。
+(Tom Lane, Dean Rasheed)
      </para>
 
      <para>
+<!--
       This could, for example, allow constraint exclusion to exclude a
       child table that should not be excluded from a query.
+-->
+これにより、例えば、制約による除外が、問い合わせから除外すべきでない子テーブルを除外することを許してしまうおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid failure if a query-cancel or session-termination interrupt
       occurs while committing a prepared transaction (Stas Kelvich)
+-->
+準備されたトランザクションをコミットする間に、問い合わせキャンセルやセッション終了の割り込みが生じた場合の失敗を回避しました。
+(Stas Kelvich)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix query-lifespan memory leakage in repeatedly executed hash joins
       (Tom Lane)
+-->
+繰り返し実行されたハッシュ結合での問い合わせの間のメモリリークを修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix overly strict sanity check
       in <function>heap_prepare_freeze_tuple</function>
       (&Aacute;lvaro Herrera)
+-->
+<function>heap_prepare_freeze_tuple</function>の厳格すぎる整合性検査を修正しました。
+(&Aacute;lvaro Herrera)
      </para>
 
      <para>
+<!--
       This could result in incorrect <quote>cannot freeze committed
       xmax</quote> failures in databases that have
       been <application>pg_upgrade</application>'d from 9.2 or earlier.
+-->
+これは、9.2以前から<application>pg_upgrade</application>されたデータベースで間違った<quote>cannot freeze committed xmax</quote>エラーになる可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent dangling-pointer dereference when a C-coded before-update row
       trigger returns the <quote>old</quote> tuple (Rushabh Lathia)
+-->
+Cで書かれた更新前実行の行トリガが<quote>old</quote>タプルを返すときの、ダングリングポインタ参照を防止しました。
+(Rushabh Lathia)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Reduce locking during autovacuum worker scheduling (Jeff Janes)
+-->
+自動バキュームワーカのスケジューリング中のロックを減らしました。
+(Jeff Janes)
      </para>
 
      <para>
+<!--
       The previous behavior caused drastic loss of potential worker
       concurrency in databases with many tables.
+-->
+これまでの振る舞いは、多数のテーブルを持つデータベースで潜在的なワーカの同時実行性の大幅な損失をひき起こしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure client hostname is copied while copying
       <structname>pg_stat_activity</structname> data to local memory
       (Edmund Horner)
+-->
+<structname>pg_stat_activity</structname>のデータをローカルメモリにコピーするときに、確実にクライアントホスト名がコピーされるようにしました。
+(Edmund Horner)
      </para>
 
      <para>
+<!--
       Previously the supposedly-local snapshot contained a pointer into
       shared memory, allowing the client hostname column to change
       unexpectedly if any existing session disconnected.
+-->
+以前はローカルと見做されていたスナップショットが共有メモリへのポインタを含んでいて、何らかの存在するセッションが切断した場合に、クライアントホスト名の列が予期せず変化することがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect processing of multiple compound affixes
       in <literal>ispell</literal> dictionaries (Arthur Zakirov)
+-->
+<literal>ispell</literal>辞書で複合接辞の誤った処理を修正しました。
+(Arthur Zakirov)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix collation-aware searches (that is, indexscans using inequality
       operators) in SP-GiST indexes on text columns (Tom Lane)
+-->
+テキスト列のSP-GiSTインデックスでの照合を伴う検索（すなわち、不等演算子を使うインデックススキャン）を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Such searches would return the wrong set of rows in most non-C
       locales.
+-->
+このような検索は大部分の非Cロケールで誤った行集合を返しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Count the number of index tuples correctly during initial build of an
       SP-GiST index (Tomas Vondra)
+-->
+SP-GiSTインデックスの初期ビルドの際にインデックスのタプル数を正しく数えるようにしました。
+(Tomas Vondra)
      </para>
 
      <para>
+<!--
       Previously, the tuple count was reported to be the same as that of
       the underlying table, which is wrong if the index is partial.
+-->
+これまでは、タプル数は元となるテーブルと同じと報告されましたが、これは部分インデックスの場合には誤りです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Count the number of index tuples correctly during vacuuming of a
       GiST index (Andrey Borodin)
+-->
+GiSTインデックスのバキュームの際にインデックスタプルの数を正しく数えるようにしました。
+ (Andrey Borodin)
      </para>
 
      <para>
+<!--
       Previously it reported the estimated number of heap tuples,
       which might be inaccurate, and is certainly wrong if the
       index is partial.
+-->
+これまでは見積られたヒープタプルの数が報告されましたが、それは不正確かもしれず、部分インデックスでは確実に誤っています。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Allow <function>scalarltsel</function>
       and <function>scalargtsel</function> to be used on non-core datatypes
       (Tomas Vondra)
+-->
+<function>scalarltsel</function>と<function>scalargtsel</function>を非コアのデータ型で使用できるようにしました。
+(Tomas Vondra)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Reduce <application>libpq</application>'s memory consumption when a
       server error is reported after a large amount of query output has
       been collected (Tom Lane)
+-->
+大量の問い合わせ出力が収集された後にサーバエラーが報告されたときの<application>libpq</application>のメモリ消費を減らしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Discard the previous output before, not after, processing the error
       message.  On some platforms, notably Linux, this can make a
       difference in the application's subsequent memory footprint.
+-->
+以前の出力を後でなく先に廃棄して、エラーメッセージを処理します。
+一部のプラットフォーム、とりわけLinuxでは、これによりアプリケーションの以降のメモリフットプリントに違いを出すことができます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix double-free crashes in <application>ecpg</application>
       (Patrick Krecker, Jeevan Ladhe)
+-->
+<application>ecpg</application>で二重解放のクラッシュを修正しました。
+(Patrick Krecker, Jeevan Ladhe)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>ecpg</application> to handle <type>long long
       int</type> variables correctly in MSVC builds (Michael Meskes,
       Andrew Gierth)
+-->
+MSVCビルドで<type>long long int</type>変数を正しく扱うように<application>ecpg</application>を修正しました。
+(Michael Meskes, Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix mis-quoting of values for list-valued GUC variables in dumps
       (Michael Paquier, Tom Lane)
+-->
+ダンプでリスト値になったGUC変数に対する誤った値のクォート付けを修正しました。
+(Michael Paquier, Tom Lane)
      </para>
 
      <para>
+<!--
       The <varname>local_preload_libraries</varname>,
       <varname>session_preload_libraries</varname>,
       <varname>shared_preload_libraries</varname>,
@@ -302,66 +461,100 @@
       cause problems if settings for these variables appeared in
       <command>CREATE FUNCTION ... SET</command> or <command>ALTER
       DATABASE/ROLE ... SET</command> clauses.
+-->
+<varname>local_preload_libraries</varname>、<varname>session_preload_libraries</varname>、<varname>shared_preload_libraries</varname>、および<varname>temp_tablespaces</varname>変数は、<application>pg_dump</application>出力で正しくクォート付けされませんでした。
+これら変数に対する設定が<command>CREATE FUNCTION ... SET</command>や<command>ALTER DATABASE/ROLE ... SET</command>句にあるとき、問題を起こしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix overflow handling in <application>PL/pgSQL</application>
       integer <command>FOR</command> loops (Tom Lane)
+-->
+<application>PL/pgSQL</application>の整数<command>FOR</command>ループでオーバーフローの扱いを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       The previous coding failed to detect overflow of the loop variable
       on some non-gcc compilers, leading to an infinite loop.
+-->
+以前のコーディングは一部の非gccコンパイラでループ変数のオーバーフローを検知するのに失敗していて、無限ループをもたらしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Adjust <application>PL/Python</application> regression tests to pass
       under Python 3.7 (Peter Eisentraut)
+-->
+<application>PL/Python</application>のリグレッションテストをPython 3.7でパスするように修正しました。
+(Peter Eisentraut)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Support testing <application>PL/Python</application> and related
       modules when building with Python 3 and MSVC (Andrew Dunstan)
+-->
+Python 3とMSVCでビルドするときに<application>PL/Python</application>と関連モジュールのテストをサポートしました。
+(Andrew Dunstan)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Rename internal <function>b64_encode</function>
       and <function>b64_decode</function> functions to avoid conflict with
       Solaris 11.4 built-in functions (Rainer Orth)
+-->
+Solaris 11.4 の組み込み関数との衝突を避けるため内部の<function>b64_encode</function>および<function>b64_decode</function>関数を改名しました。
+(Rainer Orth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Sync our copy of the timezone library with IANA tzcode release 2018e
       (Tom Lane)
+-->
+タイムゾーンライブラリのコピーをIANA tzcode release 2018eに同期しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fixes the <application>zic</application> timezone data compiler
       to cope with negative daylight-savings offsets.  While
       the <productname>PostgreSQL</productname> project will not
       immediately ship such timezone data, <application>zic</application>
       might be used with timezone data obtained directly from IANA, so it
       seems prudent to update <application>zic</application> now.
+-->
+これは<application>zic</application>タイムゾーンコンパイラを、負の夏時間オフセットを処理できるように修正します。
+<productname>PostgreSQL</productname>プロジェクトが直ちにそのようなタイムゾーンデータを使えるようにすることはありませんが、<application>zic</application>はIANAから直に取得したタイムゾーンデータで使われるかもしれませんので、確実を期してここで<application>zic</application>をアップデートしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Update time zone data files to <application>tzdata</application>
       release 2018d for DST law changes in Palestine and Antarctica (Casey
       Station), plus historical corrections for Portugal and its colonies,
       as well as Enderbury, Jamaica, Turks &amp; Caicos Islands, and
       Uruguay.
+-->
+タイムゾーンデータファイルを<application>tzdata</application> release 2018dに更新しました。
+パレスチナと南極（ケーシー基地）の夏時間法の変更に加え、ポルトガルとその植民地、エンダーベリー島、ジャマイカ、タークス・カイコス諸島、ウルグアイの歴史的修正が含まれます。
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.4.sgml
+++ b/doc/src/sgml/release-9.4.sgml
@@ -2,50 +2,80 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-4-18">
+<!--
   <title>Release 9.4.18</title>
+-->
+  <title>リリース9.4.18</title>
 
   <formalpara>
+<!--
   <title>Release date:</title>
+-->
+  <title>リリース日:</title>
   <para>2018-05-10</para>
   </formalpara>
 
   <para>
+<!--
    This release contains a variety of fixes from 9.4.17.
    For information about new features in the 9.4 major release, see
    <xref linkend="release-9-4">.
+-->
+このリリースは9.4.17に対し、各種不具合を修正したものです。
+9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4">を参照してください。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.4.18</title>
+-->
+   <title>バージョン9.4.18への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.4.X.
+-->
+9.4.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if the function marking mistakes mentioned in the first
     changelog entry below affect you, you will want to take steps to
     correct your database catalogs.
+-->
+しかしながら、1番目の変更履歴項目で言及されている誤った印付けの関数の影響があるなら、データベースカタログを補正する手順を行うのが望ましいです。
    </para>
 
    <para>
+<!--
     Also, if you are upgrading from a version earlier than 9.4.17,
     see <xref linkend="release-9-4-17">.
+-->
+また、9.4.17より前のバージョンからアップグレードする場合には<xref linkend="release-9-4-17">を参照してください。
    </para>
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Fix incorrect volatility markings on a few built-in functions
       (Thomas Munro, Tom Lane)
+-->
+いくつかの組み込み関数での誤った変動性区分を修正しました。
+(Thomas Munro, Tom Lane)
      </para>
 
      <para>
+<!--
       The functions
       <function>query_to_xml</function>,
       <function>cursor_to_xml</function>,
@@ -65,16 +95,29 @@
       done in each database of the installation.)  Another option is
       to <application>pg_upgrade</application> the database to a version
       containing the corrected initial data.
+-->
+関数<function>query_to_xml</function>、<function>cursor_to_xml</function>、<function>cursor_to_xmlschema</function>、<function>query_to_xmlschema</function>、および<function>query_to_xml_and_xmlschema</function>は、ユーザから供給される不安定な操作を含むかもしれない問い合わせを実行するため、揮発性(volatile)と印付けすべきです。
+これらはそうなっておらず、誤った問い合わせ最適化が行われる危険をもたらしました。
+これは新たなインストレーションでは補正された初期カタログデータにより修正されますが、既存のインストレーションは誤った印付けを含んだ状態のままとなります。
+これら関数の実際の使用ではほとんど害は生じないと見られますが、用心のため、手動でこれら関数の<structname>pg_proc</structname>エントリを更新することで修正できます。
+例えば<literal>ALTER FUNCTION pg_catalog.query_to_xml(text, boolean, boolean, text) VOLATILE</literal>と実行します。
+（インストレーションの各データベース上で行う必要があることに注意してください。）
+他の選択肢はそのデータベースを正しい初期データを持つバージョンに<application>pg_upgrade</application>することです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid re-using TOAST value OIDs that match dead-but-not-yet-vacuumed
       TOAST entries (Pavan Deolasee)
+-->
+無効になったものの未バキュームのTOASTエントリと一致するTOAST値のOIDの再使用を回避しました。
+(Pavan Deolasee)
      </para>
 
      <para>
+<!--
       Once the OID counter has wrapped around, it's possible to assign a
       TOAST value whose OID matches a previously deleted entry in the same
       TOAST table.  If that entry were not yet vacuumed away, this resulted
@@ -83,17 +126,27 @@
       persist until the dead entry was removed
       by <command>VACUUM</command>.  Fix by not selecting such OIDs when
       creating a new TOAST entry.
+-->
+一度OIDカウンタが周回すると、同じTOASTテーブルで以前に削除済みのエントリとOIDが一致するTOAST値を割り当てする可能性があります。
+そのエントリが未だバキュームされていないと、<quote>unexpected chunk number 0 (expected 1) for toast value <replaceable>nnnnn</replaceable>（TOAST値nnnnnに対する予期せぬチャンク番号0、(1が期待された)）</quote>というエラーをひき起こします。
+これは無効なエントリが<command>VACUUM</command>で除去されるまで持続します。
+新たなTOASTエントリを作るときにそのようなOIDを選択しないようにして修正しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Change <command>ANALYZE</command>'s algorithm for updating
       <structname>pg_class</structname>.<structfield>reltuples</structfield>
       (David Gould)
+-->
+<command>ANALYZE</command>の<structname>pg_class</structname>.<structfield>reltuples</structfield>を更新するアルゴリズムを変更しました。
+(David Gould)
      </para>
 
      <para>
+<!--
       Previously, pages not actually scanned by <command>ANALYZE</command>
       were assumed to retain their old tuple density.  In a large table
       where <command>ANALYZE</command> samples only a small fraction of the
@@ -107,223 +160,345 @@
       that <command>ANALYZE</command>'s sample is a statistically unbiased
       sample of the table (as it should be), and just extrapolate the
       density observed within those pages to the whole table.
+-->
+これまでは、<command>ANALYZE</command>で実際にはスキャンされないページは、以前のタプル密度を維持していると見做されました。
+<command>ANALYZE</command>のサンプル取得が全体のごく一部分となる大きなテーブルにおいては、これは全体のタプル密度見積が決して大きくは変更されないことを意味し、そのため、実際にテーブルに起きていることは無視されて、<structfield>reltuples</structfield>はテーブルの物理サイズ（<structfield>relpages</structfield>）の変化にほぼ比例して変化していました。
+これは、事実上自動バキュームを遮断するほどに<structfield>reltuples</structfield>が実際より大きくなる結果としてあらわれました。
+<command>ANALYZE</command>のサンプルがテーブルの統計的に偏りがないサンプルと見做し（そうであるべきなので）、観測されたページ内の密度を単にテーブル全体に外挿することで、修正しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid deadlocks in concurrent <command>CREATE INDEX
       CONCURRENTLY</command> commands that are run
       under <literal>SERIALIZABLE</literal> or <literal>REPEATABLE
       READ</literal> transaction isolation (Tom Lane)
+-->
+<literal>SERIALIZABLE</literal>または<literal>REPEATABLE READ</literal>トランザクション隔離で実行される同時実行の<command>CREATE INDEX CONCURRENTLY</command>コマンドのデッドロックを回避しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible slow execution of <command>REFRESH MATERIALIZED VIEW
       CONCURRENTLY</command> (Thomas Munro)
+-->
+<command>REFRESH MATERIALIZED VIEW CONCURRENTLY</command>の実行が遅くなる可能性があり、修正しました。
+(Thomas Munro)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <literal>UPDATE/DELETE ... WHERE CURRENT OF</literal> to not fail
       when the referenced cursor uses an index-only-scan plan (Yugo Nagata,
       Tom Lane)
+-->
+参照されるカーソルがインデックスオンリースキャンプランを使うときに<literal>UPDATE/DELETE ... WHERE CURRENT OF</literal>が失敗しないように修正しました。
+(Yugo Nagata, Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect planning of join clauses pushed into parameterized
       paths (Andrew Gierth, Tom Lane)
+-->
+パラメタライズドパスにプッシュされたJOIN句の誤ったプラン作成を修正しました。
+(Andrew Gierth, Tom Lane)
      </para>
 
      <para>
+<!--
       This error could result in misclassifying a condition as
       a <quote>join filter</quote> for an outer join when it should be a
       plain <quote>filter</quote> condition, leading to incorrect join
       output.
+-->
+この障害により、<quote>filter</quote>条件のプランであるべきときに、条件が外部結合に対する<quote>join filter</quote>であると誤った分別がされ、間違った結合結果をもたらす可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix misoptimization of <literal>CHECK</literal> constraints having
       provably-NULL subclauses of
       top-level <literal>AND</literal>/<literal>OR</literal> conditions
       (Tom Lane, Dean Rasheed)
+-->
+NULLであると証明可能なトップレベル<literal>AND</literal>/<literal>OR</literal>条件の副句を持つ、<literal>CHECK</literal>制約の誤った最適化が修正されました。
+(Tom Lane, Dean Rasheed)
      </para>
 
      <para>
+<!--
       This could, for example, allow constraint exclusion to exclude a
       child table that should not be excluded from a query.
+-->
+これにより、例えば、制約による除外が、問い合わせから除外すべきでない子テーブルを除外することを許してしまうおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid failure if a query-cancel or session-termination interrupt
       occurs while committing a prepared transaction (Stas Kelvich)
+-->
+準備されたトランザクションをコミットする間に、問い合わせキャンセルやセッション終了の割り込みが生じた場合の失敗を回避しました。
+(Stas Kelvich)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix query-lifespan memory leakage in repeatedly executed hash joins
       (Tom Lane)
+-->
+繰り返し実行されたハッシュ結合での問い合わせの間のメモリリークを修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix overly strict sanity check
       in <function>heap_prepare_freeze_tuple</function>
       (&Aacute;lvaro Herrera)
+-->
+<function>heap_prepare_freeze_tuple</function>の厳格すぎる整合性検査を修正しました。
+(&Aacute;lvaro Herrera)
      </para>
 
      <para>
+<!--
       This could result in incorrect <quote>cannot freeze committed
       xmax</quote> failures in databases that have
       been <application>pg_upgrade</application>'d from 9.2 or earlier.
+-->
+これは、9.2以前から<application>pg_upgrade</application>されたデータベースで間違った<quote>cannot freeze committed xmax</quote>エラーになる可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent dangling-pointer dereference when a C-coded before-update row
       trigger returns the <quote>old</quote> tuple (Rushabh Lathia)
+-->
+Cで書かれた更新前実行の行トリガが<quote>old</quote>タプルを返すときの、ダングリングポインタ参照を防止しました。
+(Rushabh Lathia)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Reduce locking during autovacuum worker scheduling (Jeff Janes)
+-->
+自動バキュームワーカのスケジューリング中のロックを減らしました。
+(Jeff Janes)
      </para>
 
      <para>
+<!--
       The previous behavior caused drastic loss of potential worker
       concurrency in databases with many tables.
+-->
+これまでの振る舞いは、多数のテーブルを持つデータベースで潜在的なワーカの同時実行性の大幅な損失をひき起こしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure client hostname is copied while copying
       <structname>pg_stat_activity</structname> data to local memory
       (Edmund Horner)
+-->
+<structname>pg_stat_activity</structname>のデータをローカルメモリにコピーするときに、確実にクライアントホスト名がコピーされるようにしました。
+(Edmund Horner)
      </para>
 
      <para>
+<!--
       Previously the supposedly-local snapshot contained a pointer into
       shared memory, allowing the client hostname column to change
       unexpectedly if any existing session disconnected.
+-->
+以前はローカルと見做されていたスナップショットが共有メモリへのポインタを含んでいて、何らかの存在するセッションが切断した場合に、クライアントホスト名の列が予期せず変化することがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect processing of multiple compound affixes
       in <literal>ispell</literal> dictionaries (Arthur Zakirov)
+-->
+<literal>ispell</literal>辞書で複合接辞の誤った処理を修正しました。
+(Arthur Zakirov)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix collation-aware searches (that is, indexscans using inequality
       operators) in SP-GiST indexes on text columns (Tom Lane)
+-->
+テキスト列のSP-GiSTインデックスでの照合を伴う検索（すなわち、不等演算子を使うインデックススキャン）を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Such searches would return the wrong set of rows in most non-C
       locales.
+-->
+このような検索は大部分の非Cロケールで誤った行集合を返しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Count the number of index tuples correctly during initial build of an
       SP-GiST index (Tomas Vondra)
+-->
+SP-GiSTインデックスの初期ビルドの際にインデックスのタプル数を正しく数えるようにしました。
+(Tomas Vondra)
      </para>
 
      <para>
+<!--
       Previously, the tuple count was reported to be the same as that of
       the underlying table, which is wrong if the index is partial.
+-->
+これまでは、タプル数は元となるテーブルと同じと報告されましたが、これは部分インデックスの場合には誤りです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Count the number of index tuples correctly during vacuuming of a
       GiST index (Andrey Borodin)
+-->
+GiSTインデックスのバキュームの際にインデックスタプルの数を正しく数えるようにしました。
+ (Andrey Borodin)
      </para>
 
      <para>
+<!--
       Previously it reported the estimated number of heap tuples,
       which might be inaccurate, and is certainly wrong if the
       index is partial.
+-->
+これまでは見積られたヒープタプルの数が報告されましたが、それは不正確かもしれず、部分インデックスでは確実に誤っています。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix a corner case where a streaming standby gets stuck at a WAL
       continuation record (Kyotaro Horiguchi)
+-->
+WALの継続レコードでストリーミングスタンバイが動かなくなる稀な場合が修正されました。
+(Kyotaro Horiguchi)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       In logical decoding, avoid possible double processing of WAL data
       when a walsender restarts (Craig Ringer)
+-->
+ロジカルデコーディングでwalsenderが再起動したときに起こりうるWALデータの二重処理を回避しました。
+(Craig Ringer)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Allow <function>scalarltsel</function>
       and <function>scalargtsel</function> to be used on non-core datatypes
       (Tomas Vondra)
+-->
+<function>scalarltsel</function>と<function>scalargtsel</function>を非コアのデータ型で使用できるようにしました。
+(Tomas Vondra)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Reduce <application>libpq</application>'s memory consumption when a
       server error is reported after a large amount of query output has
       been collected (Tom Lane)
+-->
+大量の問い合わせ出力が収集された後にサーバエラーが報告されたときの<application>libpq</application>のメモリ消費を減らしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Discard the previous output before, not after, processing the error
       message.  On some platforms, notably Linux, this can make a
       difference in the application's subsequent memory footprint.
+-->
+以前の出力を後でなく先に廃棄して、エラーメッセージを処理します。
+一部のプラットフォーム、とりわけLinuxでは、これによりアプリケーションの以降のメモリフットプリントに違いを出すことができます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix double-free crashes in <application>ecpg</application>
       (Patrick Krecker, Jeevan Ladhe)
+-->
+<application>ecpg</application>で二重解放のクラッシュを修正しました。
+(Patrick Krecker, Jeevan Ladhe)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>ecpg</application> to handle <type>long long
       int</type> variables correctly in MSVC builds (Michael Meskes,
       Andrew Gierth)
+-->
+MSVCビルドで<type>long long int</type>変数を正しく扱うように<application>ecpg</application>を修正しました。
+(Michael Meskes, Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix mis-quoting of values for list-valued GUC variables in dumps
       (Michael Paquier, Tom Lane)
+-->
+ダンプでリスト値になったGUC変数に対する誤った値のクォート付けを修正しました。
+(Michael Paquier, Tom Lane)
      </para>
 
      <para>
+<!--
       The <varname>local_preload_libraries</varname>,
       <varname>session_preload_libraries</varname>,
       <varname>shared_preload_libraries</varname>,
@@ -332,80 +507,121 @@
       cause problems if settings for these variables appeared in
       <command>CREATE FUNCTION ... SET</command> or <command>ALTER
       DATABASE/ROLE ... SET</command> clauses.
+-->
+<varname>local_preload_libraries</varname>、<varname>session_preload_libraries</varname>、<varname>shared_preload_libraries</varname>、および<varname>temp_tablespaces</varname>変数は、<application>pg_dump</application>出力で正しくクォート付けされませんでした。
+これら変数に対する設定が<command>CREATE FUNCTION ... SET</command>や<command>ALTER DATABASE/ROLE ... SET</command>句にあるとき、問題を起こしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_recvlogical</application> to not fail against
       pre-v10 <productname>PostgreSQL</productname> servers
       (Michael Paquier)
+-->
+<application>pg_recvlogical</application>をv10より前の<productname>PostgreSQL</productname>に対して失敗しないように修正しました。
+(Michael Paquier)
      </para>
 
      <para>
+<!--
       A previous fix caused <application>pg_recvlogical</application> to
       issue a command regardless of server version, but it should only be
       issued to v10 and later servers.
+-->
+前の修正は<application>pg_recvlogical</application>がサーババージョンにかかわらずコマンドを発行する動作を起こしていましたが、v10以降のサーバにだけ発行されるべきです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix overflow handling in <application>PL/pgSQL</application>
       integer <command>FOR</command> loops (Tom Lane)
+-->
+<application>PL/pgSQL</application>の整数<command>FOR</command>ループでオーバーフローの扱いを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       The previous coding failed to detect overflow of the loop variable
       on some non-gcc compilers, leading to an infinite loop.
+-->
+以前のコーディングは一部の非gccコンパイラでループ変数のオーバーフローを検知するのに失敗していて、無限ループをもたらしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Adjust <application>PL/Python</application> regression tests to pass
       under Python 3.7 (Peter Eisentraut)
+-->
+<application>PL/Python</application>のリグレッションテストをPython 3.7でパスするように修正しました。
+(Peter Eisentraut)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Support testing <application>PL/Python</application> and related
       modules when building with Python 3 and MSVC (Andrew Dunstan)
+-->
+Python 3とMSVCでビルドするときに<application>PL/Python</application>と関連モジュールのテストをサポートしました。
+(Andrew Dunstan)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Rename internal <function>b64_encode</function>
       and <function>b64_decode</function> functions to avoid conflict with
       Solaris 11.4 built-in functions (Rainer Orth)
+-->
+Solaris 11.4 の組み込み関数との衝突を避けるため内部の<function>b64_encode</function>および<function>b64_decode</function>関数を改名しました。
+(Rainer Orth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Sync our copy of the timezone library with IANA tzcode release 2018e
       (Tom Lane)
+-->
+タイムゾーンライブラリのコピーをIANA tzcode release 2018eに同期しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fixes the <application>zic</application> timezone data compiler
       to cope with negative daylight-savings offsets.  While
       the <productname>PostgreSQL</productname> project will not
       immediately ship such timezone data, <application>zic</application>
       might be used with timezone data obtained directly from IANA, so it
       seems prudent to update <application>zic</application> now.
+-->
+これは<application>zic</application>タイムゾーンコンパイラを、負の夏時間オフセットを処理できるように修正します。
+<productname>PostgreSQL</productname>プロジェクトが直ちにそのようなタイムゾーンデータを使えるようにすることはありませんが、<application>zic</application>はIANAから直に取得したタイムゾーンデータで使われるかもしれませんので、確実を期してここで<application>zic</application>をアップデートしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Update time zone data files to <application>tzdata</application>
       release 2018d for DST law changes in Palestine and Antarctica (Casey
       Station), plus historical corrections for Portugal and its colonies,
       as well as Enderbury, Jamaica, Turks &amp; Caicos Islands, and
       Uruguay.
+-->
+タイムゾーンデータファイルを<application>tzdata</application> release 2018dに更新しました。
+パレスチナと南極（ケーシー基地）の夏時間法の変更に加え、ポルトガルとその植民地、エンダーベリー島、ジャマイカ、タークス・カイコス諸島、ウルグアイの歴史的修正が含まれます。
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.5.sgml
+++ b/doc/src/sgml/release-9.5.sgml
@@ -2,50 +2,80 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-5-13">
+<!--
   <title>Release 9.5.13</title>
+-->
+  <title>リリース9.5.13</title>
 
   <formalpara>
+<!--
   <title>Release date:</title>
+-->
+  <title>リリース日:</title>
   <para>2018-05-10</para>
   </formalpara>
 
   <para>
+<!--
    This release contains a variety of fixes from 9.5.12.
    For information about new features in the 9.5 major release, see
    <xref linkend="release-9-5">.
+-->
+このリリースは9.5.12に対し、各種不具合を修正したものです。
+9.5メジャーリリースにおける新機能については、<xref linkend="release-9-5">を参照してください。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.5.13</title>
+-->
+   <title>バージョン9.5.13への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.5.X.
+-->
+9.5.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if the function marking mistakes mentioned in the first
     changelog entry below affect you, you will want to take steps to
     correct your database catalogs.
+-->
+しかしながら、1番目の変更履歴項目で言及されている誤った印付けの関数の影響があるなら、データベースカタログを補正する手順を行うのが望ましいです。
    </para>
 
    <para>
+<!--
     Also, if you are upgrading from a version earlier than 9.5.12,
     see <xref linkend="release-9-5-12">.
+-->
+また、9.5.12より前のバージョンからアップグレードする場合には<xref linkend="release-9-5-12">を参照してください。
    </para>
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Fix incorrect volatility markings on a few built-in functions
       (Thomas Munro, Tom Lane)
+-->
+いくつかの組み込み関数での誤った変動性区分を修正しました。
+(Thomas Munro, Tom Lane)
      </para>
 
      <para>
+<!--
       The functions
       <function>query_to_xml</function>,
       <function>cursor_to_xml</function>,
@@ -65,16 +95,29 @@
       done in each database of the installation.)  Another option is
       to <application>pg_upgrade</application> the database to a version
       containing the corrected initial data.
+-->
+関数<function>query_to_xml</function>、<function>cursor_to_xml</function>、<function>cursor_to_xmlschema</function>、<function>query_to_xmlschema</function>、および<function>query_to_xml_and_xmlschema</function>は、ユーザから供給される不安定な操作を含むかもしれない問い合わせを実行するため、揮発性(volatile)と印付けすべきです。
+これらはそうなっておらず、誤った問い合わせ最適化が行われる危険をもたらしました。
+これは新たなインストレーションでは補正された初期カタログデータにより修正されますが、既存のインストレーションは誤った印付けを含んだ状態のままとなります。
+これら関数の実際の使用ではほとんど害は生じないと見られますが、用心のため、手動でこれら関数の<structname>pg_proc</structname>エントリを更新することで修正できます。
+例えば<literal>ALTER FUNCTION pg_catalog.query_to_xml(text, boolean, boolean, text) VOLATILE</literal>と実行します。
+（インストレーションの各データベース上で行う必要があることに注意してください。）
+他の選択肢はそのデータベースを正しい初期データを持つバージョンに<application>pg_upgrade</application>することです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid re-using TOAST value OIDs that match dead-but-not-yet-vacuumed
       TOAST entries (Pavan Deolasee)
+-->
+無効になったものの未バキュームのTOASTエントリと一致するTOAST値のOIDの再使用を回避しました。
+(Pavan Deolasee)
      </para>
 
      <para>
+<!--
       Once the OID counter has wrapped around, it's possible to assign a
       TOAST value whose OID matches a previously deleted entry in the same
       TOAST table.  If that entry were not yet vacuumed away, this resulted
@@ -83,17 +126,27 @@
       persist until the dead entry was removed
       by <command>VACUUM</command>.  Fix by not selecting such OIDs when
       creating a new TOAST entry.
+-->
+一度OIDカウンタが周回すると、同じTOASTテーブルで以前に削除済みのエントリとOIDが一致するTOAST値を割り当てする可能性があります。
+そのエントリが未だバキュームされていないと、<quote>unexpected chunk number 0 (expected 1) for toast value <replaceable>nnnnn</replaceable>（TOAST値nnnnnに対する予期せぬチャンク番号0、(1が期待された)）</quote>というエラーをひき起こします。
+これは無効なエントリが<command>VACUUM</command>で除去されるまで持続します。
+新たなTOASTエントリを作るときにそのようなOIDを選択しないようにして修正しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Change <command>ANALYZE</command>'s algorithm for updating
       <structname>pg_class</structname>.<structfield>reltuples</structfield>
       (David Gould)
+-->
+<command>ANALYZE</command>の<structname>pg_class</structname>.<structfield>reltuples</structfield>を更新するアルゴリズムを変更しました。
+(David Gould)
      </para>
 
      <para>
+<!--
       Previously, pages not actually scanned by <command>ANALYZE</command>
       were assumed to retain their old tuple density.  In a large table
       where <command>ANALYZE</command> samples only a small fraction of the
@@ -107,247 +160,381 @@
       that <command>ANALYZE</command>'s sample is a statistically unbiased
       sample of the table (as it should be), and just extrapolate the
       density observed within those pages to the whole table.
+-->
+これまでは、<command>ANALYZE</command>で実際にはスキャンされないページは、以前のタプル密度を維持していると見做されました。
+<command>ANALYZE</command>のサンプル取得が全体のごく一部分となる大きなテーブルにおいては、これは全体のタプル密度見積が決して大きくは変更されないことを意味し、そのため、実際にテーブルに起きていることは無視されて、<structfield>reltuples</structfield>はテーブルの物理サイズ（<structfield>relpages</structfield>）の変化にほぼ比例して変化していました。
+これは、事実上自動バキュームを遮断するほどに<structfield>reltuples</structfield>が実際より大きくなる結果としてあらわれました。
+<command>ANALYZE</command>のサンプルがテーブルの統計的に偏りがないサンプルと見做し（そうであるべきなので）、観測されたページ内の密度を単にテーブル全体に外挿することで、修正しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid deadlocks in concurrent <command>CREATE INDEX
       CONCURRENTLY</command> commands that are run
       under <literal>SERIALIZABLE</literal> or <literal>REPEATABLE
       READ</literal> transaction isolation (Tom Lane)
+-->
+<literal>SERIALIZABLE</literal>または<literal>REPEATABLE READ</literal>トランザクション隔離で実行される同時実行の<command>CREATE INDEX CONCURRENTLY</command>コマンドのデッドロックを回避しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible slow execution of <command>REFRESH MATERIALIZED VIEW
       CONCURRENTLY</command> (Thomas Munro)
+-->
+<command>REFRESH MATERIALIZED VIEW CONCURRENTLY</command>の実行が遅くなる可能性があり、修正しました。
+(Thomas Munro)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <literal>UPDATE/DELETE ... WHERE CURRENT OF</literal> to not fail
       when the referenced cursor uses an index-only-scan plan (Yugo Nagata,
       Tom Lane)
+-->
+参照されるカーソルがインデックスオンリースキャンプランを使うときに<literal>UPDATE/DELETE ... WHERE CURRENT OF</literal>が失敗しないように修正しました。
+(Yugo Nagata, Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect planning of join clauses pushed into parameterized
       paths (Andrew Gierth, Tom Lane)
+-->
+パラメタライズドパスにプッシュされたJOIN句の誤ったプラン作成を修正しました。
+(Andrew Gierth, Tom Lane)
      </para>
 
      <para>
+<!--
       This error could result in misclassifying a condition as
       a <quote>join filter</quote> for an outer join when it should be a
       plain <quote>filter</quote> condition, leading to incorrect join
       output.
+-->
+この障害により、<quote>filter</quote>条件のプランであるべきときに、条件が外部結合に対する<quote>join filter</quote>であると誤った分別がされ、間違った結合結果をもたらす可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possibly incorrect generation of an index-only-scan plan when the
       same table column appears in multiple index columns, and only some of
       those index columns use operator classes that can return the column
       value (Kyotaro Horiguchi)
+-->
+複合インデックスの列に同じテーブル列が現れ、それらインデックス列の一部だけが列の値を返すことができる演算子クラスを使うときに、起こりうる誤ったインデックスオンリースキャンプランの生成が修正されました。
+(Kyotaro Horiguchi)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix misoptimization of <literal>CHECK</literal> constraints having
       provably-NULL subclauses of
       top-level <literal>AND</literal>/<literal>OR</literal> conditions
       (Tom Lane, Dean Rasheed)
+-->
+NULLであると証明可能なトップレベル<literal>AND</literal>/<literal>OR</literal>条件の副句を持つ、<literal>CHECK</literal>制約の誤った最適化が修正されました。
+(Tom Lane, Dean Rasheed)
      </para>
 
      <para>
+<!--
       This could, for example, allow constraint exclusion to exclude a
       child table that should not be excluded from a query.
+-->
+これにより、例えば、制約による除外が、問い合わせから除外すべきでない子テーブルを除外することを許してしまうおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix executor crash due to double free in some <literal>GROUPING
       SET</literal> usages (Peter Geoghegan)
+-->
+一部の<literal>GROUPING SET</literal>使用における二重解放によるエグゼキュータのクラッシュを修正しました。
+(Peter Geoghegan)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid crash if a table rewrite event trigger is added concurrently
       with a command that could call such a trigger (&Aacute;lvaro Herrera,
       Andrew Gierth, Tom Lane)
+-->
+テーブル書き換えイベントトリガが、そのようなトリガを呼び出す可能性のあるコマンドと同時に追加された場合のクラッシュを回避しました。
+(&Aacute;lvaro Herrera, Andrew Gierth, Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid failure if a query-cancel or session-termination interrupt
       occurs while committing a prepared transaction (Stas Kelvich)
+-->
+準備されたトランザクションをコミットする間に、問い合わせキャンセルやセッション終了の割り込みが生じた場合の失敗を回避しました。
+(Stas Kelvich)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix query-lifespan memory leakage in repeatedly executed hash joins
       (Tom Lane)
+-->
+繰り返し実行されたハッシュ結合での問い合わせの間のメモリリークを修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix overly strict sanity check
       in <function>heap_prepare_freeze_tuple</function>
       (&Aacute;lvaro Herrera)
+-->
+<function>heap_prepare_freeze_tuple</function>の厳格すぎる整合性検査を修正しました。
+(&Aacute;lvaro Herrera)
      </para>
 
      <para>
+<!--
       This could result in incorrect <quote>cannot freeze committed
       xmax</quote> failures in databases that have
       been <application>pg_upgrade</application>'d from 9.2 or earlier.
+-->
+これは、9.2以前から<application>pg_upgrade</application>されたデータベースで間違った<quote>cannot freeze committed xmax</quote>エラーになる可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent dangling-pointer dereference when a C-coded before-update row
       trigger returns the <quote>old</quote> tuple (Rushabh Lathia)
+-->
+Cで書かれた更新前実行の行トリガが<quote>old</quote>タプルを返すときの、ダングリングポインタ参照を防止しました。
+(Rushabh Lathia)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Reduce locking during autovacuum worker scheduling (Jeff Janes)
+-->
+自動バキュームワーカのスケジューリング中のロックを減らしました。
+(Jeff Janes)
      </para>
 
      <para>
+<!--
       The previous behavior caused drastic loss of potential worker
       concurrency in databases with many tables.
+-->
+これまでの振る舞いは、多数のテーブルを持つデータベースで潜在的なワーカの同時実行性の大幅な損失をひき起こしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure client hostname is copied while copying
       <structname>pg_stat_activity</structname> data to local memory
       (Edmund Horner)
+-->
+<structname>pg_stat_activity</structname>のデータをローカルメモリにコピーするときに、確実にクライアントホスト名がコピーされるようにしました。
+(Edmund Horner)
      </para>
 
      <para>
+<!--
       Previously the supposedly-local snapshot contained a pointer into
       shared memory, allowing the client hostname column to change
       unexpectedly if any existing session disconnected.
+-->
+以前はローカルと見做されていたスナップショットが共有メモリへのポインタを含んでいて、何らかの存在するセッションが切断した場合に、クライアントホスト名の列が予期せず変化することがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect processing of multiple compound affixes
       in <literal>ispell</literal> dictionaries (Arthur Zakirov)
+-->
+<literal>ispell</literal>辞書で複合接辞の誤った処理を修正しました。
+(Arthur Zakirov)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix collation-aware searches (that is, indexscans using inequality
       operators) in SP-GiST indexes on text columns (Tom Lane)
+-->
+テキスト列のSP-GiSTインデックスでの照合を伴う検索（すなわち、不等演算子を使うインデックススキャン）を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Such searches would return the wrong set of rows in most non-C
       locales.
+-->
+このような検索は大部分の非Cロケールで誤った行集合を返しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Count the number of index tuples correctly during initial build of an
       SP-GiST index (Tomas Vondra)
+-->
+SP-GiSTインデックスの初期ビルドの際にインデックスのタプル数を正しく数えるようにしました。
+(Tomas Vondra)
      </para>
 
      <para>
+<!--
       Previously, the tuple count was reported to be the same as that of
       the underlying table, which is wrong if the index is partial.
+-->
+これまでは、タプル数は元となるテーブルと同じと報告されましたが、これは部分インデックスの場合には誤りです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Count the number of index tuples correctly during vacuuming of a
       GiST index (Andrey Borodin)
+-->
+GiSTインデックスのバキュームの際にインデックスタプルの数を正しく数えるようにしました。
+ (Andrey Borodin)
      </para>
 
      <para>
+<!--
       Previously it reported the estimated number of heap tuples,
       which might be inaccurate, and is certainly wrong if the
       index is partial.
+-->
+これまでは見積られたヒープタプルの数が報告されましたが、それは不正確かもしれず、部分インデックスでは確実に誤っています。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix a corner case where a streaming standby gets stuck at a WAL
       continuation record (Kyotaro Horiguchi)
+-->
+WALの継続レコードでストリーミングスタンバイが動かなくなる稀な場合が修正されました。
+(Kyotaro Horiguchi)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       In logical decoding, avoid possible double processing of WAL data
       when a walsender restarts (Craig Ringer)
+-->
+ロジカルデコーディングでwalsenderが再起動したときに起こりうるWALデータの二重処理を回避しました。
+(Craig Ringer)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Allow <function>scalarltsel</function>
       and <function>scalargtsel</function> to be used on non-core datatypes
       (Tomas Vondra)
+-->
+<function>scalarltsel</function>と<function>scalargtsel</function>を非コアのデータ型で使用できるようにしました。
+(Tomas Vondra)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Reduce <application>libpq</application>'s memory consumption when a
       server error is reported after a large amount of query output has
       been collected (Tom Lane)
+-->
+大量の問い合わせ出力が収集された後にサーバエラーが報告されたときの<application>libpq</application>のメモリ消費を減らしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Discard the previous output before, not after, processing the error
       message.  On some platforms, notably Linux, this can make a
       difference in the application's subsequent memory footprint.
+-->
+以前の出力を後でなく先に廃棄して、エラーメッセージを処理します。
+一部のプラットフォーム、とりわけLinuxでは、これによりアプリケーションの以降のメモリフットプリントに違いを出すことができます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix double-free crashes in <application>ecpg</application>
       (Patrick Krecker, Jeevan Ladhe)
+-->
+<application>ecpg</application>で二重解放のクラッシュを修正しました。
+(Patrick Krecker, Jeevan Ladhe)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>ecpg</application> to handle <type>long long
       int</type> variables correctly in MSVC builds (Michael Meskes,
       Andrew Gierth)
+-->
+MSVCビルドで<type>long long int</type>変数を正しく扱うように<application>ecpg</application>を修正しました。
+(Michael Meskes, Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix mis-quoting of values for list-valued GUC variables in dumps
       (Michael Paquier, Tom Lane)
+-->
+ダンプでリスト値になったGUC変数に対する誤った値のクォート付けを修正しました。
+(Michael Paquier, Tom Lane)
      </para>
 
      <para>
+<!--
       The <varname>local_preload_libraries</varname>,
       <varname>session_preload_libraries</varname>,
       <varname>shared_preload_libraries</varname>,
@@ -356,66 +543,102 @@
       cause problems if settings for these variables appeared in
       <command>CREATE FUNCTION ... SET</command> or <command>ALTER
       DATABASE/ROLE ... SET</command> clauses.
+-->
+<varname>local_preload_libraries</varname>、<varname>session_preload_libraries</varname>、<varname>shared_preload_libraries</varname>、および<varname>temp_tablespaces</varname>変数は、<application>pg_dump</application>出力で正しくクォート付けされませんでした。
+これら変数に対する設定が<command>CREATE FUNCTION ... SET</command>や<command>ALTER DATABASE/ROLE ... SET</command>句にあるとき、問題を起こしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_recvlogical</application> to not fail against
       pre-v10 <productname>PostgreSQL</productname> servers
       (Michael Paquier)
+-->
+<application>pg_recvlogical</application>をv10より前の<productname>PostgreSQL</productname>に対して失敗しないように修正しました。
+(Michael Paquier)
      </para>
 
      <para>
+<!--
       A previous fix caused <application>pg_recvlogical</application> to
       issue a command regardless of server version, but it should only be
       issued to v10 and later servers.
+-->
+前の修正は<application>pg_recvlogical</application>がサーババージョンにかかわらずコマンドを発行する動作を起こしていましたが、v10以降のサーバにだけ発行されるべきです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that <application>pg_rewind</application> deletes files on the
       target server if they are deleted from the source server during the
       run (Takayuki Tsunakawa)
+-->
+<application>pg_rewind</application>が実行中にファイルがソースサーバで削除されている場合、確実にターゲットサーバのそれらファイルを削除するようにしました。
+(Takayuki Tsunakawa)
      </para>
 
      <para>
+<!--
       Failure to do this could result in data inconsistency on the target,
       particularly if the file in question is a WAL segment.
+-->
+これを行うのに失敗することで、特に問題のファイルがWALセグメントである場合に、ターゲットでデータ不整合が生じる可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_rewind</application> to handle tables in
       non-default tablespaces correctly (Takayuki Tsunakawa)
+-->
+デフォルトでないテーブルスペースにあるテーブルを正しく扱うように<application>pg_rewind</application>を修正しました。
+(Takayuki Tsunakawa)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix overflow handling in <application>PL/pgSQL</application>
       integer <command>FOR</command> loops (Tom Lane)
+-->
+<application>PL/pgSQL</application>の整数<command>FOR</command>ループでオーバーフローの扱いを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       The previous coding failed to detect overflow of the loop variable
       on some non-gcc compilers, leading to an infinite loop.
+-->
+以前のコーディングは一部の非gccコンパイラでループ変数のオーバーフローを検知するのに失敗していて、無限ループをもたらしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Adjust <application>PL/Python</application> regression tests to pass
       under Python 3.7 (Peter Eisentraut)
+-->
+<application>PL/Python</application>のリグレッションテストをPython 3.7でパスするように修正しました。
+(Peter Eisentraut)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Support testing <application>PL/Python</application> and related
       modules when building with Python 3 and MSVC (Andrew Dunstan)
+-->
+Python 3とMSVCでビルドするときに<application>PL/Python</application>と関連モジュールのテストをサポートしました。
+(Andrew Dunstan)
      </para>
     </listitem>
 
@@ -425,46 +648,69 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
 Branch: REL9_5_STABLE [3c0e07a46] 2018-05-01 12:02:41 -0400
 -->
      <para>
+<!--
       Support building with Microsoft Visual Studio 2015 (Michael Paquier)
+-->
+Microsoft Visual Studio 2015でのビルドをサポートしました。
+(Michael Paquier)
      </para>
 
      <para>
+<!--
       Various fixes needed for VS2015 compatibility were previously
       back-patched into the 9.5 branch, but this one was missed.
+-->
+VS2015との互換性のための様々なパッチが9.5ブランチに以前バックパッチされていましたが、これは抜けていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Rename internal <function>b64_encode</function>
       and <function>b64_decode</function> functions to avoid conflict with
       Solaris 11.4 built-in functions (Rainer Orth)
+-->
+Solaris 11.4 の組み込み関数との衝突を避けるため内部の<function>b64_encode</function>および<function>b64_decode</function>関数を改名しました。
+(Rainer Orth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Sync our copy of the timezone library with IANA tzcode release 2018e
       (Tom Lane)
+-->
+タイムゾーンライブラリのコピーをIANA tzcode release 2018eに同期しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fixes the <application>zic</application> timezone data compiler
       to cope with negative daylight-savings offsets.  While
       the <productname>PostgreSQL</productname> project will not
       immediately ship such timezone data, <application>zic</application>
       might be used with timezone data obtained directly from IANA, so it
       seems prudent to update <application>zic</application> now.
+-->
+これは<application>zic</application>タイムゾーンコンパイラを、負の夏時間オフセットを処理できるように修正します。
+<productname>PostgreSQL</productname>プロジェクトが直ちにそのようなタイムゾーンデータを使えるようにすることはありませんが、<application>zic</application>はIANAから直に取得したタイムゾーンデータで使われるかもしれませんので、確実を期してここで<application>zic</application>をアップデートしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Update time zone data files to <application>tzdata</application>
       release 2018d for DST law changes in Palestine and Antarctica (Casey
       Station), plus historical corrections for Portugal and its colonies,
       as well as Enderbury, Jamaica, Turks &amp; Caicos Islands, and
       Uruguay.
+-->
+タイムゾーンデータファイルを<application>tzdata</application> release 2018dに更新しました。
+パレスチナと南極（ケーシー基地）の夏時間法の変更に加え、ポルトガルとその植民地、エンダーベリー島、ジャマイカ、タークス・カイコス諸島、ウルグアイの歴史的修正が含まれます。
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.6.sgml
+++ b/doc/src/sgml/release-9.6.sgml
@@ -2,56 +2,89 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-6-9">
+<!--
   <title>Release 9.6.9</title>
+-->
+  <title>リリース9.6.9</title>
 
   <formalpara>
+<!--
   <title>Release date:</title>
+-->
+  <title>リリース日:</title>
   <para>2018-05-10</para>
   </formalpara>
 
   <para>
+<!--
    This release contains a variety of fixes from 9.6.8.
    For information about new features in the 9.6 major release, see
    <xref linkend="release-9-6">.
+-->
+このリリースは9.6.7に対し、各種不具合を修正したものです。
+9.6メジャーリリースにおける新機能については、<xref linkend="release-9-6">を参照してください。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.6.9</title>
+-->
+   <title>バージョン9.6.9への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.6.X.
+-->
+9.6.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if you use the <filename>adminpack</filename> extension,
     you should update it as per the first changelog entry below.
+-->
+しかしながら、<filename>adminpack</filename>拡張を使っているなら、下記の1番目の変更履歴項目にしたがって、それをアップデートするべきです。
    </para>
 
    <para>
+<!--
     Also, if the function marking mistakes mentioned in the second and
     third changelog entries below affect you, you will want to take steps
     to correct your database catalogs.
+-->
+また、2番目と3番目の変更履歴項目で言及されている誤った印付けの関数の影響があるなら、データベースカタログを補正する手順を行うのが望ましいです。
    </para>
 
    <para>
+<!--
     Also, if you are upgrading from a version earlier than 9.6.8,
     see <xref linkend="release-9-6-8">.
+-->
+また、9.6.8よりも前のバージョンからアップグレードする場合は、<xref linkend="release-9-6-8">を参照して下さい。
    </para>
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Remove public execute privilege
       from <filename>contrib/adminpack</filename>'s
       <function>pg_logfile_rotate()</function> function (Stephen Frost)
+-->
+<filename>contrib/adminpack</filename>の<function>pg_logfile_rotate()</function>関数からパブリック実行権限を取り除きました。
+(Stephen Frost)
      </para>
 
      <para>
+<!--
       <function>pg_logfile_rotate()</function> is a deprecated wrapper
       for the core function <function>pg_rotate_logfile()</function>.
       When that function was changed to rely on SQL privileges for access
@@ -60,24 +93,37 @@
       updated as well, but the need for this was missed.  Hence,
       if <filename>adminpack</filename> is installed, any user could
       request a logfile rotation, creating a minor security issue.
+-->
+<function>pg_logfile_rotate()</function>はコア関数<function>pg_rotate_logfile()</function>の廃れたラッパーです。
+ハードコードされたスーパーユーザ検査ではなくアクセス制御のためのSQL権限に依存するように関数が変更されたとき、<function>pg_logfile_rotate()</function>も同様に更新されるべきでしたが、その必要性が見逃されました。
+そのために、<filename>adminpack</filename>がインストールされていると、任意のユーザがログファイルのローテーションを要求できてしまい、小さいセキュリティ問題が生じていました。
      </para>
 
      <para>
+<!--
       After installing this update, administrators should
       update <filename>adminpack</filename> by performing
       <literal>ALTER EXTENSION adminpack UPDATE</literal> in each
       database in which <filename>adminpack</filename> is installed.
       (CVE-2018-1115)
+-->
+本アップデートをインストール後、管理者は、<literal>ALTER EXTENSION adminpack UPDATE</literal>を<filename>adminpack</filename>がインストールされた各データベースで実行することで、<filename>adminpack</filename>をアップデートすべきです。
+(CVE-2018-1115)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect volatility markings on a few built-in functions
       (Thomas Munro, Tom Lane)
+-->
+いくつかの組み込み関数での誤った変動性区分を修正しました。
+(Thomas Munro, Tom Lane)
      </para>
 
      <para>
+<!--
       The functions
       <function>query_to_xml</function>,
       <function>cursor_to_xml</function>,
@@ -97,16 +143,29 @@
       done in each database of the installation.)  Another option is
       to <application>pg_upgrade</application> the database to a version
       containing the corrected initial data.
+-->
+関数<function>query_to_xml</function>、<function>cursor_to_xml</function>、<function>cursor_to_xmlschema</function>、<function>query_to_xmlschema</function>、および<function>query_to_xml_and_xmlschema</function>は、ユーザから供給される不安定な操作を含むかもしれない問い合わせを実行するため、揮発性(volatile)と印付けすべきです。
+これらはそうなっておらず、誤った問い合わせ最適化が行われる危険をもたらしました。
+これは新たなインストレーションでは補正された初期カタログデータにより修正されますが、既存のインストレーションは誤った印付けを含んだ状態のままとなります。
+これら関数の実際の使用ではほとんど害は生じないと見られますが、用心のため、手動でこれら関数の<structname>pg_proc</structname>エントリを更新することで修正できます。
+例えば<literal>ALTER FUNCTION pg_catalog.query_to_xml(text, boolean, boolean, text) VOLATILE</literal>と実行します。
+（インストレーションの各データベース上で行う必要があることに注意してください。）
+他の選択肢はそのデータベースを正しい初期データを持つバージョンに<application>pg_upgrade</application>することです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect parallel-safety markings on a few built-in functions
       (Thomas Munro, Tom Lane)
+-->
+いくつかの組み込み関数での誤ったパラレルセーフの印付けが修正されました。
+(Thomas Munro, Tom Lane)
      </para>
 
      <para>
+<!--
       The functions
       <function>brin_summarize_new_values</function>,
       <function>gin_clean_pending_list</function>,
@@ -130,16 +189,22 @@
       each database of the installation.)  Another option is
       to <application>pg_upgrade</application> the database to a version
       containing the corrected initial data.
+-->
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid re-using TOAST value OIDs that match dead-but-not-yet-vacuumed
       TOAST entries (Pavan Deolasee)
+-->
+無効になったものの未バキュームのTOASTエントリと一致するTOAST値のOIDの再使用を回避しました。
+(Pavan Deolasee)
      </para>
 
      <para>
+<!--
       Once the OID counter has wrapped around, it's possible to assign a
       TOAST value whose OID matches a previously deleted entry in the same
       TOAST table.  If that entry were not yet vacuumed away, this resulted
@@ -148,17 +213,27 @@
       persist until the dead entry was removed
       by <command>VACUUM</command>.  Fix by not selecting such OIDs when
       creating a new TOAST entry.
+-->
+一度OIDカウンタが周回すると、同じTOASTテーブルで以前に削除済みのエントリとOIDが一致するTOAST値を割り当てする可能性があります。
+そのエントリが未だバキュームされていないと、<quote>unexpected chunk number 0 (expected 1) for toast value <replaceable>nnnnn</replaceable>（TOAST値nnnnnに対する予期せぬチャンク番号0、(1が期待された)）</quote>というエラーをひき起こします。
+これは無効なエントリが<command>VACUUM</command>で除去されるまで持続します。
+新たなTOASTエントリを作るときにそのようなOIDを選択しないようにして修正しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Change <command>ANALYZE</command>'s algorithm for updating
       <structname>pg_class</structname>.<structfield>reltuples</structfield>
       (David Gould)
+-->
+<command>ANALYZE</command>の<structname>pg_class</structname>.<structfield>reltuples</structfield>を更新するアルゴリズムを変更しました。
+(David Gould)
      </para>
 
      <para>
+<!--
       Previously, pages not actually scanned by <command>ANALYZE</command>
       were assumed to retain their old tuple density.  In a large table
       where <command>ANALYZE</command> samples only a small fraction of the
@@ -172,277 +247,428 @@
       that <command>ANALYZE</command>'s sample is a statistically unbiased
       sample of the table (as it should be), and just extrapolate the
       density observed within those pages to the whole table.
+-->
+これまでは、<command>ANALYZE</command>で実際にはスキャンされないページは、以前のタプル密度を維持していると見做されました。
+<command>ANALYZE</command>のサンプル取得が全体のごく一部分となる大きなテーブルにおいては、これは全体のタプル密度見積が決して大きくは変更されないことを意味し、そのため、実際にテーブルに起きていることは無視されて、<structfield>reltuples</structfield>はテーブルの物理サイズ（<structfield>relpages</structfield>）の変化にほぼ比例して変化していました。
+これは、事実上自動バキュームを遮断するほどに<structfield>reltuples</structfield>が実際より大きくなる結果としてあらわれました。
+<command>ANALYZE</command>のサンプルがテーブルの統計的に偏りがないサンプルと見做し（そうであるべきなので）、観測されたページ内の密度を単にテーブル全体に外挿することで、修正しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid deadlocks in concurrent <command>CREATE INDEX
       CONCURRENTLY</command> commands that are run
       under <literal>SERIALIZABLE</literal> or <literal>REPEATABLE
       READ</literal> transaction isolation (Tom Lane)
+-->
+<literal>SERIALIZABLE</literal>または<literal>REPEATABLE READ</literal>トランザクション隔離で実行される同時実行の<command>CREATE INDEX CONCURRENTLY</command>コマンドのデッドロックを回避しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible slow execution of <command>REFRESH MATERIALIZED VIEW
       CONCURRENTLY</command> (Thomas Munro)
+-->
+<command>REFRESH MATERIALIZED VIEW CONCURRENTLY</command>の実行が遅くなる可能性があり、修正しました。
+(Thomas Munro)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <literal>UPDATE/DELETE ... WHERE CURRENT OF</literal> to not fail
       when the referenced cursor uses an index-only-scan plan (Yugo Nagata,
       Tom Lane)
+-->
+参照されるカーソルがインデックスオンリースキャンプランを使うときに<literal>UPDATE/DELETE ... WHERE CURRENT OF</literal>が失敗しないように修正しました。
+(Yugo Nagata, Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect planning of join clauses pushed into parameterized
       paths (Andrew Gierth, Tom Lane)
+-->
+パラメタライズドパスにプッシュされたJOIN句の誤ったプラン作成を修正しました。
+(Andrew Gierth, Tom Lane)
      </para>
 
      <para>
+<!--
       This error could result in misclassifying a condition as
       a <quote>join filter</quote> for an outer join when it should be a
       plain <quote>filter</quote> condition, leading to incorrect join
       output.
+-->
+この障害により、<quote>filter</quote>条件のプランであるべきときに、条件が外部結合に対する<quote>join filter</quote>であると誤った分別がされ、間違った結合結果をもたらす可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possibly incorrect generation of an index-only-scan plan when the
       same table column appears in multiple index columns, and only some of
       those index columns use operator classes that can return the column
       value (Kyotaro Horiguchi)
+-->
+複合インデックスの列に同じテーブル列が現れ、それらインデックス列の一部だけが列の値を返すことができる演算子クラスを使うときに、起こりうる誤ったインデックスオンリースキャンプランの生成が修正されました。
+(Kyotaro Horiguchi)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix misoptimization of <literal>CHECK</literal> constraints having
       provably-NULL subclauses of
       top-level <literal>AND</literal>/<literal>OR</literal> conditions
       (Tom Lane, Dean Rasheed)
+-->
+NULLであると証明可能なトップレベル<literal>AND</literal>/<literal>OR</literal>条件の副句を持つ、<literal>CHECK</literal>制約の誤った最適化が修正されました。
+(Tom Lane, Dean Rasheed)
      </para>
 
      <para>
+<!--
       This could, for example, allow constraint exclusion to exclude a
       child table that should not be excluded from a query.
+-->
+これにより、例えば、制約による除外が、問い合わせから除外すべきでない子テーブルを除外することを許してしまうおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix executor crash due to double free in some <literal>GROUPING
       SET</literal> usages (Peter Geoghegan)
+-->
+一部の<literal>GROUPING SET</literal>使用における二重解放によるエグゼキュータのクラッシュを修正しました。
+(Peter Geoghegan)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid crash if a table rewrite event trigger is added concurrently
       with a command that could call such a trigger (&Aacute;lvaro Herrera,
       Andrew Gierth, Tom Lane)
+-->
+テーブル書き換えイベントトリガが、そのようなトリガを呼び出す可能性のあるコマンドと同時に追加された場合のクラッシュを回避しました。
+(&Aacute;lvaro Herrera, Andrew Gierth, Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid failure if a query-cancel or session-termination interrupt
       occurs while committing a prepared transaction (Stas Kelvich)
+-->
+準備されたトランザクションをコミットする間に、問い合わせキャンセルやセッション終了の割り込みが生じた場合の失敗を回避しました。
+(Stas Kelvich)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix query-lifespan memory leakage in repeatedly executed hash joins
       (Tom Lane)
+-->
+繰り返し実行されたハッシュ結合での問い合わせの間のメモリリークを修正しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible leak or double free of visibility map buffer pins
       (Amit Kapila)
+-->
+可視性マップのバッファピンのメモリリークまたは二重解放の可能性があり、修正しました。
+(Amit Kapila)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid spuriously marking pages as all-visible (Dan Wood,
       Pavan Deolasee, &Aacute;lvaro Herrera)
+-->
+ページが全て可視であるという偽性の印付けを回避しました。
+(Dan Wood, Pavan Deolasee, &Aacute;lvaro Herrera)
      </para>
 
      <para>
+<!--
       This could happen if some tuples were locked (but not deleted).  While
       queries would still function correctly, vacuum would normally ignore
       such pages, with the long-term effect that the tuples were never
       frozen.  In recent releases this would eventually result in errors
       such as <quote>found multixact <replaceable>nnnnn</replaceable> from
       before relminmxid <replaceable>nnnnn</replaceable></quote>.
+-->
+これは一部タプルがロックされている（しかし削除されていない）場合に発生するおそれがありました。
+問い合わせが未だ正しく動作している間、バキュームは通常そのようなページを無視し、タプルがずっと凍結されないという長期の影響が伴います。
+最近のリリースではこれは、<quote>found multixact <replaceable>nnnnn</replaceable> from before relminmxid <replaceable>nnnnn</replaceable></quote>といったエラーをひき起こすでしょう。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix overly strict sanity check
       in <function>heap_prepare_freeze_tuple</function>
       (&Aacute;lvaro Herrera)
+-->
+<function>heap_prepare_freeze_tuple</function>の厳格すぎる整合性検査を修正しました。
+(&Aacute;lvaro Herrera)
      </para>
 
      <para>
+<!--
       This could result in incorrect <quote>cannot freeze committed
       xmax</quote> failures in databases that have
       been <application>pg_upgrade</application>'d from 9.2 or earlier.
+-->
+これは、9.2以前から<application>pg_upgrade</application>されたデータベースで間違った<quote>cannot freeze committed xmax</quote>エラーになる可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent dangling-pointer dereference when a C-coded before-update row
       trigger returns the <quote>old</quote> tuple (Rushabh Lathia)
+-->
+Cで書かれた更新前実行の行トリガが<quote>old</quote>タプルを返すときの、ダングリングポインタ参照を防止しました。
+(Rushabh Lathia)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Reduce locking during autovacuum worker scheduling (Jeff Janes)
+-->
+自動バキュームワーカのスケジューリング中のロックを減らしました。
+(Jeff Janes)
      </para>
 
      <para>
+<!--
       The previous behavior caused drastic loss of potential worker
       concurrency in databases with many tables.
+-->
+これまでの振る舞いは、多数のテーブルを持つデータベースで潜在的なワーカの同時実行性の大幅な損失をひき起こしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure client hostname is copied while copying
       <structname>pg_stat_activity</structname> data to local memory
       (Edmund Horner)
+-->
+<structname>pg_stat_activity</structname>のデータをローカルメモリにコピーするときに、確実にクライアントホスト名がコピーされるようにしました。
+(Edmund Horner)
      </para>
 
      <para>
+<!--
       Previously the supposedly-local snapshot contained a pointer into
       shared memory, allowing the client hostname column to change
       unexpectedly if any existing session disconnected.
+-->
+以前はローカルと見做されていたスナップショットが共有メモリへのポインタを含んでいて、何らかの存在するセッションが切断した場合に、クライアントホスト名の列が予期せず変化することがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix incorrect processing of multiple compound affixes
       in <literal>ispell</literal> dictionaries (Arthur Zakirov)
+-->
+<literal>ispell</literal>辞書で複合接辞の誤った処理を修正しました。
+(Arthur Zakirov)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix collation-aware searches (that is, indexscans using inequality
       operators) in SP-GiST indexes on text columns (Tom Lane)
+-->
+テキスト列のSP-GiSTインデックスでの照合を伴う検索（すなわち、不等演算子を使うインデックススキャン）を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Such searches would return the wrong set of rows in most non-C
       locales.
+-->
+このような検索は大部分の非Cロケールで誤った行集合を返しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent query-lifespan memory leakage with SP-GiST operator classes
       that use traversal values (Anton Dign&ouml;s)
+-->
+横断値を使うSP-GiST演算子クラスでの問い合わせの間のメモリリークを防止しました。
+(Anton Dign&ouml;s)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Count the number of index tuples correctly during initial build of an
       SP-GiST index (Tomas Vondra)
+-->
+SP-GiSTインデックスの初期ビルドの際にインデックスのタプル数を正しく数えるようにしました。
+(Tomas Vondra)
      </para>
 
      <para>
+<!--
       Previously, the tuple count was reported to be the same as that of
       the underlying table, which is wrong if the index is partial.
+-->
+これまでは、タプル数は元となるテーブルと同じと報告されましたが、これは部分インデックスの場合には誤りです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Count the number of index tuples correctly during vacuuming of a
       GiST index (Andrey Borodin)
+-->
+GiSTインデックスのバキュームの際にインデックスタプルの数を正しく数えるようにしました。
+ (Andrey Borodin)
      </para>
 
      <para>
+<!--
       Previously it reported the estimated number of heap tuples,
       which might be inaccurate, and is certainly wrong if the
       index is partial.
+-->
+これまでは見積られたヒープタプルの数が報告されましたが、それは不正確かもしれず、部分インデックスでは確実に誤っています。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix a corner case where a streaming standby gets stuck at a WAL
       continuation record (Kyotaro Horiguchi)
+-->
+WALの継続レコードでストリーミングスタンバイが動かなくなる稀な場合が修正されました。
+(Kyotaro Horiguchi)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       In logical decoding, avoid possible double processing of WAL data
       when a walsender restarts (Craig Ringer)
+-->
+ロジカルデコーディングでwalsenderが再起動したときに起こりうるWALデータの二重処理を回避しました。
+(Craig Ringer)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Allow <function>scalarltsel</function>
       and <function>scalargtsel</function> to be used on non-core datatypes
       (Tomas Vondra)
+-->
+<function>scalarltsel</function>と<function>scalargtsel</function>を非コアのデータ型で使用できるようにしました。
+(Tomas Vondra)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Reduce <application>libpq</application>'s memory consumption when a
       server error is reported after a large amount of query output has
       been collected (Tom Lane)
+-->
+大量の問い合わせ出力が収集された後にサーバエラーが報告されたときの<application>libpq</application>のメモリ消費を減らしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Discard the previous output before, not after, processing the error
       message.  On some platforms, notably Linux, this can make a
       difference in the application's subsequent memory footprint.
+-->
+以前の出力を後でなく先に廃棄して、エラーメッセージを処理します。
+一部のプラットフォーム、とりわけLinuxでは、これによりアプリケーションの以降のメモリフットプリントに違いを出すことができます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix double-free crashes in <application>ecpg</application>
       (Patrick Krecker, Jeevan Ladhe)
+-->
+<application>ecpg</application>で二重解放のクラッシュを修正しました。
+(Patrick Krecker, Jeevan Ladhe)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>ecpg</application> to handle <type>long long
       int</type> variables correctly in MSVC builds (Michael Meskes,
       Andrew Gierth)
+-->
+MSVCビルドで<type>long long int</type>変数を正しく扱うように<application>ecpg</application>を修正しました。
+(Michael Meskes, Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix mis-quoting of values for list-valued GUC variables in dumps
       (Michael Paquier, Tom Lane)
+-->
+ダンプでリスト値になったGUC変数に対する誤った値のクォート付けを修正しました。
+(Michael Paquier, Tom Lane)
      </para>
 
      <para>
+<!--
       The <varname>local_preload_libraries</varname>,
       <varname>session_preload_libraries</varname>,
       <varname>shared_preload_libraries</varname>,
@@ -451,113 +677,173 @@
       cause problems if settings for these variables appeared in
       <command>CREATE FUNCTION ... SET</command> or <command>ALTER
       DATABASE/ROLE ... SET</command> clauses.
+-->
+<varname>local_preload_libraries</varname>、<varname>session_preload_libraries</varname>、<varname>shared_preload_libraries</varname>、および<varname>temp_tablespaces</varname>変数は、<application>pg_dump</application>出力で正しくクォート付けされませんでした。
+これら変数に対する設定が<command>CREATE FUNCTION ... SET</command>や<command>ALTER DATABASE/ROLE ... SET</command>句にあるとき、問題を起こしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_recvlogical</application> to not fail against
       pre-v10 <productname>PostgreSQL</productname> servers
       (Michael Paquier)
+-->
+<application>pg_recvlogical</application>をv10より前の<productname>PostgreSQL</productname>に対して失敗しないように修正しました。
+(Michael Paquier)
      </para>
 
      <para>
+<!--
       A previous fix caused <application>pg_recvlogical</application> to
       issue a command regardless of server version, but it should only be
       issued to v10 and later servers.
+-->
+前の修正は<application>pg_recvlogical</application>がサーババージョンにかかわらずコマンドを発行する動作を起こしていましたが、v10以降のサーバにだけ発行されるべきです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that <application>pg_rewind</application> deletes files on the
       target server if they are deleted from the source server during the
       run (Takayuki Tsunakawa)
+-->
+<application>pg_rewind</application>が実行中にファイルがソースサーバで削除されている場合、確実にターゲットサーバのそれらファイルを削除するようにしました。
+(Takayuki Tsunakawa)
      </para>
 
      <para>
+<!--
       Failure to do this could result in data inconsistency on the target,
       particularly if the file in question is a WAL segment.
+-->
+これを行うのに失敗することで、特に問題のファイルがWALセグメントである場合に、ターゲットでデータ不整合が生じる可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_rewind</application> to handle tables in
       non-default tablespaces correctly (Takayuki Tsunakawa)
+-->
+デフォルトでないテーブルスペースにあるテーブルを正しく扱うように<application>pg_rewind</application>を修正しました。
+(Takayuki Tsunakawa)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix overflow handling in <application>PL/pgSQL</application>
       integer <command>FOR</command> loops (Tom Lane)
+-->
+<application>PL/pgSQL</application>の整数<command>FOR</command>ループでオーバーフローの扱いを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       The previous coding failed to detect overflow of the loop variable
       on some non-gcc compilers, leading to an infinite loop.
+-->
+以前のコーディングは一部の非gccコンパイラでループ変数のオーバーフローを検知するのに失敗していて、無限ループをもたらしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Adjust <application>PL/Python</application> regression tests to pass
       under Python 3.7 (Peter Eisentraut)
+-->
+<application>PL/Python</application>のリグレッションテストをPython 3.7でパスするように修正しました。
+(Peter Eisentraut)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Support testing <application>PL/Python</application> and related
       modules when building with Python 3 and MSVC (Andrew Dunstan)
+-->
+Python 3とMSVCでビルドするときに<application>PL/Python</application>と関連モジュールのテストをサポートしました。
+(Andrew Dunstan)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix errors in initial build of <filename>contrib/bloom</filename>
       indexes (Tomas Vondra, Tom Lane)
+-->
+<filename>contrib/bloom</filename>のインデックスの初期ビルドでのエラーを修正しました。
+(Tomas Vondra, Tom Lane)
      </para>
 
      <para>
+<!--
       Fix possible omission of the table's last tuple from the index.
       Count the number of index tuples correctly, in case it is a partial
       index.
+-->
+テーブルの最後のタプルがインデックスで無視される可能性があり、修正しました。
+部分インデックスの場合にインデックスのタプル数を正しく数えるようにしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Rename internal <function>b64_encode</function>
       and <function>b64_decode</function> functions to avoid conflict with
       Solaris 11.4 built-in functions (Rainer Orth)
+-->
+Solaris 11.4 の組み込み関数との衝突を避けるため内部の<function>b64_encode</function>および<function>b64_decode</function>関数を改名しました。
+(Rainer Orth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Sync our copy of the timezone library with IANA tzcode release 2018e
       (Tom Lane)
+-->
+タイムゾーンライブラリのコピーをIANA tzcode release 2018eに同期しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fixes the <application>zic</application> timezone data compiler
       to cope with negative daylight-savings offsets.  While
       the <productname>PostgreSQL</productname> project will not
       immediately ship such timezone data, <application>zic</application>
       might be used with timezone data obtained directly from IANA, so it
       seems prudent to update <application>zic</application> now.
+-->
+これは<application>zic</application>タイムゾーンコンパイラを、負の夏時間オフセットを処理できるように修正します。
+<productname>PostgreSQL</productname>プロジェクトが直ちにそのようなタイムゾーンデータを使えるようにすることはありませんが、<application>zic</application>はIANAから直に取得したタイムゾーンデータで使われるかもしれませんので、確実を期してここで<application>zic</application>をアップデートしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Update time zone data files to <application>tzdata</application>
       release 2018d for DST law changes in Palestine and Antarctica (Casey
       Station), plus historical corrections for Portugal and its colonies,
       as well as Enderbury, Jamaica, Turks &amp; Caicos Islands, and
       Uruguay.
+-->
+タイムゾーンデータファイルを<application>tzdata</application> release 2018dに更新しました。
+パレスチナと南極（ケーシー基地）の夏時間法の変更に加え、ポルトガルとその植民地、エンダーベリー島、ジャマイカ、タークス・カイコス諸島、ウルグアイの歴史的修正が含まれます。
      </para>
     </listitem>
 
@@ -587,8 +873,7 @@
    <xref linkend="release-9-6">.
 -->
 このリリースは9.6.7に対し、各種不具合を修正したものです。
-9.6メジャーリリースにおける新機能については、<xref linkend="release-9-6">
-を参照してください。
+9.6メジャーリリースにおける新機能については、<xref linkend="release-9-6">を参照してください。
   </para>
 
   <sect2>


### PR DESCRIPTION
以下のファイルの10.4対応です。

- release-9.3.sgml
- release-9.4.sgml
- release-9.5.sgml
- release-9.6.sgml
