### PR TITLE
fix typo of Kerberos

### DIFF
--- a/doc/src/sgml/client-auth.sgml
+++ b/doc/src/sgml/client-auth.sgml
@@ -1881,7 +1881,7 @@ realmをユーザプリンシパル名に一致するように設定します。
         it is disabled (the default), the SAM-compatible user name is used.
         By default, these two names are identical for new user accounts.
 -->
-<literal>compat_realm</literal>と共にこのオプションが有効の場合、認証にはケルベルスUPNからユーザ名が使用されます。
+<literal>compat_realm</literal>と共にこのオプションが有効の場合、認証にはケルベロスUPNからユーザ名が使用されます。
 無効（デフォルト）である場合は、SAM互換ユーザ名が使用されます。
 デフォルトでは、これらの2つのユーザ名は新しいユーザアカウントでは同じものとなります。
        </para>


### PR DESCRIPTION
「ケルベロス」でしょう。（Kerberosのままでも良いかもしれません。）

ケルベルスだとかつてあった（ヘビの？）星座に、、、、