### PR TITLE
ltree.sgmlのPostgreSQL 10.5対応です。

### DIFF
--- a/doc/src/sgml/ltree.sgml
+++ b/doc/src/sgml/ltree.sgml
@@ -713,11 +713,11 @@ Europe &amp; Russia*@ &amp; !Transportation
 <!--
       <entry>longest common ancestor of paths
        (up to 8 arguments supported)</entry>
-      <entry><literal>lca('1.2.3','1.2.3.4.5.6')</literal></entry>
 -->
       <entry>
-最少共通祖先。つまり、経路で共通する最長接頭辞。（最大8個の引数をサポート）
+経路で共通する最長接頭辞。（最大8個の引数をサポート）
       </entry>
+      <entry><literal>lca('1.2.3','1.2.3.4.5.6')</literal></entry>
       <entry><literal>1.2</literal></entry>
      </row>
 
@@ -726,11 +726,11 @@ Europe &amp; Russia*@ &amp; !Transportation
       <entry><type>ltree</type></entry>
 <!--
       <entry>longest common ancestor of paths in array</entry>
-      <entry><literal>lca(array['1.2.3'::ltree,'1.2.3.4'])</literal></entry>
 -->
       <entry>
-最少共通祖先。つまり、経路で共通する最長接頭辞。
+経路で共通する配列内の最長接頭辞。
       </entry>
+      <entry><literal>lca(array['1.2.3'::ltree,'1.2.3.4'])</literal></entry>
       <entry><literal>1.2</literal></entry>
      </row>
 


### PR DESCRIPTION
lca関数の例題が以前から誤ってコメントアウトされていたのをついでに修正しました。