### PR TITLE
fix typo of replica identity

### DIFF
--- a/doc/src/sgml/logical-replication.sgml
+++ b/doc/src/sgml/logical-replication.sgml
@@ -201,17 +201,17 @@ PostgreSQLは両方の仕組みを同時にサポートします。
    operations will cause an error on the publisher.  <command>INSERT</command>
    operations can proceed regardless of any replica identity.
 -->
-パブリッシュされたテーブルは、<command>UPDATE</command>と<command>DELETE</command>をレプリケーションできるようにするために、<quote>レプリカアイデンティ</quote>の設定を含んでいなければなりません。
+パブリッシュされたテーブルは、<command>UPDATE</command>と<command>DELETE</command>をレプリケーションできるようにするために、<quote>レプリカアイデンティティ</quote>の設定を含んでいなければなりません。
 そうすることにより、サブスクライバー側で更新または削除する対象の正しい行が特定できるようになります。
-デフォルトでは主キーがあれば、それがレプリカアイデンティになります。
-他に、ユニークキー（追加の要件を伴います）もレプリカアイデンティにできます。
-テーブルに適当なキーがなければ、レプリカアイデンティを<quote>full</quote>にできます。
+デフォルトでは主キーがあれば、それがレプリカアイデンティティになります。
+他に、ユニークキー（追加の要件を伴います）もレプリカアイデンティティにできます。
+テーブルに適当なキーがなければ、レプリカアイデンティティを<quote>full</quote>にできます。
 これは、行全体がキーになることを意味します。
 しかし、これは非常に非効率なので、他の解決方法がない場合のみの代替手段にすべきです。
-<quote>full</quote>以外のレプリカアイデンティがパブリッシャー側に設定されている場合、同じか、より少ない列を含むレプリカアイデンティがサブスクライバー側に設定されていなければなりません。
-レプリカアイデンティを設定する詳細な方法については、<xref linkend="SQL-CREATETABLE-REPLICA-IDENTITY">をご覧ください。
-<command>UPDATE</command>あるいは<command>DELETE</command>操作をレプリケーションするパブリケーションに、レプリカアイデンティがないテーブルが追加されると、以後<command>UPDATE</command>あるいは<command>DELETE</command>操作が行われるとパブリッシャー側でエラーが発生します。
-<command>INSERT</command>操作は、レプリカアイデンティの設定に関わらず実行されます。
+<quote>full</quote>以外のレプリカアイデンティティがパブリッシャー側に設定されている場合、同じか、より少ない列を含むレプリカアイデンティティがサブスクライバー側に設定されていなければなりません。
+レプリカアイデンティティを設定する詳細な方法については、<xref linkend="SQL-CREATETABLE-REPLICA-IDENTITY">をご覧ください。
+<command>UPDATE</command>あるいは<command>DELETE</command>操作をレプリケーションするパブリケーションに、レプリカアイデンティティがないテーブルが追加されると、以後<command>UPDATE</command>あるいは<command>DELETE</command>操作が行われるとパブリッシャー側でエラーが発生します。
+<command>INSERT</command>操作は、レプリカアイデンティティの設定に関わらず実行されます。
   </para>
 
   <para>


### PR DESCRIPTION
replica identityの訳が「レプリカアイデンティ」になっているところがありました。