### PR TITLE
fix typos around version number

### DIFF
--- a/doc/src/sgml/release-10.sgml
+++ b/doc/src/sgml/release-10.sgml
@@ -5,7 +5,7 @@
 <!--
   <title>Release 10.4</title>
 -->
-  <title>リリース 10.4</title>
+  <title>リリース10.4</title>
 
   <formalpara>
 <!--

--- a/doc/src/sgml/release-9.6.sgml
+++ b/doc/src/sgml/release-9.6.sgml
@@ -4771,7 +4771,10 @@ MSVCビルドで、<filename>vcregress.pl</filename>のコマンドライン上�
  </sect1>
 
  <sect1 id="release-9-6-3">
+<!--
   <title>Release 9.6.3</title>
+-->
+  <title>リリース9.6.3</title>
 
   <formalpara>
 <!--
@@ -4796,7 +4799,7 @@ MSVCビルドで、<filename>vcregress.pl</filename>のコマンドライン上�
 <!--
    <title>Migration to Version 9.6.3</title>
 -->
-   <title>バージョン9.6.2への移行</title>
+   <title>バージョン9.6.3への移行</title>
 
    <para>
 <!--


### PR DESCRIPTION
リリースの番号関連でいくつか間違いを見つけました。

10は間違いとは言えないのですが、他のところでは空白を入れていないのでそちらに合わせています。
9.6は訳し忘れと番号間違いです。