### PR TITLE
config.sgmlが大きくなりすぎたので、レビュー用に分割ファイルを作成しました。

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -3206,6 +3206,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
        </listitem>
       </varlistentry>
 
+<!-- split-config0-end -->
+<!-- split-config1-start -->
+
       <varlistentry id="guc-old-snapshot-threshold" xreflabel="old_snapshot_threshold">
        <term><varname>old_snapshot_threshold</varname> (<type>integer</type>)
        <indexterm>
@@ -6385,6 +6388,9 @@ SELECT * FROM parent WHERE key = 2400;
        </para>
       </listitem>
      </varlistentry>
+
+<!-- split-config1-end -->
+<!-- split-config2-start -->
 
      <varlistentry id="guc-join-collapse-limit" xreflabel="join_collapse_limit">
       <term><varname>join_collapse_limit</varname> (<type>integer</type>)
@@ -9595,6 +9601,9 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
       </listitem>
      </varlistentry>
 
+<!-- split-config2-end -->
+<!-- split-config3-start -->
+
      <varlistentry id="guc-default-transaction-read-only" xreflabel="default_transaction_read_only">
       <term><varname>default_transaction_read_only</varname> (<type>boolean</type>)
       <indexterm>
@@ -12792,4 +12801,7 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
     </table>
 
   </sect1>
+
+<!-- split-config3-end -->
+
 </chapter>

--- a/doc/src/sgml/config0.sgml
+++ b/doc/src/sgml/config0.sgml
@@ -1,0 +1,3222 @@
+<!-- 警告：このファイルは直接編集しないでください！
+1. config.sgmlを編集したら、split-config.shを起動します。
+2. するとconfig[0-3].sgmlが生成されます。
+3. config.sgmlとともにconfig[0-3].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
+4. レビューはconfig[0-3].sgmlに対して行います。
+5. 指摘された点があればconfig.sgmlに反映し、1に戻ります。
+6. config.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
+-->
+<!-- doc/src/sgml/config.sgml -->
+
+<chapter id="runtime-config">
+<!--
+  <title>Server Configuration</title>
+  -->
+  <title>サーバの設定</title>
+
+  <indexterm>
+  <!--
+   <primary>configuration</primary>
+   <secondary>of the server</secondary>
+   -->
+   <primary>設定</primary>
+   <secondary>サーバの</secondary>
+  </indexterm>
+
+  <para>
+  <!--
+   There are many configuration parameters that affect the behavior of
+   the database system. In the first section of this chapter we
+   describe how to interact with configuration parameters. The subsequent sections
+   discuss each parameter in detail.
+   -->
+   データベースシステムの動作に影響を与える数多くのパラメータがあります。
+   この章の最初の節で、どのように設定パラメータを操作するのかについて説明します。
+   引き続く節で、それぞれのパラメータの詳細を説明します。
+  </para>
+
+  <sect1 id="config-setting">
+  <!--
+   <title>Setting Parameters</title>
+   -->
+   <title>パラメータの設定</title>
+
+   <sect2 id="config-setting-names-values">
+   <!--
+    <title>Parameter Names and Values</title>
+    -->
+    <title>パラメータ名とその値</title>
+
+    <para>
+    <!--
+     All parameter names are case-insensitive. Every parameter takes a
+     value of one of five types: boolean, string, integer, floating point,
+     or enumerated (enum).  The type determines the syntax for setting the
+     parameter:
+    -->
+    全てのパラメータの名前は大文字と小文字を区別しません。
+    それぞれのパラメータは、論理値、整数、浮動小数点、文字列、またはenum（列挙型）の5つの型のいずれかの値を取ります。
+型はパラメータをセットするための記法を定義します。
+    </para>
+
+    <itemizedlist>
+     <listitem>
+      <para>
+<!--
+       <emphasis>Boolean:</emphasis>
+       Values can be written as
+       <literal>on</literal>,
+       <literal>off</literal>,
+       <literal>true</literal>,
+       <literal>false</literal>,
+       <literal>yes</literal>,
+       <literal>no</literal>,
+       <literal>1</literal>,
+       <literal>0</literal>
+       (all case-insensitive) or any unambiguous prefix of one of these.
+-->
+<emphasis>論理型:</emphasis>
+値は<literal>on</literal>、<literal>off</literal>、<literal>true</literal>、<literal>false</literal>、<literal>yes</literal>、<literal>no</literal>、<literal>1</literal>、<literal>0</literal>（すべて大文字小文字の区別なし）、あるいは、曖昧でなければ、これらの先頭から数文字を省略形として使うこともできます。
+      </para>
+     </listitem>
+
+     <listitem>
+      <para>
+<!--
+       <emphasis>String:</emphasis>
+       In general, enclose the value in single quotes, doubling any single
+       quotes within the value.  Quotes can usually be omitted if the value
+       is a simple number or identifier, however.
+-->
+<emphasis>文字列型:</emphasis>
+一般に、単一引用符の中に値を入れます。
+単一引用符を値に含める場合は単一引用符を２つ続けます。
+なお、値が単純な数字や識別子である場合は、通常は引用符を省略できます。
+      </para>
+     </listitem>
+
+     <listitem>
+      <para>
+<!--
+       <emphasis>Numeric (integer and floating point):</emphasis>
+       A decimal point is permitted only for floating-point parameters.
+       Do not use thousands separators.  Quotes are not required.
+-->
+<emphasis>数値型(整数型と浮動小数点型):</emphasis>
+小数点は浮動小数点型のパラメータでのみ使用できます。
+1000の位取りの区切り文字は使わないでください。
+引用符は必要ありません。
+      </para>
+     </listitem>
+
+     <listitem>
+      <para>
+<!--
+       <emphasis>Numeric with Unit:</emphasis>
+       Some numeric parameters have an implicit unit, because they describe
+       quantities of memory or time. The unit might be kilobytes, blocks
+       (typically eight kilobytes), milliseconds, seconds, or minutes.
+       An unadorned numeric value for one of these settings will use the
+       setting's default unit, which can be learned from
+       <structname>pg_settings</>.<structfield>unit</>.
+       For convenience, settings can be given with a unit specified explicitly,
+       for example <literal>'120 ms'</> for a time value, and they will be
+       converted to whatever the parameter's actual unit is.  Note that the
+       value must be written as a string (with quotes) to use this feature.
+       The unit name is case-sensitive, and there can be whitespace between
+       the numeric value and the unit.
+-->
+<emphasis>単位付きの数値:</emphasis>
+数値型のパラメータによっては暗黙的な単位を持つことがあります。
+メモリの量や時間について記述するからです。
+単位はキロバイト、ブロック（通常8キロバイト）、ミリ秒、秒、分などです。
+修飾無しの数値によるこれらの設定においては、 <structname>pg_settings</>.<structfield>unit</> からデフォルト値が採用されます。
+使い勝手を考えて、たとえば<literal>'120 ms'</>のように単位を明示的に指定することもできます。
+この場合は、実際の単位に変換が行われます。
+なお、この機能を使う場合は、引用符付きの文字列として値を指定しなければならないことに注意してください。
+単位の名称は大文字小文字を区別します。
+また、数値と単位の間に空白があっても構いません。
+
+       <itemizedlist>
+        <listitem>
+         <para>
+<!--
+          Valid memory units are <literal>kB</literal> (kilobytes),
+          <literal>MB</literal> (megabytes), <literal>GB</literal>
+          (gigabytes), and <literal>TB</literal> (terabytes).
+          The multiplier for memory units is 1024, not 1000.
+-->
+           有効なメモリの単位は <literal>kB</literal> (キロバイト),
+          <literal>MB</literal> (メガバイト), <literal>GB</literal>
+          (ギガバイト), <literal>TB</literal> (テラバイト)です。
+メモリ単位の乗数は1024です。1000ではありません。
+         </para>
+        </listitem>
+
+        <listitem>
+         <para>
+<!--
+          Valid time units are <literal>ms</literal> (milliseconds),
+          <literal>s</literal> (seconds), <literal>min</literal> (minutes),
+          <literal>h</literal> (hours), and <literal>d</literal> (days).
+-->
+有効な時間の単位は <literal>ms</literal> (ミリ秒)、<literal>s</literal> (秒)、<literal>min</literal> (分)、<literal>h</literal> (時間)、<literal>d</literal> (日数) です。
+         </para>
+        </listitem>
+       </itemizedlist>
+      </para>
+     </listitem>
+
+     <listitem>
+      <para>
+<!--
+       <emphasis>Enumerated:</emphasis>
+       Enumerated-type parameters are written in the same way as string
+       parameters, but are restricted to have one of a limited set of
+       values.  The values allowable for such a parameter can be found from
+       <structname>pg_settings</>.<structfield>enumvals</>.
+       Enum parameter values are case-insensitive.
+-->
+       <emphasis>列挙型:</emphasis>
+       列挙型のパラメータは文字列パラメータと同じように記述します。
+ただ、使用できる文字列の種類が決まっているだけです。
+使用できる文字列は <structname>pg_settings</>.<structfield>enumvals</> で定義されています。
+列挙型の値は大文字小文字を区別しません。
+      </para>
+     </listitem>
+    </itemizedlist>
+   </sect2>
+
+   <sect2 id="config-setting-configuration-file">
+   <!--
+    <title>Parameter Interaction via the Configuration File</title>
+    -->
+    <title>設定ファイルによるパラメータ操作</title>
+
+    <para>
+   <!--
+     The most fundamental way to set these parameters is to edit the file
+     <filename>postgresql.conf</><indexterm><primary>postgresql.conf</></>,
+     which is normally kept in the data directory.  A default copy is
+     installed when the database cluster directory is initialized.
+     An example of what this file might look like is:
+    -->
+    これらのパラメータを設定する最も基本的な方法は、<filename>postgresql.conf</><indexterm><primary>postgresql.conf</></>ファイルを編集することで、これは通常 data ディレクトリに格納されています。
+デフォルトのコピーはデータベースクラスタディレクトリが初期化されるときそこにインストールされます。このファイルがどういったものかの例を示します。
+<programlisting>
+# This is a comment
+log_connections = yes
+log_destination = 'syslog'
+search_path = '"$user", public'
+shared_buffers = 128MB
+</programlisting>
+<!--
+     One parameter is specified per line. The equal sign between name and
+     value is optional. Whitespace is insignificant (except within a quoted
+     parameter value) and blank lines are
+     ignored. Hash marks (<literal>#</literal>) designate the remainder
+     of the line as a comment.  Parameter values that are not simple
+     identifiers or numbers must be single-quoted.  To embed a single
+     quote in a parameter value, write either two quotes (preferred)
+     or backslash-quote.
+    -->
+1つの行毎に1つのパラメータが指定されます。
+名前と値の間の等号は省略可能です。
+（引用符付きのパラメータ値内を除き）空白は特に意味を持たず、何もない行は無視されます。
+ハッシュ記号（<literal>#</literal>）はその行の後の表記がコメントであることを意味します。
+単純でない識別子、または数値でないパラメータ値は単一引用符で括られなければなりません。
+パラメータ値の中に単一引用符を埋め込むには、引用符を2つ（推奨）もしくはバックスラッシュ-引用符を使います。
+    </para>
+
+    <para>
+<!--
+     Parameters set in this way provide default values for the cluster.
+     The settings seen by active sessions will be these values unless they
+     are overridden.  The following sections describe ways in which the
+     administrator or user can override these defaults.
+-->
+この方法によりクラスタに対してデフォルト値が設定されます。
+上書きされない限り、アクティブなセッションが見るのはこの値です。
+次節以降では、管理者やユーザがこれらのデフォルト値を上書きする方法を説明します。
+    </para>
+
+    <para>
+     <indexterm>
+      <primary>SIGHUP</primary>
+     </indexterm>
+     <!--
+     The configuration file is reread whenever the main server process
+     receives a <systemitem>SIGHUP</> signal; this signal is most easily
+     sent by running <literal>pg_ctl reload</> from the command line or by
+     calling the SQL function <function>pg_reload_conf()</function>. The main
+     server process also propagates this signal to all currently running
+     server processes, so that existing sessions also adopt the new values
+     (this will happen after they complete any currently-executing client
+     command).  Alternatively, you can
+     send the signal to a single server process directly.  Some parameters
+     can only be set at server start; any changes to their entries in the
+     configuration file will be ignored until the server is restarted.
+     Invalid parameter settings in the configuration file are likewise
+     ignored (but logged) during <systemitem>SIGHUP</> processing.
+    -->
+設定ファイルは、メインサーバプロセスが<systemitem>SIGHUP</>シグナルを受け取るたびに再読み込みされます。
+このシグナルを手っ取り早く送信するには、コマンドラインから<literal>pg_ctl reload</>を実行するか、SQL関数の<function>pg_reload_conf()</function>を呼び出します。
+メインサーバプロセスは同時にこのシグナルを、現存のセッションが同様に新しい値を入手できるように、全ての現在実行しているサーバプロセスに伝播します(これは現在実行中のクライアントコマンドの処理を完了してから行われます)。
+他の手段として、直接単一のサーバプロセスにシグナルを送ることも可能です。
+一部のパラメータはサーバの起動時のみ設定されまするので、設定ファイル中のそれらのエントリの変更はすべて、サーバが再起動されるまで無視されます。
+設定ファイル内で無効なパラメータが設定された場合も、同じように（ログには残りますが）<systemitem>SIGHUP</> 処理中は無視されます。
+    </para>
+
+    <para>
+<!--
+     In addition to <filename>postgresql.conf</>,
+     a <productname>PostgreSQL</productname> data directory contains a file
+     <filename>postgresql.auto.conf</><indexterm><primary>postgresql.auto.conf</></>,
+     which has the same format as <filename>postgresql.conf</> but should
+     never be edited manually.  This file holds settings provided through
+     the <xref linkend="SQL-ALTERSYSTEM"> command.  This file is automatically
+     read whenever <filename>postgresql.conf</> is, and its settings take
+     effect in the same way.  Settings in <filename>postgresql.auto.conf</>
+     override those in <filename>postgresql.conf</>.
+-->
+<filename>postgresql.conf</>に加え、<productname>PostgreSQL</productname>のデータディレクトリには <filename>postgresql.auto.conf</><indexterm><primary>postgresql.auto.conf</></>というファイルがあります。
+このファイルは <filename>postgresql.conf</> と同じフォーマットですが、決して手動で編集してはいけません。
+このファイルは <xref linkend="SQL-ALTERSYSTEM"> コマンドを使った設定値を保存します。
+このファイルは<filename>postgresql.conf</> が読み込まれるときはいつでも自動的に読み込まれ、同じように設定が反映されます。
+<filename>postgresql.auto.conf</>は、<filename>postgresql.conf</>の設定を上書きします。
+    </para>
+
+    <para>
+<!--
+     The system view
+     <link linkend="view-pg-file-settings"><structname>pg_file_settings</structname></link>
+     can be helpful for pre-testing changes to the configuration file, or for
+     diagnosing problems if a <systemitem>SIGHUP</> signal did not have the
+     desired effects.
+-->
+システムビューの<link linkend="view-pg-file-settings"><structname>pg_file_settings</structname></link>は、設定ファイルへの変更を前もってテストしたい場合や、<systemitem>SIGHUP</>シグナルで望み通りの効果がなかった場合に問題を調査する際に役立ちます。
+    </para>
+   </sect2>
+
+   <sect2 id="config-setting-sql-command-interaction">
+<!--
+    <title>Parameter Interaction via SQL</title>
+-->
+    <title>SQLを通じたパラメータ操作</title>
+
+     <para>
+<!--
+      <productname>PostgreSQL</productname> provides three SQL
+      commands to establish configuration defaults.
+      The already-mentioned <xref linkend="SQL-ALTERSYSTEM"> command
+      provides a SQL-accessible means of changing global defaults; it is
+      functionally equivalent to editing <filename>postgresql.conf</>.
+      In addition, there are two commands that allow setting of defaults
+      on a per-database or per-role basis:
+-->
+    <productname>PostgreSQL</productname>は3つのSQLコマンドでデフォルト値を設定します。
+    すでに説明した<xref linkend="SQL-ALTERSYSTEM">コマンドは、SQLによってグローバルな設定値を変更する方法を提供します; <filename>postgresql.conf</>を編集するのと等価です。これに加え、データベース単位あるいはロール単位で設定するためのコマンドがあります:
+     </para>
+
+     <itemizedlist>
+     <listitem>
+      <para>
+<!--
+       The <xref linkend="sql-alterdatabase"> command allows global
+       settings to be overridden on a per-database basis.
+-->
+      <xref linkend="sql-alterdatabase">コマンドはデータベース単位でグローバルな設定値を上書きします。
+      </para>
+     </listitem>
+
+     <listitem>
+      <para>
+<!--
+       The <xref linkend="sql-alterrole"> command allows both global and
+       per-database settings to be overridden with user-specific values.
+-->
+      <xref linkend="sql-alterrole">コマンドはグローバルと、データベース単位の両方をユーザ固有の設定値で上書きします。
+      </para>
+     </listitem>
+    </itemizedlist>
+
+     <para>
+<!--
+      Values set with <command>ALTER DATABASE</> and <command>ALTER ROLE</>
+      are applied only when starting a fresh database session.  They
+      override values obtained from the configuration files or server
+      command line, and constitute defaults for the rest of the session.
+      Note that some settings cannot be changed after server start, and
+      so cannot be set with these commands (or the ones listed below).
+-->
+     <command>ALTER DATABASE</>と<command>ALTER ROLE</>による設定値は新しくデータベースセッションを開始した時にのみ適用されます。
+これらのコマンドは設定ファイルやサーバへのコマンド引数による設定値を上書きし、セッションの以後の状態に適用します。なお、一部の設定はサーバを起動した後では変更できず、これらのコマンドを使っては設定できません(以下に記述するコマンドでも同じことが言えます)。
+    </para>
+
+     <para>
+<!--
+      Once a client is connected to the database, <productname>PostgreSQL</>
+      provides two additional SQL commands (and equivalent functions) to
+      interact with session-local configuration settings:
+-->
+クライアントがデータベースに接続すると、<productname>PostgreSQL</>では更に2つのSQL(そして同等の関数)を使ってセッションローカルの設定変更を行うことができます。
+    </para>
+
+    <itemizedlist>
+     <listitem>
+     <para>
+<!--
+      The <xref linkend="SQL-SHOW"> command allows inspection of the
+      current value of all parameters.  The corresponding function is
+      <function>current_setting(setting_name text)</function>.
+-->
+     <xref linkend="SQL-SHOW">コマンドを使ってすべてのパラメータの現在の値を調べることができます。
+対応する関数は<function>current_setting(setting_name text)</function>です。
+     </para>
+     </listitem>
+
+     <listitem>
+      <para>
+<!--
+       The <xref linkend="SQL-SET"> command allows modification of the
+       current value of those parameters that can be set locally to a
+       session; it has no effect on other sessions.
+       The corresponding function is
+       <function>set_config(setting_name, new_value, is_local)</function>.
+-->
+      <xref linkend="SQL-SET">でセッション内でローカルに変更できるパラメータの値を変更することができます。対応する関数は<function>set_config(setting_name, new_value, is_local)</function>です。
+      </para>
+     </listitem>
+    </itemizedlist>
+
+    <para>
+<!--
+     In addition, the system view <link
+     linkend="view-pg-settings"><structname>pg_settings</></> can be
+     used to view and change session-local values:
+-->
+更にシステムビューの<link linkend="view-pg-settings"><structname>pg_settings</></>を使ってセッションローカルな値を参照したり変更することができます。
+    </para>
+
+    <itemizedlist>
+     <listitem>
+      <para>
+<!--
+       Querying this view is similar to using <command>SHOW ALL</> but
+       provides more detail.  It is also more flexible, since it's possible
+       to specify filter conditions or join against other relations.
+-->
+     このビューを問い合わせるのは、<command>SHOW ALL</>を使うのと同じですが、更に詳細な情報を提供します。
+フィルター条件を指定したり他のリレーションと結合ができるので、より柔軟です。
+      </para>
+     </listitem>
+
+     <listitem>
+      <para>
+<!--
+       Using <xref linkend="SQL-UPDATE"> on this view, specifically
+       updating the <structname>setting</> column, is the equivalent
+       of issuing <command>SET</> commands.  For example, the equivalent of
+-->
+このビューに対して<xref linkend="SQL-UPDATE">を実行する、具体的には<structname>setting</>列を更新することは、<command>SET</>コマンドを実行するのと同等です。
+たとえば、
+<programlisting>
+SET configuration_parameter TO DEFAULT;
+</programlisting>
+<!--
+       is:
+-->
+は
+<programlisting>
+UPDATE pg_settings SET setting = reset_val WHERE name = 'configuration_parameter';
+</programlisting>
+と同じです。
+      </para>
+     </listitem>
+    </itemizedlist>
+
+   </sect2>
+
+   <sect2>
+<!--
+    <title>Parameter Interaction via the Shell</title>
+-->
+    <title>シェルによるパラメータ操作</title>
+
+     <para>
+<!--
+      In addition to setting global defaults or attaching
+      overrides at the database or role level, you can pass settings to
+      <productname>PostgreSQL</productname> via shell facilities.
+      Both the server and <application>libpq</> client library
+      accept parameter values via the shell.
+-->
+      グローバルなデフォルト値を設定したりデータベース、ロール単位で上書きを行えるだけでなく、シェル機能を使って<productname>PostgreSQL</productname>に設定値を渡すことができます。
+サーバも<application>libpq</>クライアントライブラリもシェル経由でパラメータ値を受けとることができます。
+     </para>
+
+     <itemizedlist>
+      <listitem>
+      <para>
+<!--
+       During server startup, parameter settings can be
+       passed to the <command>postgres</command> command via the
+       <option>-c</> command-line parameter.  For example,
+-->
+      サーバ起動時に、<option>-c</>コマンドラインパラメータを使ってパラメータ設定値を<command>postgres</command>に渡すことができます。たとえば、
+<programlisting>
+postgres -c log_connections=yes -c log_destination='syslog'
+</programlisting>
+<!--
+       Settings provided in this way override those set via
+       <filename>postgresql.conf</> or <command>ALTER SYSTEM</>,
+       so they cannot be changed globally without restarting the server.
+-->
+       このようにして渡された設定値は、<filename>postgresql.conf</>や<command>ALTER SYSTEM</>による設定を上書きします。
+したがってサーバを再起動しない限りこれらの設定値をグローバルに変更することはできません。
+     </para>
+    </listitem>
+
+    <listitem>
+     <para>
+<!--
+      When starting a client session via <application>libpq</>,
+      parameter settings can be
+      specified using the <envar>PGOPTIONS</envar> environment variable.
+      Settings established in this way constitute defaults for the life
+      of the session, but do not affect other sessions.
+      For historical reasons, the format of <envar>PGOPTIONS</envar> is
+      similar to that used when launching the <command>postgres</command>
+      command; specifically, the <option>-c</> flag must be specified.
+      For example,
+-->
+      <application>libpq</>を使ってクライアントセッションを開始するときに<envar>PGOPTIONS</envar>環境変数を使って設定値を指定できます。
+このようにして渡された設定値はセッションのデフォルトとなりますが、他のセッションには影響を与えません。
+歴史的な理由により、<envar>PGOPTIONS</envar>の形式は<command>postgres</command>を起動するときのものと似ています。たとえば、<option>-c</>フラグを指定しなければならない点です。
+<programlisting>
+env PGOPTIONS="-c geqo=off -c statement_timeout=5min" psql
+</programlisting>
+     </para>
+
+     <para>
+<!--
+      Other clients and libraries might provide their own mechanisms,
+      via the shell or otherwise, that allow the user to alter session
+      settings without direct use of SQL commands.
+-->
+     他のクライアントやライブラリではそれぞれ固有の方法でシェルなどを経由して、SQLコマンドを直接使わずにセッションの設定を変更することができるかもしれません。
+     </para>
+    </listitem>
+   </itemizedlist>
+
+   </sect2>
+
+   <sect2 id="config-includes">
+   <!--
+    <title>Managing Configuration File Contents</title>
+   -->
+    <title>設定ファイルの内容の管理</title>
+
+     <para>
+<!--
+      <productname>PostgreSQL</> provides several features for breaking
+      down complex <filename>postgresql.conf</> files into sub-files.
+      These features are especially useful when managing multiple servers
+      with related, but not identical, configurations.
+-->
+      <productname>PostgreSQL</>は複雑な<filename>postgresql.conf</>ファイルを複数の小さなファイルに分割する複数の方法を提供しています。
+これは、とりわけお互いに関連しているものの設定が同じではない複数のサーバを管理する際に有用です。
+     </para>
+
+     <para>
+      <indexterm>
+       <primary><literal>include</></primary>
+       <!--
+       <secondary>in configuration file</secondary>
+       -->
+       <secondary>設定ファイルの中</secondary>
+      </indexterm>
+      <!--
+      In addition to individual parameter settings,
+      the <filename>postgresql.conf</> file can contain <firstterm>include
+      directives</>, which specify another file to read and process as if
+      it were inserted into the configuration file at this point.  This
+      feature allows a configuration file to be divided into physically
+      separate parts.  Include directives simply look like:
+-->
+パラメータ設定に加え、<filename>postgresql.conf</>ファイルに<firstterm>includeディレクティブ</>を入れることができます。
+このようにすると、別のファイルがあたかも設定ファイルのその場所に挿入されているかのごとく読み込まれ、処理されるように指定されます。
+この機能により、設定ファイルを物理的に異なる複数のパーツに分解することができます。
+Includeディレクティブは単に次のような形式になります。
+<!--
+<programlisting>
+include 'filename'
+</programlisting>
+-->
+<programlisting>
+include 'ファイル名'
+</programlisting>
+<!--
+      If the file name is not an absolute path, it is taken as relative to
+      the directory containing the referencing configuration file.
+      Inclusions can be nested.
+-->
+ファイル名が絶対パスでない場合、参照する設定ファイルを含むディレクトリからの相対パスであると受け取られます。
+Includeコマンドは入れ子にすることができます。
+     </para>
+
+     <para>
+      <indexterm>
+       <primary><literal>include_if_exists</></primary>
+       <!--
+       <secondary>in configuration file</secondary>
+       -->
+       <secondary>設定ファイルにおける</secondary>
+      </indexterm>
+<!--
+      There is also an <literal>include_if_exists</> directive, which acts
+      the same as the <literal>include</> directive, except
+      when the referenced file does not exist or cannot be read.  A regular
+      <literal>include</> will consider this an error condition, but
+      <literal>include_if_exists</> merely logs a message and continues
+      processing the referencing configuration file.
+-->
+<literal>include_if_exists</>ディレクティブもあります。
+これは参照ファイルが存在しないか、または読み込むことができない場合の動作を除き、<literal>include</>ディレクティブと同一の動作をします。
+通常の<literal>include</>はこれをエラーと解釈しますが、<literal>include_if_exists</>はただ単にメッセージをログ出力し、そして参照している設定ファイルの処理を続けます。
+     </para>
+
+     <para>
+      <indexterm>
+       <primary><literal>include_dir</></primary>
+       <!--
+       <secondary>in configuration file</secondary>
+       -->
+       <secondary>設定ファイルにおける</secondary>
+      </indexterm>
+<!--
+      The <filename>postgresql.conf</> file can also contain
+      <literal>include_dir</literal> directives, which specify an entire
+      directory of configuration files to include.  These look like
+-->
+includeする設定ファイルを含むディレクトリ全体を指定する<literal>include_dir</literal>ディレクティブを、<filename>postgresql.conf</>ファイルに含めることもできます。
+このような感じです。
+<!--
+<programlisting>
+include_dir 'directory'
+</programlisting>
+-->
+<programlisting>
+include_dir 'ディレクトリ名'
+</programlisting>
+<!--
+      Non-absolute directory names are taken as relative to the directory
+      containing the referencing configuration file.  Within the specified
+      directory, only non-directory files whose names end with the
+      suffix <literal>.conf</literal> will be included.  File names that
+      start with the <literal>.</literal> character are also ignored, to
+      prevent mistakes since such files are hidden on some platforms.  Multiple
+      files within an include directory are processed in file name order
+      (according to C locale rules, i.e. numbers before letters, and
+      uppercase letters before lowercase ones).
+       -->
+絶対パスではないディレクトリ名はその設定ファイルがあるディレクトリへの相対パスと見なされます。
+指定したディレクトリの中で、ディレクトリではないファイルで末尾が<literal>.conf</literal>で終わるファイルだけがincludeされます。
+また、文字<literal>.</literal> で開始するファイル名は一部のプラットフォームでは隠しファイルとされるので、間違いを防止するため無視されます。
+includeされるディレクトリにある複数ファイルはファイル名順に処理されます(ファイル名は C ロケール規則で順序付けされます。
+つまり、文字より数字、小文字より大文字が先になります)。
+     </para>
+
+     <para>
+     <!--
+      Include files or directories can be used to logically separate portions
+      of the database configuration, rather than having a single large
+      <filename>postgresql.conf</> file.  Consider a company that has two
+      database servers, each with a different amount of memory.  There are
+      likely elements of the configuration both will share, for things such
+      as logging.  But memory-related parameters on the server will vary
+      between the two.  And there might be server specific customizations,
+      too.  One way to manage this situation is to break the custom
+      configuration changes for your site into three files.  You could add
+      this to the end of your <filename>postgresql.conf</> file to include
+      them:
+      -->
+includeされるファイルもしくはディレクトリは、大きな単一の<filename>postgresql.conf</>ファイルを使う代わりに、データベース設定の一部分を論理的に分離するために使用することが可能です。
+異なるメモリー容量を持つ二つのデータベースサーバを所有する会社を考えてみてください。
+例えばログ取得のように、二つが共有する設定の要素があると思われます。
+しかし、サーバ上のメモリに関連したパラメータは二つの間では異なります。
+更に、サーバ特有のカスタマイズも存在することがあります。
+この状況に対処する一つの方法として、そのサイトに対するカスタマイズされた設定の変更を三つのファイルにすることです。
+それらをincludeするためには<filename>postgresql.conf</>ファイルの最後に以下を追加します。
+<programlisting>
+include 'shared.conf'
+include 'memory.conf'
+include 'server.conf'
+</programlisting>
+<!--
+      All systems would have the same <filename>shared.conf</>.  Each
+      server with a particular amount of memory could share the
+      same <filename>memory.conf</>; you might have one for all servers
+      with 8GB of RAM, another for those having 16GB.  And
+      finally <filename>server.conf</> could have truly server-specific
+      configuration information in it.
+      -->
+全てのシステムは同一の<filename>shared.conf</>を所有する様になるでしょう。
+特定のメモリー容量を所有するそれぞれのサーバは同じ<filename>memory.conf</>を共有できます。
+RAMが8GBのすべてのサーバには共通の<filename>memory.conf</>を1つ使い、16GBのサーバ群には別のものを使う、ということもできるでしょう。
+そして最後の<filename>server.conf</>には、本当にサーバ固有となる設定情報を記載します。
+     </para>
+
+     <para>
+     <!--
+      Another possibility is to create a configuration file directory and
+      put this information into files there. For example, a <filename>conf.d</>
+      directory could be referenced at the end of <filename>postgresql.conf</>:
+-->
+別の方法として、設定ファイルディレクトリを作成し、この情報をそこのファイルに格納することができます。
+たとえば、<filename>conf.d</>ディレクトリを<filename>postgresql.conf</>の最後で参照するようにできます。
+<programlisting>
+include_dir 'conf.d'
+</programlisting>
+<!--
+      Then you could name the files in the <filename>conf.d</> directory
+      like this:
+-->
+そして、<filename>conf.d</>の中のファイルを以下のような名前にすることができます。
+<programlisting>
+00shared.conf
+01memory.conf
+02server.conf
+</programlisting>
+ <!--
+       This naming convention establishes a clear order in which these
+       files will be loaded.  This is important because only the last
+       setting encountered for a particular parameter while the server is
+       reading configuration files will be used.  In this example,
+       something set in <filename>conf.d/02server.conf</> would override a
+       value set in <filename>conf.d/01memory.conf</>.
+       -->
+この命名規則により、これらのファイルが読み込まれる順序が明確になります。
+サーバが設定を読み込んでいるときに各パラメータについて最後にあった設定だけが使用されるので、このことは重要です。
+この例では、<filename>conf.d/02server.conf</>でされた指定は<filename>conf.d/01memory.conf</>の設定値よりも優先します。
+     </para>
+
+     <para>
+     <!--
+      You might instead use this approach to naming the files
+      descriptively:
+-->
+代わりに以下の方法を使って、ファイルにわかりやすい名前をつけることもできます。
+<programlisting>
+00shared.conf
+01memory-8GB.conf
+02server-foo.conf
+</programlisting>
+ <!--
+      This sort of arrangement gives a unique name for each configuration file
+      variation.  This can help eliminate ambiguity when several servers have
+      their configurations all stored in one place, such as in a version
+      control repository.  (Storing database configuration files under version
+      control is another good practice to consider.)
+       -->
+こういった工夫で、設定ファイルのバリエーションに対して固有の名前を付与することができます。
+また、バージョン管理リポジトリのリポジトリに複数のサーバの設定ファイルを置く場合に生じる曖昧さを排除することができます。
+（データベース設定ファイルをバージョン管理することは、これもまた検討に値するやり方です）。
+     </para>
+    </sect2>
+   </sect1>
+
+   <sect1 id="runtime-config-file-locations">
+   <!--
+    <title>File Locations</title>
+    -->
+    <title>ファイルの場所</title>
+
+     <para>
+     <!--
+      In addition to the <filename>postgresql.conf</filename> file
+      already mentioned, <productname>PostgreSQL</productname> uses
+      two other manually-edited configuration files, which control
+      client authentication (their use is discussed in <xref
+      linkend="client-authentication">).  By default, all three
+      configuration files are stored in the database cluster's data
+      directory.  The parameters described in this section allow the
+      configuration files to be placed elsewhere.  (Doing so can ease
+      administration.  In particular it is often easier to ensure that
+      the configuration files are properly backed-up when they are
+      kept separate.)
+      -->
+すでに説明した<filename>postgresql.conf</filename>ファイルに加え、<productname>PostgreSQL</productname>は、クライアント認証の管理を行うために、他の2つの手作業で編集される設定ファイルを使用します（これらの使用方法は<xref linkend="client-authentication">で説明します）。
+全ての3つの設定ファイルは、デフォルトではデータベースクラスタのdataディレクトリに格納されます。
+本節で説明するパラメータにより、設定ファイルを他の場所に置くことが可能になります。
+（そのようにすると管理がしやすくなります。
+とりわけ、設定ファイルを分けて保存することで、設定ファイルの適切なバックアップを確実に行うことがしばしば容易になります。）
+     </para>
+
+     <variablelist>
+     <varlistentry id="guc-data-directory" xreflabel="data_directory">
+      <term><varname>data_directory</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>data_directory</> configuration parameter</primary>
+       -->
+       <primary><varname>data_directory</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+         Specifies the directory to use for data storage.
+         This parameter can only be set at server start.
+        -->
+        データ格納に使用するディレクトリを指定します。
+        このパラメータはサーバ起動時のみ設定可能です
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-config-file" xreflabel="config_file">
+      <term><varname>config_file</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>config_file</> configuration parameter</primary>
+       -->
+       <primary><varname>config_file</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+         Specifies the main server configuration file
+         (customarily called <filename>postgresql.conf</>).
+         This parameter can only be set on the <command>postgres</command> command line.
+        -->
+        メインサーバ設定ファイルを指定します（通例<filename>postgresql.conf</>と呼ばれます）。
+このパラメータは<command>postgres</command>コマンドライン上でのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-hba-file" xreflabel="hba_file">
+      <term><varname>hba_file</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>hba_file</> configuration parameter</primary>
+       -->
+       <primary><varname>hba_file</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+         Specifies the configuration file for host-based authentication
+         (customarily called <filename>pg_hba.conf</>).
+         This parameter can only be set at server start.
+        -->
+        ホストベース認証（HBA）用のファイルを指定します（通例<filename>pg_hba.conf</>と呼ばれます）。
+このパラメータはサーバ起動時のみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-ident-file" xreflabel="ident_file">
+      <term><varname>ident_file</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>ident_file</> configuration parameter</primary>
+       -->
+       <primary><varname>ident_file</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+         Specifies the configuration file for user name mapping
+         (customarily called <filename>pg_ident.conf</>).
+         This parameter can only be set at server start.
+         See also <xref linkend="auth-username-maps">.
+        -->
+ユーザ名マッピングの設定ファイルを指定します（通例<filename>pg_ident.conf</>と呼ばれます）。
+このパラメータはサーバ起動時のみ設定可能です。
+<xref linkend="auth-username-maps">もご覧ください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-external-pid-file" xreflabel="external_pid_file">
+      <term><varname>external_pid_file</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>external_pid_file</> configuration parameter</primary>
+       -->
+       <primary><varname>external_pid_file</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the name of an additional process-ID (PID) file that the
+        server should create for use by server administration programs.
+        This parameter can only be set at server start.
+       -->
+サーバ管理プログラムで使用するためにサーバが作成する、追加のプロセス識別子（PID)ファイルの名前を指定します。
+このパラメータはサーバ起動時のみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+     </variablelist>
+
+     <para>
+     <!--
+      In a default installation, none of the above parameters are set
+      explicitly.  Instead, the
+      data directory is specified by the <option>-D</option> command-line
+      option or the <envar>PGDATA</envar> environment variable, and the
+      configuration files are all found within the data directory.
+      -->
+      デフォルトのインストールでは、上記のいかなるパラメータも明示的に設定されません。
+その代わり、data ディレクトリは<option>-D</option>コマンドラインオプション、または<envar>PGDATA</envar>環境変数で指定され、設定ファイル全てはその data ディレクトリ内に格納されます。
+     </para>
+
+     <para>
+     <!--
+      If you wish to keep the configuration files elsewhere than the
+      data directory, the <command>postgres</command> <option>-D</option>
+      command-line option or <envar>PGDATA</envar> environment variable
+      must point to the directory containing the configuration files,
+      and the <varname>data_directory</> parameter must be set in
+      <filename>postgresql.conf</filename> (or on the command line) to show
+      where the data directory is actually located.  Notice that
+      <varname>data_directory</> overrides <option>-D</option> and
+      <envar>PGDATA</envar> for the location
+      of the data directory, but not for the location of the configuration
+      files.
+      -->
+      dataディレクトリ以外の場所に設定ファイルを格納したいのであれば、<command>postgres</command>の<option>-D</option>コマンドラインオプション、または<envar>PGDATA</envar>環境変数で設定ファイルの場所を指し示し、そしてdataディレクトリが実際どこに存在するのかを示すため、<filename>postgresql.conf</filename>の（もしくはコマンドライン上で）<varname>data_directory</>パラメータを設定しなければなりません。
+      <varname>data_directory</>は、設定ファイルの場所ではなく、data ディレクトリの位置に関して、<option>-D</option>および<envar>PGDATA</envar>を上書きすることに注意してください。
+     </para>
+
+     <para>
+     <!--
+      If you wish, you can specify the configuration file names and locations
+      individually using the parameters <varname>config_file</>,
+      <varname>hba_file</> and/or <varname>ident_file</>.
+      <varname>config_file</> can only be specified on the
+      <command>postgres</command> command line, but the others can be
+      set within the main configuration file.  If all three parameters plus
+      <varname>data_directory</> are explicitly set, then it is not necessary
+      to specify <option>-D</option> or <envar>PGDATA</envar>.
+      -->
+必要に応じて、パラメータ<varname>config_file</>、<varname>hba_file</>、<varname>ident_file</>を使用し、設定ファイルの名前と場所を個別に指定することができます。
+<varname>config_file</>は<command>postgres</command>コマンドラインによってのみ指定されますが、その他は主設定ファイル内で設定できます。
+全ての3つのパラメータと<varname>data_directory</>が明示的に設定されていれば、<option>-D</option>または<envar>PGDATA</envar>を指定する必要はありません。
+     </para>
+
+     <para>
+     <!--
+      When setting any of these parameters, a relative path will be interpreted
+      with respect to the directory in which <command>postgres</command>
+      is started.
+      -->
+これらのパラメータのどれを設定する場合でも、相対パスは、<command>postgres</command>が起動されるディレクトリから見た相対パスとして解釈されます。
+     </para>
+   </sect1>
+
+   <sect1 id="runtime-config-connection">
+   <!--
+    <title>Connections and Authentication</title>
+    -->
+    <title>接続と認証</title>
+
+    <sect2 id="runtime-config-connection-settings">
+    <!--
+     <title>Connection Settings</title>
+     -->
+     <title>接続設定</title>
+
+     <variablelist>
+
+     <varlistentry id="guc-listen-addresses" xreflabel="listen_addresses">
+      <term><varname>listen_addresses</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>listen_addresses</> configuration parameter</primary>
+       -->
+       <primary><varname>listen_addresses</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+         Specifies the TCP/IP address(es) on which the server is
+         to listen for connections from client applications.
+         The value takes the form of a comma-separated list of host names
+         and/or numeric IP addresses.  The special entry <literal>*</>
+         corresponds to all available IP interfaces.  The entry
+         <literal>0.0.0.0</> allows listening for all IPv4 addresses and
+         <literal>::</> allows listening for all IPv6 addresses.
+         If the list is empty, the server does not listen on any IP interface
+         at all, in which case only Unix-domain sockets can be used to connect
+         to it.
+         The default value is <systemitem class="systemname">localhost</>,
+         which allows only local TCP/IP <quote>loopback</> connections to be
+         made.  While client authentication (<xref
+         linkend="client-authentication">) allows fine-grained control
+         over who can access the server, <varname>listen_addresses</varname>
+         controls which interfaces accept connection attempts, which
+         can help prevent repeated malicious connection requests on
+         insecure network interfaces.  This parameter can only be set
+         at server start.
+-->
+クライアントアプリケーションからの接続をサーバが監視する TCP/IP アドレスを指定します。
+この値は、ホスト名をコンマで区切ったリスト、そして/もしくは、数値によるIPアドレスです。
+<literal>*</>という特別なエントリは利用可能な全てのIPインタフェースに対応します。
+エントリ<literal>0.0.0.0</>は全てのIPv4アドレスの監視を、そしてエントリ<literal>::</>は全てのIPv6アドレスの監視を許容します。
+リストが空の場合、サーバはいかなるIPインタフェースも全く監視しないで、Unixドメインソケットのみを使用して接続が行われます。
+デフォルトの値は<systemitem class="systemname">localhost</>で、ローカルなTCP/IP <quote>loopback</>接続のみ許可します。
+クライアント認証 (<xref linkend="client-authentication">)は誰がサーバにアクセス可能かをきめ細かく制御するのに対し、<varname>listen_addresses</varname>はどのインタフェースが接続を試みるかを制御します。
+これにより、安全でないネットワークインタフェース上において繰り返して行われる悪意のある接続要求の防止に役立ちます。
+このパラメータはサーバ起動時のみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-port" xreflabel="port">
+      <term><varname>port</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>port</> configuration parameter</primary>
+       -->
+       <primary><varname>port</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        The TCP port the server listens on; 5432 by default.  Note that the
+        same port number is used for all IP addresses the server listens on.
+        This parameter can only be set at server start.
+       -->
+       サーバが監視するTCPポートで、デフォルトは 5432です。
+       サーバが監視する全てのIPアドレスに対し、同じポート番号が使用されることを覚えておいてください。
+       このパラメータはサーバ起動時のみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-max-connections" xreflabel="max_connections">
+      <term><varname>max_connections</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>max_connections</> configuration parameter</primary>
+       -->
+       <primary><varname>max_connections</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Determines the maximum number of concurrent connections to the
+        database server. The default is typically 100 connections, but
+        might be less if your kernel settings will not support it (as
+        determined during <application>initdb</>).  This parameter can
+        only be set at server start.
+       -->
+       データベースサーバに同時接続する最大数を決定します。
+       デフォルトは典型的に100接続ですが、カーネルの設定が（<application>initdb</>の過程で）それをサポートしていない場合、もっと少なくなることがあります。
+       このパラメータはサーバ起動時のみに設定可能です。
+       </para>
+
+       <para>
+       <!--
+        When running a standby server, you must set this parameter to the
+        same or higher value than on the master server. Otherwise, queries
+        will not be allowed in the standby server.
+       -->
+       スタンバイサーバを運用している場合、このパラメータはマスターサーバでの設定と同じ、もしくはより高い値に設定しなければなりません。そうしないと問い合わせがスタンバイサーバ内で受け入れられません。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-superuser-reserved-connections"
+     xreflabel="superuser_reserved_connections">
+      <term><varname>superuser_reserved_connections</varname>
+      (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>superuser_reserved_connections</> configuration parameter</primary>
+       -->
+       <primary><varname>superuser_reserved_connections</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Determines the number of connection <quote>slots</quote> that
+        are reserved for connections by <productname>PostgreSQL</>
+        superusers.  At most <xref linkend="guc-max-connections">
+        connections can ever be active simultaneously.  Whenever the
+        number of active concurrent connections is at least
+        <varname>max_connections</> minus
+        <varname>superuser_reserved_connections</varname>, new
+        connections will be accepted only for superusers, and no
+        new replication connections will be accepted.
+       -->
+<productname>PostgreSQL</>のスーパーユーザによる接続のために予約されている接続<quote>開口部（スロット）</quote>の数を決定します。
+最大、<xref linkend="guc-max-connections">の数までの接続を同時に有効にすることができます。
+有効な接続数が<varname>max_connections</>から<varname>superuser_reserved_connections</varname>を差し引いた数以上のときは、新規接続はスーパーユーザのみが許可され、新たなレプリケーション接続は受け入れられません。
+       </para>
+
+       <para>
+       <!--
+        The default value is three connections. The value must be less
+        than the value of <varname>max_connections</varname>. This
+        parameter can only be set at server start.
+       -->
+       デフォルトの値は3です。
+この値は <varname>max_connections</varname>での値より小さくなくてはなりません。
+このパラメータはサーバ起動時のみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-unix-socket-directories" xreflabel="unix_socket_directories">
+      <term><varname>unix_socket_directories</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>unix_socket_directories</> configuration parameter</primary>
+       -->
+       <primary><varname>unix_socket_directories</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the directory of the Unix-domain socket(s) on which the
+        server is to listen for connections from client applications.
+        Multiple sockets can be created by listing multiple directories
+        separated by commas.  Whitespace between entries is
+        ignored; surround a directory name with double quotes if you need
+        to include whitespace or commas in the name.
+        An empty value
+        specifies not listening on any Unix-domain sockets, in which case
+        only TCP/IP sockets can be used to connect to the server.
+        The default value is normally
+        <filename>/tmp</filename>, but that can be changed at build time.
+        This parameter can only be set at server start.
+       -->
+サーバがクライアントアプリケーションからの接続要求を監視するUnixドメインソケットのディレクトリを指定します。
+複数ソケットはコンマで区切られた複数ディレクトリをリストすることで作成できます。
+項目間の空白文字は無視されます。
+ディレクトリ名に空白文字もしくはコンマを使用する必要がある場合、ディレクトリ名を二重引用符で括ります。
+空の値はいかなるUnixドメインソケットも監視しないようにします。
+この場合、TCP/IPソケットのみがサーバとの接続に使用されます。
+デフォルト値は通常<filename>/tmp</filename>ですが、ビルド時に変更できます。
+このパラメータはサーバ起動時のみ設定可能です。
+       </para>
+
+       <para>
+       <!--
+        In addition to the socket file itself, which is named
+        <literal>.s.PGSQL.<replaceable>nnnn</></literal> where
+        <replaceable>nnnn</> is the server's port number, an ordinary file
+        named <literal>.s.PGSQL.<replaceable>nnnn</>.lock</literal> will be
+        created in each of the <varname>unix_socket_directories</> directories.
+        Neither file should ever be removed manually.
+       -->
+<literal>.s.PGSQL.<replaceable>nnnn</></literal>という名前のソケットファイル（<replaceable>nnnn</>はポート番号）のほかに、<literal>.s.PGSQL.<replaceable>nnnn</>.lock</literal>というの通常ファイルがそれぞれの<varname>unix_socket_directories</>ディレクトリの中に作成されます。
+いずれのファイルも手作業で削除してはいけません。
+       </para>
+
+       <para>
+<!--
+        This parameter is irrelevant on Windows, which does not have
+        Unix-domain sockets.
+-->
+Windowsでは、Unixドメインソケットがありませんので、このパラメータは無関係です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-unix-socket-group" xreflabel="unix_socket_group">
+      <term><varname>unix_socket_group</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>unix_socket_group</> configuration parameter</primary>
+       -->
+       <primary><varname>unix_socket_group</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the owning group of the Unix-domain socket(s).  (The owning
+        user of the sockets is always the user that starts the
+        server.)  In combination with the parameter
+        <varname>unix_socket_permissions</varname> this can be used as
+        an additional access control mechanism for Unix-domain connections.
+        By default this is the empty string, which uses the default
+        group of the server user.  This parameter can only be set at
+        server start.
+       -->
+Unixドメインソケット（複数も）を所有するグループを設定します（ソケットを所有するユーザは常にサーバを起動するユーザです）。
+<varname>unix_socket_permissions</varname>パラメータとの組合せで、Unixドメインソケット接続の追加的アクセス管理機構として使うことができます。
+デフォルトでは空文字列で、サーバユーザのデフォルトグループを使用します。
+このパラメータはサーバ起動時のみ設定可能です。
+       </para>
+
+       <para>
+       <!--
+        This parameter is irrelevant on Windows, which does not have
+        Unix-domain sockets.
+       -->
+Windowsでは、Unixドメインソケットがありませんので、このパラメータは無関係です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-unix-socket-permissions" xreflabel="unix_socket_permissions">
+      <term><varname>unix_socket_permissions</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>unix_socket_permissions</> configuration parameter</primary>
+       -->
+       <primary><varname>unix_socket_permissions</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the access permissions of the Unix-domain socket(s).  Unix-domain
+        sockets use the usual Unix file system permission set.
+        The parameter value is expected to be a numeric mode
+        specified in the format accepted by the
+        <function>chmod</function> and <function>umask</function>
+        system calls.  (To use the customary octal format the number
+        must start with a <literal>0</literal> (zero).)
+       -->
+Unixドメインソケット（複数も）のアクセスパーミッションを設定します。
+Unixドメインソケットは通常のUnixファイルシステムパーミッション設定の一式を使用します。
+パラメータ値は、<function>chmod</function>および<function>umask</function>システムコールが受け付ける数値形式での指定を想定しています。
+（通常使われる8進数形式を使用するのであれば、<literal>0</literal>（ゼロ）で始まらなければなりません。）
+       </para>
+
+       <para>
+<!--
+        The default permissions are <literal>0777</literal>, meaning
+        anyone can connect. Reasonable alternatives are
+        <literal>0770</literal> (only user and group, see also
+        <varname>unix_socket_group</varname>) and <literal>0700</literal>
+        (only user). (Note that for a Unix-domain socket, only write
+        permission matters, so there is no point in setting or revoking
+        read or execute permissions.)
+-->
+デフォルトのパーミッションは、誰でも接続できる<literal>0777</literal>になっています。
+変更するならば<literal>0770</literal>（ユーザとグループのみです。<varname>unix_socket_group</varname>も参照してください）や<literal>0700</literal>（ユーザのみ）が適切です。
+（Unixドメインソケットでは書き込み権限だけが問題になるため、読み込みや実行のパーミッションを設定または解除する意味はありません。）
+       </para>
+
+       <para>
+       <!--
+        This access control mechanism is independent of the one
+        described in <xref linkend="client-authentication">.
+       -->
+このアクセス制御機構は <xref linkend="client-authentication">で記述されたものとは別個のものです。
+       </para>
+
+       <para>
+       <!--
+        This parameter can only be set at server start.
+       -->
+このパラメータはサーバ起動時のみ設定可能です。
+       </para>
+
+       <para>
+       <!--
+        This parameter is irrelevant on systems, notably Solaris as of Solaris
+        10, that ignore socket permissions entirely.  There, one can achieve a
+        similar effect by pointing <varname>unix_socket_directories</> to a
+        directory having search permission limited to the desired audience.
+        This parameter is also irrelevant on Windows, which does not have
+        Unix-domain sockets.
+       -->
+このパラメータはSolaris 10の時点でのSolarisなど、ソケットのパーミッションを完全に無視するシステムでは無関係です。
+こうしたシステムでは、制限したいユーザだけが検索パーミッションを持つディレクトリを<varname>unix_socket_directories</>で指すようにすることによって同じような効果を得ることができます。
+Windowsでも、Unixドメインソケットがありませんので、このパラメータは無関係です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-bonjour" xreflabel="bonjour">
+      <term><varname>bonjour</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>bonjour</> configuration parameter</primary>
+       -->
+       <primary><varname>bonjour</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables advertising the server's existence via
+        <productname>Bonjour</productname>.  The default is off.
+        This parameter can only be set at server start.
+       -->
+       <productname>Bonjour</productname>によりサーバの存在を公表することを可能にします。デフォルトはoffです。このパラメータはサーバ起動時のみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-bonjour-name" xreflabel="bonjour_name">
+      <term><varname>bonjour_name</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>bonjour_name</> configuration parameter</primary>
+       -->
+       <primary><varname>bonjour_name</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the <productname>Bonjour</productname> service
+        name.  The computer name is used if this parameter is set to the
+        empty string <literal>''</> (which is the default).  This parameter is
+        ignored if the server was not compiled with
+        <productname>Bonjour</productname> support.
+        This parameter can only be set at server start.
+       -->
+       <productname>Bonjour</productname>サービス名を指定します。
+このパラメータが空文字列<literal>''</>（デフォルトです）に設定されていると、コンピュータ名が使用されます。
+サーバが<productname>Bonjour</productname>サポート付でコンパイルでされていない場合は無視されます。
+このオプションはサーバ起動時のみに設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-tcp-keepalives-idle" xreflabel="tcp_keepalives_idle">
+      <term><varname>tcp_keepalives_idle</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>tcp_keepalives_idle</> configuration parameter</primary>
+       -->
+       <primary><varname>tcp_keepalives_idle</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the number of seconds of inactivity after which TCP
+        should send a keepalive message to the client.  A value of 0 uses
+        the system default.
+        This parameter is supported only on systems that support
+        <symbol>TCP_KEEPIDLE</> or an equivalent socket option, and on
+        Windows; on other systems, it must be zero.
+        In sessions connected via a Unix-domain socket, this parameter is
+        ignored and always reads as zero.
+       -->
+クライアントとのやり取りがなくなった後、TCPがkeepaliveパケットをクライアントに送信するまでの時間を秒単位で指定します。
+0の場合はシステムのデフォルト値を使用します。
+このパラメータは<symbol>TCP_KEEPIDLE</>または同等のソケットオプションをサポートするシステムと、Windowsでのみサポートされます。
+その他のシステムではゼロでなければなりません。
+Unixドメインソケット経由で接続されたセッションでは、このパラメータは無視され、常にゼロとして読み取られます。
+       </para>
+       <note>
+        <para>
+         <!--
+         On Windows, a value of 0 will set this parameter to 2 hours,
+         since Windows does not provide a way to read the system default value.
+          -->
+          Windowsでは値0はこのパラメータを2時間に設定します。なぜなら、Windowsはシステムデフォルト値を読む手段を提供していないからです。
+        </para>
+       </note>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-tcp-keepalives-interval" xreflabel="tcp_keepalives_interval">
+      <term><varname>tcp_keepalives_interval</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>tcp_keepalives_interval</> configuration parameter</primary>
+       -->
+       <primary><varname>tcp_keepalives_interval</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the number of seconds after which a TCP keepalive message
+        that is not acknowledged by the client should be retransmitted.
+        A value of 0 uses the system default.
+        This parameter is supported only on systems that support
+        <symbol>TCP_KEEPINTVL</> or an equivalent socket option, and on
+        Windows; on other systems, it must be zero.
+        In sessions connected via a Unix-domain socket, this parameter is
+        ignored and always reads as zero.
+       -->
+        TCPのkeepaliveメッセージに対してクライアントから応答がない場合に、再送を行うまでの時間を秒単位で指定します。
+        0の場合はシステムのデフォルト値を使用します。
+このパラメータは<symbol>TCP_KEEPINTVL</>または同等のソケットオプションをサポートするシステムと、Windowsでのみサポートされます。
+その他のシステムではゼロでなければなりません。
+Unixドメインソケット経由で接続されたセッションでは、このパラメータは無視され、常にゼロとして読み取られます。
+       </para>
+       <note>
+        <para>
+<!--
+         On Windows, a value of 0 will set this parameter to 1 second,
+         since Windows does not provide a way to read the system default value.
+-->
+         Windowsでは値0はこのパラメータを1秒に設定します。なぜなら、Windowsはシステムデフォルト値を読む手段を提供していないからです。
+        </para>
+       </note>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-tcp-keepalives-count" xreflabel="tcp_keepalives_count">
+      <term><varname>tcp_keepalives_count</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>tcp_keepalives_count</> configuration parameter</primary>
+       -->
+       <primary><varname>tcp_keepalives_count</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the number of TCP keepalives that can be lost before
+        the server's connection to the client is considered dead.
+        A value of 0 uses the system default.
+        This parameter is supported only on systems that support
+        <symbol>TCP_KEEPCNT</> or an equivalent socket option;
+        on other systems, it must be zero.
+        In sessions connected via a Unix-domain socket, this parameter is
+        ignored and always reads as zero.
+       -->
+サーバのクライアントへの接続が切れたと判断されるまでのTCP keepaliveの数を指定します。
+0の場合はシステムのデフォルト値を使用します。
+このパラメータは<symbol>TCP_KEEPCNT</>または同等のソケットオプションをサポートするシステムでのみサポートされます。
+その他のシステムではゼロでなければなりません。
+Unixドメインソケット経由で接続されたセッションでは、このパラメータは無視され、常にゼロとして読み取られます。
+       </para>
+       <note>
+        <para>
+         <!--
+         This parameter is not supported on Windows, and must be zero.
+          -->
+          このパラメータはWindowsではサポートされておらず、ゼロでなければなりません。
+        </para>
+       </note>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+     </sect2>
+     <sect2 id="runtime-config-connection-security">
+     <!--
+     <title>Security and Authentication</title>
+     -->
+     <title>セキュリティと認証</title>
+
+     <variablelist>
+     <varlistentry id="guc-authentication-timeout" xreflabel="authentication_timeout">
+      <term><varname>authentication_timeout</varname> (<type>integer</type>)
+      <!--
+      <indexterm><primary>timeout</><secondary>client authentication</></indexterm>
+      -->
+      <indexterm><primary>timeout</><secondary>クライアント認証</></indexterm>
+      <!--
+      <indexterm><primary>client authentication</><secondary>timeout during</></indexterm>
+      -->
+      <indexterm><primary>client authentication</><secondary>タイムアウト期間</></indexterm>
+      <indexterm>
+      <!--
+       <primary><varname>authentication_timeout</> configuration parameter</primary>
+       -->
+       <primary><varname>authentication_timeout</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+
+      <listitem>
+       <para>
+       <!--
+        Maximum time to complete client authentication, in seconds. If a
+        would-be client has not completed the authentication protocol in
+        this much time, the server closes the connection. This prevents
+        hung clients from occupying a connection indefinitely.
+        The default is one minute (<literal>1m</>).
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+       秒単位による、クライアント認証を完了するまでの最大時間です。
+もし、この時間内に自称クライアントが認証プロトコルを完了しない場合、サーバは接続を閉じます。
+これはハングしたクライアントが接続を永久に占有することを防ぎます。
+デフォルトは1分（<literal>1m</>）です。
+このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバのコマンドラインでのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-ssl" xreflabel="ssl">
+      <term><varname>ssl</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>ssl</> configuration parameter</primary>
+       -->
+       <primary><varname>ssl</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables <acronym>SSL</> connections. Please read
+        <xref linkend="ssl-tcp"> before using this.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+        The default is <literal>off</>.
+       -->
+<acronym>SSL</>による接続を有効にします。
+これを使用する前に<xref linkend="ssl-tcp">をお読みください。
+このパラメータは、<filename>postgresql.conf</>ファイルか、サーバのコマンドラインでのみ設定可能です。
+デフォルトは<literal>off</>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-ssl-ca-file" xreflabel="ssl_ca_file">
+      <term><varname>ssl_ca_file</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>ssl_ca_file</> configuration parameter</primary>
+       -->
+       <primary><varname>ssl_ca_file</> 設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Specifies the name of the file containing the SSL server certificate
+        authority (CA).
+        Relative paths are relative to the data directory.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+        The default is empty, meaning no CA file is loaded,
+        and client certificate verification is not performed.
+-->
+SSLサーバ認証局（CA）が入っているファイル名を設定します。
+相対パスの場合は、データディレクトリからの相対パスになります。
+このパラメータは、<filename>postgresql.conf</>ファイルか、サーバのコマンドラインでのみ設定可能です。
+デフォルトは空で、この場合CAファイルは読み込まれず、クライアントのサーバ検証は行われません。
+       </para>
+       <para>
+<!--
+        In previous releases of PostgreSQL, the name of this file was
+        hard-coded as <filename>root.crt</filename>.
+-->
+以前のPostgreSQLリリースでは、このファイルは <filename>root.crt</filename> としてハードコードされていました。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-ssl-cert-file" xreflabel="ssl_cert_file">
+      <term><varname>ssl_cert_file</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>ssl_cert_file</> configuration parameter</primary>
+       -->
+       <primary><varname>ssl_cert_file</> 設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the name of the file containing the SSL server certificate.
+        Relative paths are relative to the data directory.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+        The default is <filename>server.crt</filename>.
+       -->
+SSLサーバ証明書が入っているファイル名を設定します。
+相対パスの場合は、データディレクトリからの相対パスになります。
+このパラメータは、<filename>postgresql.conf</>ファイルか、サーバのコマンドラインでのみ設定可能です。
+デフォルトは <filename>server.crt</filename> です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-ssl-crl-file" xreflabel="ssl_crl_file">
+      <term><varname>ssl_crl_file</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>ssl_crl_file</> configuration parameter</primary>
+       -->
+       <primary><varname>ssl_crl_file</> 設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Specifies the name of the file containing the SSL server certificate
+        revocation list (CRL).
+        Relative paths are relative to the data directory.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+        The default is empty, meaning no CRL file is loaded.
+-->
+SSLサーバ証明書失効リスト（CRL）が入っているファイル名を設定します。
+相対パスの場合は、データディレクトリからの相対パスになります。
+このパラメータは、<filename>postgresql.conf</>ファイルか、サーバのコマンドラインでのみ設定可能です。
+デフォルトは空で、この場合CRLファイルは読み込まれません。
+       </para>
+       <para>
+<!--
+        In previous releases of PostgreSQL, the name of this file was
+        hard-coded as <filename>root.crl</filename>.
+-->
+（以前のPostgreSQLリリースでは、このファイルは <filename>root.crl</filename> としてハードコードされていました。）
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-ssl-key-file" xreflabel="ssl_key_file">
+      <term><varname>ssl_key_file</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>ssl_key_file</> configuration parameter</primary>
+       -->
+       <primary><varname>ssl_key_file</> 設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the name of the file containing the SSL server private key.
+        Relative paths are relative to the data directory.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+        The default is <filename>server.key</filename>.
+       -->
+SSLサーバの秘密鍵が入っているファイル名を設定します。
+相対パスの場合は、データディレクトリからの相対パスになります。
+このパラメータは、<filename>postgresql.conf</>ファイルか、サーバのコマンドラインでのみ設定可能です。
+デフォルトは <filename>server.key</filename> です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-ssl-ciphers" xreflabel="ssl_ciphers">
+      <term><varname>ssl_ciphers</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>ssl_ciphers</> configuration parameter</primary>
+       -->
+       <primary><varname>ssl_ciphers</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Specifies a list of <acronym>SSL</> cipher suites that are allowed to be
+        used on secure connections.  See
+        the <citerefentry><refentrytitle>ciphers</></citerefentry> manual page
+        in the <application>OpenSSL</> package for the syntax of this setting
+        and a list of supported values.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+        The default value is <literal>HIGH:MEDIUM:+3DES:!aNULL</>.  The
+        default is usually a reasonable choice unless you have specific
+        security requirements.
+-->
+セキュアな接続で使用できる<acronym>SSL</>暗号スイートのリストを指定します。
+設定構文と使用可能な値のリストについては<application>OpenSSL</>パッケージの
+<citerefentry><refentrytitle>ciphers</></citerefentry>マニュアルをご覧ください。
+このパラメータは、<filename>postgresql.conf</>ファイルか、サーバのコマンドラインでのみ設定可能です。
+デフォルト値は<literal>HIGH:MEDIUM:+3DES:!aNULL</>です。
+特別なセキュリティ要件でなければ通常これが適当です。
+       </para>
+
+       <para>
+<!--
+        Explanation of the default value:
+-->
+デフォルト値の説明:
+        <variablelist>
+         <varlistentry>
+          <term><literal>HIGH</literal></term>
+          <listitem>
+           <para>
+<!--
+            Cipher suites that use ciphers from <literal>HIGH</> group (e.g.,
+            AES, Camellia, 3DES)
+-->
+<literal>HIGH</>グループ(たとえばAES, Camellia, 3DES)を使用する暗号スイート
+           </para>
+          </listitem>
+         </varlistentry>
+
+         <varlistentry>
+          <term><literal>MEDIUM</literal></term>
+          <listitem>
+           <para>
+<!--
+            Cipher suites that use ciphers from <literal>MEDIUM</> group
+            (e.g., RC4, SEED)
+-->
+<literal>MEDIUM</>グループ(たとえば RC4, SEED)を使用する暗号スイート
+           </para>
+          </listitem>
+         </varlistentry>
+
+         <varlistentry>
+          <term><literal>+3DES</literal></term>
+          <listitem>
+           <para>
+<!--
+            The OpenSSL default order for <literal>HIGH</> is problematic
+            because it orders 3DES higher than AES128.  This is wrong because
+            3DES offers less security than AES128, and it is also much
+            slower.  <literal>+3DES</> reorders it after all other
+            <literal>HIGH</> and <literal>MEDIUM</> ciphers.
+-->
+OpenSSLの<literal>HIGH</>に対するデフォルトの並び順には問題があります。
+3DESがAES128より高いとしているからです。
+3DESはAES128よりもセキュアではなく、またずっと遅いので、これは間違っています。
+<literal>+3DES</>ではそれを他のすべての<literal>HIGH</>と<literal>MEDIUM</>暗号よりも後に位置づけます。
+           </para>
+          </listitem>
+         </varlistentry>
+
+         <varlistentry>
+          <term><literal>!aNULL</literal></term>
+          <listitem>
+           <para>
+<!--
+            Disables anonymous cipher suites that do no authentication.  Such
+            cipher suites are vulnerable to man-in-the-middle attacks and
+            therefore should not be used.
+-->
+認証を行わない無名暗号スイートを無効にします。
+そういった暗号スイートは中間者攻撃に対して脆弱で、使用すべきではありません。
+           </para>
+          </listitem>
+         </varlistentry>
+        </variablelist>
+       </para>
+
+       <para>
+<!--
+        Available cipher suite details will vary across OpenSSL versions.  Use
+        the command
+        <literal>openssl ciphers -v 'HIGH:MEDIUM:+3DES:!aNULL'</literal> to
+        see actual details for the currently installed <application>OpenSSL</>
+        version.  Note that this list is filtered at run time based on the
+        server key type.
+-->
+OpenSSLのバージョンにより、利用可能な暗号スイートの詳細は異なります。
+<literal>openssl ciphers -v 'HIGH:MEDIUM:+3DES:!aNULL'</literal>
+コマンドを使って現在インストールされている<application>OpenSSL</>のバージョンに関する詳細情報を得てください。
+ここで得られるリストは、サーバキータイプにより実行時にフィルターされることに注意してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-ssl-prefer-server-ciphers" xreflabel="ssl_prefer_server_ciphers">
+      <term><varname>ssl_prefer_server_ciphers</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>ssl_prefer_server_ciphers</> configuration parameter</primary>
+       -->
+       <primary><varname>ssl_prefer_server_ciphers</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Specifies whether to use the server's SSL cipher preferences, rather
+        than the client's.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+        The default is <literal>true</>.
+-->
+サーバのSSL暗号設定をクライアントに優先して使うかどうかを指定します。
+このパラメータは、<filename>postgresql.conf</>ファイルか、サーバのコマンドラインでのみ設定可能です。
+デフォルトは<literal>true</>です。
+       </para>
+
+       <para>
+<!--
+        Older PostgreSQL versions do not have this setting and always use the
+        client's preferences.  This setting is mainly for backward
+        compatibility with those versions.  Using the server's preferences is
+        usually better because it is more likely that the server is appropriately
+        configured.
+-->
+        古いバージョンのPostgreSQLにはこの設定がなく、常にクライアントの設定を使います。
+        この設定は、主に古いバージョンとの互換性のために設けられています。
+        通常サーバの設定に従うほうが良いです。大抵の場合、サーバはより適切に設定されているからです。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-ssl-ecdh-curve" xreflabel="ssl_ecdh_curve">
+      <term><varname>ssl_ecdh_curve</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>ssl_ecdh_curve</> configuration parameter</primary>
+       -->
+       <primary><varname>ssl_ecdh_curve</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Specifies the name of the curve to use in <acronym>ECDH</> key
+        exchange.  It needs to be supported by all clients that connect.
+        It does not need to be the same curve used by the server's Elliptic
+        Curve key.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+        The default is <literal>prime256v1</>.
+-->
+<acronym>ECDH</>キー交換で使われる曲線の名前を指定します。
+接続するすべてのクライアントがこの設定をサポートしている必要があります。
+サーバの楕円曲線キーで使用されるのと同じ曲線である必要はありません。
+このパラメータは、<filename>postgresql.conf</>ファイルか、サーバのコマンドラインでのみ設定可能です。
+デフォルト値は<literal>prime256v1</>です。
+       </para>
+
+       <para>
+<!--
+        OpenSSL names for the most common curves are:
+-->
+        OpenSSLはよく使われる曲線に名前を付けています。
+        <literal>prime256v1</> (NIST P-256),
+        <literal>secp384r1</> (NIST P-384),
+        <literal>secp521r1</> (NIST P-521).
+<!--
+        The full list of available curves can be shown with the command
+        <command>openssl ecparam -list_curves</command>.  Not all of them
+        are usable in <acronym>TLS</> though.
+-->
+        利用できる曲線の完全なリストは<command>openssl ecparam -list_curves</command>で得られます。ただし、<acronym>TLS</>ではこのすべてが利用できるわけではありません。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-password-encryption" xreflabel="password_encryption">
+      <term><varname>password_encryption</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>password_encryption</> configuration parameter</primary>
+       -->
+       <primary><varname>password_encryption</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        When a password is specified in <xref linkend="sql-createrole"> or
+        <xref linkend="sql-alterrole">, this parameter determines the algorithm
+        to use to encrypt the password. The default value is <literal>md5</>,
+        which stores the password as an MD5 hash (<literal>on</> is also
+        accepted, as alias for <literal>md5</>). Setting this parameter to
+        <literal>scram-sha-256</> will encrypt the password with SCRAM-SHA-256.
+-->
+<xref linkend="sql-createrole">もしくは<xref linkend="sql-alterrole">でパスワードが指定されている場合、このパラメータはパスワードを暗号化するアルゴリズムを決定します。
+デフォルトは<literal>md5</>で、これはパスワードをMD5ハッシュで格納します。
+（<literal>on</>も受け付けます。これは<literal>md5</>の別名です。）
+このパラメータを<literal>scram-sha-256</>とすると、パスワードをSCRAM-SHA-256で暗号化します。
+       </para>
+       <para>
+<!--
+        Note that older clients might lack support for the SCRAM authentication
+        mechanism, and hence not work with passwords encrypted with
+        SCRAM-SHA-256.  See <xref linkend="auth-password"> for more details.
+-->
+古いクライアントではSCRAM認証機構がサポートされておらず、SCRAM-SHA-256で暗号化されたパスワードは使えないかもしれないことに注意してください。
+詳細は、<xref linkend="auth-password">をご覧ください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-ssl-dh-params-file" xreflabel="ssl_dh_params_file">
+      <term><varname>ssl_dh_params_file</varname> (<type>string</type>)
+      <indexterm>
+<!--
+       <primary><varname>ssl_dh_params_file</> configuration parameter</primary>
+-->
+       <primary><varname>ssl_dh_params_file</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Specifies the name of the file containing Diffie-Hellman parameters
+        used for so-called ephemeral DH family of SSL ciphers. The default is
+        empty, in which case compiled-in default DH parameters used. Using
+        custom DH parameters reduces the exposure if an attacker manages to
+        crack the well-known compiled-in DH parameters. You can create your own
+        DH parameters file with the command
+        <command>openssl dhparam -out dhparams.pem 2048</command>.
+-->
+いわゆる短命DH系SSL暗号で使用するディフィー・ヘルマンパラメータを格納するファイル名を指定します。
+デフォルトは空で、この場合はコンパイル時に決められたデフォルトのDHパラメータが使用されます。
+攻撃者が、よく知られたコンパイル時設定のDHパラメータを解読しようとしている場合には、カスタムDHパラメータを使うことでその危険性を低減できます。
+<command>openssl dhparam -out dhparams.pem 2048</command>を使って、独自のDHパラメータファイルを作ることができます。
+       </para>
+
+       <para>
+<!--
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+-->
+このパラメータは、<filename>postgresql.conf</>ファイルか、サーバのコマンドラインでのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-krb-server-keyfile" xreflabel="krb_server_keyfile">
+      <term><varname>krb_server_keyfile</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>krb_server_keyfile</> configuration parameter</primary>
+       -->
+       <primary><varname>krb_server_keyfile</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the location of the Kerberos server key file. See
+        <xref linkend="gssapi-auth">
+        for details. This parameter can only be set in the
+        <filename>postgresql.conf</> file or on the server command line.
+       -->
+       Kerberosサーバの鍵ファイルの場所を設定します。詳細は<xref linkend="gssapi-auth">を参照してください。
+このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバのコマンドラインでのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-krb-caseins-users" xreflabel="krb_caseins_users">
+      <term><varname>krb_caseins_users</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>krb_caseins_users</varname> configuration parameter</primary>
+       -->
+       <primary><varname>krb_caseins_users</varname>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets whether GSSAPI user names should be treated
+        case-insensitively.
+        The default is <literal>off</> (case sensitive). This parameter can only be
+        set in the <filename>postgresql.conf</> file or on the server command line.
+       -->
+       GSSAPIのユーザ名が大文字小文字を区別すべきかの設定をします。
+デフォルトは<literal>off</>（大文字小文字を区別する）です。
+このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバのコマンドラインでのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-db-user-namespace" xreflabel="db_user_namespace">
+      <term><varname>db_user_namespace</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>db_user_namespace</> configuration parameter</primary>
+       -->
+       <primary><varname>db_user_namespace</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        This parameter enables per-database user names.  It is off by default.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+       このパラメータはデータベース毎のユーザ名を可能にします。
+デフォルトではオフです。
+このパラメータは<filename>postgresql.conf</>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+       </para>
+
+       <para>
+       <!--
+        If this is on, you should create users as <replaceable>username@dbname</>.
+        When <replaceable>username</> is passed by a connecting client,
+        <literal>@</> and the database name are appended to the user
+        name and that database-specific user name is looked up by the
+        server. Note that when you create users with names containing
+        <literal>@</> within the SQL environment, you will need to
+        quote the user name.
+       -->
+これがオンの場合、<replaceable>username@dbname</>の様にしてユーザを作成しなければなりません。<replaceable>username</>が接続中のクライアントより渡された時、 <literal>@</>およびデータベース名がユーザ名に付加され、そのデータベース特有のユーザ名をサーバが見に行きます。SQL環境下で<literal>@</>を含む名前のユーザを作成する場合、そのユーザ名は引用符で括られなければならないことに注意してください。
+       </para>
+
+       <para>
+       <!--
+        With this parameter enabled, you can still create ordinary global
+        users.  Simply append <literal>@</> when specifying the user
+        name in the client, e.g. <literal>joe@</>.  The <literal>@</>
+        will be stripped off before the user name is looked up by the
+        server.
+       -->
+       このパラメータを有効にしていても通常の広域ユーザを作成することができます。
+クライアントにユーザ名を指定する時に、たとえば<literal>joe@</>のように単に<literal>@</>を付け加えてください。<literal>@</>はサーバがユーザ名を検索する以前に取り去られます。
+       </para>
+
+       <para>
+       <!--
+        <varname>db_user_namespace</> causes the client's and
+        server's user name representation to differ.
+        Authentication checks are always done with the server's user name
+        so authentication methods must be configured for the
+        server's user name, not the client's.  Because
+        <literal>md5</> uses the user name as salt on both the
+        client and server, <literal>md5</> cannot be used with
+        <varname>db_user_namespace</>.
+       -->
+       <varname>db_user_namespace</>はクライアントとサーバのユーザ名の表示を区別することができます。
+認証検査は常にサーバのユーザ名で行われるので、認証方式はクライアントのではなくサーバのユーザ名で構成されなければなりません。
+<literal>md5</>では、クライアントおよびサーバの両方でユーザ名をソルトとして使用しますので、<literal>md5</>を<varname>db_user_namespace</>と一緒に使用することはできません。
+       </para>
+
+       <note>
+        <para>
+       <!--
+         This feature is intended as a temporary measure until a
+         complete solution is found.  At that time, this option will
+         be removed.
+        -->
+        この機能は完全な解決策が見つかるまでの暫定的な手段です。見つかった時点でこのオプションは削除されます。
+        </para>
+       </note>
+      </listitem>
+     </varlistentry>
+
+    </variablelist>
+    </sect2>
+   </sect1>
+
+   <sect1 id="runtime-config-resource">
+   <!--
+    <title>Resource Consumption</title>
+    -->
+    <title>資源の消費</title>
+
+    <sect2 id="runtime-config-resource-memory">
+    <!--
+     <title>Memory</title>
+     -->
+     <title>メモリ</title>
+
+     <variablelist>
+     <varlistentry id="guc-shared-buffers" xreflabel="shared_buffers">
+      <term><varname>shared_buffers</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>shared_buffers</> configuration parameter</primary>
+       -->
+       <primary><varname>shared_buffers</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the amount of memory the database server uses for shared
+        memory buffers.  The default is typically 128 megabytes
+        (<literal>128MB</>), but might be less if your kernel settings will
+        not support it (as determined during <application>initdb</>).
+        This setting must be at least 128 kilobytes.  (Non-default
+        values of <symbol>BLCKSZ</symbol> change the minimum.)  However,
+        settings significantly higher than the minimum are usually needed
+        for good performance.  This parameter can only be set at server start.
+       -->
+データベースサーバが共有メモリバッファのために使用するメモリ量を設定します。
+デフォルトは一般的に128メガバイト(<literal>128MB</>)です。
+しかし、稼働中のカーネルの設定がこの値をサポートしていない場合、より少なくなることがあります（<application>initdb</>の過程で決定されます）。
+この設定は最低限128キロバイトなければなりません。
+（<symbol>BLCKSZ</symbol>がデフォルト値と異なる場合、この最小値も異なる値になります。）
+しかし、良い性能を引き出すためには、最小値よりかなり高い値の設定が通例必要です。
+このパラメータはサーバ起動時にのみ設定可能です。
+       </para>
+
+       <para>
+       <!--
+        If you have a dedicated database server with 1GB or more of RAM, a
+        reasonable starting value for <varname>shared_buffers</varname> is 25%
+        of the memory in your system.  There are some workloads where even
+        larger settings for <varname>shared_buffers</varname> are effective, but
+        because <productname>PostgreSQL</productname> also relies on the
+        operating system cache, it is unlikely that an allocation of more than
+        40% of RAM to <varname>shared_buffers</varname> will work better than a
+        smaller amount.  Larger settings for <varname>shared_buffers</varname>
+        usually require a corresponding increase in
+        <varname>max_wal_size</varname>, in order to spread out the
+        process of writing large quantities of new or changed data over a
+        longer period of time.
+       -->
+1GB以上のRAMを載せた専用データベースサーバを使用している場合、<varname>shared_buffers</varname>に対する妥当な初期値はシステムメモリの25%です。
+<varname>shared_buffers</varname>をこれよりも大きな値に設定することが有効なワークロードもあります。
+しかし、<productname>PostgreSQL</productname>はオペレーティングシステムキャッシュにも依存するため、<varname>shared_buffers</varname>にRAMの40%以上を割り当てても、それより小さい値の時より動作が良くなる見込みはありません。
+<varname>shared_buffers</varname>をより大きく設定する場合は、大抵<varname>max_wal_size</varname>も合わせて増やす必要があります。これは、新規または変更された多量のデータを書き出す処理をより長い時間に渡って分散させるためです。
+       </para>
+
+       <para>
+       <!--
+        On systems with less than 1GB of RAM, a smaller percentage of RAM is
+        appropriate, so as to leave adequate space for the operating system.
+       -->
+1GB未満のRAMのシステムでは、オペレーティングシステムに十分な余裕を残すために、RAMに対してより小さい割合を設定することが適切です。
+       </para>
+
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-huge-pages" xreflabel="huge_pages">
+      <term><varname>huge_pages</varname> (<type>enum</type>)
+      <indexterm>
+<!--
+       <primary><varname>huge_pages</> configuration parameter</primary>
+-->
+       <primary><varname>huge_pages</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Enables/disables the use of huge memory pages. Valid values are
+        <literal>try</literal> (the default), <literal>on</literal>,
+        and <literal>off</literal>.
+-->
+        huge memoryページの利用を有効/無効にします。
+        可能な値は
+        <literal>try</literal> (デフォルト), <literal>on</literal>,
+         <literal>off</literal>です。
+       </para>
+
+       <para>
+<!--
+        At present, this feature is supported only on Linux. The setting is
+        ignored on other systems when set to <literal>try</literal>.
+-->
+        今のところこの機能はLinuxでのみサポートされています。
+        他のシステムでは<literal>try</literal>と設定しても無視されます。
+       </para>
+
+       <para>
+<!--
+        The use of huge pages results in smaller page tables and less CPU time
+        spent on memory management, increasing performance. For more details,
+        see <xref linkend="linux-huge-pages">.
+-->
+        huge pageを使うと、ページテーブルが小さくなり、メモリ管理に使用されるCPU時間が少なくなり、性能が向上します。詳細は、<xref linkend="linux-huge-pages">を見てください。
+       </para>
+
+       <para>
+<!--
+        With <varname>huge_pages</varname> set to <literal>try</literal>,
+        the server will try to use huge pages, but fall back to using
+        normal allocation if that fails. With <literal>on</literal>, failure
+        to use huge pages will prevent the server from starting up. With
+        <literal>off</literal>, huge pages will not be used.
+-->
+        <varname>huge_pages</varname>を<literal>try</literal>に設定すると、サーバはhuge pageの利用を試み、失敗すると通常のアロケーションを行います。
+        <literal>on</literal>にすると、huge pageの利用に失敗した場合サーバは起動しなくなります。
+        <literal>off</literal>にすると、huge pageは使用されません。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-temp-buffers" xreflabel="temp_buffers">
+      <term><varname>temp_buffers</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>temp_buffers</> configuration parameter</primary>
+       -->
+       <primary><varname>temp_buffers</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the maximum number of temporary buffers used by each database
+        session.  These are session-local buffers used only for access to
+        temporary tables.  The default is eight megabytes
+        (<literal>8MB</>).  The setting can be changed within individual
+        sessions, but only before the first use of temporary tables
+        within the session; subsequent attempts to change the value will
+        have no effect on that session.
+       -->
+それぞれのデータベースセッションが使用する一時バッファの最大数を設定します。
+一時バッファは、一時テーブルにアクセスする時にのみ使用されるセッションローカルのバッファです。
+デフォルトは8メガバイト（<literal>8MB</>）です。
+設定はそれぞれのセッション内で変更できますが、そのセッション内で一時テーブルが最初に使用されるまでになります。それより後に値の変更を試みても、そのセッションでは効果がありません。
+       </para>
+
+       <para>
+       <!--
+        A session will allocate temporary buffers as needed up to the limit
+        given by <varname>temp_buffers</>.  The cost of setting a large
+        value in sessions that do not actually need many temporary
+        buffers is only a buffer descriptor, or about 64 bytes, per
+        increment in <varname>temp_buffers</>.  However if a buffer is
+        actually used an additional 8192 bytes will be consumed for it
+        (or in general, <symbol>BLCKSZ</symbol> bytes).
+       -->
+セッションは、<varname>temp_buffers</>を上限として、必要に応じて一時バッファを確保します。
+多くの一時バッファを実際に必要としないセッションで大きな値を設定するコストとは、<varname>temp_buffers</>の増分毎に、1つのバッファ記述子、約64バイトだけです。
+しかし、バッファが実際に使用されると、それに対して追加の8192バイト（汎用的に言えば<symbol>BLCKSZ</symbol>バイト）が消費されます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-max-prepared-transactions" xreflabel="max_prepared_transactions">
+      <term><varname>max_prepared_transactions</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>max_prepared_transactions</> configuration parameter</primary>
+       -->
+       <primary><varname>max_prepared_transactions</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the maximum number of transactions that can be in the
+        <quote>prepared</> state simultaneously (see <xref
+        linkend="sql-prepare-transaction">).
+        Setting this parameter to zero (which is the default)
+        disables the prepared-transaction feature.
+        This parameter can only be set at server start.
+       -->
+同時に<quote>プリペアド</>状態にできるトランザクションの最大数を設定します（<xref linkend="sql-prepare-transaction">を参照してください）。
+このパラメータをゼロ（これがデフォルトです）に設定すると、プリペアドトランザクション機能が無効になります。
+このパラメータはサーバ起動時にのみ設定可能です。
+       </para>
+
+       <para>
+       <!--
+        If you are not planning to use prepared transactions, this parameter
+        should be set to zero to prevent accidental creation of prepared
+        transactions.  If you are using prepared transactions, you will
+        probably want <varname>max_prepared_transactions</varname> to be at
+        least as large as <xref linkend="guc-max-connections">, so that every
+        session can have a prepared transaction pending.
+       -->
+プリペアドトランザクションの使用を意図しないのであれば、このパラメータはプリペアドトランザクションが偶然に作成されないようゼロに設定すべきです。
+プリペアドトランザクションを使用する場合、全てのセッションがプリペアドトランザクションを保留できるように、<varname>max_prepared_transactions</varname>を少なくとも<xref linkend="guc-max-connections">と同じ大きさに設定するのが良いでしょう。
+       </para>
+
+       <para>
+       <!--
+        When running a standby server, you must set this parameter to the
+        same or higher value than on the master server. Otherwise, queries
+        will not be allowed in the standby server.
+       -->
+       スタンバイサーバを運用している場合、このパラメータはマスターサーバ上の設定よりも同等かもしくはより高水準に設定しなければなりません。そうしないと問い合わせがスタンバイサーバ内で受け入れられません。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-work-mem" xreflabel="work_mem">
+      <term><varname>work_mem</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>work_mem</> configuration parameter</primary>
+       -->
+       <primary><varname>work_mem</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the amount of memory to be used by internal sort operations
+        and hash tables before writing to temporary disk files. The value
+        defaults to four megabytes (<literal>4MB</>).
+        Note that for a complex query, several sort or hash operations might be
+        running in parallel; each operation will be allowed to use as much memory
+        as this value specifies before it starts to write data into temporary
+        files. Also, several running sessions could be doing such operations
+        concurrently.  Therefore, the total memory used could be many
+        times the value of <varname>work_mem</varname>; it is necessary to
+        keep this fact in mind when choosing the value. Sort operations are
+        used for <literal>ORDER BY</>, <literal>DISTINCT</>, and
+        merge joins.
+        Hash tables are used in hash joins, hash-based aggregation, and
+        hash-based processing of <literal>IN</> subqueries.
+       -->
+       一時ディスクファイルに書き込む前に、内部並べ替えとハッシュテーブル操作が使用するメモリ容量を指定します。
+デフォルト値は4メガバイト（<literal>4MB</>）です。
+        複雑な問い合わせの場合、いくつかの並び替えもしくはハッシュ操作が並行して実行されることに注意してください。
+        それぞれの操作による一時メモリへの書き込み開始の前に、この値が指定するのと同じメモリ容量の使用をそれらの操作に許容します。さらに、いくつかの実行中のセッションはこれらの動作を同時に行います。したがって、使用されるメモリの合計は、<varname>work_mem</varname>の数倍になります。値を選択する時には、この事実に留意することが必要です。並び替え操作は<literal>ORDER BY</>、<literal>DISTINCT</>、およびマージ結合に対して使われます。ハッシュテーブルはハッシュ結合、ハッシュに基づいた集約、および<literal>IN</>副問い合わせのハッシュに基づいた処理で使用されます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-maintenance-work-mem" xreflabel="maintenance_work_mem">
+      <term><varname>maintenance_work_mem</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>maintenance_work_mem</> configuration parameter</primary>
+       -->
+       <primary><varname>maintenance_work_mem</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the maximum amount of memory to be used by maintenance
+        operations, such as <command>VACUUM</command>, <command>CREATE
+        INDEX</>, and <command>ALTER TABLE ADD FOREIGN KEY</>.  It defaults
+        to 64 megabytes (<literal>64MB</>).  Since only one of these
+        operations can be executed at a time by a database session, and
+        an installation normally doesn't have many of them running
+        concurrently, it's safe to set this value significantly larger
+        than <varname>work_mem</varname>.  Larger settings might improve
+        performance for vacuuming and for restoring database dumps.
+       -->
+       <command>VACUUM</command>、<command>CREATE INDEX</>、および<command>ALTER TABLE ADD FOREIGN KEY</>の様な保守操作で使用されるメモリの最大容量を指定します。
+デフォルト値は64メガバイト（<literal>64MB</>）です。
+1つのデータベースセッションでは、一度に1つしか上記操作はできませんし、通常インストレーションでこうした操作が同時に非常に多く発生することはありませんので、これを<varname>work_mem</varname>よりもかなり多めの値にしても安全です。
+大きい値を設定することでvacuum処理と、ダンプしたデータベースのリストア性能が向上します。
+       </para>
+       <para>
+       <!--
+        Note that when autovacuum runs, up to
+        <xref linkend="guc-autovacuum-max-workers"> times this memory
+        may be allocated, so be careful not to set the default value
+        too high.  It may be useful to control for this by separately
+        setting <xref linkend="guc-autovacuum-work-mem">.
+-->
+自動バキュームが稼動すると、最大でこのメモリの<xref linkend="guc-autovacuum-max-workers">倍が配分されるので、デフォルトの値をあまり高く設定しないよう注意してください。
+別の設定項目<xref linkend="guc-autovacuum-work-mem">で制御するのが良いかもしれません。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-replacement-sort-tuples" xreflabel="replacement_sort_tuples">
+      <term><varname>replacement_sort_tuples</varname> (<type>integer</type>)
+      <indexterm>
+       <primary><varname>replacement_sort_tuples</> configuration parameter</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        When the number of tuples to be sorted is smaller than this number,
+        a sort will produce its first output run using replacement selection
+        rather than quicksort.  This may be useful in memory-constrained
+        environments where tuples that are input into larger sort operations
+        have a strong physical-to-logical correlation.  Note that this does
+        not include input tuples with an <emphasis>inverse</emphasis>
+        correlation.  It is possible for the replacement selection algorithm
+        to generate one long run that requires no merging, where use of the
+        default strategy would result in many runs that must be merged
+        to produce a final sorted output.  This may allow sort
+        operations to complete sooner.
+-->
+ソート対象のタプル数がこの指定値よりも小さい場合、クイックソートではなく、置換選択法を使ってソート処理の最初のラン出力を作ります。
+メモリが限られた環境で、物理から論理への強い相関性を持つタプルが大量のソート処理に投入される場合に有用かもしれません。
+なお、入力タプルが<emphasis>逆</emphasis>相関性を示す場合にはこの限りではありません。
+デフォルトの戦略が多数のランを実行してしまい、その結果を最後にマージしなければならないのと違って、置換選択アルゴリズムにおいては、マージを必要としない一つの長いランを実行できる可能性があります。
+このことにより、ソート処理を素早く完了できるかもしれません。
+       </para>
+       <para>
+<!--
+        The default is 150,000 tuples.  Note that higher values are typically
+        not much more effective, and may be counter-productive, since the
+        priority queue is sensitive to the size of available CPU cache, whereas
+        the default strategy sorts runs using a <firstterm>cache
+        oblivious</firstterm> algorithm.  This property allows the default sort
+        strategy to automatically and transparently make effective use
+        of available CPU cache.
+-->
+デフォルト値は150,000タプルです。
+多くの場合、より高い設定値がより良い効率をもたらすどころか、むしろ非生産的かもしれません。
+なぜなら、優先度キューは、利用可能なCPUキャッシュの大きさに敏感な一方、デフォルトのソート戦略は<firstterm>キャッシュに縛られない（cache-oblivious）</firstterm>アルゴリズムを使用して実行されるからです。
+この性質により、デフォルトのソート戦略では自動的かつ透過的に利用可能なCPUキャッシュを有効に利用できます。
+       </para>
+       <para>
+<!--
+        Setting <varname>maintenance_work_mem</varname> to its default
+        value usually prevents utility command external sorts (e.g.,
+        sorts used by <command>CREATE INDEX</> to build B-Tree
+        indexes) from ever using replacement selection sort, unless the
+        input tuples are quite wide.
+-->
+<varname>maintenance_work_mem</varname>をデフォルト値に設定すると、入力タプルの幅が非常に大きい場合を除き、通常ユーティリティコマンドが外部ソート(たとえば、<command>CREATE INDEX</>がB-Treeインデックスを作成するために行うソート)が置換選択アルゴリズムを使うことはなくなります。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-autovacuum-work-mem" xreflabel="autovacuum_work_mem">
+      <term><varname>autovacuum_work_mem</varname> (<type>integer</type>)
+      <indexterm>
+<!--
+       <primary><varname>autovacuum_work_mem</> configuration parameter</primary>
+-->
+       <primary><varname>autovacuum_work_mem</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Specifies the maximum amount of memory to be used by each
+        autovacuum worker process.  It defaults to -1, indicating that
+        the value of <xref linkend="guc-maintenance-work-mem"> should
+        be used instead.  The setting has no effect on the behavior of
+        <command>VACUUM</command> when run in other contexts.
+       -->
+        個々の自動バキュームワーカプロセスが使用する最大のメモリ量を指定します。
+デフォルトは-1で、<xref linkend="guc-maintenance-work-mem">が代わりに使われる設定になります。
+       別の文脈で実行される<command>VACUUM</command>にはこの設定は影響しません。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-max-stack-depth" xreflabel="max_stack_depth">
+      <term><varname>max_stack_depth</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>max_stack_depth</> configuration parameter</primary>
+       -->
+       <primary><varname>max_stack_depth</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the maximum safe depth of the server's execution stack.
+        The ideal setting for this parameter is the actual stack size limit
+        enforced by the kernel (as set by <literal>ulimit -s</> or local
+        equivalent), less a safety margin of a megabyte or so.  The safety
+        margin is needed because the stack depth is not checked in every
+        routine in the server, but only in key potentially-recursive routines
+        such as expression evaluation.  The default setting is two
+        megabytes (<literal>2MB</>), which is conservatively small and
+        unlikely to risk crashes.  However, it might be too small to allow
+        execution of complex functions.  Only superusers can change this
+        setting.
+       -->
+サーバの実行スタックの最大安全深度を指定します。
+このパラメータの理想的な設定はカーネルにより強要される実際のスタック容量の（<literal>ulimit -s</>もしくはそれと同等の機能で設定された）限界から、1メガバイト程度の安全余地を差し引いたものです。
+安全余地は、サーバがすべてのルーチンではスタック深度を検査をせず、式評価などの主要な潜在的に再帰的なルーチンでのみ検査をするために必要となるものです。
+デフォルト設定は2メガバイト（<literal>2MB</>）で、かなり控え目で、クラッシュの危険はなさそうです。
+しかし、複雑な関数の実行を許容するには小さ過ぎるかも知れません。
+スーパーユーザのみがこの設定を変更することができます。
+       </para>
+
+       <para>
+       <!--
+        Setting <varname>max_stack_depth</> higher than
+        the actual kernel limit will mean that a runaway recursive function
+        can crash an individual backend process.  On platforms where
+        <productname>PostgreSQL</productname> can determine the kernel limit,
+        the server will not allow this variable to be set to an unsafe
+        value.  However, not all platforms provide the information,
+        so caution is recommended in selecting a value.
+       -->
+       <varname>max_stack_depth</>を実際のカーネルの制限よりも高い値に設定した場合、暴走した再帰関数により、個々のバックエンドプロセスがクラッシュするかもしれません。
+<productname>PostgreSQL</productname>がカーネルの制限を決定することができるプラットフォームでは、この変数を危険な値に設定させません。
+しかし、すべてのプラットフォームがこの情報を提供できるわけではありません。
+このため、値を選ぶ時には注意が必要です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-dynamic-shared-memory-type" xreflabel="dynamic_shared_memory_type">
+      <term><varname>dynamic_shared_memory_type</varname> (<type>enum</type>)
+      <indexterm>
+<!--
+       <primary><varname>dynamic_shared_memory_type</> configuration parameter</primary>
+-->
+       <primary><varname>dynamic_shared_memory_type</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Specifies the dynamic shared memory implementation that the server
+        should use.  Possible values are <literal>posix</> (for POSIX shared
+        memory allocated using <literal>shm_open</>), <literal>sysv</literal>
+        (for System V shared memory allocated via <literal>shmget</>),
+        <literal>windows</> (for Windows shared memory), <literal>mmap</>
+        (to simulate shared memory using memory-mapped files stored in the
+        data directory), and <literal>none</> (to disable this feature).
+        Not all values are supported on all platforms; the first supported
+        option is the default for that platform.  The use of the
+        <literal>mmap</> option, which is not the default on any platform,
+        is generally discouraged because the operating system may write
+        modified pages back to disk repeatedly, increasing system I/O load;
+        however, it may be useful for debugging, when the
+        <literal>pg_dynshmem</> directory is stored on a RAM disk, or when
+        other shared memory facilities are not available.
+-->
+        サーバが使う動的共有メモリの実装を指定します。可能な値は
+        <literal>posix</> (<literal>shm_open</>で獲得するPOSIX共有メモリ)、
+         <literal>sysv</literal>
+        (<literal>shmget</>で獲得するSystem V共有メモリ)、
+        <literal>windows</> (Windows共有メモリ)、 <literal>mmap</>
+        (データディレクトリ内のメモリマップファイルを使ってシミュレートする共有メモリ)、
+<literal>none</> (この機能を使用しない)です。
+       すべての値がすべてのプラットフォームでサポートされているわけではありません。
+       そのプラットフォームでの推奨実装がデフォルトになります。
+       どのプラットフォームでもデフォルトになっていない<literal>mmap</>は、オペレーティングシステムが変更されたページをディスクに継続的に書き込み、I/O負荷を増加させるので一般的には利用が推奨されていません。
+       しかし、デバッグ目的のために<literal>pg_dynshmem</>ディスクがRAMディスク上にある場合や、他の共有メモリ機能が使えない場合は有用かもしれません。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+     </sect2>
+
+     <sect2 id="runtime-config-resource-disk">
+     <!--
+     <title>Disk</title>
+     -->
+     <title>ディスク</title>
+
+     <variablelist>
+     <varlistentry id="guc-temp-file-limit" xreflabel="temp_file_limit">
+      <term><varname>temp_file_limit</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>temp_file_limit</> configuration parameter</primary>
+       -->
+       <primary><varname>temp_file_limit</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the maximum amount of disk space that a process can use
+        for temporary files, such as sort and hash temporary files, or the
+        storage file for a held cursor.  A transaction attempting to exceed
+        this limit will be canceled.
+        The value is specified in kilobytes, and <literal>-1</> (the
+        default) means no limit.
+        Only superusers can change this setting.
+       -->
+あるプロセスが一時ファイルとして使用できるディスクの最大容量を設定します。
+例えば、ソートやハッシュの一時ファイルであったり、カーソルを保持する格納ファイルです。
+この制限値を超えようとするトランザクションはキャンセルされます。
+値はキロバイト単位で指定され、（デフォルトである） <literal>-1</> の場合は制限がありません。
+この設定はスーパーユーザのみ変更可能です。
+       </para>
+       <para>
+       <!--
+        This setting constrains the total space used at any instant by all
+        temporary files used by a given <productname>PostgreSQL</> process.
+        It should be noted that disk space used for explicit temporary
+        tables, as opposed to temporary files used behind-the-scenes in query
+        execution, does <emphasis>not</emphasis> count against this limit.
+       -->
+       この設定により、ある <productname>PostgreSQL</> セッションによって使用される一時ファイルの合計の容量が常に制約されることになります。
+       なお、問い合わせの実行において暗黙的に使用される一時ファイルとは異なり、一時テーブルとして明示的に使用されるディスク容量は、この制限には<emphasis>含まれません</emphasis>。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+     </sect2>
+
+     <sect2 id="runtime-config-resource-kernel">
+     <!--
+     <title>Kernel Resource Usage</title>
+     -->
+     <title>カーネル資源使用</title>
+
+     <variablelist>
+     <varlistentry id="guc-max-files-per-process" xreflabel="max_files_per_process">
+      <term><varname>max_files_per_process</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>max_files_per_process</> configuration parameter</primary>
+       -->
+       <primary><varname>max_files_per_process</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the maximum number of simultaneously open files allowed to each
+        server subprocess. The default is one thousand files. If the kernel is enforcing
+        a safe per-process limit, you don't need to worry about this setting.
+        But on some platforms (notably, most BSD systems), the kernel will
+        allow individual processes to open many more files than the system
+        can actually support if many processes all try to open
+        that many files. If you find yourself seeing <quote>Too many open
+        files</> failures, try reducing this setting.
+        This parameter can only be set at server start.
+       -->
+       それぞれのサーバ子プロセスが同時にオープンできるファイル数の最大値をセットします。
+デフォルトは1000ファイルです。
+もしもカーネルがプロセス毎の安全制限を強要している場合、この設定を気にかける必要はありません。
+しかし、いくつかのプラットフォーム（特にほとんどのBSDシステム）では、もし多くのプロセス全てがそれだけ多くのファイルを開くことを試みたとした場合、実際にサポートできるファイル数より多くのファイルを開くことを許しています。もしも<quote>Too many open files</>エラーが発生した場合、この設定を削減してみてください。
+このパラメータはサーバ起動時にのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+     </variablelist>
+    </sect2>
+
+    <sect2 id="runtime-config-resource-vacuum-cost">
+    <!--
+     <title>Cost-based Vacuum Delay</title>
+     -->
+     <title>コストに基づくVacuum遅延</title>
+
+     <para>
+     <!--
+      During the execution of <xref linkend="sql-vacuum">
+      and <xref linkend="sql-analyze">
+      commands, the system maintains an
+      internal counter that keeps track of the estimated cost of the
+      various I/O operations that are performed.  When the accumulated
+      cost reaches a limit (specified by
+      <varname>vacuum_cost_limit</varname>), the process performing
+      the operation will sleep for a short period of time, as specified by
+      <varname>vacuum_cost_delay</varname>. Then it will reset the
+      counter and continue execution.
+      -->
+      <xref linkend="sql-vacuum"> および <xref linkend="sql-analyze"> コマンドの実行中、実行される各種I/O操作の予測コストを追跡し続ける内部カウンタをシステムが保守します。
+      累積されたコストが（<varname>vacuum_cost_limit</varname>で指定された）限度に達すると、操作を実行しているプロセスは<varname>vacuum_cost_delay</varname>で指定されたちょっとの間スリープします。その後、カウンタをリセットし、実行を継続します。
+     </para>
+
+     <para>
+     <!--
+      The intent of this feature is to allow administrators to reduce
+      the I/O impact of these commands on concurrent database
+      activity. There are many situations where it is not
+      important that maintenance commands like
+      <command>VACUUM</command> and <command>ANALYZE</command> finish
+      quickly; however, it is usually very important that these
+      commands do not significantly interfere with the ability of the
+      system to perform other database operations. Cost-based vacuum
+      delay provides a way for administrators to achieve this.
+      -->
+この機能の目的は、同時に実行されているデータベースの活動に対するこれらコマンドによるI/Oへの影響を、管理者が軽減できるようにすることです。
+<command>VACUUM</command> および <command>ANALYZE</command>の様な保守用コマンドが即座に終了することが重要ではない事態が数多くあります。
+しかし、他のデータベースの操作を行うに当たって、これらのコマンドがシステムの能力に多大な阻害を与えないことは通常とても重要です。
+コストに基づいたvacuum遅延はこれを実現するための方法を管理者に提供します。
+     </para>
+
+     <para>
+     <!--
+      This feature is disabled by default for manually issued
+      <command>VACUUM</command> commands. To enable it, set the
+      <varname>vacuum_cost_delay</varname> variable to a nonzero
+      value.
+      -->
+手動で実行した<command>VACUUM</command>コマンドについては、デフォルトでこの機能は無効になっています。
+有効にするには、<varname>vacuum_cost_delay</varname>変数をゼロでない値に設定します。
+     </para>
+
+     <variablelist>
+      <varlistentry id="guc-vacuum-cost-delay" xreflabel="vacuum_cost_delay">
+       <term><varname>vacuum_cost_delay</varname> (<type>integer</type>)
+       <indexterm>
+       <!--
+        <primary><varname>vacuum_cost_delay</> configuration parameter</primary>
+       -->
+       <primary><varname>vacuum_cost_delay</>設定パラメータ</primary>
+       </indexterm>
+       </term>
+       <listitem>
+        <para>
+       <!--
+         The length of time, in milliseconds, that the process will sleep
+         when the cost limit has been exceeded.
+         The default value is zero, which disables the cost-based vacuum
+         delay feature.  Positive values enable cost-based vacuuming.
+         Note that on many systems, the effective resolution
+         of sleep delays is 10 milliseconds; setting
+         <varname>vacuum_cost_delay</varname> to a value that is
+         not a multiple of 10 might have the same results as setting it
+         to the next higher multiple of 10.
+        -->
+        コストの限度を越えた場合、プロセスがスリープするミリ秒単位の時間の長さです。
+デフォルトの値は0で、コストに基づいたvacuum遅延機能を無効にします。
+正の整数はコストに基づいたvacuumを有効にします。
+多くのシステムで、スリープ遅延の有効な分解能は10ミリ秒です。
+<varname>vacuum_cost_delay</varname>の値の設定を10の倍数としない場合、次に大きい10の倍数に設定した結果と同一になるかもしれないことを覚えておいてください。
+        </para>
+
+        <para>
+       <!--
+         When using cost-based vacuuming, appropriate values for
+         <varname>vacuum_cost_delay</> are usually quite small, perhaps
+         10 or 20 milliseconds.  Adjusting vacuum's resource consumption
+         is best done by changing the other vacuum cost parameters.
+        -->
+        コストに基づいたバキューム処理を使用する場合、<varname>vacuum_cost_delay</>の適切な値は通常かなり小さくなり、たいていは10または20ミリ秒になります。
+        バキュームによるリソース消費の調整は、他のバキュームのコストパラメータを変更して行うことが最善です。
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry id="guc-vacuum-cost-page-hit" xreflabel="vacuum_cost_page_hit">
+       <term><varname>vacuum_cost_page_hit</varname> (<type>integer</type>)
+       <indexterm>
+       <!--
+        <primary><varname>vacuum_cost_page_hit</> configuration parameter</primary>
+       -->
+       <primary><varname>vacuum_cost_page_hit</>設定パラメータ</primary>
+       </indexterm>
+       </term>
+       <listitem>
+        <para>
+       <!--
+         The estimated cost for vacuuming a buffer found in the shared buffer
+         cache. It represents the cost to lock the buffer pool, lookup
+         the shared hash table and scan the content of the page. The
+         default value is one.
+        -->
+        共有バッファキャッシュの中のバッファにvacuumを掛ける予測コストです。バッファプールのロック、共有ハッシュテーブルの検索、およびページ内容走査のコストを示します。デフォルトの値は1です。
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry id="guc-vacuum-cost-page-miss" xreflabel="vacuum_cost_page_miss">
+       <term><varname>vacuum_cost_page_miss</varname> (<type>integer</type>)
+       <indexterm>
+       <!--
+        <primary><varname>vacuum_cost_page_miss</> configuration parameter</primary>
+       -->
+       <primary><varname>vacuum_cost_page_miss</>設定パラメータ</primary>
+       </indexterm>
+       </term>
+       <listitem>
+        <para>
+       <!--
+         The estimated cost for vacuuming a buffer that has to be read from
+         disk.  This represents the effort to lock the buffer pool,
+         lookup the shared hash table, read the desired block in from
+         the disk and scan its content. The default value is 10.
+        -->
+        ディスクから読み込まれなければならないバッファにvacuumを掛ける予測コストです。これが示すものは、バッファプールロックの試み、共有ハッシュテーブルの参照、ディスクから目的ブロックの読み込み、そしてその内容走査です。デフォルトの値は10です。
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry id="guc-vacuum-cost-page-dirty" xreflabel="vacuum_cost_page_dirty">
+       <term><varname>vacuum_cost_page_dirty</varname> (<type>integer</type>)
+       <indexterm>
+       <!--
+        <primary><varname>vacuum_cost_page_dirty</> configuration parameter</primary>
+       -->
+       <primary><varname>vacuum_cost_page_dirty</>設定パラメータ</primary>
+       </indexterm>
+       </term>
+       <listitem>
+        <para>
+       <!--
+         The estimated cost charged when vacuum modifies a block that was
+         previously clean. It represents the extra I/O required to
+         flush the dirty block out to disk again. The default value is
+         20.
+        -->
+        vacuumが、先だって掃除したブロックを変更する時に果たされた予測コストです。
+        ダーティブロックを再度ディスクに吐き出すのに必要な余分なI/Oを表します。デフォルトの値は20です。
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry id="guc-vacuum-cost-limit" xreflabel="vacuum_cost_limit">
+       <term><varname>vacuum_cost_limit</varname> (<type>integer</type>)
+       <indexterm>
+       <!--
+        <primary><varname>vacuum_cost_limit</> configuration parameter</primary>
+       -->
+       <primary><varname>vacuum_cost_limit</>設定パラメータ</primary>
+       </indexterm>
+       </term>
+       <listitem>
+        <para>
+       <!--
+         The accumulated cost that will cause the vacuuming process to sleep.
+         The default value is 200.
+        -->
+        vacuumを掛けるプロセスをスリープさせることになる累計されたコストです。
+        デフォルトの値は200です。
+        </para>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+
+     <note>
+      <para>
+      <!--
+       There are certain operations that hold critical locks and should
+       therefore complete as quickly as possible.  Cost-based vacuum
+       delays do not occur during such operations.  Therefore it is
+       possible that the cost accumulates far higher than the specified
+       limit.  To avoid uselessly long delays in such cases, the actual
+       delay is calculated as <varname>vacuum_cost_delay</varname> *
+       <varname>accumulated_balance</varname> /
+       <varname>vacuum_cost_limit</varname> with a maximum of
+       <varname>vacuum_cost_delay</varname> * 4.
+       -->
+重要なロックを保有し可能なかぎり早急に完了しなければならないある種の操作があります。コストに基づいたvacuum遅延はこの様な操作では起こりません。
+したがって、コストの累計が指定された限度をかなり高く越える可能性があります。
+このような場合無駄な長い遅延を防止するため、実際の遅延は<varname>vacuum_cost_delay</varname> * 4 を上限として、以下のように計算されます。
+       <varname>vacuum_cost_delay</varname> * <varname>accumulated_balance</varname> / <varname>vacuum_cost_limit</varname>
+      </para>
+     </note>
+    </sect2>
+
+    <sect2 id="runtime-config-resource-background-writer">
+    <!--
+     <title>Background Writer</title>
+     -->
+     <title>バックグラウンドライタ</title>
+
+     <para>
+     <!--
+      There is a separate server
+      process called the <firstterm>background writer</>, whose function
+      is to issue writes of <quote>dirty</> (new or modified) shared
+      buffers.  It writes shared buffers so server processes handling
+      user queries seldom or never need to wait for a write to occur.
+      However, the background writer does cause a net overall
+      increase in I/O load, because while a repeatedly-dirtied page might
+      otherwise be written only once per checkpoint interval, the
+      background writer might write it several times as it is dirtied
+      in the same interval.  The parameters discussed in this subsection
+      can be used to tune the behavior for local needs.
+      -->
+<firstterm>バックグラウンドライタ</>と呼ばれる個別のサーバプロセスがあり、その機能は（新規または更新された）<quote>ダーティ</>な共有バッファの書き込みを行うことです。
+ユーザの問い合わせを処理するサーバプロセスが、書き込みが起きるまで滅多に待つ必要がない、あるいは決して待つ必要がないように、共有バッファの書き込みを行います。
+しかし、バックグラウンドライタは正味の全体的I/O負荷の増加を引き起こします。
+その理由は、繰り返しダーティ化されるページは、バックグラウンドライタを使わなければチェックポイント間隔で一度だけ書き出されれば十分なのに対し、バックグラウンドライタは同じ間隔内で何度もダーティ化されると、それを複数回書き出すかもしれないからです。
+本節で説明する各パラメータは、サイト独自の必要に応じて動作を調整することに使用できます。
+     </para>
+
+     <variablelist>
+      <varlistentry id="guc-bgwriter-delay" xreflabel="bgwriter_delay">
+       <term><varname>bgwriter_delay</varname> (<type>integer</type>)
+       <indexterm>
+       <!--
+        <primary><varname>bgwriter_delay</> configuration parameter</primary>
+       -->
+       <primary><varname>bgwriter_delay</>設定パラメータ</primary>
+       </indexterm>
+       </term>
+       <listitem>
+        <para>
+       <!--
+         Specifies the delay between activity rounds for the
+         background writer.  In each round the writer issues writes
+         for some number of dirty buffers (controllable by the
+         following parameters).  It then sleeps for <varname>bgwriter_delay</>
+         milliseconds, and repeats.  When there are no dirty buffers in the
+         buffer pool, though, it goes into a longer sleep regardless of
+         <varname>bgwriter_delay</>.  The default value is 200
+         milliseconds (<literal>200ms</>). Note that on many systems, the
+         effective resolution of sleep delays is 10 milliseconds; setting
+         <varname>bgwriter_delay</> to a value that is not a multiple of 10
+         might have the same results as setting it to the next higher multiple
+         of 10.  This parameter can only be set in the
+         <filename>postgresql.conf</> file or on the server command line.
+        -->
+        バックグラウンドライタの動作周期間の遅延を指定します。
+それぞれの周期でライタは、（以下のパラメータで管理される）一部のダーティバッファの書き込みを行います。
+そして<varname>bgwriter_delay</>ミリ秒スリープした後、これを繰りかえします。
+しかし、バッファプールにダーティバッファが存在しない場合、<varname>bgwriter_delay</>に係わらずより長くスリープします。
+デフォルトの値は200ミリ秒（<literal>200ms</>）です。
+多くのシステムで、スリープ遅延の実精度は10ミリ秒です。
+<varname>bgwriter_delay</varname>の値の設定を10の倍数としない場合、次に大きい10の倍数に設定した結果と同一になるかもしれないことを覚えておいてください。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインで設定可能です。
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry id="guc-bgwriter-lru-maxpages" xreflabel="bgwriter_lru_maxpages">
+       <term><varname>bgwriter_lru_maxpages</varname> (<type>integer</type>)
+       <indexterm>
+<!--
+        <primary><varname>bgwriter_lru_maxpages</> configuration parameter</primary>
+-->
+        <primary><varname>bgwriter_lru_maxpages</>設定パラメータ</primary>
+       </indexterm>
+       </term>
+       <listitem>
+        <para>
+       <!--
+         In each round, no more than this many buffers will be written
+         by the background writer.  Setting this to zero disables
+         background writing.  (Note that checkpoints, which are managed by
+         a separate, dedicated auxiliary process, are unaffected.)
+         The default value is 100 buffers.
+         This parameter can only be set in the <filename>postgresql.conf</>
+         file or on the server command line.
+        -->
+        それぞれの周期で、この数以上のバッファはバックグラウンドライタにより書き込まれません。
+         ゼロに設定することでバックグラウンド書き込みは無効になります。
+        （分離し、そして専用の補助プロセスにより管理されるチェックポイントは影響を受けません。）
+         デフォルト値は100バッファです。
+         このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみで設定可能です。
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry id="guc-bgwriter-lru-multiplier" xreflabel="bgwriter_lru_multiplier">
+       <term><varname>bgwriter_lru_multiplier</varname> (<type>floating point</type>)
+       <indexterm>
+       <!--
+        <primary><varname>bgwriter_lru_multiplier</> configuration parameter</primary>
+       -->
+       <primary><varname>bgwriter_lru_multiplier</>設定パラメータ</primary>
+       </indexterm>
+       </term>
+       <listitem>
+        <para>
+       <!--
+         The number of dirty buffers written in each round is based on the
+         number of new buffers that have been needed by server processes
+         during recent rounds.  The average recent need is multiplied by
+         <varname>bgwriter_lru_multiplier</> to arrive at an estimate of the
+         number of buffers that will be needed during the next round.  Dirty
+         buffers are written until there are that many clean, reusable buffers
+         available.  (However, no more than <varname>bgwriter_lru_maxpages</>
+         buffers will be written per round.)
+         Thus, a setting of 1.0 represents a <quote>just in time</> policy
+         of writing exactly the number of buffers predicted to be needed.
+         Larger values provide some cushion against spikes in demand,
+         while smaller values intentionally leave writes to be done by
+         server processes.
+         The default is 2.0.
+         This parameter can only be set in the <filename>postgresql.conf</>
+         file or on the server command line.
+        -->
+        各周期で書き出されるダーティバッファ数は、最近の周期でサーバプロセスが必要とした新しいバッファ数を基にします。
+次の周期で必要となるバッファ数を推定するために、最近必要とされた平均が<varname>bgwriter_lru_multiplier</>と掛け合わせられます。
+ダーティバッファの書き出しは、同数の整理済み、再利用可能なバッファが利用できるようになるまで行われます。
+（しかし1周期に<varname>bgwriter_lru_maxpages</>を越えるバッファ数を書き出しません。）
+したがって、1.0と設定することは、必要と予想されるバッファ数の書き込みについて<quote>必要なときに必要なだけ</>というポリシーを表します。
+より大きな値は突発的な要求に対する多少の緩衝材を提供します。
+より小さな値はサーバプロセスでなされる書き込みを意図的に残します。
+デフォルトは2.0です。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定可能です。
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry id="guc-bgwriter-flush-after" xreflabel="bgwriter_flush_after">
+       <term><varname>bgwriter_flush_after</varname> (<type>integer</type>)
+       <indexterm>
+        <primary><varname>bgwriter_flush_after</> configuration parameter</primary>
+       </indexterm>
+       </term>
+       <listitem>
+        <para>
+<!--
+         Whenever more than <varname>bgwriter_flush_after</varname> bytes have
+         been written by the background writer, attempt to force the OS to issue these
+         writes to the underlying storage.  Doing so will limit the amount of
+         dirty data in the kernel's page cache, reducing the likelihood of
+         stalls when an <function>fsync</function> is issued at the end of a checkpoint, or when
+         the OS writes data back in larger batches in the background.  Often
+         that will result in greatly reduced transaction latency, but there
+         also are some cases, especially with workloads that are bigger than
+         <xref linkend="guc-shared-buffers">, but smaller than the OS's page
+         cache, where performance might degrade.  This setting may have no
+         effect on some platforms.  The valid range is between
+         <literal>0</literal>, which disables forced writeback, and
+         <literal>2MB</literal>.  The default is <literal>512kB</> on Linux,
+         <literal>0</> elsewhere.  (If <symbol>BLCKSZ</symbol> is not 8kB,
+         the default and maximum values scale proportionally to it.)
+         This parameter can only be set in the <filename>postgresql.conf</>
+         file or on the server command line.
+-->
+バックグラウンドライターが<varname>bgwriter_flush_after</varname>バイトより多く書く度に、OSが記憶装置に書き込むことを強制しようとします。
+このことにより、カーネルのページキャッシュが持つダーティデータの量を一定量に制限し、チェックポイントの最後に<function>fsync</function>が実行される際、あるいはOSがバックグラウンドでデータを大きな塊で書き出す際に性能の急激な低下を招く可能性を減らします。
+多くの場合これによってトランザクションの遅延が大幅に少なくなりますが、あるケース、特にワークロードが<xref linkend="guc-shared-buffers">よりも大きく、OSのページキャッシュよりも小さい時には性能が低下するかもしれません。
+この設定が無効なプラットフォームがあります。
+有効な設定値は、この強制書き込み機能が無効になる<literal>0</literal>から、<literal>2MB</literal>までです。
+デフォルト値は、Linuxでは<literal>512kB</>で、それ以外は<literal>0</>です。
+(<symbol>BLCKSZ</symbol>が8kBでなければ、この設定のデフォルト値と最大値が<symbol>BLCKSZ</symbol>に比例して変更されます。)
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定可能です。
+        </para>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+
+     <para>
+     <!--
+      Smaller values of <varname>bgwriter_lru_maxpages</varname> and
+      <varname>bgwriter_lru_multiplier</varname> reduce the extra I/O load
+      caused by the background writer, but make it more likely that server
+      processes will have to issue writes for themselves, delaying interactive
+      queries.
+      -->
+      <varname>bgwriter_lru_maxpages</varname>および<varname>bgwriter_lru_multiplier</varname>の値がより少ないと、バックグラウンドライタで引き起こされる追加のI/O負荷を軽減しますが、サーバプロセスが自分自身で行わなければならない書き込みが増加することになり、会話型問い合わせを遅らせることになります。
+     </para>
+    </sect2>
+
+    <sect2 id="runtime-config-resource-async-behavior">
+    <!--
+     <title>Asynchronous Behavior</title>
+     -->
+     <title>非同期動作</title>
+
+     <variablelist>
+      <varlistentry id="guc-effective-io-concurrency" xreflabel="effective_io_concurrency">
+       <term><varname>effective_io_concurrency</varname> (<type>integer</type>)
+       <indexterm>
+       <!--
+        <primary><varname>effective_io_concurrency</> configuration parameter</primary>
+       -->
+       <primary><varname>effective_io_concurrency</>設定パラメータ</primary>
+       </indexterm>
+       </term>
+       <listitem>
+        <para>
+       <!--
+         Sets the number of concurrent disk I/O operations that
+         <productname>PostgreSQL</> expects can be executed
+         simultaneously.  Raising this value will increase the number of I/O
+         operations that any individual <productname>PostgreSQL</> session
+         attempts to initiate in parallel.  The allowed range is 1 to 1000,
+         or zero to disable issuance of asynchronous I/O requests. Currently,
+         this setting only affects bitmap heap scans.
+        -->
+<productname>PostgreSQL</>が同時実行可能であると想定する同時ディスクI/O操作の数を設定します。
+この値を大きくすると、あらゆる個別の<productname>PostgreSQL</>セッションが並行して開始を試みるI/O操作の数が増加します。
+設定可能な範囲は1から1000まで、または非同期I/Oリクエストの発行を無効にするゼロです。
+現在、この設定はビットマップヒープスキャンのみに影響します。
+        </para>
+
+        <para>
+       <!--
+         For magnetic drives, a good starting point for this setting is the
+         number of separate
+         drives comprising a RAID 0 stripe or RAID 1 mirror being used for the
+         database.  (For RAID 5 the parity drive should not be counted.)
+         However, if the database is often busy with multiple queries issued in
+         concurrent sessions, lower values may be sufficient to keep the disk
+         array busy.  A value higher than needed to keep the disks busy will
+         only result in extra CPU overhead.
+         SSDs and other memory-based storage can often process many
+         concurrent requests, so the best value might be in the hundreds.
+-->
+磁気ディスクドライブにおいては、データベースに使用されるRAID 0ストライプ、RAID 1ミラーを構成する個々のドライブ数から始めると良いでしょう。（RAID 5ではパリティ用のドライブを数に含めません）
+しかし、同時実行セッションで発行される複数の問い合わせでデータベースが頻繁にビジーとなる場合、小さめの値で十分ディスクアレイがビジーになるかもしれません。
+ディスクをビジーにするのに必要な値より大きな値を設定しても、余計なCPUオーバーヘッドを発生させるだけです。
+SSDやそれ以外のメモリーベースの記憶装置は、多くの同時リクエストをこなすことができるので、最適な値は数百になるかもしれません。
+        </para>
+
+        <para>
+       <!--
+         Asynchronous I/O depends on an effective <function>posix_fadvise</>
+         function, which some operating systems lack.  If the function is not
+         present then setting this parameter to anything but zero will result
+         in an error.  On some operating systems (e.g., Solaris), the function
+         is present but does not actually do anything.
+        -->
+        非同期I/Oは実質的に<function>posix_fadvise</>関数に依存します。
+        これは一部のオペレーティングシステムには存在しません。
+        この関数が存在しない場合、この値をゼロ以外に設定するとエラーとなります。
+        一部のオペレーティングシステム（例えばSolaris）では存在するけれども、実際何も行わないものもあります。
+        </para>
+
+        <para>
+<!--
+         The default is 1 on supported systems, otherwise 0.  This value can
+         be overridden for tables in a particular tablespace by setting the
+         tablespace parameter of the same name (see
+         <xref linkend="sql-altertablespace">).
+-->
+デフォルトは、サポートされているシステムでは1、そうでなければ0です。
+この値は、テーブルスペースパラメータの同じ名前のパラメータを設定することで、特定のテーブルスペース内のテーブルに対して上書きできます。
+(<xref linkend="sql-altertablespace">を参照ください)。
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry id="guc-max-worker-processes" xreflabel="max_worker_processes">
+       <term><varname>max_worker_processes</varname> (<type>integer</type>)
+       <indexterm>
+<!--
+        <primary><varname>max_worker_processes</> configuration parameter</primary>
+-->
+        <primary><varname>max_worker_processes</>設定パラメータ</primary>
+       </indexterm>
+       </term>
+       <listitem>
+        <para>
+<!--
+         Sets the maximum number of background processes that the system
+         can support.  This parameter can only be set at server start.  The
+         default is 8.
+-->
+システムがサポートするバックグラウンドプロセスの最大数を指定します。
+このパラメータはサーバ起動時にのみ設定できます。
+デフォルトは8です。
+        </para>
+
+        <para>
+<!--
+         When running a standby server, you must set this parameter to the
+         same or higher value than on the master server. Otherwise, queries
+         will not be allowed in the standby server.
+-->
+         スタンバイサーバを起動しているときは、このパラメータを、マスタサーバの設定値と同じかそれ以上にしなければなりません。さもなければ、スタンバイサーバで問い合わせの実行ができなくなります。
+        </para>
+
+        <para>
+<!--
+         When changing this value, consider also adjusting
+         <xref linkend="guc-max-parallel-workers"> and
+         <xref linkend="guc-max-parallel-workers-per-gather">.
+-->
+この値を変更する際は、<xref linkend="guc-max-parallel-workers">と<xref linkend="guc-max-parallel-workers-per-gather">を変更することも考慮してください。
+
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry id="guc-max-parallel-workers-per-gather" xreflabel="max_parallel_workers_per_gather">
+       <term><varname>max_parallel_workers_per_gather</varname> (<type>integer</type>)
+       <indexterm>
+<!--
+        <primary><varname>max_parallel_workers_per_gather</> configuration parameter</primary>
+-->
+        <primary><varname>max_parallel_workers_per_gather</> 設定パラメータ</primary>
+       </indexterm>
+       </term>
+       <listitem>
+        <para>
+<!--
+         Sets the maximum number of workers that can be started by a single
+         <literal>Gather</literal> or <literal>Gather Merge</literal> node.
+         Parallel workers are taken from the pool of processes established by
+         <xref linkend="guc-max-worker-processes">, limited by
+         <xref linkend="guc-max-parallel-workers">.  Note that the requested
+         number of workers may not actually be available at run time.  If this
+         occurs, the plan will run with fewer workers than expected, which may
+         be inefficient.  The default value is 2.  Setting this value to 0
+         disables parallel query execution.
+-->
+一つの<literal>Gather</literal>または<literal>Gather Merge</literal>ノードに対して起動できるワーカー数の最大値を設定します。
+パラレルワーカーは、<xref linkend="guc-max-parallel-workers">で上限が決まる<xref linkend="guc-max-worker-processes">で確立されたプロセスのプールから取得されます。
+実行時には、要求された数のワーカーは取得できないかもしれないことに注意してください。
+そうなると、実行プランは期待していたよりも少ない数のワーカーで実行されることになり、効率は悪化するかもしれません。
+デフォルト値は2です。
+この設定値を0にすると、パラレルクエリの実行は行われません。
+        </para>
+
+        <para>
+<!--
+         Note that parallel queries may consume very substantially more
+         resources than non-parallel queries, because each worker process is
+         a completely separate process which has roughly the same impact on the
+         system as an additional user session.  This should be taken into
+         account when choosing a value for this setting, as well as when
+         configuring other settings that control resource utilization, such
+         as <xref linkend="guc-work-mem">.  Resource limits such as
+         <varname>work_mem</> are applied individually to each worker,
+         which means the total utilization may be much higher across all
+         processes than it would normally be for any single process.
+         For example, a parallel query using 4 workers may use up to 5 times
+         as much CPU time, memory, I/O bandwidth, and so forth as a query which
+         uses no workers at all.
+-->
+パラレルクエリの実行により、パラレルクエリではない場合に比べて非常に多くのリソースが使用されるかもしれないことに注意してください。
+これは、個々のワーカープロセスは完全に別個のプロセスであり、システムに対してユーザセッションが追加されたのと大体同じくらいの影響があるからです。
+この設定値を選択する際には、他のリソースの消費量を制御する他の設定値、たとえば<xref linkend="guc-work-mem">を設定するときと同様に、この点を考慮しておく必要があります。
+<varname>work_mem</>のような設定値によるリソース制限は、個々のワーカーに対して個別に適用されます。
+つまり、ひとつのプロセス対するよりも、すべてのプロセスの全体のリソース消費はずっと多いかもしれないということです。
+たとえば、あるパラレルクエリが4つのワーカーを使っているとすると、ワーカーを使わない場合に比べて、最大5倍のCPU時間、メモリ、I/Oバンド幅、その他を使うかもしれません。
+        </para>
+
+        <para>
+<!--
+         For more information on parallel query, see
+         <xref linkend="parallel-query">.
+-->
+         パラレルクエリに関する更なる情報については、<xref linkend="parallel-query">をご覧ください。
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry id="guc-max-parallel-workers" xreflabel="max_parallel_workers">
+       <term><varname>max_parallel_workers</varname> (<type>integer</type>)
+       <indexterm>
+<!--
+        <primary><varname>max_parallel_workers</> configuration parameter</primary>
+-->
+        <primary><varname>max_parallel_workers</>設定パラメータ</primary>
+       </indexterm>
+       </term>
+       <listitem>
+        <para>
+<!--
+         Sets the maximum number of workers that the system can support for
+         parallel queries.  The default value is 8.  When increasing or
+         decreasing this value, consider also adjusting
+         <xref linkend="guc-max-parallel-workers-per-gather">.
+         Also, note that a setting for this value which is higher than
+         <xref linkend="guc-max-worker-processes"> will have no effect,
+         since parallel workers are taken from the pool of worker processes
+         established by that setting.
+-->
+パラレルクエリ用にシステムがサポートできる最大のワーカー数を設定します。
+デフォルト値は8です。
+この値を増減するときは、<xref linkend="guc-max-parallel-workers-per-gather">を調整することを考慮してください。
+また、この設定値を<xref linkend="guc-max-worker-processes">よりも高い値にしても効果がないことに注意してください。
+<xref linkend="guc-max-worker-processes">で決まるワーカープロセスのプールから、パラレルワーカーが使われるからです。
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry id="guc-backend-flush-after" xreflabel="backend_flush_after">
+       <term><varname>backend_flush_after</varname> (<type>integer</type>)
+       <indexterm>
+<!--
+        <primary><varname>backend_flush_after</> configuration parameter</primary>
+-->
+        <primary><varname>backend_flush_after</> 設定パラメータ</primary>
+       </indexterm>
+       </term>
+       <listitem>
+        <para>
+<!--
+         Whenever more than <varname>backend_flush_after</varname> bytes have
+         been written by a single backend, attempt to force the OS to issue
+         these writes to the underlying storage.  Doing so will limit the
+         amount of dirty data in the kernel's page cache, reducing the
+         likelihood of stalls when an <function>fsync</function> is issued at the end of a
+         checkpoint, or when the OS writes data back in larger batches in the
+         background.  Often that will result in greatly reduced transaction
+         latency, but there also are some cases, especially with workloads
+         that are bigger than <xref linkend="guc-shared-buffers">, but smaller
+         than the OS's page cache, where performance might degrade.  This
+         setting may have no effect on some platforms.  The valid range is
+         between <literal>0</literal>, which disables forced writeback,
+         and <literal>2MB</literal>.  The default is <literal>0</>, i.e., no
+         forced writeback.  (If <symbol>BLCKSZ</symbol> is not 8kB,
+         the maximum value scales proportionally to it.)
+-->
+<varname>backend_flush_after</varname>バイトが単一のバックエンドによって書き込まれる度に、OSが記憶装置に書き込むことを強制します。
+このことにより、カーネルのページキャッシュが持つダーティデータの量を一定量に制限し、チェックポイントの最後に<function>fsync</function>が実行される際、あるいはバックグラウンドで実行される大きなバッチの中でOSがデータを書き出す際に性能の急激な低下を招く可能性を減らします。
+多くの場合これによってトランザクションの遅延を大幅に少なくなりますが、あるケース、特にワークロードが<xref linkend="guc-shared-buffers">よりも大きく、OSのページキャッシュよりも小さい時には性能が低下するかもしれません。
+この設定が無効なプラットフォームがあります。
+有効な設定値は、この強制書き込み機能が無効になる<literal>0</literal>から、<literal>2MB</literal>までです。
+デフォルト値は<literal>0</>です(すなわち書き出し制御を行いません)。
+(<symbol>BLCKSZ</symbol>が8kbでなければ、最大値が<symbol>BLCKSZ</symbol>に比例して変更されます。)
+        </para>
+       </listitem>
+      </varlistentry>
+
+&config1;
+&config2;
+&config3;
+<!-- split-config0-end -->
+
+</chapter>

--- a/doc/src/sgml/config1.sgml
+++ b/doc/src/sgml/config1.sgml
@@ -1,0 +1,3191 @@
+<!-- 警告：このファイルは直接編集しないでください！
+1. config.sgmlを編集したら、split-config.shを起動します。
+2. するとconfig[0-3].sgmlが生成されます。
+3. config.sgmlとともにconfig[0-3].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
+4. レビューはconfig[0-3].sgmlに対して行います。
+5. 指摘された点があればconfig.sgmlに反映し、1に戻ります。
+6. config.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
+-->
+<!-- split-config1-start -->
+
+      <varlistentry id="guc-old-snapshot-threshold" xreflabel="old_snapshot_threshold">
+       <term><varname>old_snapshot_threshold</varname> (<type>integer</type>)
+       <indexterm>
+<!--
+        <primary><varname>old_snapshot_threshold</> configuration parameter</primary>
+-->
+        <primary><varname>old_snapshot_threshold</> 設定パラメータ</primary>
+       </indexterm>
+       </term>
+       <listitem>
+        <para>
+<!--
+         Sets the minimum time that a snapshot can be used without risk of a
+         <literal>snapshot too old</> error occurring when using the snapshot.
+         This parameter can only be set at server start.
+-->
+スナップショットが使用されるときに、<literal>snapshot too old</>エラーを引き起こす危険性なしにスナップショットを利用できる最小時間を設定します。
+このパラメータはサーバ起動時にのみ設定できます。
+        </para>
+
+        <para>
+<!--
+         Beyond the threshold, old data may be vacuumed away.  This can help
+         prevent bloat in the face of snapshots which remain in use for a
+         long time.  To prevent incorrect results due to cleanup of data which
+         would otherwise be visible to the snapshot, an error is generated
+         when the snapshot is older than this threshold and the snapshot is
+         used to read a page which has been modified since the snapshot was
+         built.
+-->
+この制限値を越えると、古いデータはバキュームされます。
+これにより、長い間残っていたスナップショットによりデータが溢れてしまうのを防ぐことができます。
+スナップショットから見えるデータが消えることによる不正な結果を防ぐため、スナップショットがこの制限値よりも古く、かつこのスナップショットが作られた以降に変更されたページを読むためにスナップショットが使用されるときはエラーが発生します。
+        </para>
+
+        <para>
+<!--
+         A value of <literal>-1</> disables this feature, and is the default.
+         Useful values for production work probably range from a small number
+         of hours to a few days.  The setting will be coerced to a granularity
+         of minutes, and small numbers (such as <literal>0</> or
+         <literal>1min</>) are only allowed because they may sometimes be
+         useful for testing.  While a setting as high as <literal>60d</> is
+         allowed, please note that in many workloads extreme bloat or
+         transaction ID wraparound may occur in much shorter time frames.
+-->
+<literal>-1</>を設定するとこの機能が無効になります。
+これがデフォルトです。
+実際の環境でのおすすめの値はおそらく数時間から2, 3日の間となるでしょう。
+設定値は、分の粒度に書き換えられます。
+小さな値(たとえば<literal>0</>や<literal>1min</>)は、テストの際に有用だということで許可されています。
+<literal>60d</>のような大きな値の設定もできますが、多くのワークロードにおいて、大きなデータ溢れやトランザクションIDの周回がそれよりはずっと短い期間で起こる可能性があることに注意してください。
+        </para>
+
+        <para>
+<!--
+         When this feature is enabled, freed space at the end of a relation
+         cannot be released to the operating system, since that could remove
+         information needed to detect the <literal>snapshot too old</>
+         condition.  All space allocated to a relation remains associated with
+         that relation for reuse only within that relation unless explicitly
+         freed (for example, with <command>VACUUM FULL</>).
+-->
+この機能が有効であると、リレーションの終端部にあるフリースペースはオペレーティングシステムには返却されません。
+そうしないと、<literal>snapshot too old</>の条件の検出に必要な情報を削除してしまうことになるからです。
+明示的に解放されない限り（たとえば<command>VACUUM FULL</>によって）、リレーションに割り当てられた領域は、そのリレーションの中での再利用に限定して紐付けられます。
+        </para>
+
+        <para>
+<!--
+         This setting does not attempt to guarantee that an error will be
+         generated under any particular circumstances.  In fact, if the
+         correct results can be generated from (for example) a cursor which
+         has materialized a result set, no error will be generated even if the
+         underlying rows in the referenced table have been vacuumed away.
+         Some tables cannot safely be vacuumed early, and so will not be
+         affected by this setting, such as system catalogs.  For such tables
+         this setting will neither reduce bloat nor create a possibility
+         of a <literal>snapshot too old</> error on scanning.
+-->
+この設定は、どのような状況でもエラーが検出されることを保証するものではありません。
+（たとえば）マテリアライズされた結果集合を持つカーソルから正しい結果を得ることができるのであれば、たとえ参照している元のテーブルからVACUUMによって行が削除されたとしてもエラーにはなりません。
+ある種のテーブルでは、早期にVACUUMできないので、この設定の影響を受けません。
+例としては、システムカタログが挙げられます。
+このようなテーブルにおいては、この設定によってデータ溢れを防ぐことも、スキャンの際に<literal>snapshot too old</>エラーを起こす可能性を作り出すこともできません。
+        </para>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+    </sect2>
+   </sect1>
+
+   <sect1 id="runtime-config-wal">
+   <!--
+    <title>Write Ahead Log</title>
+    -->
+    <title>ログ先行書き込み（WAL）</title>
+
+   <para>
+   <!--
+    For additional information on tuning these settings,
+    see <xref linkend="wal-configuration">.
+    -->
+    これらの設定をチューニングする追加情報は<xref linkend="wal-configuration">を参照してください。
+   </para>
+
+    <sect2 id="runtime-config-wal-settings">
+    <!--
+     <title>Settings</title>
+     -->
+     <title>諸設定</title>
+     <variablelist>
+
+     <varlistentry id="guc-wal-level" xreflabel="wal_level">
+      <term><varname>wal_level</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>wal_level</> configuration parameter</primary>
+       -->
+       <primary><varname>wal_level</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        <varname>wal_level</> determines how much information is written to
+        the WAL. The default value is <literal>replica</>, which writes enough
+        data to support WAL archiving and replication, including running
+        read-only queries on a standby server. <literal>minimal</> removes all
+        logging except the information required to recover from a crash or
+        immediate shutdown.  Finally,
+        <literal>logical</> adds information necessary to support logical
+        decoding.  Each level includes the information logged at all lower
+        levels.  This parameter can only be set at server start.
+-->
+<varname>wal_level</>はどれだけの情報がWALに書かれるかを決定します。
+デフォルト値は<literal>replica</>で、WALアーカイビングおよびレプリケーションをサポートするために十分なデータを書き出し、これにはスタンバイサーバで読み取り専用の問い合わせを実行することも含みます。
+<literal>minimal</>はクラッシュまたは即時停止から回復するのに必要な情報を除き、すべてのログを削除します。
+最後に、<literal>logical</>は、更にロジカルデコーディングをサポートするのに必要な情報を追加します。
+それぞれのレベルは、下位のレベルのログ出力を含んでいます。
+このパラメータはサーバ起動時のみ設定可能です。
+       </para>
+       <para>
+       <!--
+        In <literal>minimal</> level, WAL-logging of some bulk
+        operations can be safely skipped, which can make those
+        operations much faster (see <xref linkend="populate-pitr">).
+        Operations in which this optimization can be applied include:
+        <simplelist>
+         <member><command>CREATE TABLE AS</></member>
+         <member><command>CREATE INDEX</></member>
+         <member><command>CLUSTER</></member>
+         <member><command>COPY</> into tables that were created or truncated in the same
+         transaction</member>
+        </simplelist>
+        But minimal WAL does not contain enough information to reconstruct the
+        data from a base backup and the WAL logs, so <literal>replica</> or
+        higher must be used to enable WAL archiving
+        (<xref linkend="guc-archive-mode">) and streaming replication.
+       -->
+<literal>minimal</>レベルでは、一部の巨大な操作でのWAL出力は安全に省略でき、そうすることで、それらの操作が大幅に高速になります（<xref linkend="populate-pitr">を参照してください）。
+この最適化が適用される操作には以下のものがあげられます。
+        <simplelist>
+         <member><command>CREATE TABLE AS</></member>
+         <member><command>CREATE INDEX</></member>
+         <member><command>CLUSTER</></member>
+         <member>同一トランザクション内で作成されたか、もしくは切り詰められたテーブルに対する<command>COPY</></member>
+        </simplelist>
+しかしminimal WALはベースバックアップとWALログからデータを再構築するための充分な情報を持ち合わせていません。
+したがって、WALアーカイビング（<xref linkend="guc-archive-mode">）とストリーミングレプリケーションを有効にするには、<literal>replica</>以上を使用しなければなりません。
+       </para>
+       <para>
+<!--
+        In <literal>logical</> level, the same information is logged as
+        with <literal>replica</>, plus information needed to allow
+        extracting logical change sets from the WAL. Using a level of
+        <literal>logical</> will increase the WAL volume, particularly if many
+        tables are configured for <literal>REPLICA IDENTITY FULL</literal> and
+        many <command>UPDATE</> and <command>DELETE</> statements are
+        executed.
+-->
+<literal>logical</>レベルでは、<literal>replica</>と同じ情報がログされるのに加え、ロジカルチェンジセットをWALから取り出すのに必要な情報が追加されます。
+<literal>logical</>を使うとWALの量が増えます。
+とりわけ、多数のテーブルが<literal>REPLICA IDENTITY FULL</literal>と設定されていて(訳注: ALTER TABLE参照)、多くの<command>UPDATE</>と<command>DELETE</>文が実行される場合はこのことが言えます。
+       </para>
+       <para>
+<!--
+        In releases prior to 9.6, this parameter also allowed the
+        values <literal>archive</literal> and <literal>hot_standby</literal>.
+        These are still accepted but mapped to <literal>replica</literal>.
+-->
+9.6よりも前のリリースでは、このパラメータは<literal>archive</literal>と<literal>hot_standby</literal>という設定値も可能でした。
+引き続きこれらも受け付けられますが、<literal>replica</literal>へとマップされます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-fsync" xreflabel="fsync">
+      <term><varname>fsync</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>fsync</> configuration parameter</primary>
+       -->
+       <primary><varname>fsync</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        If this parameter is on, the <productname>PostgreSQL</> server
+        will try to make sure that updates are physically written to
+        disk, by issuing <function>fsync()</> system calls or various
+        equivalent methods (see <xref linkend="guc-wal-sync-method">).
+        This ensures that the database cluster can recover to a
+        consistent state after an operating system or hardware crash.
+-->
+このパラメータがオンの場合、<productname>PostgreSQL</>サーバは<function>fsync()</>システムコールを発行するか、もしくはこれに相当する方法（<xref linkend="guc-wal-sync-method">を参照）で、更新が物理的にディスクに確実に書き込まれるように試みます。
+これは、オペレーティングシステムもしくはハードウェアがクラッシュした後、データベースクラスタを一貫した状態に復旧させることを確実にします。
+       </para>
+
+       <para>
+       <!--
+        While turning off <varname>fsync</varname> is often a performance
+        benefit, this can result in unrecoverable data corruption in
+        the event of a power failure or system crash.  Thus it
+        is only advisable to turn off <varname>fsync</varname> if
+        you can easily recreate your entire database from external
+        data.
+       -->
+<varname>fsync</varname>を停止することはしばしば性能上の利益になるとは言っても、停電やクラッシュの際に回復不可能なデータ破壊になることがあります。
+従って外部データから全てのデータベースを簡単に再構築できる場合のみ<varname>fsync</varname>を停止してください。
+       </para>
+
+       <para>
+       <!--
+        Examples of safe circumstances for turning off
+        <varname>fsync</varname> include the initial loading of a new
+        database cluster from a backup file, using a database cluster
+        for processing a batch of data after which the database
+        will be thrown away and recreated,
+        or for a read-only database clone which
+        gets recreated frequently and is not used for failover.  High
+        quality hardware alone is not a sufficient justification for
+        turning off <varname>fsync</varname>.
+       -->
+<varname>fsync</varname>を停止しても安全な状況の例としては、以下があげられます。
+バックアップファイルから新しいデータベースクラスタにデータの初期読み込みを行う場合、バッチデータの処理のためにデータベースクラスタを使用し、その後データベースを削除して再構築する場合、読み込み専用のデータベースのクローンを頻繁に再作成するが、それをフェイルオーバーに使用しない場合、などです。
+高性能なハードウェアであるからと言って、<varname>fsync</varname>を停止することは正当性を主張する十分な理由とはなりません。
+       </para>
+
+       <para>
+<!--
+        For reliable recovery when changing <varname>fsync</varname>
+        off to on, it is necessary to force all modified buffers in the
+        kernel to durable storage.  This can be done while the cluster
+        is shutdown or while <varname>fsync</varname> is on by running <command>initdb
+        &#045;&#045;sync-only</command>, running <command>sync</>, unmounting the
+        file system, or rebooting the server.
+-->
+<varname>fsync</varname>を無効(off)から有効(on）に変更したときの信頼できるリカバリのためには、カーネル内の全ての変更されたバッファを恒久的ストレージに強制的に吐き出させることが必要です。
+これは、クラスタがシャットダウンしている間、または<varname>fsync</varname>が有効のときに、<command>initdb --sync-only</command>を実行する、<command>sync</>を実行する、ファイルシステムをアンマウントする、またはサーバを再起動することによって可能となります。
+       </para>
+
+       <para>
+       <!--
+        In many situations, turning off <xref linkend="guc-synchronous-commit">
+        for noncritical transactions can provide much of the potential
+        performance benefit of turning off <varname>fsync</varname>, without
+        the attendant risks of data corruption.
+       -->
+多くの場合、重要でないトランザクションに対して<xref linkend="guc-synchronous-commit">を無効にすることにより、データ破壊という付随的危険性を伴うことなく、<varname>fsync</varname>を無効にすることで得られるであろう性能上のメリットの多くを得ることができます。
+       </para>
+
+       <para>
+       <!--
+        <varname>fsync</varname> can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+        If you turn this parameter off, also consider turning off
+        <xref linkend="guc-full-page-writes">.
+       -->
+<varname>fsync</varname> は<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータを無効にする場合、<xref linkend="guc-full-page-writes">も同時に無効にすることを検討してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-synchronous-commit" xreflabel="synchronous_commit">
+      <term><varname>synchronous_commit</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>synchronous_commit</> configuration parameter</primary>
+       -->
+       <primary><varname>synchronous_commit</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Specifies whether transaction commit will wait for WAL records
+        to be written to disk before the command returns a <quote>success</>
+        indication to the client.  Valid values are <literal>on</>,
+        <literal>remote_apply</>, <literal>remote_write</>, <literal>local</>,
+        and <literal>off</>.  The default, and safe, setting
+        is <literal>on</>.  When <literal>off</>, there can be a delay between
+        when success is reported to the client and when the transaction is
+        really guaranteed to be safe against a server crash.  (The maximum
+        delay is three times <xref linkend="guc-wal-writer-delay">.)  Unlike
+        <xref linkend="guc-fsync">, setting this parameter to <literal>off</>
+        does not create any risk of database inconsistency: an operating
+        system or database crash might
+        result in some recent allegedly-committed transactions being lost, but
+        the database state will be just the same as if those transactions had
+        been aborted cleanly.  So, turning <varname>synchronous_commit</> off
+        can be a useful alternative when performance is more important than
+        exact certainty about the durability of a transaction.  For more
+        discussion see <xref linkend="wal-async-commit">.
+-->
+トランザクションのコミットがクライアントに<quote>成功</>の報告を返す前に、WALレコードがディスク上に書き込まれるまで待つかどうかの指定をします。
+有効な値は<literal>on</>、<literal>remote_apply</>、<literal>remote_write</>、<literal>local</>、および<literal>off</>です。
+デフォルトかつ安全な設定は<literal>on</>です。
+<literal>off</>の場合、クライアントに成功を報告する時点とトランザクションが本当にサーバクラッシュに対して安全になるまでの間に遅延が発生する場合があります。
+（遅延は最大で、<xref linkend="guc-wal-writer-delay">の3倍です。）
+<xref linkend="guc-fsync">と異なり、このパラメータを<literal>off</>に設定することによって、データベースの一貫性が損なわれる可能性はありません。
+オペレーティングシステムやデータベースのクラッシュにより最近コミットされたということになっているトランザクションの一部が失われる可能性がありますが、これらのトランザクションが正常にアボートされた時とデータベースの状態は変わりません。
+ですので、<varname>synchronous_commit</>を無効にすることは、トランザクションの信頼性が確実であることよりも性能が重要である場合に有効な方法です。
+詳細は<xref linkend="wal-async-commit">を参照してください。
+       </para>
+       <para>
+<!--
+        If <xref linkend="guc-synchronous-standby-names"> is non-empty, this
+        parameter also controls whether or not transaction commits will wait
+        for their WAL records to be replicated to the standby server(s).
+        When set to <literal>on</>, commits will wait until replies
+        from the current synchronous standby(s) indicate they have received
+        the commit record of the transaction and flushed it to disk.  This
+        ensures the transaction will not be lost unless both the primary and
+        all synchronous standbys suffer corruption of their database storage.
+        When set to <literal>remote_apply</>, commits will wait until replies
+        from the current synchronous standby(s) indicate they have received the
+        commit record of the transaction and applied it, so that it has become
+        visible to queries on the standby(s).
+        When set to <literal>remote_write</>, commits will wait until replies
+        from the current synchronous standby(s) indicate they have
+        received the commit record of the transaction and written it out to
+        their operating system. This setting is sufficient to
+        ensure data preservation even if a standby instance of
+        <productname>PostgreSQL</> were to crash, but not if the standby
+        suffers an operating-system-level crash, since the data has not
+        necessarily reached stable storage on the standby.
+        Finally, the setting <literal>local</> causes commits to wait for
+        local flush to disk, but not for replication.  This is not usually
+        desirable when synchronous replication is in use, but is provided for
+        completeness.
+-->
+<xref linkend="guc-synchronous-standby-names">が空文字でない場合は、このパラメータは、WALレコードが、スタンバイサーバに複製されるまでトランザクションコミットを待機するか否かも制御します。
+<literal>on</>に設定すると、現在の同期スタンバイがトランザクションのコミットレコードを受け取り、記憶装置に吐き出したことを報告するまでコミットは待機します。
+このモードでは、プライマリおよびすべての同期スタンバイがデータベース記憶装置の故障を被った場合を除いて、トランザクションが失われないことが保証されます。
+<literal>remote_apply</>に設定すると、現在の同期スタンバイがトランザクションのコミットレコードを受け取って適用し、スタンバイ上で発行されたクエリから見えるようになったことを報告するまでコミットは待機します。
+<literal>remote_write</>に設定すると、現在の同期スタンバイがトランザクションのコミットレコードを受け取り、スタンバイのオペレーティングシステムに書き出したことを報告するまでコミットは待機します。
+この設定は仮に<productname>PostgreSQL</>のスタンバイインスタンスがクラッシュしたとしても、データ保護を保証するのに充分です。
+しかし、スタンバイがオペレーティングシステムのレベルでクラッシュした場合はこの限りではありません。
+データが必ずしもスタンバイの永続的な記憶装置に到達したとは言えないからです。
+最後に、<literal>local</>設定は、コミットがローカルにディスクに吐出されるまで待機しますが、レプリケーションされるまでは待機しません。
+これは通常同期レプリケーションが使用されている場合は望ましい設定ではありませんが、完全さのために提供されています。
+       </para>
+       <para>
+<!--
+        If <varname>synchronous_standby_names</> is empty, the settings
+        <literal>on</>, <literal>remote_apply</>, <literal>remote_write</>
+        and <literal>local</> all provide the same synchronization level:
+        transaction commits only wait for local flush to disk.
+-->
+もし <varname>synchronous_standby_names</> が設定されていなければ、<literal>on</>、<literal>remote_apply</>、<literal>remote_write</> および <literal>local</> の設定は全て同一の同期レベルを提供します。
+すなわちトランザクションのコミットはローカルディスクへの吐き出しのみを待機します。
+       </para>
+       <para>
+       <!--
+        This parameter can be changed at any time; the behavior for any
+        one transaction is determined by the setting in effect when it
+        commits.  It is therefore possible, and useful, to have some
+        transactions commit synchronously and others asynchronously.
+        For example, to make a single multistatement transaction commit
+        asynchronously when the default is the opposite, issue <command>SET
+        LOCAL synchronous_commit TO OFF</> within the transaction.
+       -->
+このパラメータはいつでも変更可能です。
+どのトランザクションの動作も、コミット時に有効であった設定によって決まります。
+したがって、一部のトランザクションのコミットを同期的に、その他を非同期的にすることが可能で、かつ、有用です。
+例えば、デフォルトが同期コミットの場合に複数文トランザクションを一つだけ非同期にコミットさせるためには、トランザクション内で<command>SET LOCAL synchronous_commit TO OFF</>を発行します。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-wal-sync-method" xreflabel="wal_sync_method">
+      <term><varname>wal_sync_method</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>wal_sync_method</> configuration parameter</primary>
+       -->
+       <primary><varname>wal_sync_method</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Method used for forcing WAL updates out to disk.
+        If <varname>fsync</varname> is off then this setting is irrelevant,
+        since WAL file updates will not be forced out at all.
+        Possible values are:
+       -->
+       WALの更新をディスクへ強制するのに使用される方法です。<varname>fsync</varname>がオフの場合この設定は役に立ちません。と言うのはWALファイルの更新が全く強制されないからです。取り得る値は以下のものです。
+       </para>
+       <itemizedlist>
+        <listitem>
+        <para>
+       <!--
+         <literal>open_datasync</> (write WAL files with <function>open()</> option <symbol>O_DSYNC</>)
+        -->
+        <literal>open_datasync</>（<function>open()</>のオプション<symbol>O_DSYNC</>でWALファイルに書き込む）
+        </para>
+        </listitem>
+        <listitem>
+        <para>
+       <!--
+         <literal>fdatasync</> (call <function>fdatasync()</> at each commit)
+        -->
+        <literal>fdatasync</>（コミット毎に<function>fdatasync()</>を呼び出す）
+        </para>
+        </listitem>
+        <listitem>
+        <para>
+        <!--
+         <literal>fsync</> (call <function>fsync()</> at each commit)
+        -->
+        <literal>fsync</>（コミット毎に<function>fsync()</>を呼び出す）
+        </para>
+        </listitem>
+        <listitem>
+        <para>
+       <!--
+         <literal>fsync_writethrough</> (call <function>fsync()</> at each commit, forcing write-through of any disk write cache)
+        -->
+        <literal>fsync_writethrough</>（すべてのディスク書き込みキャッシュをライトスルーさせるため、コミット毎に<function>fsync()</>を呼び出す）
+        </para>
+        </listitem>
+        <listitem>
+        <para>
+       <!--
+         <literal>open_sync</> (write WAL files with <function>open()</> option <symbol>O_SYNC</>)
+        -->
+        <literal>open_sync</>（<function>open()</>のオプション<symbol>O_SYNC</>でWALファイルに書き込む）
+        </para>
+        </listitem>
+       </itemizedlist>
+       <para>
+       <!--
+        The <literal>open_</>* options also use <literal>O_DIRECT</> if available.
+        Not all of these choices are available on all platforms.
+        The default is the first method in the above list that is supported
+        by the platform, except that <literal>fdatasync</> is the default on
+        Linux.  The default is not necessarily ideal; it might be
+        necessary to change this setting or other aspects of your system
+        configuration in order to create a crash-safe configuration or
+        achieve optimal performance.
+        These aspects are discussed in <xref linkend="wal-reliability">.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+可能なら<literal>open_</>*オプションも<literal>O_DIRECT</>を使用します。
+全てのプラットフォームでこれら全ての選択肢が使えるわけではありません。
+デフォルトは、上のリストのプラットフォームでサポートされるものの最初に列挙されているものです。
+ただしLinuxでは<literal>fdatasync</>がデフォルトです。
+デフォルトは必ずしも理想的なものではありません。
+クラッシュに適応した構成にする、あるいはアーカイブの最適性能を導くためには、この設定あるいはシステム構成の他の部分を変更することが必要かもしれません。
+これらの側面は <xref linkend="wal-reliability">で解説されます。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-full-page-writes" xreflabel="full_page_writes">
+      <term><varname>full_page_writes</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>full_page_writes</> configuration parameter</primary>
+       -->
+       <primary><varname>full_page_writes</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        When this parameter is on, the <productname>PostgreSQL</> server
+        writes the entire content of each disk page to WAL during the
+        first modification of that page after a checkpoint.
+        This is needed because
+        a page write that is in process during an operating system crash might
+        be only partially completed, leading to an on-disk page
+        that contains a mix of old and new data.  The row-level change data
+        normally stored in WAL will not be enough to completely restore
+        such a page during post-crash recovery.  Storing the full page image
+        guarantees that the page can be correctly restored, but at the price
+        of increasing the amount of data that must be written to WAL.
+        (Because WAL replay always starts from a checkpoint, it is sufficient
+        to do this during the first change of each page after a checkpoint.
+        Therefore, one way to reduce the cost of full-page writes is to
+        increase the checkpoint interval parameters.)
+       -->
+このパラメータが有効の場合、<productname>PostgreSQL</>サーバは、チェックポイントの後にそのページが最初に変更された過程で、ディスクページの全ての内容をWALに書き込みます。
+オペレーティングシステムがクラッシュした時に進行中のページ書き込みは途中までしか終わっていない可能性があり、ディスク上のページが古いデータと新しいデータが混在する状態になるため、この機能が必要です。
+通常WAL内に保存される行レベルの変更データは、クラッシュ後のリカバリ時にこうしたページを完全に復旧させるには不十分です。
+完全なページイメージを保存することにより、ページを正しく復旧できることを保証しますが、その代わりに、WALに書き込まなければならないデータ量が増加することになります。
+（WAL再生は常にチェックポイントから始まるため、チェックポイント後のそれぞれのページの最初の変更時にこれを行えば十分です。
+従って、完全ページ書き出しのコストを低減する方法の1つは、チェックポイント間隔パラメータを大きくすることです。）
+       </para>
+
+       <para>
+       <!--
+        Turning this parameter off speeds normal operation, but
+        might lead to either unrecoverable data corruption, or silent
+        data corruption, after a system failure. The risks are similar to turning off
+        <varname>fsync</varname>, though smaller, and it should be turned off
+        only based on the same circumstances recommended for that parameter.
+       -->
+       このパラメータを無効にすると、通常の操作速度が上がりますが、システム障害後に、回復不能なデータ破損、あるいは警告なしのデータ損壊をもたらすかもしれません。
+このリスクは小さいながら<varname>fsync</>を無効にした場合と似ています。そしてその<varname>fsync</varname>に対して推奨されている同一の状況に基づく限りにおいて停止されなければなりません。
+       </para>
+
+       <para>
+       <!--
+        Turning off this parameter does not affect use of
+        WAL archiving for point-in-time recovery (PITR)
+        (see <xref linkend="continuous-archiving">).
+       -->
+       このパラメータを無効にしてもポイントインタイムリカバリ（PITR）用のWALアーカイブの使用に影響ありません（ <xref linkend="continuous-archiving">を参照してください）。
+       </para>
+
+       <para>
+       <!--
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+        The default is <literal>on</>.
+       -->
+       このパラメータは<filename>postgresql.conf</>ファイル内、または、サーバのコマンドラインでのみ設定可能です。
+デフォルトは<literal>on</>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-wal-log-hints" xreflabel="wal_log_hints">
+      <term><varname>wal_log_hints</varname> (<type>boolean</type>)
+      <indexterm>
+<!--
+       <primary><varname>wal_log_hints</> configuration parameter</primary>
+-->
+       <primary><varname>wal_log_hints</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        When this parameter is <literal>on</>, the <productname>PostgreSQL</>
+        server writes the entire content of each disk page to WAL during the
+        first modification of that page after a checkpoint, even for
+        non-critical modifications of so-called hint bits.
+-->
+        このパラメータが<literal>on</>の場合、<productname>PostgreSQL</>サーバはチェックポイント後にはじめてページを変更する際に、ディスクページの全内容をWALに書き出します。
+これは、あまり重要でない、ヒントビットと呼ばれるものに対する変更にさえ当てはまります。
+       </para>
+
+       <para>
+<!--
+        If data checksums are enabled, hint bit updates are always WAL-logged
+        and this setting is ignored. You can use this setting to test how much
+        extra WAL-logging would occur if your database had data checksums
+        enabled.
+-->
+        データチェックサムが有効であると、ヒントビットの更新は常にWALにログされ、この設定パラメータは無視されます。この設定パラメータを使って、データチェックサムが有効なときにどれだけのWALログは余計に書きだされるかをテストすることができます。
+       </para>
+
+       <para>
+<!--
+        This parameter can only be set at server start. The default value is <literal>off</>.
+-->
+       このパラメータはサーバ起動時のみ設定可能です。
+デフォルト値は<literal>off</>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-wal-compression" xreflabel="wal_compression">
+      <term><varname>wal_compression</varname> (<type>boolean</type>)
+      <indexterm>
+<!--
+       <primary><varname>wal_compression</> configuration parameter</primary>
+-->
+       <primary><varname>wal_compression</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        When this parameter is <literal>on</>, the <productname>PostgreSQL</>
+        server compresses a full page image written to WAL when
+        <xref linkend="guc-full-page-writes"> is on or during a base backup.
+        A compressed page image will be decompressed during WAL replay.
+        The default value is <literal>off</>.
+        Only superusers can change this setting.
+-->
+このパラメータが<literal>on</>なら、<xref linkend="guc-full-page-writes">がonあるいはベースバックアップの際、<productname>PostgreSQL</>サーバはWALに書き出すフルページイメージを圧縮します。
+圧縮されたページイメージは、WALリプレイのときに伸張されます。
+デフォルト値は<literal>off</>です。
+スーパーユーザだけがこの設定を変更できます。
+       </para>
+
+       <para>
+<!--
+        Turning this parameter on can reduce the WAL volume without
+        increasing the risk of unrecoverable data corruption,
+        but at the cost of some extra CPU spent on the compression during
+        WAL logging and on the decompression during WAL replay.
+-->
+このパラメータを有効にすると、回復不可能なデータ破壊のリスクを増やすこと無しにWALの量を減らすことができます。
+しかし、WALロギングの際の圧縮のため、またWALリプレイの際には伸張のために余分なCPUを使用するというコストが発生します。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-wal-buffers" xreflabel="wal_buffers">
+      <term><varname>wal_buffers</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>wal_buffers</> configuration parameter</primary>
+       -->
+       <primary><varname>wal_buffers</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        The amount of shared memory used for WAL data that has not yet been
+        written to disk.  The default setting of -1 selects a size equal to
+        1/32nd (about 3%) of <xref linkend="guc-shared-buffers">, but not less
+        than <literal>64kB</literal> nor more than the size of one WAL
+        segment, typically <literal>16MB</literal>.  This value can be set
+        manually if the automatic choice is too large or too small,
+        but any positive value less than <literal>32kB</literal> will be
+        treated as <literal>32kB</literal>.
+        This parameter can only be set at server start.
+       -->
+       未だディスクに書き込まれていないWALデータに対して使用される共有メモリ容量です。
+       デフォルトの設定である-1は、<xref linkend="guc-shared-buffers">の1/32（約3%）の容量に等しい大きさを選択します。
+       しかし、<literal>64kB</literal>未満ではなく、かつ典型的に<literal>16MB</literal>であるWALセグメントの大きさを越えることはありません。
+       もし、自動設定による選択が大きすぎたり、小さすぎる場合この値は手作業で設定可能です。
+       しかし、<literal>32kB</literal>未満のどんな正の値であっても、<literal>32kB</literal>
+として取り扱われます。
+このパラメータはサーバ起動時のみ設定可能です。
+       </para>
+
+       <para>
+       <!--
+        The contents of the WAL buffers are written out to disk at every
+        transaction commit, so extremely large values are unlikely to
+        provide a significant benefit.  However, setting this value to at
+        least a few megabytes can improve write performance on a busy
+        server where many clients are committing at once.  The auto-tuning
+        selected by the default setting of -1 should give reasonable
+        results in most cases.
+       -->
+       WALバッファの内容はトランザクションのコミット毎にディスクに書き込まれます。
+       したがって、極端に大きな値は有意な効果を期待できません。
+       しかし、この値を数メガバイトに設定することにより、多くのクライアントが同時にコミットするトラフィック量の多いサーバでは書き込み性能が向上します。
+       デフォルト設定の-1で選択される自動チューニングによると、ほとんどの場合妥当な結果が得られます。
+       </para>
+
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-wal-writer-delay" xreflabel="wal_writer_delay">
+      <term><varname>wal_writer_delay</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>wal_writer_delay</> configuration parameter</primary>
+       -->
+       <primary><varname>wal_writer_delay</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+      <para>
+<!--
+        Specifies how often the WAL writer flushes WAL. After flushing WAL it
+        sleeps for <varname>wal_writer_delay</> milliseconds, unless woken up
+        by an asynchronously committing transaction. If the last flush
+        happened less than <varname>wal_writer_delay</> milliseconds ago and
+        less than <varname>wal_writer_flush_after</> bytes of WAL have been
+        produced since, then WAL is only written to the operating system, not
+        flushed to disk.
+        The default value is 200 milliseconds (<literal>200ms</>).  Note that
+        on many systems, the effective resolution of sleep delays is 10
+        milliseconds; setting <varname>wal_writer_delay</> to a value that is
+        not a multiple of 10 might have the same results as setting it to the
+        next higher multiple of 10. This parameter can only be set in the
+        <filename>postgresql.conf</> file or on the server command line.
+-->
+WALライタがWALを吐き出す頻度を指定します。
+WALを吐き出したとあと、非同期コミットしているトランザクションに起こされない限り、<varname>wal_writer_delay</>ミリ秒待機します。
+最後の吐き出しが過去<varname>wal_writer_delay</>ミリ秒以内に起こなわれ、かつそれ以降<varname>wal_writer_flush_after</>バイト以内のWALが生成されている場合は、WALはオペレーティングシステムに書き込まれますが、ディスクには吐出されません。
+デフォルト値は200ミリ秒（<literal>200ms</>）です。
+多くのシステムでは、待機間隔の実質的な分解能は10ミリ秒です。
+10の倍数以外の値を<varname>wal_writer_delay</>に設定しても、その次に大きい10の倍数を設定した場合と同じ結果となります。
+このパラメータは<filename>postgresql.conf</>ファイル内またはサーバのコマンドラインでのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-wal-writer-flush-after" xreflabel="wal_writer_flush_after">
+      <term><varname>wal_writer_flush_after</varname> (<type>integer</type>)
+      <indexterm>
+<!--
+       <primary><varname>wal_writer_flush_after</> configuration parameter</primary>
+-->
+       <primary><varname>wal_writer_flush_after</> 設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+      <para>
+<!--
+        Specifies how often the WAL writer flushes WAL. If the last flush
+        happened less than <varname>wal_writer_delay</> milliseconds ago and
+        less than <varname>wal_writer_flush_after</> bytes of WAL have been
+        produced since, then WAL is only written to the operating system, not
+        flushed to disk.  If <varname>wal_writer_flush_after</> is set
+        to <literal>0</> then WAL data is flushed immediately.  The default is
+        <literal>1MB</literal>. This parameter can only be set in the
+        <filename>postgresql.conf</> file or on the server command line.
+-->
+WALライタがWALを吐き出す頻度を指定します。
+最後の吐き出しが過去<varname>wal_writer_delay</>ミリ秒以内に起こなわれ、かつそれ以降<varname>wal_writer_flush_after</>バイト以内のWALが生成されている場合は、WALはオペレーティングシステムに書き込まれますが、ディスクには吐出されません。
+<varname>wal_writer_flush_after</>が<literal>0</>に設定されている場合は、WALが書かれるたびにWALが吐出されます。
+デフォルト値は<literal>1MB</literal>です。
+このパラメータは<filename>postgresql.conf</>ファイル内またはサーバのコマンドラインでのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-commit-delay" xreflabel="commit_delay">
+      <term><varname>commit_delay</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>commit_delay</> configuration parameter</primary>
+       -->
+       <primary><varname>commit_delay</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        <varname>commit_delay</varname> adds a time delay, measured in
+        microseconds, before a WAL flush is initiated.  This can improve
+        group commit throughput by allowing a larger number of transactions
+        to commit via a single WAL flush, if system load is high enough
+        that additional transactions become ready to commit within the
+        given interval.  However, it also increases latency by up to
+        <varname>commit_delay</varname> microseconds for each WAL
+        flush.  Because the delay is just wasted if no other transactions
+        become ready to commit, a delay is only performed if at least
+        <varname>commit_siblings</varname> other transactions are active
+        when a flush is about to be initiated.  Also, no delays are
+        performed if <varname>fsync</varname> is disabled.
+        The default <varname>commit_delay</> is zero (no delay).
+        Only superusers can change this setting.
+-->
+<varname>commit_delay</varname>は、WALフラッシュを開始する前の時間遅延を追加します。単位はマイクロ秒です。
+このことにより、もし追加のトランザクションが与えられた時間間隔内でコミットが可能になるほどシステム負荷が充分に高い場合、一回のWALフラッシュでより多くの数のトランザクションをコミットできるようになり、コミット群のスループットを改善できます。
+とは言っても、それぞれのWALフラッシュに対して最大<varname>commit_delay</varname>マイクロ秒の待ち時間の増加をきたします。
+コミットの準備が完了したトランザクションが他に存在しない場合、遅延は無駄になるため、遅延はフラッシュが開始されようとしている時点で少なくとも<varname>commit_siblings</varname>だけのトランザクションが活動している場合にだけ機能します。
+同様に、<varname>fsync</varname>が無効の場合も遅延は機能しません。
+デフォルトの<varname>commit_delay</>はゼロ（遅延無し）です。
+この設定はスーパーユーザのみ変更可能です。
+       </para>
+       <para>
+       <!--
+        In <productname>PostgreSQL</> releases prior to 9.3,
+        <varname>commit_delay</varname> behaved differently and was much
+        less effective: it affected only commits, rather than all WAL flushes,
+        and waited for the entire configured delay even if the WAL flush
+        was completed sooner.  Beginning in <productname>PostgreSQL</> 9.3,
+        the first process that becomes ready to flush waits for the configured
+        interval, while subsequent processes wait only until the leader
+        completes the flush operation.
+       -->
+        9.3より前の<productname>PostgreSQL</>では、<varname>commit_delay</varname>の振る舞いは異なっており、あまり効果がありませんでした。
+       全てのWALフラッシュではなく、コミットだけに影響していました。また、そしてWALフラッシュが早めに完了しても設定された遅延分待機していました。
+       <productname>PostgreSQL</> 9.3以降では、フラッシュの準備が整った最初のプロセスが設定値分待機し、後続のプロセスは最初のプロセスがフラッシュ操作を完了するまでの間だけ待機をします。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-commit-siblings" xreflabel="commit_siblings">
+      <term><varname>commit_siblings</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>commit_siblings</> configuration parameter</primary>
+       -->
+       <primary><varname>commit_siblings</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Minimum number of concurrent open transactions to require
+        before performing the <varname>commit_delay</> delay. A larger
+        value makes it more probable that at least one other
+        transaction will become ready to commit during the delay
+        interval. The default is five transactions.
+       -->
+<varname>commit_delay</>の遅延を実行するときに必要とされる同時に開いているトランザクションの最小数です。
+より大きい値にすると、遅延周期の間に、少なくとも1つの他のトランザクションのコミットの準備が整う確率が高くなります。
+デフォルトは5トランザクションです。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+     </sect2>
+     <sect2 id="runtime-config-wal-checkpoints">
+     <!--
+     <title>Checkpoints</title>
+     -->
+     <title>チェックポイント</title>
+
+    <variablelist>
+     <varlistentry id="guc-checkpoint-timeout" xreflabel="checkpoint_timeout">
+      <term><varname>checkpoint_timeout</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>checkpoint_timeout</> configuration parameter</primary>
+       -->
+       <primary><varname>checkpoint_timeout</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Maximum time between automatic WAL checkpoints, in seconds.
+        The valid range is between 30 seconds and one day.
+        The default is five minutes (<literal>5min</>).
+        Increasing this parameter can increase the amount of time needed
+        for crash recovery.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+自動的WALチェックポイント間の最大間隔を秒単位で指定します。
+有効な範囲は、30秒から1日の間です。
+デフォルトは5分（<literal>5min</>）です。
+このパラメータを増やすと、クラッシュリカバリで必要となる時間が増加します。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-checkpoint-completion-target" xreflabel="checkpoint_completion_target">
+      <term><varname>checkpoint_completion_target</varname> (<type>floating point</type>)
+      <indexterm>
+      <!--
+       <primary><varname>checkpoint_completion_target</> configuration parameter</primary>
+       -->
+       <primary><varname>checkpoint_completion_target</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the target of checkpoint completion, as a fraction of
+        total time between checkpoints. The default is 0.5.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+       チェックポイントの完了目標をチェックポイント間の総時間の割合として指定します。
+デフォルトは0.5です。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-checkpoint-flush-after" xreflabel="checkpoint_flush_after">
+      <term><varname>checkpoint_flush_after</varname> (<type>integer</type>)
+      <indexterm>
+<!--
+       <primary><varname>checkpoint_flush_after</> configuration parameter</primary>
+-->
+       <primary><varname>checkpoint_flush_after</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Whenever more than <varname>checkpoint_flush_after</varname> bytes
+        have been written while performing a checkpoint, attempt to force the
+        OS to issue these writes to the underlying storage.  Doing so will
+        limit the amount of dirty data in the kernel's page cache, reducing
+        the likelihood of stalls when an <function>fsync</function> is issued at the end of the
+        checkpoint, or when the OS writes data back in larger batches in the
+        background.  Often that will result in greatly reduced transaction
+        latency, but there also are some cases, especially with workloads
+        that are bigger than <xref linkend="guc-shared-buffers">, but smaller
+        than the OS's page cache, where performance might degrade.  This
+        setting may have no effect on some platforms.  The valid range is
+        between <literal>0</literal>, which disables forced writeback,
+        and <literal>2MB</literal>.  The default is <literal>256kB</> on
+        Linux, <literal>0</> elsewhere.  (If <symbol>BLCKSZ</symbol> is not
+        8kB, the default and maximum values scale proportionally to it.)
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+-->
+チェックポイント実行中に<varname>checkpoint_flush_after</varname>バイトより多く書く度に、OSが記憶装置に書き込むことを強制しようとします。
+このことにより、カーネルのページキャッシュが持つダーティデータの量を一定量に制限し、チェックポイントの最後に<function>fsync</function>が実行される際、あるいはOSがバックグラウンドでデータを大きな塊で書き出す際に性能の急激な低下を招く可能性を減らします。
+多くの場合これによってトランザクションの遅延が大幅に少なくなりますが、あるケース、特にワークロードが<xref linkend="guc-shared-buffers">よりも大きく、OSのページキャッシュよりも小さい時には性能が低下するかもしれません。
+この設定が無効なプラットフォームがあります。
+有効な設定値は、この強制書き込み機能が無効になる<literal>0</literal>から、<literal>2MB</literal>までです。
+デフォルト値は、Linuxでは<literal>256kB</>で、それ以外は<literal>0</>です。
+(<symbol>BLCKSZ</symbol>が8kbでなければ、この設定のデフォルト値と最大値が<symbol>BLCKSZ</symbol>に比例して変更されます。)
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-checkpoint-warning" xreflabel="checkpoint_warning">
+      <term><varname>checkpoint_warning</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>checkpoint_warning</> configuration parameter</primary>
+       -->
+       <primary><varname>checkpoint_warning</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Write a message to the server log if checkpoints caused by
+        the filling of checkpoint segment files happen closer together
+        than this many seconds (which suggests that
+        <varname>max_wal_size</> ought to be raised).  The default is
+        30 seconds (<literal>30s</>).  Zero disables the warning.
+        No warnings will be generated if <varname>checkpoint_timeout</varname>
+        is less than <varname>checkpoint_warning</varname>.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+チェックポイントセグメントファイルが溢れることが原因で起きるチェックポイントが、ここで指定した秒数よりも短い間隔で発生したとき、サーバログにメッセージを書き出します
+（これは、<varname>max_wal_size</>を増やす必要があることを示唆しています）。
+デフォルトは30秒（<literal>30s</>）です。
+零の場合は警告を出しません。
+<varname>checkpoint_timeout</varname>が<varname>checkpoint_warning</varname>より小さい場合は警告を出しません。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-max-wal-size" xreflabel="max_wal_size">
+      <term><varname>max_wal_size</varname> (<type>integer</type>)
+      <indexterm>
+<!--
+       <primary><varname>max_wal_size</> configuration parameter</primary>
+-->
+       <primary><varname>max_wal_size</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Maximum size to let the WAL grow to between automatic WAL
+        checkpoints. This is a soft limit; WAL size can exceed
+        <varname>max_wal_size</> under special circumstances, like
+        under heavy load, a failing <varname>archive_command</>, or a high
+        <varname>wal_keep_segments</> setting. The default is 1 GB.
+        Increasing this parameter can increase the amount of time needed for
+        crash recovery.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+-->
+自動WALチェックポイントの間にWALが増加する最大サイズです。
+これはソフトリミットです。特別な状況下、たとえば高負荷、<varname>archive_command</>の失敗、<varname>wal_keep_segments</>が大きな値に設定されている、などの時には、WALサイズは<varname>max_wal_size</>を超えることがあります。
+デフォルトは1GBです。
+このパラメータを大きくすると、クラッシュリカバリに必要な時間が長くなります。
+このパラメータは、<filename>postgresql.conf</>ファイルで設定するか、サーバのコマンドラインでのみ指定できます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-min-wal-size" xreflabel="min_wal_size">
+      <term><varname>min_wal_size</varname> (<type>integer</type>)
+      <indexterm>
+<!--
+       <primary><varname>min_wal_size</> configuration parameter</primary>
+-->
+       <primary><varname>min_wal_size</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        As long as WAL disk usage stays below this setting, old WAL files are
+        always recycled for future use at a checkpoint, rather than removed.
+        This can be used to ensure that enough WAL space is reserved to
+        handle spikes in WAL usage, for example when running large batch
+        jobs. The default is 80 MB.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+-->
+この設定以下にWALのディスク使用量が保たれる限り、古いWALファイルは、消去されることなく今後のチェックポイントで使用するために常にリサイクルされます。
+この設定は、たとえば大きなバッチジョブを走らせる際のWALの利用スパイクを取り扱うために、十分なWALのスペースが予約されていることを保証するために使用できます。
+デフォルトは80MBです。
+このパラメータは、<filename>postgresql.conf</>ファイルで設定するか、サーバのコマンドラインでのみ指定できます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+     </sect2>
+     <sect2 id="runtime-config-wal-archiving">
+     <!--
+     <title>Archiving</title>
+     -->
+     <title>アーカイビング</title>
+
+    <variablelist>
+     <varlistentry id="guc-archive-mode" xreflabel="archive_mode">
+      <term><varname>archive_mode</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>archive_mode</> configuration parameter</primary>
+       -->
+       <primary><varname>archive_mode</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        When <varname>archive_mode</> is enabled, completed WAL segments
+        are sent to archive storage by setting
+        <xref linkend="guc-archive-command">. In addition to <literal>off</>,
+        to disable, there are two modes: <literal>on</>, and
+        <literal>always</>. During normal operation, there is no
+        difference between the two modes, but when set to <literal>always</>
+        the WAL archiver is enabled also during archive recovery or standby
+        mode. In <literal>always</> mode, all files restored from the archive
+        or streamed with streaming replication will be archived (again). See
+        <xref linkend="continuous-archiving-in-standby"> for details.
+       </para>
+       <para>
+        <varname>archive_mode</> and <varname>archive_command</> are
+        separate variables so that <varname>archive_command</> can be
+        changed without leaving archiving mode.
+        This parameter can only be set at server start.
+        <varname>archive_mode</> cannot be enabled when
+        <varname>wal_level</> is set to <literal>minimal</>.
+       -->
+       <varname>archive_mode</>が有効な場合、<xref linkend="guc-archive-command">を設定することにより、完了したWALセグメントはアーカイブ格納領域に送信されます。
+無効にするための<literal>off</>に加え、2つのモードがあります。<literal>on</>と<literal>always</>です。
+通常の運用ではこの2つのモードには違いはありませんが、<literal>always</>に設定すると、アーカイブリカバリおよびスタンバイモードでWALアーカイバが有効になります。
+<literal>always</>モードでは、アーカイブからリストアされたファイルや、ストリーミングレプリケーションでストリームされたファイルもすべて(再び)アーカイブされます。
+詳細は<xref linkend="continuous-archiving-in-standby">を参照してください。
+       </para>
+       <para>
+アーカイブモードを抜けることなく<varname>archive_command</>を変更できるように、<varname>archive_mode</>と<varname>archive_command</>は分離されました。
+このパラメータはサーバ起動時のみ設定可能です。
+<varname>wal_level</> が
+<literal>minimal</>に設定されている場合、<varname>archive_mode</>は有効になりません。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-archive-command" xreflabel="archive_command">
+      <term><varname>archive_command</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>archive_command</> configuration parameter</primary>
+       -->
+       <primary><varname>archive_command</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        The local shell command to execute to archive a completed WAL file
+        segment.  Any <literal>%p</> in the string is
+        replaced by the path name of the file to archive, and any
+        <literal>%f</> is replaced by only the file name.
+        (The path name is relative to the working directory of the server,
+        i.e., the cluster's data directory.)
+        Use <literal>%%</> to embed an actual <literal>%</> character in the
+        command.  It is important for the command to return a zero
+        exit status only if it succeeds. For more information see
+        <xref linkend="backup-archiving-wal">.
+       -->
+完了したWALファイルセグメントのアーカイブを実行するローカルのシェルコマンドです。
+文字列内のすべての<literal>%p</>は、格納されるファイルのパスで置き換えられ、そして、<literal>%f</>はファイル名のみ置換します。
+（このパス名はサーバの作業用ディレクトリ、つまり、クラスタのデータディレクトリからの相対パスです。）
+コマンド内に<literal>%</>文字そのものを埋め込むには<literal>%%</>を使用します。
+コマンドが成功した場合にのみ終了ステータスゼロを返すことが重要です。
+より詳しくは<xref linkend="backup-archiving-wal">を参照ください。
+       </para>
+       <para>
+       <!--
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.  It is ignored unless
+        <varname>archive_mode</> was enabled at server start.
+        If <varname>archive_command</> is an empty string (the default) while
+        <varname>archive_mode</> is enabled, WAL archiving is temporarily
+        disabled, but the server continues to accumulate WAL segment files in
+        the expectation that a command will soon be provided.  Setting
+        <varname>archive_command</> to a command that does nothing but
+        return true, e.g. <literal>/bin/true</> (<literal>REM</> on
+        Windows), effectively disables
+        archiving, but also breaks the chain of WAL files needed for
+        archive recovery, so it should only be used in unusual circumstances.
+       -->
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+サーバ起動時に<varname>archive_mode</>が有効でなければ、これは無視されます。
+<varname>archive_command</>が空文字列（デフォルト）、かつ、<varname>archive_mode</>が有効な場合、WALアーカイブ処理は一時的に無効になりますが、コマンドが後で提供されることを見越して、サーバはWALセグメントの蓄積を続けます。
+例えば、<literal>/bin/true</>（Windowsでは<literal>REM</>）のように、真を返すだけで何もしないコマンドを<varname>archive_command</>に設定すると、実質的にアーカイブ処理が無効になりますが、アーカイブからの復帰に必要なWALファイルの連鎖も同時に断ち切るため、特別な場合のみ使用するようにしなければなりません。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-archive-timeout" xreflabel="archive_timeout">
+      <term><varname>archive_timeout</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>archive_timeout</> configuration parameter</primary>
+       -->
+       <primary><varname>archive_timeout</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        The <xref linkend="guc-archive-command"> is only invoked for
+        completed WAL segments. Hence, if your server generates little WAL
+        traffic (or has slack periods where it does so), there could be a
+        long delay between the completion of a transaction and its safe
+        recording in archive storage.  To limit how old unarchived
+        data can be, you can set <varname>archive_timeout</> to force the
+        server to switch to a new WAL segment file periodically.  When this
+        parameter is greater than zero, the server will switch to a new
+        segment file whenever this many seconds have elapsed since the last
+        segment file switch, and there has been any database activity,
+        including a single checkpoint (checkpoints are skipped if there is
+        no database activity).  Note that archived files that are closed
+        early due to a forced switch are still the same length as completely
+        full files.  Therefore, it is unwise to use a very short
+        <varname>archive_timeout</> &mdash; it will bloat your archive
+        storage.  <varname>archive_timeout</> settings of a minute or so are
+        usually reasonable.  You should consider using streaming replication,
+        instead of archiving, if you want data to be copied off the master
+        server more quickly than that.
+        This parameter can only be set in the
+        <filename>postgresql.conf</> file or on the server command line.
+       -->
+<xref linkend="guc-archive-command">は完了したWALセグメントに対してのみ呼び出されます。
+従って、サーバのWAL転送量が少ししかない（あるいは処理が少ないなぎの期間がある）場合、トランザクションの完了とアーカイブ格納領域への安全な記録との間に長期にわたる遅延があることになります。
+データが未アーカイブのままでいられる期間を制限するために、<varname>archive_timeout</>を設定して、強制的にサーバを新しいWALセグメントに定期的に切り替えるようにすることができます。
+このパラメータが0より大きければ、サーバは前回のセグメントファイル切り替えから指定秒数経過し、かつ単一のチェックポイントを含む何らかのデータベース操作が行われた場合、新しいセグメントファイルに切り替えます。
+（データベースが活動していなければ、チェックポイントはスキップされます。）
+強制切り替えにより早期にクローズされたアーカイブ済みファイルは、完全に完了したファイルと同じ大きさを持つことに注意してください。
+そのため、非常に小さな<varname>archive_timeout</>を使用することは賢明ではなく、格納領域を膨張させてしまいます。
+１分程度の<varname>archive_timeout</>設定が通常は妥当です。
+もしそれより高速にデータをマスターサーバからコピーをしてしまいたいのであれば、アーカイブするよりストリーミングレプリケーションの選択を検討すべきです。
+このパラメータは <filename>postgresql.conf</>ファイル、または、サーバのコマンドラインでのみで設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+    </sect2>
+
+   </sect1>
+
+   <sect1 id="runtime-config-replication">
+    <!--
+    <title>Replication</title>
+     -->
+    <title>レプリケーション</title>
+
+    <para>
+    <!--
+     These settings control the behavior of the built-in
+     <firstterm>streaming replication</> feature (see
+     <xref linkend="streaming-replication">).  Servers will be either a
+     Master or a Standby server.  Masters can send data, while Standby(s)
+     are always receivers of replicated data.  When cascading replication
+     (see <xref linkend="cascading-replication">) is used, Standby server(s)
+     can also be senders, as well as receivers.
+     Parameters are mainly for Sending and Standby servers, though some
+     parameters have meaning only on the Master server.  Settings may vary
+     across the cluster without problems if that is required.
+     -->
+     これらの設定は組み込みの<firstterm>ストリーミングレプリケーション</>機能の動作を制御します（<xref linkend="streaming-replication">を参照ください）。
+      サーバ群のサーバはマスターかスタンバイのいずれかです。マスターはデータを送出する一方、複数のスタンバイは複製されたデータを常に受け取ります。カスケードレプリケーション（<xref linkend="cascading-replication">を参照）が使用されている場合、スタンバイサーバ群は受け取り手でもあり、送り手でもあります。
+      パラメータは主として送出サーバとスタンバイサーバ用ですが、いくつかのパラメータはマスターサーバのみに効力を発します。
+      必要とあればクラスターに渡って問題なく設定を変化させることができます。
+    </para>
+
+    <sect2 id="runtime-config-replication-sender">
+    <!--
+     <title>Sending Server(s)</title>
+     -->
+     <title>送出サーバ群</title>
+
+     <para>
+     <!--
+      These parameters can be set on any server that is
+      to send replication data to one or more standby servers.
+      The master is always a sending server, so these parameters must
+      always be set on the master.
+      The role and meaning of these parameters does not change after a
+      standby becomes the master.
+      -->
+      これらのパラメータはレプリケーションデータを１つ、またはそれ以上複数のスタンバイサーバに送るいかなるサーバ上で設定することができます。マスターは常に送出サーバであるため、パラメータは常にマスター上に設定されなければなりません。これらのパラメータの役割と意味はスタンバイが後にマスターに昇格しても変わりません。
+     </para>
+
+     <variablelist>
+      <varlistentry id="guc-max-wal-senders" xreflabel="max_wal_senders">
+       <term><varname>max_wal_senders</varname> (<type>integer</type>)
+       <indexterm>
+       <!--
+        <primary><varname>max_wal_senders</> configuration parameter</primary>
+       -->
+       <primary><varname>max_wal_senders</>設定パラメータ</primary>
+       </indexterm>
+       </term>
+       <listitem>
+       <para>
+       <!--
+        Specifies the maximum number of concurrent connections from
+        standby servers or streaming base backup clients (i.e., the
+        maximum number of simultaneously running WAL sender
+        processes). The default is 10. The value 0 means replication is
+        disabled. WAL sender processes count towards the total number
+        of connections, so the parameter cannot be set higher than
+        <xref linkend="guc-max-connections">.  Abrupt streaming client
+        disconnection might cause an orphaned connection slot until
+        a timeout is reached, so this parameter should be set slightly
+        higher than the maximum number of expected clients so disconnected
+        clients can immediately reconnect.  This parameter can only
+        be set at server start. <varname>wal_level</> must be set to
+        <literal>replica</> or higher to allow connections from standby
+        servers.
+       -->
+複数のスタンバイサーバあるいは、ストリーミングを使ったベースバックアップクライアントからの同時接続を受ける接続最大値を設定します（つまり、同時に稼動するWAL送信プロセスの最大値です）。
+デフォルトは10です。
+0ならば、レプリケーションは無効であるという意味になります。
+WAL送出プロセスは接続の総数カウントに考慮されるため、パラメータは<xref linkend="guc-max-connections">より大きくは設定できません。
+クライアント接続が突然切断されると、タイムアウトするまで孤児接続スロットが残ってしまうかもしれません。
+ですから、このパラメータは想定されるクライアント数の最大値よりも少し大きめにして、切断されたクライアントが直ちに再接続できるようにした方が良いでしょう。
+このパラメータはサーバ起動時のみ設定可能です。
+スタンバイサーバからの接続を許可するには、<varname>wal_level</>を<literal>replica</>以上に設定しておかなければなりません。
+       </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry id="guc-max-replication-slots" xreflabel="max_replication_slots">
+       <term><varname>max_replication_slots</varname> (<type>integer</type>)
+       <indexterm>
+<!--
+        <primary><varname>max_replication_slots</> configuration parameter</primary>
+-->
+        <primary><varname>max_replication_slots</>設定パラメータ</primary>
+       </indexterm>
+       </term>
+       <listitem>
+        <para>
+<!--
+         Specifies the maximum number of replication slots
+         (see <xref linkend="streaming-replication-slots">) that the server
+         can support. The default is 10.  This parameter can only be set at
+         server start.
+         <varname>wal_level</varname> must be set
+         to <literal>replica</literal> or higher to allow replication slots to
+         be used. Setting it to a lower value than the number of currently
+         existing replication slots will prevent the server from starting.
+-->
+サーバが使用できるレプリケーションスロット(<xref linkend="streaming-replication-slots">参照)の最大数を指定します。
+デフォルトは10です。
+このパラメータはサーバ起動時のみ設定可能です。
+レプリケーションスロットが使用できるためには、<varname>wal_level</varname>を<literal>replica</literal>以上に設定しなければなりません。
+現在存在しているレプリケーションスロットの数よりも少ない値を設定すると、サーバは起動しません。
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry id="guc-wal-keep-segments" xreflabel="wal_keep_segments">
+       <term><varname>wal_keep_segments</varname> (<type>integer</type>)
+       <indexterm>
+<!--
+        <primary><varname>wal_keep_segments</> configuration parameter</primary>
+-->
+        <primary><varname>wal_keep_segments</>設定パラメータ</primary>
+       </indexterm>
+       </term>
+       <listitem>
+       <para>
+       <!--
+        Specifies the minimum number of past log file segments kept in the
+        <filename>pg_wal</>
+        directory, in case a standby server needs to fetch them for streaming
+        replication. Each segment is normally 16 megabytes. If a standby
+        server connected to the sending server falls behind by more than
+        <varname>wal_keep_segments</> segments, the sending server might remove
+        a WAL segment still needed by the standby, in which case the
+        replication connection will be terminated.  Downstream connections
+        will also eventually fail as a result.  (However, the standby
+        server can recover by fetching the segment from archive, if WAL
+        archiving is in use.)
+       -->
+ストリーミングレプリケーションにおいて、スタンバイサーバが過去のファイルセグメントを取得する必要がある場合に備え、<filename>pg_wal</>ディレクトリに保持しておくファイルセグメント数の最小値を指定します。
+それぞれのセグメントは通常16メガバイトです。
+もし送出サーバに接続しているスタンバイサーバが<varname>wal_keep_segments</>セグメントを越えて遅延した場合、送出サーバはスタンバイサーバが今後とも必要とするWALセグメントを削除する可能性があります。
+この場合、レプリケーション接続は終了させられます。結果として下流に対する接続も結局は終了されることがあります。（しかし、WALアーカイブが使用されていれば、スタンバイサーバはアーカイブからセグメントを取り出し、復旧することができます。）
+       </para>
+
+       <para>
+       <!--
+        This sets only the minimum number of segments retained in
+        <filename>pg_wal</>; the system might need to retain more segments
+        for WAL archival or to recover from a checkpoint. If
+        <varname>wal_keep_segments</> is zero (the default), the system
+        doesn't keep any extra segments for standby purposes, so the number
+        of old WAL segments available to standby servers is a function of
+        the location of the previous checkpoint and status of WAL
+        archiving.
+        This parameter can only be set in the
+        <filename>postgresql.conf</> file or on the server command line.
+       -->
+<filename>pg_wal</>に保持され続けるセグメントの最小値のみを設定します。
+システムはWALアーカイブのため、またはチェックポイントからの復旧のため、より多くのセグメント保持が必要となることがあります。
+もし<varname>wal_keep_segments</>が（デフォルトの）ゼロの場合、システムはスタンバイサーバのために追加セグメントを保持することはしません。
+従って、スタンバイサーバが使用できる古いWALセグメントの数は、直前のチェックポイントの場所とWALアーカイブの状況によって算出されます。
+このパラメータは、<filename>postgresql.conf</>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+       </para>
+       </listitem>
+      </varlistentry>
+
+     <varlistentry id="guc-wal-sender-timeout" xreflabel="wal_sender_timeout">
+      <term><varname>wal_sender_timeout</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>wal_sender_timeout</> configuration parameter</primary>
+       -->
+       <primary><varname>wal_sender_timeout</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Terminate replication connections that are inactive longer
+        than the specified number of milliseconds. This is useful for
+        the sending server to detect a standby crash or network outage.
+        A value of zero disables the timeout mechanism.  This parameter
+        can only be set in
+        the <filename>postgresql.conf</> file or on the server command line.
+        The default value is 60 seconds.
+       -->
+       指定されたミリ秒単位の値より長く非活動のレプリケーション接続を停止します。
+       スタンバイサーバのクラッシュ、またはネットワークの停止を送出サーバが検出することにこれが役立ちます。
+       値ゼロはタイムアウト機能を無効にします。
+       このパラメータは、<filename>postgresql.conf</>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+       デフォルトの値は60秒です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-track-commit-timestamp" xreflabel="track_commit_timestamp">
+      <term><varname>track_commit_timestamp</varname> (<type>boolean</type>)
+      <indexterm>
+<!--
+       <primary><varname>track_commit_timestamp</> configuration parameter</primary>
+-->
+       <primary><varname>track_commit_timestamp</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Record commit time of transactions. This parameter
+        can only be set in <filename>postgresql.conf</> file or on the server
+        command line. The default value is <literal>off</literal>.
+-->
+トランザクションのコミットタイムを記録します。
+このパラメータは、<filename>postgresql.conf</>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+デフォルトは<literal>off</literal>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+    </sect2>
+
+    <sect2 id="runtime-config-replication-master">
+     <!--
+     <title>Master Server</title>
+     -->
+     <title>マスターサーバ</title>
+
+     <para>
+      <!--
+      These parameters can be set on the master/primary server that is
+      to send replication data to one or more standby servers.
+      Note that in addition to these parameters,
+      <xref linkend="guc-wal-level"> must be set appropriately on the master
+      server, and optionally WAL archiving can be enabled as
+      well (see <xref linkend="runtime-config-wal-archiving">).
+      The values of these parameters on standby servers are irrelevant,
+      although you may wish to set them there in preparation for the
+      possibility of a standby becoming the master.
+      -->
+      これらのパラメータはレプリケーションデータを１つ、またはそれ以上複数のスタンバイサーバに送るマスター/プライマリサーバ上で設定することができます。
+      これらパラメータに加え、<xref linkend="guc-wal-level">はマスターサーバ上で適切に設定される必要があり、オプションとしてWALアーカイブを有効にしてもかまいません（<xref linkend="runtime-config-wal-archiving">を参照してください）。
+      スタンバイサーバがマスターサーバになるかもしれない状況に備え、それらのパラメータをスタンバイサーバで設定したいと考えたとしても、スタンバイサーバ上でのパラメータの値は意味をなしません。
+     </para>
+
+    <variablelist>
+
+     <varlistentry id="guc-synchronous-standby-names" xreflabel="synchronous_standby_names">
+      <term><varname>synchronous_standby_names</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>synchronous_standby_names</> configuration parameter</primary>
+       -->
+       <primary><varname>synchronous_standby_names</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Specifies a list of standby servers that can support
+        <firstterm>synchronous replication</>, as described in
+        <xref linkend="synchronous-replication">.
+        There will be one or more active synchronous standbys;
+        transactions waiting for commit will be allowed to proceed after
+        these standby servers confirm receipt of their data.
+        The synchronous standbys will be those whose names appear
+        in this list, and
+        that are both currently connected and streaming data in real-time
+        (as shown by a state of <literal>streaming</literal> in the
+        <link linkend="pg-stat-replication-view">
+        <literal>pg_stat_replication</></link> view).
+        Specifying more than one synchronous standby can allow for very high
+        availability and protection against data loss.
+       </para>
+       -->
+<xref linkend="synchronous-replication">で説明されているように、<firstterm>同期レプリケーション</>をサポート可能なスタンバイサーバのリストを指定します。
+活動中の同期スタンバイサーバは1つまたはそれ以上です。
+コミットを待機しているトランザクションは、このスタンバイサーバがそのデータの受信を確認してから処理の継続が許可されます。
+同期スタンバイサーバはこのリストに名前が挙げられていており、現時点で接続され、そしてデータをリアルタイムでストリーミングしているものです（<link linkend="pg-stat-replication-view"><literal>pg_stat_replication</></link> ビューにおいて<literal>streaming</literal>状態として示されています）。
+このリストの後の方に記載されているその他のスタンバイサーバは潜在的に同期スタンバイサーバになることを示しています。
+二つ以上の同期スタンバイサーバ名を指定することで、かなりの高可用性とデータ損失に対する保護が得られます。
+       </para>
+       <para>
+<!--
+        The name of a standby server for this purpose is the
+        <varname>application_name</> setting of the standby, as set in the
+        standby's connection information.  In case of a physical replication
+        standby, this should be set in the <varname>primary_conninfo</>
+        setting in <filename>recovery.conf</filename>; the default
+        is <literal>walreceiver</literal>.  For logical replication, this can
+        be set in the connection information of the subscription, and it
+        defaults to the subscription name.  For other replication stream
+        consumers, consult their documentation.
+-->
+この目的のためのスタンバイサーバ名は、スタンバイの接続情報で指定された、スタンバイの<varname>application_name</>設定です。
+物理レプリケーションスタンバイでは、<filename>recovery.conf</filename>中の<varname>primary_conninfo</>設定です。
+デフォルトは<literal>walreceiver</literal>です。
+論理レプリケーションでは、サブスクリプションの接続情報でで設定でき、デフォルトはサブスクリプション名です。
+それ以外のレプリケーションストリームコンシューマーについては、それぞれのドキュメントをご覧ください。
+       </para>
+       <para>
+<!--
+        This parameter specifies a list of standby servers using
+        either of the following syntaxes:
+-->
+このパラメータは、以下の構文のいずれかを用いてスタンバイサーバのリストを指定します。
+<synopsis>
+[FIRST] <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="parameter">standby_name</replaceable> [, ...] )
+ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="parameter">standby_name</replaceable> [, ...] )
+<replaceable class="parameter">standby_name</replaceable> [, ...]
+</synopsis>
+<!--
+        where <replaceable class="parameter">num_sync</replaceable> is
+        the number of synchronous standbys that transactions need to
+        wait for replies from,
+        and <replaceable class="parameter">standby_name</replaceable>
+        is the name of a standby server.
+        <literal>FIRST</> and <literal>ANY</> specify the method to choose
+        synchronous standbys from the listed servers.
+-->
+ここで、<replaceable class="parameter">num_sync</replaceable>は、トランザクションが応答を待機する必要のある同期スタンバイの数です。
+<replaceable class="parameter">standby_name</replaceable>は、スタンバイサーバの名前です。
+<literal>FIRST</>と<literal>ANY</>は、リスト中のサーバーから同期スタンバイを選ぶ方法を指定します。
+       </para>
+       <para>
+<!--
+        The keyword <literal>FIRST</>, coupled with
+        <replaceable class="parameter">num_sync</replaceable>, specifies a
+        priority-based synchronous replication and makes transaction commits
+        wait until their WAL records are replicated to
+        <replaceable class="parameter">num_sync</replaceable> synchronous
+        standbys chosen based on their priorities. For example, a setting of
+        <literal>FIRST 3 (s1, s2, s3, s4)</> will cause each commit to wait for
+        replies from three higher-priority standbys chosen from standby servers
+        <literal>s1</>, <literal>s2</>, <literal>s3</> and <literal>s4</>.
+        The standbys whose names appear earlier in the list are given higher
+        priority and will be considered as synchronous. Other standby servers
+        appearing later in this list represent potential synchronous standbys.
+        If any of the current synchronous standbys disconnects for whatever
+        reason, it will be replaced immediately with the next-highest-priority
+        standby. The keyword <literal>FIRST</> is optional.
+-->
+キーワード<literal>FIRST</>を<replaceable class="parameter">num_sync</replaceable>と組み合わせると、優先度に基づく同期レプリケーションを指定し、優先度に基づいて選ばれた<replaceable class="parameter">num_sync</replaceable>個の同期スタンバイにWALレコードがレプリケーションされるまで、トランザクションのコミットは待機します。
+たとえば<literal>FIRST 3 (s1, s2, s3, s4)</>とすると、<literal>s1</>、<literal>s2</>、<literal>s3</>、<literal>s4</>の中から選ばれた優先順位の高い3つのスタンバイサーバが応答を返すまでコミットは待機します。
+リストの中で前の方に名前が出現するスタンバイには高い優先度が与えられ、同期と見なされます。
+それ以外のリストの中で後の方に名前が上がっているスタンバイサーバーは、潜在的な同期スタンバイであることを表しています。
+どんな理由であれ、現在の同期スタンバイが切断されると、次に高い優先度を持つスタンバイに直ちに取って代わられます。
+キーワード<literal>FIRST</>はオプションです。
+       </para>
+       <para>
+<!--
+        The keyword <literal>ANY</>, coupled with
+        <replaceable class="parameter">num_sync</replaceable>, specifies a
+        quorum-based synchronous replication and makes transaction commits
+        wait until their WAL records are replicated to <emphasis>at least</>
+        <replaceable class="parameter">num_sync</replaceable> listed standbys.
+        For example, a setting of <literal>ANY 3 (s1, s2, s3, s4)</> will cause
+        each commit to proceed as soon as at least any three standbys of
+        <literal>s1</>, <literal>s2</>, <literal>s3</> and <literal>s4</>
+        reply.
+-->
+キーワード<literal>ANY</>と組わせると、<replaceable class="parameter">num_sync</replaceable>はクォーラムに基づく同期レプリケーションを指定し、優先度に基づいて選ばれた<emphasis>少なくとも</><replaceable class="parameter">num_sync</replaceable>個の同期スタンバイにWALレコードがレプリケーションされるまで、トランザクションのコミットを待たせます。
+たとえば<literal>ANY 3 (s1, s2, s3, s4)</>とすると、<literal>s1</>、<literal>s2</>、<literal>s3</>の3つのうちのどれかが応答を返した時点でコミットが進行します。
+       </para>
+       <para>
+<!--
+        <literal>FIRST</> and <literal>ANY</> are case-insensitive. If these
+        keywords are used as the name of a standby server,
+        its <replaceable class="parameter">standby_name</replaceable> must
+        be double-quoted.
+-->
+<literal>FIRST</>と<literal>ANY</>は、大文字小文字を区別しません。
+もしこれらのキーワードをスタンバイサーバの名前に使う場合は、<replaceable class="parameter">standby_name</replaceable>は二重引用符で囲わなければなりません。
+       </para>
+       <para>
+<!--
+        The third syntax was used before <productname>PostgreSQL</>
+        version 9.6 and is still supported. It's the same as the first syntax
+        with <literal>FIRST</> and
+        <replaceable class="parameter">num_sync</replaceable> equal to 1.
+        For example, <literal>FIRST 1 (s1, s2)</> and <literal>s1, s2</> have
+        the same meaning: either <literal>s1</> or <literal>s2</> is chosen
+        as a synchronous standby.
+-->
+3番目の構文は、<productname>PostgreSQL</>9.6よりも前のバージョンで用いられていたもので、依然としてサポートされています。
+最初の構文で、<literal>FIRST</>、<replaceable class="parameter">num_sync</replaceable>を1とした時と同じです。
+たとえば、<literal>FIRST 1 (s1, s2)</>と<literal>s1, s2</>は同じ意味です。
+<literal>s1</>か<literal>s2</>が同期スタンバイとして選ばれます。
+       </para>
+       <para>
+<!--
+        The special entry <literal>*</> matches any standby name.
+-->
+特別なエントリ<literal>*</>は、すべてのスタンバイ名に一致します。
+       </para>
+       <para>
+<!--
+        There is no mechanism to enforce uniqueness of standby names.  In case
+        of duplicates one of the matching standbys will be considered as
+        higher priority, though exactly which one is indeterminate.
+-->
+スタンバイの一意性を強要する仕組みはありません。
+重複があった場合、一致したスタンバイは優先順位が高いと見なされますが、どれが選ばれるかは非決定的です。
+        </para>
+       <note>
+        <para>
+<!--
+         Each <replaceable class="parameter">standby_name</replaceable>
+         should have the form of a valid SQL identifier, unless it
+         is <literal>*</>.  You can use double-quoting if necessary.  But note
+         that <replaceable class="parameter">standby_name</replaceable>s are
+         compared to standby application names case-insensitively, whether
+         double-quoted or not.
+-->
+各々の<replaceable class="parameter">standby_name</replaceable>は、<literal>*</>である場合を除き、SQL識別子の形式を取らなければなりません。
+二重引用符を用いることもできます。
+しかし、二重引用符の有無に関わらず、<replaceable class="parameter">standby_name</replaceable>とスタンバイのアプリケーション名の比較は、大文字小文字の区別なしに行われることに注意してください。
+        </para>
+       </note>
+       <para>
+       <!--
+        If no synchronous standby names are specified here, then synchronous
+        replication is not enabled and transaction commits will not wait for
+        replication.  This is the default configuration.  Even when
+        synchronous replication is enabled, individual transactions can be
+        configured not to wait for replication by setting the
+        <xref linkend="guc-synchronous-commit"> parameter to
+        <literal>local</> or <literal>off</>.
+       -->
+       ここに同期スタンバイ名が指定されていない場合、同期レプリケーションは有効とはならず、トランザクションコミットはレプリケーションを待機しません。これがデフォルトの設定です。同期レプリケーションが有効であっても、<xref linkend="guc-synchronous-commit">パラメータを<literal>local</> または <literal>off</>に設定することにより、個別のトランザクションをレプリケーションに対して待機しないように設定できます。
+       </para>
+       <para>
+       <!--
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+       このパラメータは、<filename>postgresql.conf</>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-vacuum-defer-cleanup-age" xreflabel="vacuum_defer_cleanup_age">
+      <term><varname>vacuum_defer_cleanup_age</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>vacuum_defer_cleanup_age</> configuration parameter</primary>
+       -->
+       <primary><varname>vacuum_defer_cleanup_age</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the number of transactions by which <command>VACUUM</> and
+        <acronym>HOT</> updates will defer cleanup of dead row versions. The
+        default is zero transactions, meaning that dead row versions can be
+        removed as soon as possible, that is, as soon as they are no longer
+        visible to any open transaction.  You may wish to set this to a
+        non-zero value on a primary server that is supporting hot standby
+        servers, as described in <xref linkend="hot-standby">.  This allows
+        more time for queries on the standby to complete without incurring
+        conflicts due to early cleanup of rows.  However, since the value
+        is measured in terms of number of write transactions occurring on the
+        primary server, it is difficult to predict just how much additional
+        grace time will be made available to standby queries.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+<command>VACUUM</> および <acronym>HOT</>更新が不要行バージョンの回収を決めるのを延期するトランザクションの数を指定します。
+デフォルトはゼロトランザクションで、つまり、開いている全てのトランザクションから不可視になった不要行バージョンは速やかに削除されうることを意味します。
+<xref linkend="hot-standby">に記載されているように、ホットスタンバイサーバをサポートしている場合、プライマリサーバ上で非ゼロ値に設定したい場合があります。
+そうすることで、スタンバイ上での問い合わせが、行の早期回収によるコンフリクトを被ることなく完了するように時間を与えます。
+しかし、値はプライマリーサーバ上で発生している書き込みトランザクションの観点から計測されるため、スタンバイの問い合わせにたいして猶予時間がどのくらい有効となるかは予測できません。
+このパラメータは、<filename>postgresql.conf</>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+       </para>
+       <para>
+       <!--
+        You should also consider setting <varname>hot_standby_feedback</>
+        on standby server(s) as an alternative to using this parameter.
+       -->
+このパラメータを使う代わりにスタンバイサーバ上に <varname>hot_standby_feedback</>の設定を考慮する必要もあります。
+       </para>
+       <para>
+<!--
+        This does not prevent cleanup of dead rows which have reached the age
+        specified by <varname>old_snapshot_threshold</>.
+-->
+<varname>old_snapshot_threshold</>で指定された年齢に達した無効行のクリーンアップを妨げることはありません。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+    </sect2>
+
+    <sect2 id="runtime-config-replication-standby">
+    <!--
+     <title>Standby Servers</title>
+    -->
+     <title>スタンバイサーバ</title>
+
+     <para>
+     <!--
+      These settings control the behavior of a standby server that is
+      to receive replication data.  Their values on the master server
+      are irrelevant.
+      -->
+      これらの設定はレプリケーションデータを受け取るスタンバイサーバの動作を管理します。
+      マスターサーバ上のこれらの値は無意味です。
+     </para>
+
+    <variablelist>
+
+     <varlistentry id="guc-hot-standby" xreflabel="hot_standby">
+      <term><varname>hot_standby</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>hot_standby</> configuration parameter</primary>
+       -->
+       <primary><varname>hot_standby</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies whether or not you can connect and run queries during
+        recovery, as described in <xref linkend="hot-standby">.
+        The default value is <literal>on</literal>.
+        This parameter can only be set at server start. It only has effect
+        during archive recovery or in standby mode.
+       -->
+       <xref linkend="hot-standby">に記載されている通り、リカバリの最中に接続し、そして問い合わせを実行できるか否かを設定します。デフォルト値は<literal>on</literal>です。
+       このパラメータはサーバ起動時のみ設定可能です。これは、アーカイブリカバリ期間、又はスタンバイモードにある場合にのみ効果をもたらします。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-max-standby-archive-delay" xreflabel="max_standby_archive_delay">
+      <term><varname>max_standby_archive_delay</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>max_standby_archive_delay</> configuration parameter</primary>
+       -->
+       <primary><varname>max_standby_archive_delay</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        When Hot Standby is active, this parameter determines how long the
+        standby server should wait before canceling standby queries that
+        conflict with about-to-be-applied WAL entries, as described in
+        <xref linkend="hot-standby-conflict">.
+        <varname>max_standby_archive_delay</> applies when WAL data is
+        being read from WAL archive (and is therefore not current).
+        The default is 30 seconds. Units are milliseconds if not specified.
+        A value of -1 allows the standby to wait forever for conflicting
+        queries to complete.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+ホットスタンバイが稼動している場合、このパラメータは<xref linkend="hot-standby-conflict">で記載されているように、まさに適用されようとしているWALエントリと衝突するスタンバイサーバの問い合わせをキャンセルするにはどれだけ待機しなければならないかを設定します。
+<varname>max_standby_archive_delay</>はWALデータをWALアーカイブ（すなわち最新ではありません）から読み込んでいる時に適用されます。
+デフォルトは30秒です。
+特に指定が無ければ単位はミリ秒です。
+値-1は衝突する問い合わせが完了するまでスタンバイサーバが待ち続けられるようにします。
+このパラメータは、<filename>postgresql.conf</>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+       </para>
+       <para>
+       <!--
+        Note that <varname>max_standby_archive_delay</> is not the same as the
+        maximum length of time a query can run before cancellation; rather it
+        is the maximum total time allowed to apply any one WAL segment's data.
+        Thus, if one query has resulted in significant delay earlier in the
+        WAL segment, subsequent conflicting queries will have much less grace
+        time.
+       -->
+<varname>max_standby_archive_delay</>はキャンセル前に問い合わせが実行できる最大の時間の長さと同じでないことに注意してください。
+むしろ、任意の１つのWALセグメントのデータの適用のために許される最大合計時間です。
+従って、ある問い合わせによりWALセグメント内の前の部分で大幅な遅延となった場合、その後の衝突する問い合わせの猶予時間はずっと短くなります。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-max-standby-streaming-delay" xreflabel="max_standby_streaming_delay">
+      <term><varname>max_standby_streaming_delay</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>max_standby_streaming_delay</> configuration parameter</primary>
+       -->
+       <primary><varname>max_standby_streaming_delay</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        When Hot Standby is active, this parameter determines how long the
+        standby server should wait before canceling standby queries that
+        conflict with about-to-be-applied WAL entries, as described in
+        <xref linkend="hot-standby-conflict">.
+        <varname>max_standby_streaming_delay</> applies when WAL data is
+        being received via streaming replication.
+        The default is 30 seconds. Units are milliseconds if not specified.
+        A value of -1 allows the standby to wait forever for conflicting
+        queries to complete.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+ホットスタンバイが稼動している場合、このパラメータは<xref linkend="hot-standby-conflict">で記載されているように、まさに適用されようとしているWALエントリと衝突するスタンバイサーバの問い合わせをキャンセルするにはどれだけ待機しなければならないかを設定します。
+<varname>max_standby_streaming_delay</>はWALデータをストリーミングレプリケーションから受け取っている時に適用されます。
+デフォルトは30秒です。
+特に指定が無ければ単位はミリ秒です。
+値-1は衝突する問い合わせが完了するまでスタンバイサーバが待ち続けられるようにします。
+このパラメータは、<filename>postgresql.conf</>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+       </para>
+       <para>
+       <!--
+        Note that <varname>max_standby_streaming_delay</> is not the same as
+        the maximum length of time a query can run before cancellation; rather
+        it is the maximum total time allowed to apply WAL data once it has
+        been received from the primary server.  Thus, if one query has
+        resulted in significant delay, subsequent conflicting queries will
+        have much less grace time until the standby server has caught up
+        again.
+       -->
+<varname>max_standby_streaming_delay</>はキャンセル前に問い合わせが実行できる最大の時間の長さと同じでないことに注意してください。
+むしろ、プライマリサーバから一度受け取られたWALデータを適用するために許される最大合計時間です。
+従って、ある問い合わせが大幅な遅延を起こした場合、その後の衝突する問い合わせは、スタンバイサーバがふたたび遅れを取り戻すまでの間、猶予時間はずっと短くなります。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-wal-receiver-status-interval" xreflabel="wal_receiver_status_interval">
+      <term><varname>wal_receiver_status_interval</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>wal_receiver_status_interval</> configuration parameter</primary>
+       -->
+       <primary><varname>wal_receiver_status_interval</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+      <para>
+      <!--
+       Specifies the minimum frequency for the WAL receiver
+       process on the standby to send information about replication progress
+       to the primary or upstream standby, where it can be seen using the
+       <link linkend="pg-stat-replication-view">
+       <literal>pg_stat_replication</></link> view.  The standby will report
+       the last write-ahead log location it has written, the last position it
+       has flushed to disk, and the last position it has applied.
+       This parameter's
+       value is the maximum interval, in seconds, between reports.  Updates are
+       sent each time the write or flush positions change, or at least as
+       often as specified by this parameter.  Thus, the apply position may
+       lag slightly behind the true position.  Setting this parameter to zero
+       disables status updates completely.  This parameter can only be set in
+       the <filename>postgresql.conf</> file or on the server command line.
+       The default value is 10 seconds.
+       -->
+スタンバイサーバ上のWAL受信プロセスがプライマリー、または上位サーバに対してレプリケーションの進捗情報を送信する最小頻度を指定します。
+送信された進捗情報は<link linkend="pg-stat-replication-view"><literal>pg_stat_replication</></link>ビューにより確認することが可能です。
+スタンバイサーバは書き込みがされた直近の先行書き込みログ位置、ディスクにフラッシュされた直近のログ位置、およびリカバリ適用された直近のログ位置を報告します。
+このパラメータの値がそれぞれの報告間における秒単位の最大の時間間隔です。
+書き込み、またはフラッシュ位置が変更される毎、あるいは最低でもこのパラメータで設定された頻度で更新情報が送信されます。
+従って、適用位置は真の位置よりも少し後ろにずれることがあります。
+このパラメータをゼロに設定すると、ステータスの更新を完全に無効化します。
+このパラメータは、<filename>postgresql.conf</>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+デフォルトの値は10秒です。
+      </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-hot-standby-feedback" xreflabel="hot_standby_feedback">
+      <term><varname>hot_standby_feedback</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>hot_standby_feedback</> configuration parameter</primary>
+       -->
+       <primary><varname>hot_standby_feedback</> 設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies whether or not a hot standby will send feedback to the primary
+        or upstream standby
+        about queries currently executing on the standby. This parameter can
+        be used to eliminate query cancels caused by cleanup records, but
+        can cause database bloat on the primary for some workloads.
+        Feedback messages will not be sent more frequently than once per
+        <varname>wal_receiver_status_interval</>. The default value is
+        <literal>off</literal>. This parameter can only be set in the
+        <filename>postgresql.conf</> file or on the server command line.
+       -->
+       ホットスタンバイがスタンバイサーバ上で現在処理を行っている問い合わせについて、プライマリーまたは上位サーバにフィードバックを送るか否かを指定します。
+       このパラメータはレコードの回収に起因する問い合わせの取り消しを排除するために使用することができます。
+       しかし、いくつかのワークロードに対してはプライマリーサーバ上でのデータベース肥大の原因となります。
+       フィードバックメッセージは<varname>wal_receiver_status_interval</>毎に、2回以上送信されません。
+       デフォルトの値は<literal>off</literal>です。
+        このパラメータは、<filename>postgresql.conf</>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+       </para>
+       <para>
+       <!--
+        If cascaded replication is in use the feedback is passed upstream
+        until it eventually reaches the primary.  Standbys make no other use
+        of feedback they receive other than to pass upstream.
+       -->
+       カスケードレプリケーションが使用されている場合、フィードバックは最終的にプライマリーに到達するまで上位サーバに転送されます。スタンバイは上位に転送する以外、受け取ったフィードバックを他に使用しません。
+       </para>
+       <para>
+<!--
+        This setting does not override the behavior of
+        <varname>old_snapshot_threshold</> on the primary; a snapshot on the
+        standby which exceeds the primary's age threshold can become invalid,
+        resulting in cancellation of transactions on the standby.  This is
+        because <varname>old_snapshot_threshold</> is intended to provide an
+        absolute limit on the time which dead rows can contribute to bloat,
+        which would otherwise be violated because of the configuration of a
+        standby.
+-->
+この設定は、プライマリの<varname>old_snapshot_threshold</>の挙動を上書きしません。
+プライマリの年齢上限を超えたスタンバイ上のスナップショットは無効となる可能性があり、その場合スタンバイにおいてトランザクションのキャンセルを引き起こします。
+これは、<varname>old_snapshot_threshold</>が、無効行によってデータ溢れが起こる時刻の絶対的な制限を提供することを意図しているからです。
+そうでなければ、スタンバイの設定によってこの目的は成立しなくなってしまいます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-wal-receiver-timeout" xreflabel="wal_receiver_timeout">
+      <term><varname>wal_receiver_timeout</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>wal_receiver_timeout</> configuration parameter</primary>
+       -->
+       <primary><varname>wal_receiver_timeout</> 設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Terminate replication connections that are inactive longer
+        than the specified number of milliseconds. This is useful for
+        the receiving standby server to detect a primary node crash or network
+        outage.
+        A value of zero disables the timeout mechanism.  This parameter
+        can only be set in
+        the <filename>postgresql.conf</> file or on the server command line.
+        The default value is 60 seconds.
+       -->
+指定されたミリ秒より長い間、活動していないレプリケーション接続は停止します。
+このことは受信するスタンバイサーバがプライマリノードの機能停止、またはネットワーク停止を検出するのに便利です。
+値ゼロは時間切れメカニズムを無効にします。
+このパラメータは<filename>postgresql.conf</>ファイルまたはサーバのコマンドラインのみで設定可能です。
+デフォルト値は60秒です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-wal-retrieve-retry-interval" xreflabel="wal_retrieve_retry_interval">
+      <term><varname>wal_retrieve_retry_interval</varname> (<type>integer</type>)
+      <indexterm>
+<!--
+       <primary><varname>wal_retrieve_retry_interval</> configuration parameter</primary>
+-->
+       <primary><varname>wal_retrieve_retry_interval</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Specify how long the standby server should wait when WAL data is not
+        available from any sources (streaming replication,
+        local <filename>pg_wal</> or WAL archive) before retrying to
+        retrieve WAL data.  This parameter can only be set in the
+        <filename>postgresql.conf</> file or on the server command line.
+        The default value is 5 seconds. Units are milliseconds if not specified.
+-->
+WALデータがソース(ストリーミングレプリケーション、ローカルの<filename>pg_wal</>、またはWALアーカイブ)から取得できない時に、スタンバイサーバがWALデータ受信をリトライするまでにどの位の時間待つべきかを指定します。
+このパラメータは、<filename>postgresql.conf</>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+デフォルト値は5秒です。
+特に指定がなければ単位はミリ秒です。
+       </para>
+       <para>
+<!--
+        This parameter is useful in configurations where a node in recovery
+        needs to control the amount of time to wait for new WAL data to be
+        available. For example, in archive recovery, it is possible to
+        make the recovery more responsive in the detection of a new WAL
+        log file by reducing the value of this parameter. On a system with
+        low WAL activity, increasing it reduces the amount of requests necessary
+        to access WAL archives, something useful for example in cloud
+        environments where the amount of times an infrastructure is accessed
+        is taken into account.
+-->
+このパラメータは、リカバリ対象のノードにおいて、新しいWALデータが読み込み可能になるまでの待ち時間を制御する必要のある時に有用です。
+たとえば、アーカイブリカバリにおいては、このパラメータの値を小さくすることにより、新しいWALログファイルを検出する際にリカバリの応答を早くすることができます。
+WALの生成頻度が少ないシステムでは、この値を大きくすることにより、WALアーカイブへのアクセス頻度を減らすことができます。
+これは、たとえば基盤へのアクセス回数が課金対象になるクラウド環境において、有用です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+    </sect2>
+
+    <sect2 id="runtime-config-replication-subscriber">
+<!--
+     <title>Subscribers</title>
+-->
+     <title>サブスクライバー</title>
+
+     <para>
+<!--
+      These settings control the behavior of a logical replication subscriber.
+      Their values on the publisher are irrelevant.
+-->
+これらの設定項目は、論理レプリケーションのサブスクライバーの挙動を制御します。
+パブリッシャーにおける設定値とは無関係です。
+     </para>
+
+     <para>
+<!--
+      Note that <varname>wal_receiver_timeout</varname>,
+      <varname>wal_receiver_status_interval</varname> and
+      <varname>wal_retrieve_retry_interval</varname> configuration parameters
+      affect the logical replication workers as well.
+-->
+<varname>wal_receiver_timeout</varname>、<varname>wal_receiver_status_interval</varname>そして<varname>wal_retrieve_retry_interval</varname>設定パラメータは、論理レプリケーションワーカーにも影響することに注意してください。
+     </para>
+
+     <variablelist>
+
+     <varlistentry id="guc-max-logical-replication-workers" xreflabel="max_logical_replication_workers">
+      <term><varname>max_logical_replication_workers</varname> (<type>int</type>)
+      <indexterm>
+<!--
+       <primary><varname>max_logical_replication_workers</> configuration parameter</primary>
+-->
+       <primary><varname>max_logical_replication_workers</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Specifies maximum number of logical replication workers. This includes
+        both apply workers and table synchronization workers.
+-->
+論理レプリケーションワーカーの最大数を指定します。
+適用ワーカーと、テーブル同期ワーカーの両方が含まれます。
+       </para>
+       <para>
+<!--
+        Logical replication workers are taken from the pool defined by
+        <varname>max_worker_processes</varname>.
+-->
+論理レプリケーションワーカーは、<varname>max_worker_processes</varname>で定義されたプールから取得されます。
+       </para>
+       <para>
+<!--
+        The default value is 4.
+-->
+デフォルト値は4です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-max-sync-workers-per-subscription" xreflabel="max_sync_workers_per_subscription">
+      <term><varname>max_sync_workers_per_subscription</varname> (<type>integer</type>)
+      <indexterm>
+<!--
+       <primary><varname>max_sync_workers_per_subscription</> configuration parameter</primary>
+-->
+       <primary><varname>max_sync_workers_per_subscription</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Maximum number of synchronization workers per subscription. This
+        parameter controls the amount of parallelism of the initial data copy
+        during the subscription initialization or when new tables are added.
+-->
+サブスクリプションごとの同期ワーカーの最大数です。
+このパラメータは、サブスクリプションの初期化中、あるいは新しいテーブルが追加されたときの初期データコピーの並列度を制御します。
+       </para>
+       <para>
+<!--
+        Currently, there can be only one synchronization worker per table.
+-->
+今のところ、一つのテーブルにつき、同期ワーカーは一つだけです。
+       </para>
+       <para>
+<!--
+        The synchronization workers are taken from the pool defined by
+        <varname>max_logical_replication_workers</varname>.
+-->
+同期ワーカーは、<varname>max_logical_replication_workers</varname>で定義されたプールから取得されます。
+       </para>
+       <para>
+<!--
+        The default value is 2.
+-->
+デフォルト値は2です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+    </sect2>
+
+   </sect1>
+
+   <sect1 id="runtime-config-query">
+   <!--
+    <title>Query Planning</title>
+    -->
+    <title>問い合わせ計画</title>
+
+    <sect2 id="runtime-config-query-enable">
+    <!--
+     <title>Planner Method Configuration</title>
+     -->
+     <title>プランナメソッド設定</title>
+
+      <para>
+      <!--
+       These configuration parameters provide a crude method of
+       influencing the query plans chosen by the query optimizer. If
+       the default plan chosen by the optimizer for a particular query
+       is not optimal, a <emphasis>temporary</> solution is to use one
+       of these configuration parameters to force the optimizer to
+       choose a different plan.
+       Better ways to improve the quality of the
+       plans chosen by the optimizer include adjusting the planner cost
+       constants (see <xref linkend="runtime-config-query-constants">),
+       running <xref linkend="sql-analyze"> manually, increasing
+       the value of the <xref
+       linkend="guc-default-statistics-target"> configuration parameter,
+       and increasing the amount of statistics collected for
+       specific columns using <command>ALTER TABLE SET
+       STATISTICS</command>.
+       -->
+以下の設定パラメータは、問い合わせオプティマイザが選択する問い合わせ計画に影響する大雑把な手法を提供します。
+ある問い合わせに対してオプティマイザが選択したデフォルト計画が最適でない場合、<emphasis>暫定的な</>解決策は、これらの設定パラメータの1つを使用し、オプティマイザに異なる計画を選択するように仕向けることです。
+オプティマイザが選択する計画の品質を改善するためのより良い方法には、プランナコスト定数を調節する（<xref linkend="runtime-config-query-constants">を参照）、<xref linkend="sql-analyze">を手作業で実行する、<xref linkend="guc-default-statistics-target">設定パラメータの値を大きくする、<command>ALTER TABLE SET STATISTICS</command>を使用して、特定の列に対して収集される統計情報を増やす、などがあります。
+      </para>
+
+     <variablelist>
+     <varlistentry id="guc-enable-bitmapscan" xreflabel="enable_bitmapscan">
+      <term><varname>enable_bitmapscan</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary>bitmap scan</primary>
+       -->
+       <primary>ビットマップ走査</primary>
+      </indexterm>
+      <indexterm>
+      <!--
+       <primary><varname>enable_bitmapscan</> configuration parameter</primary>
+       -->
+       <primary><varname>enable_bitmapscan</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables or disables the query planner's use of bitmap-scan plan
+        types. The default is <literal>on</>.
+       -->
+       問い合わせプランナがビットマップスキャン計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-enable-gathermerge" xreflabel="enable_gathermerge">
+      <term><varname>enable_gathermerge</varname> (<type>boolean</type>)
+      <indexterm>
+<!--
+       <primary><varname>enable_gathermerge</> configuration parameter</primary>
+-->
+       <primary><varname>enable_gathermerge</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Enables or disables the query planner's use of gather
+        merge plan types. The default is <literal>on</>.
+-->
+問い合わせプランナがギャザーマージ計画型を選択することを有効もしくは無効にします。
+デフォルトは<literal>on</>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-enable-hashagg" xreflabel="enable_hashagg">
+      <term><varname>enable_hashagg</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>enable_hashagg</> configuration parameter</primary>
+       -->
+       <primary><varname>enable_hashagg</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables or disables the query planner's use of hashed
+        aggregation plan types. The default is <literal>on</>.
+       -->
+問い合わせプランナがハッシュ集約計画型を選択することを有効もしくは無効にします。
+デフォルトは<literal>on</>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-enable-hashjoin" xreflabel="enable_hashjoin">
+      <term><varname>enable_hashjoin</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>enable_hashjoin</> configuration parameter</primary>
+       -->
+       <primary><varname>enable_hashjoin</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables or disables the query planner's use of hash-join plan
+        types. The default is <literal>on</>.
+       -->
+       問い合わせプランナがハッシュ結合計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-enable-indexscan" xreflabel="enable_indexscan">
+      <term><varname>enable_indexscan</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary>index scan</primary>
+       -->
+       <primary>インデックス走査</primary>
+      </indexterm>
+      <indexterm>
+      <!--
+       <primary><varname>enable_indexscan</> configuration parameter</primary>
+       -->
+       <primary><varname>enable_indexscan</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables or disables the query planner's use of index-scan plan
+        types. The default is <literal>on</>.
+       -->
+       問い合わせプランナがインデックス走査計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-enable-indexonlyscan" xreflabel="enable_indexonlyscan">
+      <term><varname>enable_indexonlyscan</varname> (<type>boolean</type>)
+      <indexterm>
+<!--
+       <primary><varname>enable_indexonlyscan</> configuration parameter</primary>
+-->
+       <primary><varname>enable_indexonlyscan</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Enables or disables the query planner's use of index-only-scan plan
+        types (see <xref linkend="indexes-index-only-scans">).
+        The default is <literal>on</>.
+-->
+問い合わせプランナがインデックスオンリースキャン計画型を選択することを有効もしくは無効にします。
+(<xref linkend="indexes-index-only-scans">を参照してください)
+デフォルトは<literal>on</>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-enable-material" xreflabel="enable_material">
+      <term><varname>enable_material</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>enable_material</> configuration parameter</primary>
+       -->
+       <primary><varname>enable_material</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables or disables the query planner's use of materialization.
+        It is impossible to suppress materialization entirely,
+        but turning this variable off prevents the planner from inserting
+        materialize nodes except in cases where it is required for correctness.
+        The default is <literal>on</>.
+       -->
+       問い合わせプランナの具体化の使用を有効、または無効にします。
+       全体にわたって具体化を差し止めることはできませんが、この値をoffにすることにより、正確性が要求される場合を除いて、具体化ノードをプランナが挿入することを防止します。デフォルトは<literal>on</>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-enable-mergejoin" xreflabel="enable_mergejoin">
+      <term><varname>enable_mergejoin</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>enable_mergejoin</> configuration parameter</primary>
+       -->
+       <primary><varname>enable_mergejoin</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables or disables the query planner's use of merge-join plan
+        types. The default is <literal>on</>.
+       -->
+       問い合わせプランナがマージ結合計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-enable-nestloop" xreflabel="enable_nestloop">
+      <term><varname>enable_nestloop</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>enable_nestloop</> configuration parameter</primary>
+       -->
+       <primary><varname>enable_nestloop</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables or disables the query planner's use of nested-loop join
+        plans. It is impossible to suppress nested-loop joins entirely,
+        but turning this variable off discourages the planner from using
+        one if there are other methods available. The default is
+        <literal>on</>.
+       -->
+       問い合わせプランナがネステッドループ結合計画を選択することを有効もしくは無効にします。
+       ネステッドループ結合を完全に禁止することは不可能ですが、この変数をオフにすると、もし他の方法が利用できるのであれば、プランナはその使用を行わないようになります。
+       デフォルトは<literal>on</>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-enable-seqscan" xreflabel="enable_seqscan">
+      <term><varname>enable_seqscan</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary>sequential scan</primary>
+       -->
+       <primary>シーケンシャル走査</primary>
+      </indexterm>
+      <indexterm>
+      <!--
+       <primary><varname>enable_seqscan</> configuration parameter</primary>
+       -->
+       <primary><varname>enable_seqscan</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables or disables the query planner's use of sequential scan
+        plan types. It is impossible to suppress sequential scans
+        entirely, but turning this variable off discourages the planner
+        from using one if there are other methods available. The
+        default is <literal>on</>.
+       -->
+       問い合わせプランナがシーケンシャル走査計画を選択することを有効もしくは無効にします。
+       シーケンシャル走査を完全に禁止することは不可能ですが、この変数をオフにすると、もし他の方法が利用できるのであれば、プランナはその使用を行わないようになります。デフォルトは<literal>on</>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-enable-sort" xreflabel="enable_sort">
+      <term><varname>enable_sort</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>enable_sort</> configuration parameter</primary>
+       -->
+       <primary><varname>enable_sort</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables or disables the query planner's use of explicit sort
+        steps. It is impossible to suppress explicit sorts entirely,
+        but turning this variable off discourages the planner from
+        using one if there are other methods available. The default
+        is <literal>on</>.
+       -->
+       問い合わせプランナが明示的並び替え手順を選択することを有効もしくは無効にします。
+       明示的並び替えを完全に禁止することは不可能ですが、この変数をオフにすると、もし他の方法が利用できるのであれば、プランナはその使用を行わないようになります。デフォルトは<literal>on</>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-enable-tidscan" xreflabel="enable_tidscan">
+      <term><varname>enable_tidscan</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>enable_tidscan</> configuration parameter</primary>
+       -->
+       <primary><varname>enable_tidscan</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables or disables the query planner's use of <acronym>TID</>
+        scan plan types. The default is <literal>on</>.
+       -->
+       問い合わせプランナが<acronym>TID</>走査計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+     </sect2>
+     <sect2 id="runtime-config-query-constants">
+     <!--
+     <title>Planner Cost Constants</title>
+     -->
+     <title>プランナコスト定数</title>
+
+    <para>
+    <!--
+     The <firstterm>cost</> variables described in this section are measured
+     on an arbitrary scale.  Only their relative values matter, hence
+     scaling them all up or down by the same factor will result in no change
+     in the planner's choices.  By default, these cost variables are based on
+     the cost of sequential page fetches; that is,
+     <varname>seq_page_cost</> is conventionally set to <literal>1.0</>
+     and the other cost variables are set with reference to that.  But
+     you can use a different scale if you prefer, such as actual execution
+     times in milliseconds on a particular machine.
+     -->
+本節で扱う<firstterm>コスト</>変数は、任意の尺度で測られます。
+これらは相対的な値のみが意味を持つため、それらの値をすべて同じ係数で大きく、あるいは小さくしても、プランナの選択は結果として変わりません。
+デフォルトではこれらのコスト変数はシーケンシャルなページ取り込みに基づいています。
+つまり、<varname>seq_page_cost</>を慣習的に<literal>1.0</>とし、他のコスト変数はそれを参考にして設定されています。
+しかし望むなら、特定のマシンにおけるミリ秒単位の実行時間など、異なる尺度を使用することができます。
+    </para>
+
+   <note>
+    <para>
+    <!--
+     Unfortunately, there is no well-defined method for determining ideal
+     values for the cost variables.  They are best treated as averages over
+     the entire mix of queries that a particular installation will receive.  This
+     means that changing them on the basis of just a few experiments is very
+     risky.
+     -->
+残念ながら、コスト変数に対する理想的な値を決定する、上手く定義された方法がありません。
+特定のインストレーションが受け取る問い合わせ全体を混在させたものの平均として扱うのが最善でしょう。
+数回の実験のみを根拠にこの値を変更することは危険であるといえます。
+    </para>
+   </note>
+
+     <variablelist>
+
+     <varlistentry id="guc-seq-page-cost" xreflabel="seq_page_cost">
+      <term><varname>seq_page_cost</varname> (<type>floating point</type>)
+      <indexterm>
+      <!--
+       <primary><varname>seq_page_cost</> configuration parameter</primary>
+       -->
+       <primary><varname>seq_page_cost</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the planner's estimate of the cost of a disk page fetch
+        that is part of a series of sequential fetches.  The default is 1.0.
+        This value can be overridden for tables and indexes in a particular
+        tablespace by setting the tablespace parameter of the same name
+        (see <xref linkend="sql-altertablespace">).
+       -->
+シーケンシャルな一連の取り出しの一部となる、ディスクページ取り出しに関する、プランナの推定コストを設定します。
+デフォルトは1.0です。
+この値は同じ名前のテーブル空間パラメータを設定することで、特定のテーブル空間の中にあるテーブルとインデックスに対して上書きできます（<xref linkend="sql-altertablespace">を参照してください）。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-random-page-cost" xreflabel="random_page_cost">
+      <term><varname>random_page_cost</varname> (<type>floating point</type>)
+      <indexterm>
+      <!--
+       <primary><varname>random_page_cost</> configuration parameter</primary>
+       -->
+       <primary><varname>random_page_cost</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the planner's estimate of the cost of a
+        non-sequentially-fetched disk page.  The default is 4.0.
+        This value can be overridden for tables and indexes in a particular
+        tablespace by setting the tablespace parameter of the same name
+        (see <xref linkend="sql-altertablespace">).
+       -->
+非シーケンシャル的に取り出されるディスクページのコストに対するプランナの推測を設定します。
+デフォルトは4です。
+この値は同じ名前のテーブル空間パラメータを設定することで、特定のテーブル空間の中にあるテーブルとインデックスに対して上書きできます（<xref linkend="sql-altertablespace">を参照してください）。
+       </para>
+
+       <para>
+       <!--
+        Reducing this value relative to <varname>seq_page_cost</>
+        will cause the system to prefer index scans; raising it will
+        make index scans look relatively more expensive.  You can raise
+        or lower both values together to change the importance of disk I/O
+        costs relative to CPU costs, which are described by the following
+        parameters.
+       -->
+この値を<varname>seq_page_cost</>と比較して小さくすると、システムはなるべくインデックススキャンを使用するようになります。
+大きくすると、インデックススキャンが相対的に高価になります。
+両方の値を増減させることで、CPUコストに対するディスクI/Oコストの重要性を変更させることができます。
+これについては、後述のパラメータで説明します。
+       </para>
+
+       <para>
+       <!--
+        Random access to mechanical disk storage is normally much more expensive
+        than four times sequential access.  However, a lower default is used
+        (4.0) because the majority of random accesses to disk, such as indexed
+        reads, are assumed to be in cache.  The default value can be thought of
+        as modeling random access as 40 times slower than sequential, while
+        expecting 90% of random reads to be cached.
+       -->
+機械的ディスク記憶装置に対するランダムアクセスは通常はシーケンシャルアクセスの4倍よりもかなり高価です。
+しかし、より低いデフォルト（4.0）が使用されます。というのはインデックスのついた読み取りのようなディスクに対するランダムアクセスのほとんどはキャッシュにあると想定されるからです。
+このデフォルト値は、ランダムアクセスがシーケンシャルアクセスより40倍遅い一方で、ランダム読み込みの90%はキャッシュされていることが期待されるというモデルとして考えることができます。
+       </para>
+
+       <para>
+       <!--
+        If you believe a 90% cache rate is an incorrect assumption
+        for your workload, you can increase random_page_cost to better
+        reflect the true cost of random storage reads. Correspondingly,
+        if your data is likely to be completely in cache, such as when
+        the database is smaller than the total server memory, decreasing
+        random_page_cost can be appropriate.  Storage that has a low random
+        read cost relative to sequential, e.g. solid-state drives, might
+        also be better modeled with a lower value for random_page_cost.
+       -->
+自環境の作業負荷において、90％のキャッシュ率は誤った仮定と考えられるのであれば、ランダム記憶装置読み込みのコストをより良く反映するため random_page_cost を大きくすることができます。
+反対に、データが完全にキャッシュされていると思われるのであれば、random_page_cost を小さくすることが適切です。例えば、データベースの容量がサーバのメモリより小さい場合などです。
+例えばSSDのような、シーケンシャルアクセスに比べてランダム読み込みコストがあまり大きくない記憶装置の場合も、random_page_cost に対しより低い値のモデル化の方が良いでしょう。
+       </para>
+
+       <tip>
+        <para>
+       <!--
+         Although the system will let you set <varname>random_page_cost</> to
+         less than <varname>seq_page_cost</>, it is not physically sensible
+         to do so.  However, setting them equal makes sense if the database
+         is entirely cached in RAM, since in that case there is no penalty
+         for touching pages out of sequence.  Also, in a heavily-cached
+         database you should lower both values relative to the CPU parameters,
+         since the cost of fetching a page already in RAM is much smaller
+         than it would normally be.
+        -->
+システムは<varname>random_page_cost</>を<varname>seq_page_cost</>よりも小さな値に設定することを許しますが、そのようにすることは物理的にはおかしなことです。
+しかし、データベースが完全にRAMにキャッシュされる場合、同じ値に設定することは意味を持ちます。
+この場合、順序通りではないページアクセスに対するペナルティが存在しないからです。
+また、多くがキャッシュされるデータベースでは、CPUパラメータに対して両値を小さく設定すべきです。
+RAM内に存在するページの取り出しコストは通常よりもかなり小さくなるためです。
+        </para>
+       </tip>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-cpu-tuple-cost" xreflabel="cpu_tuple_cost">
+      <term><varname>cpu_tuple_cost</varname> (<type>floating point</type>)
+      <indexterm>
+      <!--
+       <primary><varname>cpu_tuple_cost</> configuration parameter</primary>
+       -->
+       <primary><varname>cpu_tuple_cost</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the planner's estimate of the cost of processing
+        each row during a query.
+        The default is 0.01.
+       -->
+問い合わせ時のそれぞれの行の処理コストに対するプランナの推測を設定します。
+デフォルトは0.01です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-cpu-index-tuple-cost" xreflabel="cpu_index_tuple_cost">
+      <term><varname>cpu_index_tuple_cost</varname> (<type>floating point</type>)
+      <indexterm>
+      <!--
+       <primary><varname>cpu_index_tuple_cost</> configuration parameter</primary>
+       -->
+       <primary><varname>cpu_index_tuple_cost</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the planner's estimate of the cost of processing
+        each index entry during an index scan.
+        The default is 0.005.
+       -->
+インデックス走査時のそれぞれのインデックス行の処理コストに対するプランナの推測を設定します。
+デフォルトは0.005です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-cpu-operator-cost" xreflabel="cpu_operator_cost">
+      <term><varname>cpu_operator_cost</varname> (<type>floating point</type>)
+      <indexterm>
+      <!--
+       <primary><varname>cpu_operator_cost</> configuration parameter</primary>
+       -->
+       <primary><varname>cpu_operator_cost</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the planner's estimate of the cost of processing each
+        operator or function executed during a query.
+        The default is 0.0025.
+       -->
+       問い合わせ時に実行される各演算子や関数の処理コストに対するプランナの推測を設定します。デフォルトは0.0025です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-parallel-setup-cost" xreflabel="parallel_setup_cost">
+      <term><varname>parallel_setup_cost</varname> (<type>floating point</type>)
+      <indexterm>
+<!--
+       <primary><varname>parallel_setup_cost</> configuration parameter</primary>
+-->
+       <primary><varname>parallel_setup_cost</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Sets the planner's estimate of the cost of launching parallel worker
+        processes.
+        The default is 1000.
+-->
+パラレルワーカープロセスを起動するためのコストに対するプランナの推測値を設定します。
+デフォルトは1000です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-parallel-tuple-cost" xreflabel="parallel_tuple_cost">
+      <term><varname>parallel_tuple_cost</varname> (<type>floating point</type>)
+      <indexterm>
+<!--
+       <primary><varname>parallel_tuple_cost</> configuration parameter</primary>
+-->
+       <primary><varname>parallel_tuple_cost</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Sets the planner's estimate of the cost of transferring one tuple
+        from a parallel worker process to another process.
+        The default is 0.1.
+-->
+あるパラレルワーカープロセスから、1行を他のプロセスに転送するためのコストに対するプランナの推測値を設定します。
+デフォルトは0.1です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-min-parallel-table-scan-size" xreflabel="min_parallel_table_scan_size">
+      <term><varname>min_parallel_table_scan_size</varname> (<type>integer</type>)
+      <indexterm>
+<!--
+       <primary><varname>min_parallel_table_scan_size</> configuration parameter</primary>
+-->
+       <primary><varname>min_parallel_relation_size</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Sets the minimum amount of table data that must be scanned in order
+        for a parallel scan to be considered.  For a parallel sequential scan,
+        the amount of table data scanned is always equal to the size of the
+        table, but when indexes are used the amount of table data
+        scanned will normally be less.  The default is 8
+        megabytes (<literal>8MB</>).
+-->
+パラレルスキャンを考慮する最小のテーブルデータのサイズを指定します。
+パラレル順スキャンでは、スキャンされるテーブルのデータ量は、常にテーブルのサイズと同じです。
+しかし、インデックスが使われる場合は、スキャンされるテーブルの量は通常少なくなるでしょう。
+デフォルトは8メガバイト（ <literal>8MB</>）です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-min-parallel-index-scan-size" xreflabel="min_parallel_index_scan_size">
+      <term><varname>min_parallel_index_scan_size</varname> (<type>integer</type>)
+      <indexterm>
+<!--
+       <primary><varname>min_parallel_index_scan_size</> configuration parameter</primary>
+-->
+       <primary><varname>min_parallel_index_scan_size</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Sets the minimum amount of index data that must be scanned in order
+        for a parallel scan to be considered.  Note that a parallel index scan
+        typically won't touch the entire index; it is the number of pages
+        which the planner believes will actually be touched by the scan which
+        is relevant.  The default is 512 kilobytes (<literal>512kB</>).
+-->
+パラレルスキャンが考慮されるために、スキャンされなければならないインデックスデータの最小量を設定します。
+通常パラレルインデックススキャンは、典型的にはインデックス全体をアクセスしないことに注意してください。
+これは、関連するスキャンにより、プランナが実際にアクセスされると信じるページ数です。
+デフォルトは512キロバイト（<literal>512kB</>）です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-effective-cache-size" xreflabel="effective_cache_size">
+      <term><varname>effective_cache_size</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>effective_cache_size</> configuration parameter</primary>
+       -->
+       <primary><varname>effective_cache_size</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the planner's assumption about the effective size of the
+        disk cache that is available to a single query.  This is
+        factored into estimates of the cost of using an index; a
+        higher value makes it more likely index scans will be used, a
+        lower value makes it more likely sequential scans will be
+        used. When setting this parameter you should consider both
+        <productname>PostgreSQL</productname>'s shared buffers and the
+        portion of the kernel's disk cache that will be used for
+        <productname>PostgreSQL</productname> data files.  Also, take
+        into account the expected number of concurrent queries on different
+        tables, since they will have to share the available
+        space.  This parameter has no effect on the size of shared
+        memory allocated by <productname>PostgreSQL</productname>, nor
+        does it reserve kernel disk cache; it is used only for estimation
+        purposes.  The system also does not assume data remains in
+        the disk cache between queries.  The default is 4 gigabytes
+        (<literal>4GB</>).
+       -->
+単一の問い合わせで利用できるディスクキャッシュの実効容量に関するプランナの条件を設定します。
+これは、インデックスを使用するコスト推定値の要素となります。
+より高い値にすれば、よりインデックススキャンが使用されるようになり、より小さく設定すれば、シーケンシャルスキャンがより使用されるようになります。
+このパラメータを設定する時には、<productname>PostgreSQL</productname>の共有バッファと<productname>PostgreSQL</productname>データファイルに使用されるカーネルのディスクキャッシュの量の両方を考慮しなければなりません。
+また、利用可能な領域を共有しますので、異なるテーブルに対して同時に実行される問い合わせの想定数も考慮してください。
+このパラメータは、<productname>PostgreSQL</productname>で割り当てられる共有メモリの大きさには影響を与えません。また、カーネルのディスクキャッシュを予約したりもしません。
+これは推定目的のみで使用されます。
+同時に、システムは問い合わせの間のディスクキャッシュ内のデータの残滓を想定していません。
+デフォルトは4ギガバイト（<literal>4GB</>）です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+
+    </sect2>
+     <sect2 id="runtime-config-query-geqo">
+     <!--
+     <title>Genetic Query Optimizer</title>
+     -->
+     <title>遺伝的問い合わせオプティマイザ</title>
+
+     <para>
+     <!--
+      The genetic query optimizer (GEQO) is an algorithm that does query
+      planning using heuristic searching.  This reduces planning time for
+      complex queries (those joining many relations), at the cost of producing
+      plans that are sometimes inferior to those found by the normal
+      exhaustive-search algorithm.
+      For more information see <xref linkend="geqo">.
+      -->
+      遺伝的問い合わせオプティマイザ（GEQO）はヒューリスティック（発見的）検索法を用いた問い合わせ計画を行なう演算手法です。
+      通常のしらみつぶしの検索演算手法で見いだされる計画よりも時として劣った計画を作成するという代償を払いますが、この手法は（多くのリレーションを結合するような）複雑な問い合わせに対し計画時間を軽減します。
+      より詳細は<xref linkend="geqo">を参照してください。
+     </para>
+
+     <variablelist>
+
+     <varlistentry id="guc-geqo" xreflabel="geqo">
+      <term><varname>geqo</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary>genetic query optimization</primary>
+       -->
+       <primary>遺伝的問い合わせ最適化</primary>
+      </indexterm>
+      <indexterm>
+       <primary>GEQO</primary>
+       <!--
+       <see>genetic query optimization</see>
+       -->
+       <see>遺伝的問い合わせ最適化</see>
+      </indexterm>
+      <indexterm>
+      <!--
+       <primary><varname>geqo</> configuration parameter</primary>
+       -->
+       <primary><varname>geqo</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables or disables genetic query optimization.
+        This is on by default.  It is usually best not to turn it off in
+        production; the <varname>geqo_threshold</varname> variable provides
+        more granular control of GEQO.
+       -->
+       遺伝的問い合わせ最適化を有効もしくは無効にします。デフォルトは有効です。
+       運用時には無効にしないことが通常最善です。<varname>geqo_threshold</varname>変数は、GEQOを制御するためよりきめ細かな方法を提供します。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-geqo-threshold" xreflabel="geqo_threshold">
+      <term><varname>geqo_threshold</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>geqo_threshold</> configuration parameter</primary>
+       -->
+       <primary><varname>geqo_threshold</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Use genetic query optimization to plan queries with at least
+        this many <literal>FROM</> items involved. (Note that a
+        <literal>FULL OUTER JOIN</> construct counts as only one <literal>FROM</>
+        item.) The default is 12. For simpler queries it is usually best
+        to use the regular, exhaustive-search planner, but for queries with
+        many tables the exhaustive search takes too long, often
+        longer than the penalty of executing a suboptimal plan.  Thus,
+        a threshold on the size of the query is a convenient way to manage
+        use of GEQO.
+       -->
+少なくともこれだけの数の<literal>FROM</>項目数があるときに、問い合わせを計画するのに遺伝的問い合わせ最適化を使用します。
+（<literal>FULL OUTER JOIN</>の生成子は、<literal>FROM</>項目が１つだけとして計算することに注意してください。）
+デフォルトは12です。
+もっと単純な問い合わせでは、通常の、そしてしらみつぶしの検索プランナを使用するのが最善ですが、多くのテーブルを持つ問い合わせでは、しらみつぶしの検索は非常に時間がかかり、しばしば次善の計画を実行する代償より長くなります。
+従って、問い合わせの大きさに対する閾値はGEQOの使用を管理するのに便利な方法です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-geqo-effort" xreflabel="geqo_effort">
+      <term><varname>geqo_effort</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>geqo_effort</> configuration parameter</primary>
+       -->
+       <primary><varname>geqo_effort</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Controls the trade-off between planning time and query plan
+        quality in GEQO. This variable must be an integer in the
+        range from 1 to 10. The default value is five. Larger values
+        increase the time spent doing query planning, but also
+        increase the likelihood that an efficient query plan will be
+        chosen.
+       -->
+       GEQOにおける計画時間と問い合わせ計画の品質間のトレードオフを制御します。この変数は1から10までの範囲の整数でなければなりません。
+       デフォルトの値は5です。値を大きくすると、問い合わせ計画作成により多くの時間を費すことになりますが、より効率的な問い合わせ計画が選択される可能性が増加します。
+       </para>
+
+       <para>
+       <!--
+        <varname>geqo_effort</varname> doesn't actually do anything
+        directly; it is only used to compute the default values for
+        the other variables that influence GEQO behavior (described
+        below). If you prefer, you can set the other parameters by
+        hand instead.
+       -->
+       実際<varname>geqo_effort</varname>は直接何も行いません。それはGEQOの動作に影響を与える他の変数に対し、デフォルトの値を計算するためにのみ使用されます（以下で説明します）。もしよければ、代わりに手作業で他のパラメータを設定できます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-geqo-pool-size" xreflabel="geqo_pool_size">
+      <term><varname>geqo_pool_size</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>geqo_pool_size</> configuration parameter</primary>
+       -->
+       <primary><varname>geqo_pool_size</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Controls the pool size used by GEQO, that is the
+        number of individuals in the genetic population.  It must be
+        at least two, and useful values are typically 100 to 1000.  If
+        it is set to zero (the default setting) then a suitable
+        value is chosen based on <varname>geqo_effort</varname> and
+        the number of tables in the query.
+       -->
+       GEQOで使用されるプール容量を管理します。それは遺伝的個体群内の個体数です。最低でも2つはなければならず、よく100から1000までの値が使用されます。もし（デフォルトの設定である）零に設定されると、<varname>geqo_effort</varname>および問い合わせの中のテーブル数に基づいて、適切な値が選択されます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-geqo-generations" xreflabel="geqo_generations">
+      <term><varname>geqo_generations</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>geqo_generations</> configuration parameter</primary>
+       -->
+       <primary><varname>geqo_generations</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Controls the number of generations used by GEQO, that is
+        the number of iterations of the algorithm.  It must
+        be at least one, and useful values are in the same range as
+        the pool size.  If it is set to zero (the default setting)
+        then a suitable value is chosen based on
+        <varname>geqo_pool_size</varname>.
+       -->
+       GEQOで使用される世代の数を管理します。それはアルゴリズムの反復数です。最低でも1はなければならず、よくプールサイズと同じ範囲の値が使用されます。これを0に設定（デフォルトの設定）すると、適切な値が<varname>geqo_effort</varname>に基づいて選択されます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-geqo-selection-bias" xreflabel="geqo_selection_bias">
+      <term><varname>geqo_selection_bias</varname> (<type>floating point</type>)
+      <indexterm>
+      <!--
+       <primary><varname>geqo_selection_bias</> configuration parameter</primary>
+       -->
+       <primary><varname>geqo_selection_bias</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Controls the selection bias used by GEQO. The selection bias
+        is the selective pressure within the population. Values can be
+        from 1.50 to 2.00; the latter is the default.
+       -->
+       GEQOで使用される淘汰の偏りを管理します。淘汰の偏りは個体群内の（遺伝的な）自然淘汰です。値は1.50から2.00で、2.00がデフォルトです。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-geqo-seed" xreflabel="geqo_seed">
+      <term><varname>geqo_seed</varname> (<type>floating point</type>)
+      <indexterm>
+      <!--
+       <primary><varname>geqo_seed</> configuration parameter</primary>
+       -->
+       <primary><varname>geqo_seed</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Controls the initial value of the random number generator used
+        by GEQO to select random paths through the join order search space.
+        The value can range from zero (the default) to one.  Varying the
+        value changes the set of join paths explored, and may result in a
+        better or worse best path being found.
+       -->
+結合順序検索空間にわたって、GEQOが無作為のパスを選択するために使用される乱数発生器の初期値を制御します。
+値は0（デフォルト）から1までの範囲です。
+値を変動させると探査される結合パスの集合が変化するため、見つかる最善のパスが良くなる場合も悪くなる場合もあります。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+    </sect2>
+     <sect2 id="runtime-config-query-other">
+     <!--
+     <title>Other Planner Options</title>
+     -->
+     <title>その他のプランナオプション</title>
+
+     <variablelist>
+
+     <varlistentry id="guc-default-statistics-target" xreflabel="default_statistics_target">
+      <term><varname>default_statistics_target</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>default_statistics_target</> configuration parameter</primary>
+       -->
+       <primary><varname>default_statistics_target</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the default statistics target for table columns without
+        a column-specific target set via <command>ALTER TABLE
+        SET STATISTICS</>.  Larger values increase the time needed to
+        do <command>ANALYZE</>, but might improve the quality of the
+        planner's estimates. The default is 100. For more information
+        on the use of statistics by the <productname>PostgreSQL</>
+        query planner, refer to <xref linkend="planner-stats">.
+       -->
+       <command>ALTER TABLE SET STATISTICS</>で列特定の目的セットの無いテーブル列に対し、デフォルトの統計対象を設定します。
+より大きい値は<command>ANALYZE</>に必要な時間を増加させますが、プランナの予測の品質を向上させます。
+デフォルトは100です。
+<productname>PostgreSQL</>の問い合わせプランナによる統計情報の使用方法に関するより詳細な情報は、<xref linkend="planner-stats">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-constraint-exclusion" xreflabel="constraint_exclusion">
+      <term><varname>constraint_exclusion</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary>constraint exclusion</primary>
+       -->
+       <primary>制約除外</primary>
+      </indexterm>
+      <indexterm>
+      <!--
+       <primary><varname>constraint_exclusion</> configuration parameter</primary>
+       -->
+       <primary><varname>constraint_exclusion</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Controls the query planner's use of table constraints to
+        optimize queries.
+        The allowed values of <varname>constraint_exclusion</> are
+        <literal>on</> (examine constraints for all tables),
+        <literal>off</> (never examine constraints), and
+        <literal>partition</> (examine constraints only for inheritance child
+        tables and <literal>UNION ALL</> subqueries).
+        <literal>partition</> is the default setting.
+        It is often used with inheritance and partitioned tables to
+        improve performance.
+       -->
+       問い合わせを最適化するため、テーブル制約に対しての問い合わせプランナの使用を制御します。<varname>constraint_exclusion</>に許容される値は、<literal>on</>（全てのテーブルに対し制約を検査する）、<literal>off</>（決して制約を検査しない）、および<literal>partition</>（継承された子テーブルおよび<literal>UNION ALL</>副問い合わせのみ制約を検査する）です。<literal>partition</>がデフォルトです。
+継承テーブルと分割されたテーブルの性能向上のためしばしば使用されます。
+      </para>
+
+       <para>
+       <!--
+        When this parameter allows it for a particular table, the planner
+        compares query conditions with the table's <literal>CHECK</>
+        constraints, and omits scanning tables for which the conditions
+        contradict the constraints.  For example:
+       -->
+       このパラメータが特定のテーブルに対して許される時、プランナはそのテーブルの<literal>CHECK</>制約で問い合わせ条件を比較し、制約と矛盾する条件のテーブルの走査を省きます。
+例えば以下のようになります。
+
+<programlisting>
+CREATE TABLE parent(key integer, ...);
+CREATE TABLE child1000(check (key between 1000 and 1999)) INHERITS(parent);
+CREATE TABLE child2000(check (key between 2000 and 2999)) INHERITS(parent);
+...
+SELECT * FROM parent WHERE key = 2400;
+</programlisting>
+
+<!--
+        With constraint exclusion enabled, this <command>SELECT</>
+        will not scan <structname>child1000</> at all, improving performance.
+       -->
+       制約排除が有効であると、この<command>SELECT</>は全く<structname>child1000</>を走査せず、性能を向上させます。
+       </para>
+
+       <para>
+       <!--
+        Currently, constraint exclusion is enabled by default
+        only for cases that are often used to implement table partitioning.
+        Turning it on for all tables imposes extra planning overhead that is
+        quite noticeable on simple queries, and most often will yield no
+        benefit for simple queries.  If you have no partitioned tables
+        you might prefer to turn it off entirely.
+       -->
+       現在<varname>constraint_exclusion</>はデフォルトで、テーブルパーティショニングを実装するためによく使用される場合のみで有効です。
+       すべてのテーブルを有効にすることは、計画作成において単純な問い合わせでは無視できない程の余計なオーバーヘッドをもたらします。
+       パーティショニングされたテーブルがない場合、完全に無効にする方が良いでしょう。
+       </para>
+
+       <para>
+       <!--
+        Refer to <xref linkend="ddl-partitioning-constraint-exclusion"> for
+        more information on using constraint exclusion and partitioning.
+       -->
+       制約排除とテーブル分割についてのより進んだ情報は<xref linkend="ddl-partitioning-constraint-exclusion">を参照ください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-cursor-tuple-fraction" xreflabel="cursor_tuple_fraction">
+      <term><varname>cursor_tuple_fraction</varname> (<type>floating point</type>)
+      <indexterm>
+      <!--
+       <primary><varname>cursor_tuple_fraction</> configuration parameter</primary>
+       -->
+       <primary><varname>cursor_tuple_fraction</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the planner's estimate of the fraction of a cursor's rows that
+        will be retrieved.  The default is 0.1.  Smaller values of this
+        setting bias the planner towards using <quote>fast start</> plans
+        for cursors, which will retrieve the first few rows quickly while
+        perhaps taking a long time to fetch all rows.  Larger values
+        put more emphasis on the total estimated time.  At the maximum
+        setting of 1.0, cursors are planned exactly like regular queries,
+        considering only the total estimated time and not how soon the
+        first rows might be delivered.
+       -->
+       検索されるカーソル行の割合のプランナの見積もりを設定します。
+       デフォルトは0.1です。
+       この設定をより小さくすると、プランナはカーソルに対し<quote>起動を高速にする</>計画を使用するようになりがちになります。
+       この場合先頭の数行の取り出しは高速になりますが、行全体を取り出す場合に時間がかかるようになる可能性があります。
+       この値をより大きくすると、推定時間全体がより強調されるようになります。
+       最大の設定である1.0の場合、カーソルは通常の問い合わせとまったく同様に計画されます。
+       つまり、推定時間全体のみが考慮され、先頭の行の取り出しにかかる時間は考慮されなくなります。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-from-collapse-limit" xreflabel="from_collapse_limit">
+      <term><varname>from_collapse_limit</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>from_collapse_limit</> configuration parameter</primary>
+       -->
+       <primary><varname>from_collapse_limit</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        The planner will merge sub-queries into upper queries if the
+        resulting <literal>FROM</literal> list would have no more than
+        this many items.  Smaller values reduce planning time but might
+        yield inferior query plans.  The default is eight.
+        For more information see <xref linkend="explicit-joins">.
+       -->
+       プランナは、<literal>FROM</literal>リストがこの数の項目より少ない結果の場合、副問い合わせを上位の問い合わせに併合します。
+より小さい値は計画時間を縮小させますが、劣った問い合わせ計画をもたらす可能性があります。
+デフォルトは8です。
+詳細は<xref linkend="explicit-joins">を参照してください。
+       </para>
+
+       <para>
+       <!--
+        Setting this value to <xref linkend="guc-geqo-threshold"> or more
+        may trigger use of the GEQO planner, resulting in non-optimal
+        plans.  See <xref linkend="runtime-config-query-geqo">.
+       -->
+       この値を<xref linkend="guc-geqo-threshold">か、それ以上に設定するとGEQOプランナ使用の誘引となり、最適ではない計画をもたらします。<xref linkend="runtime-config-query-geqo">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+<!-- split-config1-end -->

--- a/doc/src/sgml/config2.sgml
+++ b/doc/src/sgml/config2.sgml
@@ -1,0 +1,3220 @@
+<!-- 警告：このファイルは直接編集しないでください！
+1. config.sgmlを編集したら、split-config.shを起動します。
+2. するとconfig[0-3].sgmlが生成されます。
+3. config.sgmlとともにconfig[0-3].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
+4. レビューはconfig[0-3].sgmlに対して行います。
+5. 指摘された点があればconfig.sgmlに反映し、1に戻ります。
+6. config.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
+-->
+<!-- split-config2-start -->
+
+     <varlistentry id="guc-join-collapse-limit" xreflabel="join_collapse_limit">
+      <term><varname>join_collapse_limit</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>join_collapse_limit</> configuration parameter</primary>
+       -->
+       <primary><varname>join_collapse_limit</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        The planner will rewrite explicit <literal>JOIN</>
+        constructs (except <literal>FULL JOIN</>s) into lists of
+        <literal>FROM</> items whenever a list of no more than this many items
+        would result.  Smaller values reduce planning time but might
+        yield inferior query plans.
+       -->
+       最終的にリストがこの項目数以下になる時、プランナは、明示的な<literal>JOIN</>構文（<literal>FULL JOIN</>を除く）を<literal>FROM</>項目のリストに直します。
+この値を小さくすれば計画作成時間は減少しますが、劣った問い合わせ計画が作成される可能性があります。
+       </para>
+
+       <para>
+       <!--
+        By default, this variable is set the same as
+        <varname>from_collapse_limit</varname>, which is appropriate
+        for most uses. Setting it to 1 prevents any reordering of
+        explicit <literal>JOIN</>s. Thus, the explicit join order
+        specified in the query will be the actual order in which the
+        relations are joined. Because the query planner does not always choose
+        the optimal join order, advanced users can elect to
+        temporarily set this variable to 1, and then specify the join
+        order they desire explicitly.
+        For more information see <xref linkend="explicit-joins">.
+       -->
+       デフォルトでは、この値は<varname>from_collapse_limit</varname>と同じ値に設定されており、殆どの場合に適切です。
+これを1に設定すると明示的な<literal>JOIN</>の再順序付けは行われなくなります。
+したがって、問い合わせで指定された明示的結合順序は、関係（リレーション）が結合される実際の順序となります。
+問い合わせプランナは常に最適な結合順序を選択するとは限らないので、
+上級ユーザなら暫定的にこの変数を1に設定し、明示的に希望とする結合順序を指定してもよいでしょう。
+詳細は<xref linkend="explicit-joins">を参照してください。
+       </para>
+
+       <para>
+       <!--
+        Setting this value to <xref linkend="guc-geqo-threshold"> or more
+        may trigger use of the GEQO planner, resulting in non-optimal
+        plans.  See <xref linkend="runtime-config-query-geqo">.
+       -->
+       この値を<xref linkend="guc-geqo-threshold">か、それ以上に設定するとGEQOプランナ使用の誘引となり、最適ではない計画をもたらします。<xref linkend="runtime-config-query-geqo">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-force-parallel-mode" xreflabel="force_parallel_mode">
+      <term><varname>force_parallel_mode</varname> (<type>enum</type>)
+      <indexterm>
+<!--
+       <primary><varname>force_parallel_mode</> configuration parameter</primary>
+-->
+       <primary><varname>force_parallel_mode</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Allows the use of parallel queries for testing purposes even in cases
+        where no performance benefit is expected.
+        The allowed values of <varname>force_parallel_mode</> are
+        <literal>off</> (use parallel mode only when it is expected to improve
+        performance), <literal>on</> (force parallel query for all queries
+        for which it is thought to be safe), and <literal>regress</> (like
+        <literal>on</>, but with additional behavior changes as explained
+        below).
+-->
+性能改善が期待できなくても、テスト目的のためにパラレルクエリを利用できるようにします。
+<varname>force_parallel_mode</>に設定できる値は、<literal>off</>（性能改善が期待できるときにだけパラレルクエリを使用する）、<literal>on</>（安全なクエリに対しては常にパラレルクエリを強制する）、<literal>regress</>（<literal>on</>と同様だが、下記のような振る舞いの変更を伴う）です。
+       </para>
+
+       <para>
+<!--
+        More specifically, setting this value to <literal>on</> will add
+        a <literal>Gather</> node to the top of any query plan for which this
+        appears to be safe, so that the query runs inside of a parallel worker.
+        Even when a parallel worker is not available or cannot be used,
+        operations such as starting a subtransaction that would be prohibited
+        in a parallel query context will be prohibited unless the planner
+        believes that this will cause the query to fail.  If failures or
+        unexpected results occur when this option is set, some functions used
+        by the query may need to be marked <literal>PARALLEL UNSAFE</literal>
+        (or, possibly, <literal>PARALLEL RESTRICTED</literal>).
+-->
+正確に言えば、この値を<literal>on</>にすると、安全と見なされるすべての問い合わせ計画の上に<literal>Gather</>ノードを追加し、クエリをパラレルワーカー上で実行するようにします。
+プランナがこれによってクエリが失敗すると思わない限り、パラレルワーカーが利用できない、あるいは使用できないような場合でも、たとえばサブトランザクションの開始のように、パラレルクエリコンテキストでは許可されない操作は不許可となります。
+このオプションを設定することによって、エラーとなったり、あるいは期待していなかった結果がもたらされる場合には、クエリで使用されている関数は<literal>PARALLEL UNSAFE</literal>（もしくは、<literal>PARALLEL RESTRICTED</literal>）と印を付ける必要があるかもしません。
+       </para>
+
+       <para>
+<!--
+        Setting this value to <literal>regress</> has all of the same effects
+        as setting it to <literal>on</> plus some additional effects that are
+        intended to facilitate automated regression testing.  Normally,
+        messages from a parallel worker include a context line indicating that,
+        but a setting of <literal>regress</> suppresses this line so that the
+        output is the same as in non-parallel execution.  Also,
+        the <literal>Gather</> nodes added to plans by this setting are hidden
+        in <literal>EXPLAIN</> output so that the output matches what
+        would be obtained if this setting were turned <literal>off</>.
+-->
+この設定値を<literal>regress</>とすると、<literal>on</>とするのに加え、自動リグレッションテストを助けるための付加的な効果が現れます。
+通常パラレルワーカーからのメッセージは、そのことを表すコンテキスト行を表示しますが、<literal>regress</>と設定すると、非パラレル実行と同じ出力になるように、これを抑止します。
+また、プランに追加された<literal>Gather</>ノードは、<literal>EXPLAIN</>出力から隠され、<literal>off</>に設定したときと同じ出力が得られるようにします。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+    </sect2>
+   </sect1>
+
+   <sect1 id="runtime-config-logging">
+   <!--
+    <title>Error Reporting and Logging</title>
+    -->
+    <title>エラー報告とログ取得</title>
+
+    <indexterm zone="runtime-config-logging">
+    <!--
+     <primary>server log</primary>
+     -->
+     <primary>サーバログ</primary>
+    </indexterm>
+
+    <sect2 id="runtime-config-logging-where">
+    <!--
+     <title>Where To Log</title>
+     -->
+     <title>ログの出力先</title>
+
+     <indexterm zone="runtime-config-logging-where">
+     <!--
+      <primary>where to log</primary>
+      -->
+      <primary>ログの出力先</primary>
+     </indexterm>
+
+     <indexterm>
+       <primary>current_logfiles</primary>
+<!--
+       <secondary>and the log_destination configuration parameter</secondary>
+-->
+       <secondary>およびlog_destination設定パラメータ</secondary>
+     </indexterm>
+
+     <variablelist>
+
+     <varlistentry id="guc-log-destination" xreflabel="log_destination">
+      <term><varname>log_destination</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_destination</> configuration parameter</primary>
+       -->
+       <primary><varname>log_destination</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        <productname>PostgreSQL</productname> supports several methods
+         for logging server messages, including
+         <systemitem>stderr</systemitem>, <systemitem>csvlog</systemitem> and
+         <systemitem>syslog</systemitem>. On Windows,
+         <systemitem>eventlog</systemitem> is also supported. Set this
+         parameter to a list of desired log destinations separated by
+         commas. The default is to log to <systemitem>stderr</systemitem>
+         only.
+         This parameter can only be set in the <filename>postgresql.conf</>
+         file or on the server command line.
+        -->
+        <productname>PostgreSQL</productname>は、<systemitem>stderr</systemitem>、<systemitem>csvlog</systemitem>および<systemitem>syslog</systemitem>を含めて、サーバメッセージのログ取得に対し数種類の方法を提供します。
+Windowsでは、<systemitem>eventlog</systemitem>も同時に提供します。
+このパラメータを設定するには、コンマ区切りでお好みのログ出力先を記載します。
+デフォルトでは、ログは<systemitem>stderr</systemitem>のみに出力されます。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定されます。
+       </para>
+       <para>
+       <!--
+        If <systemitem>csvlog</> is included in <varname>log_destination</>,
+        log entries are output in <quote>comma separated
+        value</> (<acronym>CSV</>) format, which is convenient for
+        loading logs into programs.
+        See <xref linkend="runtime-config-logging-csvlog"> for details.
+        <xref linkend="guc-logging-collector"> must be enabled to generate
+        CSV-format log output.
+       -->
+       <systemitem>csvlog</>が<varname>log_destination</>に含まれる場合、ログ項目はプログラムへの読み込みが簡便な<quote>カンマ区切り値</>書式（<acronym>CSV</>）で出力されます。
+詳細は<xref linkend="runtime-config-logging-csvlog">を参照してください。
+CSV書式のログ出力を生成するためには<xref linkend="guc-logging-collector">を有効にする必要があります。
+       </para>
+       <para>
+<!--
+        When either <systemitem>stderr</systemitem> or
+        <systemitem>csvlog</systemitem> are included, the file
+        <filename>current_logfiles</> is created to record the location
+        of the log file(s) currently in use by the logging collector and the
+        associated logging destination. This provides a convenient way to
+        find the logs currently in use by the instance. Here is an example of
+        this file's content:
+-->
+<systemitem>stderr</systemitem>あるいは<systemitem>csvlog</systemitem>が含まれる場合、ログ収集機構が使用しているログファイルの場所と、その出力先を記録する<filename>current_logfiles</>が作られます。
+これにより、現在のインスタンスが使っているログを簡単に見つけることができます。
+このファイルの内容の例を示します。
+<programlisting>
+stderr log/postgresql.log
+csvlog log/postgresql.csv
+</programlisting>
+
+<!--
+        <filename>current_logfiles</filename> is recreated when a new log file
+        is created as an effect of rotation, and
+        when <varname>log_destination</> is reloaded.  It is removed when
+        neither <systemitem>stderr</systemitem>
+        nor <systemitem>csvlog</systemitem> are included
+        in <varname>log_destination</>, and when the logging collector is
+        disabled.
+-->
+ログローテーションの効果で新しいログファイルが作られると、<filename>current_logfiles</filename>は再作成され、<varname>log_destination</>は再ロードされます。
+このファイルは、<systemitem>stderr</systemitem>も<systemitem>csvlog</systemitem>も<varname>log_destination</>に含まれなくなり、かつログ収集機構が無効になったときに削除されます。
+       </para>
+
+       <note>
+        <para>
+       <!--
+         On most Unix systems, you will need to alter the configuration of
+         your system's <application>syslog</application> daemon in order
+         to make use of the <systemitem>syslog</systemitem> option for
+         <varname>log_destination</>.  <productname>PostgreSQL</productname>
+         can log to <application>syslog</application> facilities
+         <literal>LOCAL0</> through <literal>LOCAL7</> (see <xref
+         linkend="guc-syslog-facility">), but the default
+         <application>syslog</application> configuration on most platforms
+         will discard all such messages.  You will need to add something like:
+        -->
+        <varname>log_destination</>で<systemitem>syslog</systemitem>オプションを使用できるようにするために、ほとんどのUnixシステムではシステムの<application>syslog</application>デーモンの設定を変更しなければならないでしょう。
+<productname>PostgreSQL</productname>ではログを<literal>LOCAL0</>から<literal>LOCAL7</>までの<application>syslog</application>ファシリティで記録することができます（<xref linkend="guc-syslog-facility">を参照してください）。
+しかし、ほとんどのプラットフォームのデフォルトの<application>syslog</application>設定ではこれらのメッセージはすべて破棄されます。
+うまく動作させるために<application>syslog</application>デーモンの設定に以下のようなものを追加しなければならないでしょう。
+<programlisting>
+local0.*    /var/log/postgresql
+</programlisting>
+        <!--
+         to the  <application>syslog</application> daemon's configuration file
+         to make it work.
+        -->
+        </para>
+        <para>
+       <!--
+         On Windows, when you use the <literal>eventlog</literal>
+         option for <varname>log_destination</>, you should
+         register an event source and its library with the operating
+         system so that the Windows Event Viewer can display event
+         log messages cleanly.
+         See <xref linkend="event-log-registration"> for details.
+        -->
+        Windowsで<varname>log_destination</>に対し<literal>eventlog</literal>オプションを使用する場合、Windows Event Viewer がイベントログメッセージを手際良く表示できるよう、オペレーティングシステムでイベントソースとそのライブラリを登録しなければなりません。
+        詳細は<xref linkend="event-log-registration">を参照ください。
+        </para>
+       </note>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-logging-collector" xreflabel="logging_collector">
+      <term><varname>logging_collector</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>logging_collector</> configuration parameter</primary>
+       -->
+       <primary><varname>logging_collector</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+         This parameter enables the <firstterm>logging collector</>, which
+         is a background process that captures log messages
+         sent to <systemitem>stderr</> and redirects them into log files.
+         This approach is often more useful than
+         logging to <application>syslog</>, since some types of messages
+         might not appear in <application>syslog</> output.  (One common
+         example is dynamic-linker failure messages; another is error messages
+         produced by scripts such as <varname>archive_command</>.)
+         This parameter can only be set at server start.
+        -->
+このパラメータは<firstterm>ログ収集機構</>を有効にします。
+それは<systemitem>stderr</>に送られたログメッセージを捕捉し、ログファイルにリダイレクトするバックグラウンドプロセスです。
+この手法は<application>syslog</>へのログよりもしばしば有用です。
+メッセージの一部の種類が<application>syslog</>では出力されない可能性があるためです。
+（一般的な例として、ダイナミックリンカのエラーメッセージがあり、その他の例として<varname>archive_command</>のようなスクリプトにより生成されたエラーメッセージが挙げられます）。
+このパラメータはサーバ起動時のみ設定可能です。
+       </para>
+
+       <note>
+        <para>
+       <!--
+         It is possible to log to <systemitem>stderr</> without using the
+         logging collector; the log messages will just go to wherever the
+         server's <systemitem>stderr</> is directed.  However, that method is
+         only suitable for low log volumes, since it provides no convenient
+         way to rotate log files.  Also, on some platforms not using the
+         logging collector can result in lost or garbled log output, because
+         multiple processes writing concurrently to the same log file can
+         overwrite each other's output.
+        -->
+        ログ収集機構を使用せずに<systemitem>stderr</>のログを取ることは可能です。
+        ログメッセージはサーバの<systemitem>stderr</>が指し示すいかなる場所にも向かうだけです。
+        しかし、その方法はログファイルを巡回させる都合のよい方法を提供しないので、ログ容量が小さい場合のみに適しています。
+        同時に、ログ収集機構を使用しないいくつかのプラットフォームにおいては、ログ出力が失われたり、文字化けします。なぜなら、同一のログファイルに同時に書き込みを行うマルチプロセッサはそれぞれの出力を上書きできるからです。
+        </para>
+       </note>
+
+       <note>
+        <para>
+       <!--
+          The logging collector is designed to never lose messages.  This means
+          that in case of extremely high load, server processes could be
+          blocked while trying to send additional log messages when the
+          collector has fallen behind.  In contrast, <application>syslog</>
+          prefers to drop messages if it cannot write them, which means it
+          may fail to log some messages in such cases but it will not block
+          the rest of the system.
+         -->
+ログ収集機構はメッセージを決して失わないために設計されています。
+これは、極端に高い負荷の場合、サーバプロセスはコレクタが遅れをとった場合、追加のログメッセージを送信しようと試みる時に阻止される可能性があります。
+それとは対象的に<application>syslog</>は、もし書き込みができなかったときメッセージの廃棄を選びます。
+これらの場合にはいくつかのログメッセージを失うことになりますが、残ったシステムを阻止しません。
+        </para>
+       </note>
+
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-directory" xreflabel="log_directory">
+      <term><varname>log_directory</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_directory</> configuration parameter</primary>
+       -->
+       <primary><varname>log_directory</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        When <varname>logging_collector</> is enabled,
+        this parameter determines the directory in which log files will be created.
+        It can be specified as an absolute path, or relative to the
+        cluster data directory.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+        The default is <literal>log</literal>.
+       -->
+       <varname>logging_collector</varname>を有効と設定した場合、このパラメータはログファイルが作成されるディレクトリを確定します。
+        ディレクトリは、絶対パス、もしくはデータベースクラスタのディレクトリに対する相対パスで指定することができます。
+        このパラメータは<filename>postgresql.conf</>ファイル、またはサーバコマンドラインからのみ設定可能です。
+デフォルトは<literal>log</literal>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-filename" xreflabel="log_filename">
+      <term><varname>log_filename</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_filename</> configuration parameter</primary>
+       -->
+       <primary><varname>log_filename</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        When <varname>logging_collector</varname> is enabled,
+        this parameter sets the file names of the created log files.  The value
+        is treated as a <function>strftime</function> pattern,
+        so <literal>%</literal>-escapes can be used to specify time-varying
+        file names.  (Note that if there are
+        any time-zone-dependent <literal>%</literal>-escapes, the computation
+        is done in the zone specified
+        by <xref linkend="guc-log-timezone">.)
+        The supported <literal>%</literal>-escapes are similar to those
+        listed in the Open Group's <ulink
+        url="http://pubs.opengroup.org/onlinepubs/009695399/functions/strftime.html">strftime
+        </ulink> specification.
+        Note that the system's <function>strftime</function> is not used
+        directly, so platform-specific (nonstandard) extensions do not work.
+        The default is <literal>postgresql-%Y-%m-%d_%H%M%S.log</literal>.
+       -->
+       <varname>logging_collector</varname>が有効な場合、このパラメータは作成されたログファイルのファイル名を設定します。
+値は<function>strftime</function>パターンとして扱われるため、<literal>%</literal>エスケープを使用して、時刻によって変動するファイル名を指定することができます。
+（時間帯に依存した<literal>%</literal>エスケープが存在する場合、<xref
+linkend="guc-log-timezone">で指定された時間帯で計算が行われます。）
+サポートされている<literal>%</literal>-エスケープは<ulink
+        url="http://pubs.opengroup.org/onlinepubs/009695399/functions/strftime.html">strftime</ulink> 仕様によく似ています。
+システムの<systemitem>strftime</systemitem>は直接使用されないので、プラットフォーム固有の（非標準）の拡張は動作しません。
+デフォルトは<literal>postgresql-%Y-%m-%d_%H%M%S.log</literal>です。
+       </para>
+       <para>
+       <!--
+        If you specify a file name without escapes, you should plan to
+        use a log rotation utility to avoid eventually filling the
+        entire disk.  In releases prior to 8.4, if
+        no <literal>%</literal> escapes were
+        present, <productname>PostgreSQL</productname> would append
+        the epoch of the new log file's creation time, but this is no
+        longer the case.
+       -->
+       エスケープすることなくファイル名を指定する場合、ディスク全体を使い切ってしまうことを防止するためにログローテーションを行うユーティリティを使用することを計画しなければなりません。
+       8.4より前のリリースの<productname>PostgreSQL</productname>では、<literal>%</literal>エスケープがなければ、新しいログファイルの生成時のエポック時刻を付与しますが、これはもはや当てはまりません。
+       </para>
+       <para>
+       <!--
+        If CSV-format output is enabled in <varname>log_destination</>,
+        <literal>.csv</> will be appended to the timestamped
+        log file name to create the file name for CSV-format output.
+        (If <varname>log_filename</> ends in <literal>.log</>, the suffix is
+        replaced instead.)
+       -->
+       CSV書式の出力が<varname>log_destination</>で有効な場合、タイムスタンプ付きのログファイル名に<literal>.csv</>を付与し、最終的なCSV書式出力用のファイル名が作成されます。
+（log_filenameが<literal>.log</>で終わる場合は後置詞が置き換えられます。）
+       </para>
+       <para>
+       <!--
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+このパラメータは<filename>postgresql.conf</>ファイルか、サーバコマンドラインのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-file-mode" xreflabel="log_file_mode">
+      <term><varname>log_file_mode</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_file_mode</> configuration parameter</primary>
+       -->
+       <primary><varname>log_file_mode</> 設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        On Unix systems this parameter sets the permissions for log files
+        when <varname>logging_collector</varname> is enabled. (On Microsoft
+        Windows this parameter is ignored.)
+        The parameter value is expected to be a numeric mode
+        specified in the format accepted by the
+        <function>chmod</function> and <function>umask</function>
+        system calls.  (To use the customary octal format the number
+        must start with a <literal>0</literal> (zero).)
+       -->
+       Unixシステムにおいては、<varname>logging_collector</varname>が有効になっている場合、このパラメータはログファイルのパーミッションを設定します。
+       （Microsoft Windowsではこのパラメータは無視されます。）
+       パラメータの値は<function>chmod</function> および <function>umask</function>システムコールで許容されるフォーマットで指定される数値モードであると期待されます。
+       （慣例的な8進数フォーマットを使用する場合、番号は<literal>0</literal>（ゼロ）で始まらなければなりません。
+       </para>
+       <para>
+       <!--
+        The default permissions are <literal>0600</>, meaning only the
+        server owner can read or write the log files.  The other commonly
+        useful setting is <literal>0640</>, allowing members of the owner's
+        group to read the files.  Note however that to make use of such a
+        setting, you'll need to alter <xref linkend="guc-log-directory"> to
+        store the files somewhere outside the cluster data directory.  In
+        any case, it's unwise to make the log files world-readable, since
+        they might contain sensitive data.
+       -->
+       デフォルトのパーミッションは<literal>0600</>で、意味するところはサーバの所有者のみログファイルの読み書きが可能です。
+       そのほか一般的に実用的な設定は<literal>0640</>で、所有者のグループはファイルを読み込めます。
+       しかし、これらの設定を活用するには<xref linkend="guc-log-directory">がクラスタデータディレクトリの外部のどこかにあるファイルを格納できるように変更する必要があります。
+       </para>
+       <para>
+<!--
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+       このパラメータは<filename>postgresql.conf</>ファイル、またはサーバコマンドラインからのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-rotation-age" xreflabel="log_rotation_age">
+      <term><varname>log_rotation_age</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_rotation_age</> configuration parameter</primary>
+       -->
+       <primary><varname>log_rotation_age</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        When <varname>logging_collector</varname> is enabled,
+        this parameter determines the maximum lifetime of an individual log file.
+        After this many minutes have elapsed, a new log file will
+        be created.  Set to zero to disable time-based creation of
+        new log files.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+       <varname>logging_collector</varname>が有効な場合、このパラメータは個々のログファイルの最大寿命を決定します。
+ここで指定した時間（分単位）経過すると、新しいログファイルが生成されます。
+ゼロに設定することで、時間に基づいた新しいログファイルの生成は無効になります。
+このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-rotation-size" xreflabel="log_rotation_size">
+      <term><varname>log_rotation_size</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_rotation_size</> configuration parameter</primary>
+       -->
+       <primary><varname>log_rotation_size</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        When <varname>logging_collector</varname> is enabled,
+        this parameter determines the maximum size of an individual log file.
+        After this many kilobytes have been emitted into a log file,
+        a new log file will be created.  Set to zero to disable size-based
+        creation of new log files.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+<varname>logging_collector</varname>が有効な場合、このパラメータは個々のログファイルの最大容量を決定します。
+ここで指定したキロバイト分ログファイルに出力された後、新しいログファイルが生成されます。
+ゼロに設定することで、サイズに基づいた新しいログファイルの生成は無効になります。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-truncate-on-rotation" xreflabel="log_truncate_on_rotation">
+      <term><varname>log_truncate_on_rotation</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_truncate_on_rotation</> configuration parameter</primary>
+       -->
+       <primary><varname>log_truncate_on_rotation</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        When <varname>logging_collector</varname> is enabled,
+        this parameter will cause <productname>PostgreSQL</productname> to truncate (overwrite),
+        rather than append to, any existing log file of the same name.
+        However, truncation will occur only when a new file is being opened
+        due to time-based rotation, not during server startup or size-based
+        rotation.  When off, pre-existing files will be appended to in
+        all cases.  For example, using this setting in combination with
+        a <varname>log_filename</varname> like <literal>postgresql-%H.log</literal>
+        would result in generating twenty-four hourly log files and then
+        cyclically overwriting them.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+       <varname>logging_collector</varname>が有効な場合、このパラメータにより、<productname>PostgreSQL</productname>は既存の同名のファイルに追加するのではなく、そのファイルを切り詰める（上書きする）ようになります。
+しかし、切り詰めは時間を基にしたローテーションのために新規にファイルが開かれた時にのみ発生し、サーバ起動時やサイズを基にしたローテーションでは発生しません。
+偽の場合、全ての場合において既存のファイルは追記されます。
+例えば、この設定を<literal>postgresql-%H.log</literal>のような<varname>log_filename</varname>と組み合わせて使用すると、24個の時別のログファイルが生成され、それらは周期的に上書きされることになります。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインで設定されます。
+       </para>
+       <para>
+<!--
+        Example:  To keep 7 days of logs, one log file per day named
+        <literal>server_log.Mon</literal>, <literal>server_log.Tue</literal>,
+        etc, and automatically overwrite last week's log with this week's log,
+        set <varname>log_filename</varname> to <literal>server_log.%a</literal>,
+        <varname>log_truncate_on_rotation</varname> to <literal>on</literal>, and
+        <varname>log_rotation_age</varname> to <literal>1440</literal>.
+-->
+例：7日間のログを保存し、毎日のログを <literal>server_log.Mon</literal>、<literal>server_log.Tue</literal>、等とし、そして自動的に前週のログを今週のログで上書きするには以下のように設定します。
+<varname>log_filename</varname> を <literal>server_log.%a</literal>とし、<varname>log_truncate_on_rotation</varname> を <literal>on</literal>にし、そして<varname>log_rotation_age</varname> を <literal>1440</literal>に設定します。
+       </para>
+       <para>
+<!--
+        Example: To keep 24 hours of logs, one log file per hour, but
+        also rotate sooner if the log file size exceeds 1GB, set
+        <varname>log_filename</varname> to <literal>server_log.%H%M</literal>,
+        <varname>log_truncate_on_rotation</varname> to <literal>on</literal>,
+        <varname>log_rotation_age</varname> to <literal>60</literal>, and
+        <varname>log_rotation_size</varname> to <literal>1000000</literal>.
+        Including <literal>%M</> in <varname>log_filename</varname> allows
+        any size-driven rotations that might occur to select a file name
+        different from the hour's initial file name.
+-->
+例：24時間のログを保持、1時間おきに1つのログファイルを作成、ただし、ログファイルのサイズが1ギガバイトを超えた場合それより早く切り替えさせるには、<varname>log_filename</varname>を<literal>server_log.%H%M</literal>にし、<varname>log_truncate_on_rotation</varname>を<literal>on</literal>にし、<varname>log_rotation_age</varname>を<literal>60</literal>にし、そして<varname>log_rotation_size</varname>を<literal>1000000</literal>に設定します。
+<varname>log_filename</varname>に<literal>%M</>を含めると、サイズを元にしたローテーションが時間毎の始めのファイル名とは異なる名前のファイルを選択するようにできます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-syslog-facility" xreflabel="syslog_facility">
+      <term><varname>syslog_facility</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>syslog_facility</> configuration parameter</primary>
+       -->
+       <primary><varname>syslog_facility</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        When logging to <application>syslog</> is enabled, this parameter
+        determines the <application>syslog</application>
+        <quote>facility</quote> to be used.  You can choose
+        from <literal>LOCAL0</>, <literal>LOCAL1</>,
+        <literal>LOCAL2</>, <literal>LOCAL3</>, <literal>LOCAL4</>,
+        <literal>LOCAL5</>, <literal>LOCAL6</>, <literal>LOCAL7</>;
+        the default is <literal>LOCAL0</>. See also the
+        documentation of your system's
+        <application>syslog</application> daemon.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+       <application>syslog</>へのログ取得が有効な場合、このパラメータは<application>syslog</application>の<quote>facility</quote>が使われるように確定します。
+<literal>LOCAL0</>、<literal>LOCAL1</>、<literal>LOCAL2</>、<literal>LOCAL3</>、<literal>LOCAL4</>、<literal>LOCAL5</>、<literal>LOCAL6</>、<literal>LOCAL7</>の中から選んでください。
+デフォルトは<literal>LOCAL0</>です。
+使用しているシステムの<application>syslog</application>デーモンの文書を同時に参照してください。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-syslog-ident" xreflabel="syslog_ident">
+      <term><varname>syslog_ident</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>syslog_ident</> configuration parameter</primary>
+       -->
+       <primary><varname>syslog_ident</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+       <listitem>
+        <para>
+       <!--
+         When logging to <application>syslog</> is enabled, this parameter
+         determines the program name used to identify
+         <productname>PostgreSQL</productname> messages in
+         <application>syslog</application> logs. The default is
+         <literal>postgres</literal>.
+         This parameter can only be set in the <filename>postgresql.conf</>
+         file or on the server command line.
+        -->
+        <application>syslog</>にログ取得が有効な場合、このパラメータは<application>syslog</application>ログ内の<productname>PostgreSQL</productname>メッセージを特定するのに使用するプログラム名を確定します。デフォルトは<literal>postgres</literal>です。
+このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry id="guc-syslog-sequence-numbers" xreflabel="syslog_sequence_numbers">
+       <term><varname>syslog_sequence_numbers</varname> (<type>boolean</type>)
+        <indexterm>
+<!--
+         <primary><varname>syslog_sequence_numbers</> configuration parameter</primary>
+-->
+         <primary><varname>syslog_sequence_numbers</>設定パラメータ</primary>
+        </indexterm>
+       </term>
+
+       <listitem>
+        <para>
+<!--
+         When logging to <application>syslog</application> and this is on (the
+         default), then each message will be prefixed by an increasing
+         sequence number (such as <literal>[2]</literal>).  This circumvents
+         the <quote>&#045;&#045;- last message repeated N times &#045;&#045;-</quote> suppression
+         that many syslog implementations perform by default.  In more modern
+         syslog implementations, repeated message suppression can be configured
+         (for example, <literal>$RepeatedMsgReduction</literal>
+         in <productname>rsyslog</productname>), so this might not be
+         necessary.  Also, you could turn this off if you actually want to
+         suppress repeated messages.
+-->
+<application>syslog</application>にログを出力している場合で、これがオン（デフォルト）であると、各メッセージには（<literal>[2]</literal>のような）増加する順序数が頭に追加されます。
+これにより、多くのsyslogの実装がデフォルトで行う<quote>--- last message repeated N times ---</quote>による出力の抑止が回避されます。
+より近代的なsyslogの実装では、繰り返されるメッセージの抑止は設定変更できるので（たとえば、<productname>rsyslog</productname>)における<literal>$RepeatedMsgReduction</literal>）、この機能は必要ないかもしれません。
+繰り返されるメッセージを抑止したい場合には、これをオフにできます。
+        </para>
+
+        <para>
+<!--
+         This parameter can only be set in the <filename>postgresql.conf</>
+         file or on the server command line.
+-->
+このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+        </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-syslog-split-messages" xreflabel="syslog_split_messages">
+      <term><varname>syslog_split_messages</varname> (<type>boolean</type>)
+      <indexterm>
+<!--
+       <primary><varname>syslog_split_messages</> configuration parameter</primary>
+-->
+       <primary><varname>syslog_split_messages</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        When logging to <application>syslog</> is enabled, this parameter
+        determines how messages are delivered to syslog.  When on (the
+        default), messages are split by lines, and long lines are split so
+        that they will fit into 1024 bytes, which is a typical size limit for
+        traditional syslog implementations.  When off, PostgreSQL server log
+        messages are delivered to the syslog service as is, and it is up to
+        the syslog service to cope with the potentially bulky messages.
+-->
+<application>syslog</>へのログ出力が有効な場合、このパラメータはメッセージがどのようにsyslogに送られるかを規定します。
+オンなら（デフォルト）、メッセージは行に分割され、長い行は、伝統的なsyslog実装のサイズ上限でである1024バイト以内に分割されます。
+オフならば、PostgreSQLサーバログメッセージは、そのままsyslogサービスに送られます。
+大きなサイズになるかもしれないメッセージにどう対応するかは、syslogサービス次第となります。
+       </para>
+
+       <para>
+<!--
+        If syslog is ultimately logging to a text file, then the effect will
+        be the same either way, and it is best to leave the setting on, since
+        most syslog implementations either cannot handle large messages or
+        would need to be specially configured to handle them.  But if syslog
+        is ultimately writing into some other medium, it might be necessary or
+        more useful to keep messages logically together.
+-->
+もしsyslogが最終的にテキストファイルにログを出力するのであれば、どちらに設定しても効果は同じです。
+設定値をオンにしておくのが最善です。
+多くのsyslogの実装では、長いメッセージを扱えないか、長いメッセージを扱うための特別な設定が必要だからです。
+しかし、syslogが最終的に他のメディアに書き込むのであれば、メッセージを論理的に一緒にしておくことが必要か、もしくは有用です。
+       </para>
+
+       <para>
+<!--
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+-->
+このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-event-source" xreflabel="event_source">
+      <term><varname>event_source</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>event_source</> configuration parameter</primary>
+       -->
+       <primary><varname>event_source</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        When logging to <application>event log</> is enabled, this parameter
+        determines the program name used to identify
+        <productname>PostgreSQL</productname> messages in
+        the log. The default is <literal>PostgreSQL</literal>.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+       <application>event log</>へのログ取得が有効になっていると、このパラメータはログ中の<productname>PostgreSQL</productname>メッセージを特定するのに使用されるプログラム名を決定します。デフォルトは<literal>PostgreSQL</literal>です。このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+      </variablelist>
+    </sect2>
+     <sect2 id="runtime-config-logging-when">
+     <!--
+     <title>When To Log</title>
+     -->
+     <title>いつログを取得するか</title>
+
+     <variablelist>
+
+     <varlistentry id="guc-client-min-messages" xreflabel="client_min_messages">
+      <term><varname>client_min_messages</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>client_min_messages</> configuration parameter</primary>
+       -->
+       <primary><varname>client_min_messages</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Controls which message levels are sent to the client.
+        Valid values are <literal>DEBUG5</>,
+        <literal>DEBUG4</>, <literal>DEBUG3</>, <literal>DEBUG2</>,
+        <literal>DEBUG1</>, <literal>LOG</>, <literal>NOTICE</>,
+        <literal>WARNING</>, <literal>ERROR</>, <literal>FATAL</>,
+        and <literal>PANIC</>.  Each level
+        includes all the levels that follow it.  The later the level,
+        the fewer messages are sent.  The default is
+        <literal>NOTICE</>.  Note that <literal>LOG</> has a different
+        rank here than in <varname>log_min_messages</>.
+       -->
+       どのメッセージ階層をクライアントに送るかを管理します。有効な値は、<literal>DEBUG5</>、
+        <literal>DEBUG4</>、<literal>DEBUG3</>、<literal>DEBUG2</>、
+        <literal>DEBUG1</>、<literal>LOG</>、<literal>NOTICE</>、
+        <literal>WARNING</>、<literal>ERROR</>、<literal>FATAL</>、および<literal>PANIC</>です。それぞれの階層はそれに続く全ての階層を包含します。階層が後の方になるにつれ、より少ないメッセージが送られます。デフォルトは<literal>NOTICE</>です。ここでの<literal>LOG</>の優先順位が<varname>log_min_messages</>の場合と異なることに注意してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-min-messages" xreflabel="log_min_messages">
+      <term><varname>log_min_messages</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_min_messages</> configuration parameter</primary>
+       -->
+       <primary><varname>log_min_messages</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Controls which message levels are written to the server log.
+        Valid values are <literal>DEBUG5</>, <literal>DEBUG4</>,
+        <literal>DEBUG3</>, <literal>DEBUG2</>, <literal>DEBUG1</>,
+        <literal>INFO</>, <literal>NOTICE</>, <literal>WARNING</>,
+        <literal>ERROR</>, <literal>LOG</>, <literal>FATAL</>, and
+        <literal>PANIC</>.  Each level includes all the levels that
+        follow it.  The later the level, the fewer messages are sent
+        to the log.  The default is <literal>WARNING</>.  Note that
+        <literal>LOG</> has a different rank here than in
+        <varname>client_min_messages</>.
+        Only superusers can change this setting.
+       -->
+       どのメッセージ階層をサーバログに書き込むかを管理します。有効な値は
+        <literal>DEBUG5</>、<literal>DEBUG4</>、
+        <literal>DEBUG3</>、<literal>DEBUG2</>、<literal>DEBUG1</>、
+        <literal>INFO</>、<literal>NOTICE</>、<literal>WARNING</>、
+        <literal>ERROR</>、<literal>LOG</>、<literal>FATAL</>、および
+        <literal>PANIC</>です。それぞれの階層はその下の全ての階層を含みます。階層を低くする程、より少ないメッセージがログに送られます。デフォルトは<literal>WARNING</>です。ここでの<literal>LOG</>の優先順位が<varname>client_min_messages</>の場合と異なることに注意してください。スーパーユーザのみこの設定を変更できます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-min-error-statement" xreflabel="log_min_error_statement">
+      <term><varname>log_min_error_statement</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_min_error_statement</> configuration parameter</primary>
+       -->
+       <primary><varname>log_min_error_statement</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Controls which SQL statements that cause an error
+        condition are recorded in the server log.  The current
+        SQL statement is included in the log entry for any message of
+        the specified severity or higher.
+        Valid values are <literal>DEBUG5</literal>,
+        <literal>DEBUG4</literal>, <literal>DEBUG3</literal>,
+        <literal>DEBUG2</literal>, <literal>DEBUG1</literal>,
+        <literal>INFO</literal>, <literal>NOTICE</literal>,
+        <literal>WARNING</literal>, <literal>ERROR</literal>,
+        <literal>LOG</literal>,
+        <literal>FATAL</literal>, and <literal>PANIC</literal>.
+        The default is <literal>ERROR</literal>, which means statements
+        causing errors, log messages, fatal errors, or panics will be logged.
+        To effectively turn off logging of failing statements,
+        set this parameter to <literal>PANIC</literal>.
+        Only superusers can change this setting.
+       -->
+       エラー条件の原因となったどのSQL文をサーバログに記録するかを制御します。
+設定したレベル以上のメッセージについては現在のSQL文がログに記録されます。
+有効な値は、<literal>DEBUG5</literal>、<literal>DEBUG4</literal>、<literal>DEBUG3</literal>、<literal>DEBUG2</literal>、<literal>DEBUG1</literal>、<literal>INFO</literal>、<literal>NOTICE</literal>、<literal>WARNING</literal>、<literal>ERROR</literal>、<literal>LOG</literal>、<literal>FATAL</literal>、<literal>PANIC</literal>です。
+デフォルトは<literal>ERROR</literal>です。
+エラー、ログメッセージ、致命的エラー、パニックを引き起こした文がログに記録されることを意味します。
+失敗した文の記録を実質的に無効にするには、このパラメータを<literal>PANIC</literal>に設定してください。
+スーパーユーザのみがこのオプションを変更することができます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-min-duration-statement" xreflabel="log_min_duration_statement">
+      <term><varname>log_min_duration_statement</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_min_duration_statement</> configuration parameter</primary>
+       -->
+       <primary><varname>log_min_duration_statement</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+       <listitem>
+        <para>
+       <!--
+         Causes the duration of each completed statement to be logged
+         if the statement ran for at least the specified number of
+         milliseconds.  Setting this to zero prints all statement durations.
+         Minus-one (the default) disables logging statement durations.
+         For example, if you set it to <literal>250ms</literal>
+         then all SQL statements that run 250ms or longer will be
+         logged.  Enabling this parameter can be helpful in tracking down
+         unoptimized queries in your applications.
+         Only superusers can change this setting.
+        -->
+        文の実行に少なくとも指定したミリ秒数かかった場合、それぞれの文の実行に要した時間をログに記録します。
+0に設定すれば、すべての文の実行時間が出力されます。
+-1（デフォルト）は、文実行時間の記録を無効にします。
+例えば、<literal>250ms</literal>と設定した場合、250msもしくはそれ以上長くかかった全てのSQL文がログとして残ります。
+このパラメータを有効にすることにより、アプリケーションで最適化されていない問い合わせを追跡するのが便利になります。
+スーパーユーザのみこの設定を変更できます。
+        </para>
+
+        <para>
+       <!--
+         For clients using extended query protocol, durations of the Parse,
+         Bind, and Execute steps are logged independently.
+        -->
+        拡張問い合わせプロトコルを使用するクライアントでは、Parse、Bind、Executeそれぞれの段階で要した時間が独立して記録されます。
+        </para>
+
+       <note>
+        <para>
+       <!--
+         When using this option together with
+         <xref linkend="guc-log-statement">,
+         the text of statements that are logged because of
+         <varname>log_statement</> will not be repeated in the
+         duration log message.
+         If you are not using <application>syslog</>, it is recommended
+         that you log the PID or session ID using
+         <xref linkend="guc-log-line-prefix">
+         so that you can link the statement message to the later
+         duration message using the process ID or session ID.
+        -->
+        このオプションと<xref linkend="guc-log-statement">を一緒に使用する時、<varname>log_statement</>によってログされるテキスト文は、実行時間のログには重複されません。
+<application>syslog</>を使用していなければ、プロセスIDとセッションIDを使用して、文メッセージと後の実行時間メッセージを関連付けできるように、<xref linkend="guc-log-line-prefix">を使用してPIDまたはセッションIDをログに記録することを勧めます。
+        </para>
+       </note>
+       </listitem>
+      </varlistentry>
+
+     </variablelist>
+
+    <para>
+    <!--
+     <xref linkend="runtime-config-severity-levels"> explains the message
+     severity levels used by <productname>PostgreSQL</>.  If logging output
+     is sent to <systemitem>syslog</systemitem> or Windows'
+     <systemitem>eventlog</systemitem>, the severity levels are translated
+     as shown in the table.
+     -->
+     <xref linkend="runtime-config-severity-levels">で、<productname>PostgreSQL</>で使用されるメッセージ深刻度レベルを説明します。
+ログ出力が<systemitem>syslog</systemitem>またはWindowsの<systemitem>eventlog</systemitem>に送られる場合、この深刻度レベルは表で示すように変換されます。
+    </para>
+
+    <table id="runtime-config-severity-levels">
+    <!--
+     <title>Message Severity Levels</title>
+     -->
+     <title>メッセージ深刻度レベル</title>
+     <tgroup cols="4">
+      <thead>
+       <row>
+       <!--
+        <entry>Severity</entry>
+        <entry>Usage</entry>
+        <entry><systemitem>syslog</></entry>
+        <entry><systemitem>eventlog</></entry>
+       -->
+       <entry>深刻度</entry>
+        <entry>使用方法</entry>
+        <entry><systemitem>syslog</></entry>
+        <entry><systemitem>eventlog</></entry>
+       </row>
+      </thead>
+
+      <tbody>
+       <row>
+        <entry><literal>DEBUG1..DEBUG5</></entry>
+       <!--
+        <entry>Provides successively-more-detailed information for use by
+         developers.</entry>
+        -->
+        <entry>開発者が使用する連続的かつより詳細な情報を提供します。</entry>
+        <entry><literal>DEBUG</></entry>
+        <entry><literal>INFORMATION</></entry>
+       </row>
+
+       <row>
+        <entry><literal>INFO</></entry>
+       <!--
+        <entry>Provides information implicitly requested by the user,
+         e.g., output from <command>VACUUM VERBOSE</>.</entry>
+        -->
+        <entry><command>VACUUM VERBOSE</>の出力などの、
+        ユーザによって暗黙的に要求された情報を提供します。</entry>
+        <entry><literal>INFO</></entry>
+        <entry><literal>INFORMATION</></entry>
+       </row>
+
+       <row>
+        <entry><literal>NOTICE</></entry>
+       <!--
+        <entry>Provides information that might be helpful to users, e.g.,
+         notice of truncation of long identifiers.</entry>
+        -->
+        <entry>長い識別子の切り詰めに関する注意など、
+        ユーザの補助になる情報を提供します。</entry>
+        <entry><literal>NOTICE</></entry>
+        <entry><literal>INFORMATION</></entry>
+       </row>
+
+       <row>
+        <entry><literal>WARNING</></entry>
+       <!--
+        <entry>Provides warnings of likely problems, e.g., <command>COMMIT</>
+         outside a transaction block.</entry>
+        -->
+        <entry>トランザクションブロック外での<command>COMMIT</>の様な、
+        ユーザへの警告を提供します。</entry>
+        <entry><literal>NOTICE</></entry>
+        <entry><literal>WARNING</></entry>
+       </row>
+
+       <row>
+        <entry><literal>ERROR</></entry>
+       <!--
+        <entry>Reports an error that caused the current command to
+         abort.</entry>
+        -->
+        <entry>現在のコマンドを中断させる原因となったエラーを報告します。</entry>
+        <entry><literal>WARNING</></entry>
+        <entry><literal>ERROR</></entry>
+       </row>
+
+       <row>
+        <entry><literal>LOG</></entry>
+       <!--
+        <entry>Reports information of interest to administrators, e.g.,
+         checkpoint activity.</entry>
+        -->
+        <entry>チェックポイントの活動の様な、
+        管理者に関心のある情報を報告します。</entry>
+        <entry><literal>INFO</></entry>
+        <entry><literal>INFORMATION</></entry>
+       </row>
+
+       <row>
+        <entry><literal>FATAL</></entry>
+       <!--
+        <entry>Reports an error that caused the current session to
+         abort.</entry>
+        -->
+        <entry>現在のセッションを中断させる原因となったエラーを報告します。</entry>
+        <entry><literal>ERR</></entry>
+        <entry><literal>ERROR</></entry>
+       </row>
+
+       <row>
+        <entry><literal>PANIC</></entry>
+       <!--
+        <entry>Reports an error that caused all database sessions to abort.</entry>
+       -->
+       <entry>全てのデータベースセッションを中断させる原因となったエラーを報告します。</entry>
+        <entry><literal>CRIT</></entry>
+        <entry><literal>ERROR</></entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </table>
+
+    </sect2>
+     <sect2 id="runtime-config-logging-what">
+     <!--
+     <title>What To Log</title>
+     -->
+     <title>何をログに</title>
+
+     <variablelist>
+
+     <varlistentry id="guc-application-name" xreflabel="application_name">
+      <term><varname>application_name</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>application_name</> configuration parameter</primary>
+       -->
+       <primary><varname>application_name</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        The <varname>application_name</varname> can be any string of less than
+        <symbol>NAMEDATALEN</> characters (64 characters in a standard build).
+        It is typically set by an application upon connection to the server.
+        The name will be displayed in the <structname>pg_stat_activity</> view
+        and included in CSV log entries.  It can also be included in regular
+        log entries via the <xref linkend="guc-log-line-prefix"> parameter.
+        Only printable ASCII characters may be used in the
+        <varname>application_name</varname> value. Other characters will be
+        replaced with question marks (<literal>?</literal>).
+       -->
+<varname>application_name</varname>は<symbol>NAMEDATALEN</>（標準構築では64）文字以下の任意の文字列を指定できます。
+通常はサーバへの接続時にアプリケーションによって設定されます。
+この名前は <structname>pg_stat_activity</>ビューに表示され、CSVログに含まれます。
+また<xref linkend="guc-log-line-prefix">パラメータにより通常のログ項目に含めることができます。
+<varname>application_name</varname>には表示可能なASCII文字のみ使用することができ、それ以外の文字は疑問符（<literal>?</literal>）に置換されます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
+      <term><varname>debug_print_parse</varname> (<type>boolean</type>)
+      <indexterm>
+<!--
+       <primary><varname>debug_print_parse</> configuration parameter</primary>
+-->
+       <primary><varname>debug_print_parse</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <term><varname>debug_print_rewritten</varname> (<type>boolean</type>)
+      <indexterm>
+<!--
+       <primary><varname>debug_print_rewritten</> configuration parameter</primary>
+-->
+       <primary><varname>debug_print_rewritten</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <term><varname>debug_print_plan</varname> (<type>boolean</type>)
+      <indexterm>
+<!--
+       <primary><varname>debug_print_plan</> configuration parameter</primary>
+-->
+       <primary><varname>debug_print_plan</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        These parameters enable various debugging output to be emitted.
+        When set, they print the resulting parse tree, the query rewriter
+        output, or the execution plan for each executed query.
+        These messages are emitted at <literal>LOG</> message level, so by
+        default they will appear in the server log but will not be sent to the
+        client.  You can change that by adjusting
+        <xref linkend="guc-client-min-messages"> and/or
+        <xref linkend="guc-log-min-messages">.
+        These parameters are off by default.
+       -->
+       これらのパラメータは生成される各種デバッグ出力を有効にします。
+       設定すると実行された問い合わせそれぞれに対し、最終的な解析ツリー、問い合わせリライタの出力、実行計画を出力します。
+       これらのメッセージは<literal>LOG</>メッセージレベルで出力されますので、デフォルトではサーバログに出力され、クライアントには渡されません。
+       <xref linkend="guc-client-min-messages">、<xref linkend="guc-log-min-messages">またはその両方を調整することで変更することができます。
+       デフォルトではこれらのパラメータは無効です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
+      <term><varname>debug_pretty_print</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>debug_pretty_print</> configuration parameter</primary>
+       -->
+       <primary><varname>debug_pretty_print</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        When set, <varname>debug_pretty_print</varname> indents the messages
+        produced by <varname>debug_print_parse</varname>,
+        <varname>debug_print_rewritten</varname>, or
+        <varname>debug_print_plan</varname>.  This results in more readable
+        but much longer output than the <quote>compact</> format used when
+        it is off.  It is on by default.
+       -->
+       設定された場合、<varname>debug_print_parse</varname>、
+       <varname>debug_print_rewritten</varname>、または
+        <varname>debug_print_plan</varname>で生成されたメッセージを字下げします。設定されない場合の<quote>コンパクト</>形式よりもより見やすく、しかしより長いものとなります。デフォルトは有効です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-checkpoints" xreflabel="log_checkpoints">
+      <term><varname>log_checkpoints</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_checkpoints</> configuration parameter</primary>
+       -->
+       <primary><varname>log_checkpoints</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Causes checkpoints and restartpoints to be logged in the server log.
+        Some statistics are included in the log messages, including the number
+        of buffers written and the time spent writing them.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line. The default is off.
+       -->
+       チェックポイントおよびリスタートポイントをサーバログに記録するようにします。
+       書き出されたバッファ数や書き出しに要した時間など、いくつかの統計情報がこのログメッセージに含まれます。
+このパラメータは<filename>postgresql.conf</>ファイルまたはサーバのコマンドラインでのみ設定可能です。
+デフォルトはoffです。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-connections" xreflabel="log_connections">
+      <term><varname>log_connections</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_connections</> configuration parameter</primary>
+       -->
+       <primary><varname>log_connections</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Causes each attempted connection to the server to be logged,
+        as well as successful completion of client authentication.
+        Only superusers can change this parameter at session start,
+        and it cannot be changed at all within a session.
+        The default is <literal>off</>.
+       -->
+       これにより、クライアント認証の成功終了などのサーバへの接続試行がログに残ります。
+スーパーユーザだけがセッション開始時にこのパラメータを変更でき、セッションが開始された後は変更できません。
+デフォルトは<literal>off</>です。
+       </para>
+
+       <note>
+        <para>
+       <!--
+         Some client programs, like <application>psql</>, attempt
+         to connect twice while determining if a password is required, so
+         duplicate <quote>connection received</> messages do not
+         necessarily indicate a problem.
+        -->
+        <application>psql</>などクライアントプログラムは、パスワードが要求されているかどうか確認するまで2回接続を試みるので、二重の<quote>connection received</>メッセージは必ずしも問題を示すものではありません。
+        </para>
+       </note>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-disconnections" xreflabel="log_disconnections">
+      <term><varname>log_disconnections</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_disconnections</> configuration parameter</primary>
+       -->
+       <primary><varname>log_disconnections</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Causes session terminations to be logged.  The log output
+        provides information similar to <varname>log_connections</varname>,
+        plus the duration of the session.
+        Only superusers can change this parameter at session start,
+        and it cannot be changed at all within a session.
+        The default is <literal>off</>.
+       -->
+セッションの終了をログします。
+ログ出力の情報は<varname>log_connections</varname>と同様で、更にセッションの経過時間が追加されます。
+スーパーユーザだけがセッション開始時にこのパラメータを変更でき、セッションが開始された後は変更できません。
+デフォルトは<literal>off</>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+
+     <varlistentry id="guc-log-duration" xreflabel="log_duration">
+      <term><varname>log_duration</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_duration</> configuration parameter</primary>
+       -->
+       <primary><varname>log_duration</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Causes the duration of every completed statement to be logged.
+        The default is <literal>off</>.
+        Only superusers can change this setting.
+       -->
+       すべての完了した文について、その経過時間をログするようにします。
+デフォルトは<literal>off</>です。
+スーパーユーザのみがこの設定を変更することができます。
+       </para>
+
+       <para>
+       <!--
+        For clients using extended query protocol, durations of the Parse,
+        Bind, and Execute steps are logged independently.
+       -->
+       拡張問い合わせプロトコルを使用するクライアントでは、Parse、Bind、Executeそれぞれの段階で要した時間が独立して記録されます。
+       </para>
+
+       <note>
+        <para>
+       <!--
+         The difference between setting this option and setting
+         <xref linkend="guc-log-min-duration-statement"> to zero is that
+         exceeding <varname>log_min_duration_statement</> forces the text of
+         the query to be logged, but this option doesn't.  Thus, if
+         <varname>log_duration</> is <literal>on</> and
+         <varname>log_min_duration_statement</> has a positive value, all
+         durations are logged but the query text is included only for
+         statements exceeding the threshold.  This behavior can be useful for
+         gathering statistics in high-load installations.
+        -->
+        このオプションと<xref linkend="guc-log-min-duration-statement">を0に設定する方法との違いは、<varname>log_min_duration_statement</>を超えた場合、テキスト版の問い合わせが強制的に出力されるのに対して、このオプションでは出力されないという点です。
+したがって、<varname>log_duration</>が<literal>on</>、かつ、<varname>log_min_duration_statement</>が正の値を持つ場合、すべての経過時間がログに記録されますが、閾値を超えた文のみがテキスト版の問い合わせが含められるようになります。
+この動作は、高負荷なインストレーションで統計情報を収集する際に有用です。
+        </para>
+       </note>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-error-verbosity" xreflabel="log_error_verbosity">
+      <term><varname>log_error_verbosity</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_error_verbosity</> configuration parameter</primary>
+       -->
+       <primary><varname>log_error_verbosity</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Controls the amount of detail written in the server log for each
+        message that is logged.  Valid values are <literal>TERSE</>,
+        <literal>DEFAULT</>, and <literal>VERBOSE</>, each adding more
+        fields to displayed messages.  <literal>TERSE</> excludes
+        the logging of <literal>DETAIL</>, <literal>HINT</>,
+        <literal>QUERY</>, and <literal>CONTEXT</> error information.
+        <literal>VERBOSE</> output includes the <symbol>SQLSTATE</> error
+        code (see also <xref linkend="errcodes-appendix">) and the source code file name, function name,
+        and line number that generated the error.
+        Only superusers can change this setting.
+       -->
+       ログ取得されるそれぞれのメッセージに対し、サーバログに書き込まれる詳細の量を制御します。
+       有効な値は、<literal>TERSE</>、<literal>DEFAULT</>、および<literal>VERBOSE</>で、それぞれは表示されるメッセージにより多くのフィールドを追加します。
+       <literal>TERSE</>は<literal>DETAIL</>、<literal>HINT</>、<literal>QUERY</>、および<literal>CONTEXT</>エラー情報を除外します。
+       <literal>VERBOSE</>出力は、<symbol>SQLSTATE</>エラーコード（<xref linkend="errcodes-appendix">も参照）、および、ソースコードファイル名、関数名、そしてエラーを生成した行番号を含みます。
+       スーパーユーザのみこの設定を変更できます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-hostname" xreflabel="log_hostname">
+      <term><varname>log_hostname</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_hostname</> configuration parameter</primary>
+       -->
+       <primary><varname>log_hostname</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        By default, connection log messages only show the IP address of the
+        connecting host. Turning this parameter on causes logging of the
+        host name as well.  Note that depending on your host name resolution
+        setup this might impose a non-negligible performance penalty.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+       デフォルトでは、接続ログメッセージは接続元ホストのIPアドレスのみを表示します。
+このパラメータを有効にすると、ホスト名もログに残るようになります。
+ホスト名解決方法の設定に依存しますが、これが無視できないほどの性能劣化を起こす可能性があることに注意してください。
+このパラメータは<filename>postgresql.conf</>ファイル内またはサーバのコマンドラインでのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-line-prefix" xreflabel="log_line_prefix">
+      <term><varname>log_line_prefix</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_line_prefix</> configuration parameter</primary>
+       -->
+       <primary><varname>log_line_prefix</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+         This is a <function>printf</>-style string that is output at the
+         beginning of each log line.
+         <literal>%</> characters begin <quote>escape sequences</>
+         that are replaced with status information as outlined below.
+         Unrecognized escapes are ignored. Other
+         characters are copied straight to the log line. Some escapes are
+         only recognized by session processes, and will be treated as empty by
+         background processes such as the main server process. Status
+         information may be aligned either left or right by specifying a
+         numeric literal after the % and before the option. A negative
+         value will cause the status information to be padded on the
+         right with spaces to give it a minimum width, whereas a positive
+         value will pad on the left. Padding can be useful to aid human
+         readability in log files.
+         This parameter can only be set in the <filename>postgresql.conf</>
+         file or on the server command line. The default is
+         <literal>'%m [%p] '</> which logs a time stamp and the process ID.
+         -->
+        これは、各ログ行の先頭に出力する<function>printf</>の書式文字列です。
+<literal>%</>から始まる<quote>エスケープシーケンス</>は、後述の通りのステータス情報で置き換えられます。
+この他のエスケープは無視されます。
+他の文字はそのままログ行に出力されます。
+エスケープの中には、セッションプロセスによってのみ認識可能なものがあり、これらはメインサーバプロセスなどのバックグラウンドプロセスでは空文字として扱われます。
+状態情報はオプション名の%の後か前に数字を指定することにより、左寄せまた右寄せにすることができます。
+数字が負ならば状態情報を右側に空白を詰めて最小限の幅にし、正の値は左に空白を詰めます。
+ログファイルではパディングは人間の視認性を向上させるので有用です。
+このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定することができます。
+デフォルトは、タイムスタンプとプロセスIDをログ出力する<literal>'%m [%p] '</>です。
+
+         <informaltable>
+          <tgroup cols="3">
+           <thead>
+            <row>
+           <!--
+             <entry>Escape</entry>
+             <entry>Effect</entry>
+             <entry>Session only</entry>
+            -->
+            <entry>エスケープ</entry>
+             <entry>効果</entry>
+             <entry>セッションのみ</entry>
+             </row>
+            </thead>
+           <tbody>
+            <row>
+             <entry><literal>%a</literal></entry>
+            <!--
+             <entry>Application name</entry>
+            -->
+            <entry>アプリケーション名</entry>
+             <entry><!--yes-->○</entry>
+            </row>
+            <row>
+             <entry><literal>%u</literal></entry>
+            <!--
+             <entry>User name</entry>
+            -->
+            <entry>ユーザ名</entry>
+             <entry><!--yes-->○</entry>
+            </row>
+            <row>
+             <entry><literal>%d</literal></entry>
+            <!--
+             <entry>Database name</entry>
+            -->
+            <entry>データベース名</entry>
+             <entry><!--yes-->○</entry>
+            </row>
+            <row>
+             <entry><literal>%r</literal></entry>
+            <!--
+             <entry>Remote host name or IP address, and remote port</entry>
+            -->
+            <entry>遠隔ホスト名、またはIPアドレス、およびポート番号</entry>
+             <entry><!--yes-->○</entry>
+            </row>
+            <row>
+             <entry><literal>%h</literal></entry>
+            <!--
+             <entry>Remote host name or IP address</entry>
+            -->
+            <entry>遠隔ホスト名、またはIPアドレス</entry>
+             <entry><!--yes-->○</entry>
+            </row>
+            <row>
+             <entry><literal>%p</literal></entry>
+            <!--
+             <entry>Process ID</entry>
+            -->
+            <entry>プロセス識別子</entry>
+             <entry><!--no-->×</entry>
+            </row>
+            <row>
+             <entry><literal>%t</literal></entry>
+            <!--
+             <entry>Time stamp without milliseconds</entry>
+            -->
+            <entry>ミリ秒無しのタイムスタンプ</entry>
+             <entry><!--no-->×</entry>
+            </row>
+            <row>
+             <entry><literal>%m</literal></entry>
+            <!--
+             <entry>Time stamp with milliseconds</entry>
+            -->
+            <entry>ミリ秒付きタイムスタンプ</entry>
+             <entry><!--no-->×</entry>
+            </row>
+            <row>
+             <entry><literal>%n</literal></entry>
+<!--
+             <entry>Time stamp with milliseconds (as a Unix epoch)</entry>
+-->
+             <entry>ミリ秒付きタイムスタンプ（Unixエポックとして）</entry>
+             <entry><!--no-->×</entry>
+            </row>
+            <row>
+             <entry><literal>%i</literal></entry>
+            <!--
+             <entry>Command tag: type of session's current command</entry>
+            -->
+            <entry>コマンドタグ。セッションの現在のコマンド種類</entry>
+             <entry><!--yes-->○</entry>
+            </row>
+            <row>
+             <entry><literal>%e</literal></entry>
+            <!--
+             <entry>SQLSTATE error code</entry>
+            -->
+            <entry>SQLSTATE エラーコード</entry>
+             <entry><!--no-->×</entry>
+            </row>
+            <row>
+             <entry><literal>%c</literal></entry>
+            <!--
+             <entry>Session ID: see below</entry>
+            -->
+            <entry>セッションID。下記参照</entry>
+             <entry><!--no-->×</entry>
+            </row>
+            <row>
+             <entry><literal>%l</literal></entry>
+            <!--
+             <entry>Number of the log line for each session or process, starting at 1</entry>
+            -->
+            <entry>各セッションまたは各プロセスのログ行の番号。1から始まります。</entry>
+             <entry><!--no-->×</entry>
+            </row>
+            <row>
+             <entry><literal>%s</literal></entry>
+            <!--
+             <entry>Process start time stamp</entry>
+            -->
+            <entry>プロセスの開始タイムスタンプ</entry>
+            <entry><!--no-->×</entry>
+            </row>
+            <row>
+             <entry><literal>%v</literal></entry>
+            <!--
+             <entry>Virtual transaction ID (backendID/localXID)</entry>
+            -->
+            <entry>仮想トランザクションID（backendID/localXID）</entry>
+             <entry><!--no-->×</entry>
+            </row>
+            <row>
+             <entry><literal>%x</literal></entry>
+            <!--
+             <entry>Transaction ID (0 if none is assigned)</entry>
+            -->
+            <entry>トランザクションID （未割り当ての場合は0）</entry>
+             <entry><!--no-->×</entry>
+            </row>
+            <row>
+             <entry><literal>%q</literal></entry>
+            <!--
+             <entry>Produces no output, but tells non-session
+             processes to stop at this point in the string; ignored by
+             session processes</entry>
+            -->
+            <entry>何も出力しません。
+            非セッションプロセスではこのエスケープ以降の出力を停止します。
+            セッションプロセスでは無視されます。</entry>
+             <entry><!--no-->×</entry>
+            </row>
+            <row>
+             <entry><literal>%%</literal></entry>
+            <!--
+             <entry>Literal <literal>%</></entry>
+            -->
+            <entry><literal>%</>文字そのもの</entry>
+             <entry><!--no-->×</entry>
+            </row>
+           </tbody>
+          </tgroup>
+         </informaltable>
+
+        <!--
+         The <literal>%c</> escape prints a quasi-unique session identifier,
+         consisting of two 4-byte hexadecimal numbers (without leading zeros)
+         separated by a dot.  The numbers are the process start time and the
+         process ID, so <literal>%c</> can also be used as a space saving way
+         of printing those items.  For example, to generate the session
+         identifier from <literal>pg_stat_activity</>, use this query:
+        -->
+        <literal>%c</>エスケープは、2つの4バイトの16進数（先頭のゼロは省略）をドットで区切った構成の、準一意なセッション識別子を表示します。
+この数値はプロセスの起動時間とそのプロセスIDです。
+したがって、<literal>%c</>を使用して、これらの項目を出力するための文字数を省略することができます。例として、<literal>pg_stat_activity</>からセッション識別子を生成するには以下の問い合わせを行ないます。
+<programlisting>
+SELECT to_hex(trunc(EXTRACT(EPOCH FROM backend_start))::integer) || '.' ||
+       to_hex(pid)
+FROM pg_stat_activity;
+</programlisting>
+
+       </para>
+
+       <tip>
+        <para>
+       <!--
+         If you set a nonempty value for <varname>log_line_prefix</>,
+         you should usually make its last character be a space, to provide
+         visual separation from the rest of the log line.  A punctuation
+         character can be used too.
+        -->
+        <varname>log_line_prefix</>に空白文字以外の値を設定する場合、通常、ログ行の残りとの区切りを明確にするために、その最後の文字を空白文字にすべきです。
+句読点用の文字も使用できます。
+        </para>
+       </tip>
+
+       <tip>
+        <para>
+       <!--
+         <application>Syslog</> produces its own
+         time stamp and process ID information, so you probably do not want to
+         include those escapes if you are logging to <application>syslog</>.
+        -->
+        <application>Syslog</>は独自にタイムスタンプとプロセスID情報を生成します。
+ですのでおそらく、<application>Syslog</>にログを保管する場合は、こうしたエスケープを含めるとは考えないでしょう。
+        </para>
+       </tip>
+
+       <tip>
+        <para>
+<!--
+         The <literal>%q</> escape is useful when including information that is
+         only available in session (backend) context like user or database
+         name.  For example:
+-->
+<literal>%q</>エスケープは、ユーザやデータベース名のように、セッション（バックエンド）コンテキストでのみ存在する情報を含める場合に有用です。
+<literal>%q</>
+<programlisting>
+log_line_prefix = '%m [%p] %q%u@%d/%a '
+</programlisting>
+        </para>
+       </tip>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-lock-waits" xreflabel="log_lock_waits">
+      <term><varname>log_lock_waits</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_lock_waits</> configuration parameter</primary>
+       -->
+       <primary><varname>log_lock_waits</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Controls whether a log message is produced when a session waits
+        longer than <xref linkend="guc-deadlock-timeout"> to acquire a
+        lock.  This is useful in determining if lock waits are causing
+        poor performance.  The default is <literal>off</>.
+        Only superusers can change this setting.
+       -->
+セッションがロックの獲得までの間に<xref linkend="guc-deadlock-timeout">より長く待機する場合にログメッセージを生成するかどうかを制御します。
+これは、ロック待ちによって性能がでていないのかどうか確認する時に有用です。
+デフォルトは<literal>off</>です。
+スーパーユーザのみこの設定を変更できます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-statement" xreflabel="log_statement">
+      <term><varname>log_statement</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_statement</> configuration parameter</primary>
+       -->
+       <primary><varname>log_statement</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Controls which SQL statements are logged. Valid values are
+        <literal>none</> (off), <literal>ddl</>, <literal>mod</>, and
+        <literal>all</> (all statements). <literal>ddl</> logs all data definition
+        statements, such as <command>CREATE</>, <command>ALTER</>, and
+        <command>DROP</> statements. <literal>mod</> logs all
+        <literal>ddl</> statements, plus data-modifying statements
+        such as <command>INSERT</>,
+        <command>UPDATE</>, <command>DELETE</>, <command>TRUNCATE</>,
+        and <command>COPY FROM</>.
+        <command>PREPARE</>, <command>EXECUTE</>, and
+        <command>EXPLAIN ANALYZE</> statements are also logged if their
+        contained command is of an appropriate type.  For clients using
+        extended query protocol, logging occurs when an Execute message
+        is received, and values of the Bind parameters are included
+        (with any embedded single-quote marks doubled).
+       -->
+       どのSQL文をログに記録するかを制御します。
+有効な値は、<literal>none</>（off）、<literal>ddl</>、<literal>mod</>、および<literal>all</>（全てのメッセージ）です。
+<literal>ddl</>は、<literal>CREATE</>、<literal>ALTER</>、および<literal>DROP</>文といった、データ定義文を全てログに記録します。
+<literal>mod</>は、全ての<literal>ddl</>文に加え、<literal>INSERT</>、<literal>UPDATE</>、<literal>DELETE</>、<literal>TRUNCATE</>、および<literal>COPY FROM</>といった、データ変更文をログに記録します。
+<literal>PREPARE</>と<literal>EXPLAIN ANALYZE</>コマンドも、そこに含まれるコマンドが適切な種類であればログが録られます。
+拡張問い合わせプロトコルを使用するクライアントでは、Executeメッセージを受け取った時にBindパラメータの値が（すべての単一引用符が二重にされた状態で）含まれていた場合、ログに記録されます。
+       </para>
+
+       <para>
+       <!--
+        The default is <literal>none</>. Only superusers can change this
+        setting.
+       -->
+       デフォルトは<literal>none</>です。スーパーユーザのみこの設定を変更できます。
+       </para>
+
+       <note>
+        <para>
+       <!--
+         Statements that contain simple syntax errors are not logged
+         even by the <varname>log_statement</> = <literal>all</> setting,
+         because the log message is emitted only after basic parsing has
+         been done to determine the statement type.  In the case of extended
+         query protocol, this setting likewise does not log statements that
+         fail before the Execute phase (i.e., during parse analysis or
+         planning).  Set <varname>log_min_error_statement</> to
+         <literal>ERROR</> (or lower) to log such statements.
+        -->
+        ログメッセージの発行は、基本解析により文の種類が決まった後に行われますので、<varname>log_statement</> = <literal>all</>という設定を行ったとしても、単純な構文エラーを持つ文は記録されません。
+拡張問い合わせプロトコルの場合も同様に、この設定ではExecute段階以前（つまり、解析や計画作成期間）に失敗した文は記録されません。
+こうした文のログを記録するには、<varname>log_min_error_statement</>を<literal>ERROR</>（以下）に設定してください。
+        </para>
+       </note>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-replication-commands" xreflabel="log_replication_commands">
+      <term><varname>log_replication_commands</varname> (<type>boolean</type>)
+      <indexterm>
+<!--
+       <primary><varname>log_replication_commands</> configuration parameter</primary>
+-->
+       <primary><varname>log_replication_commands</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Causes each replication command to be logged in the server log.
+        See <xref linkend="protocol-replication"> for more information about
+        replication command. The default value is <literal>off</>.
+        Only superusers can change this setting.
+-->
+サーバログにレプリケーションコマンドを記録します。
+レプリケーションコマンドの更なる情報は<xref linkend="protocol-replication">をご覧ください。
+デフォルト値は<literal>off</>です。
+スーパーユーザだけがこの設定を変更できます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-temp-files" xreflabel="log_temp_files">
+      <term><varname>log_temp_files</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_temp_files</> configuration parameter</primary>
+       -->
+       <primary><varname>log_temp_files</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Controls logging of temporary file names and sizes.
+        Temporary files can be
+        created for sorts, hashes, and temporary query results.
+        A log entry is made for each temporary file when it is deleted.
+        A value of zero logs all temporary file information, while positive
+        values log only files whose size is greater than or equal to
+        the specified number of kilobytes.  The
+        default setting is -1, which disables such logging.
+        Only superusers can change this setting.
+       -->
+       一時ファイルのファイル名とサイズのログ出力を制御します。
+一時ファイルはソート処理やハッシュ処理、一時的な問い合わせの結果のために作成されます。
+ログの項目はすべての一時ファイルそれぞれについて削除されたときに生成されます。
+0を指定すると、すべての一時ファイル情報のログが残ります。
+正の数を指定すると、指定した値のキロバイト以上の容量のファイルのみがログに残ります。
+デフォルトの設定は-1で、このログ出力を無効にします。
+スーパーユーザのみがこの設定を変更できます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-timezone" xreflabel="log_timezone">
+      <term><varname>log_timezone</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_timezone</> configuration parameter</primary>
+       -->
+       <primary><varname>log_timezone</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the time zone used for timestamps written in the server log.
+        Unlike <xref linkend="guc-timezone">, this value is cluster-wide,
+        so that all sessions will report timestamps consistently.
+        The built-in default is <literal>GMT</>, but that is typically
+        overridden in <filename>postgresql.conf</>; <application>initdb</>
+        will install a setting there corresponding to its system environment.
+        See <xref linkend="datatype-timezones"> for more information.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+サーバログに書き出す際に使用される時間帯を設定します。
+<xref linkend="guc-timezone">と異なり、すべてのセッションで一貫性を持ってタイムスタンプが報告されるようにこの値はクラスタ全体に適用されます。
+組み込まれているデフォルトは<literal>GMT</>ですが、<filename>postgresql.conf</>により通常は上書きされます。<application>initdb</>によりこれらと関連した設定をシステム環境にインストールされます。
+詳細は<xref linkend="datatype-timezones">を参照してください。
+このパラメータは<filename>postgresql.conf</>ファイル内またはサーバのコマンドラインでのみ設定することができます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+    </sect2>
+     <sect2 id="runtime-config-logging-csvlog">
+     <!--
+     <title>Using CSV-Format Log Output</title>
+     -->
+     <title>CSV書式のログ出力の利用</title>
+
+       <para>
+       <!--
+        Including <literal>csvlog</> in the <varname>log_destination</> list
+        provides a convenient way to import log files into a database table.
+        This option emits log lines in comma-separated-values
+        (<acronym>CSV</>) format,
+        with these columns:
+        time stamp with milliseconds,
+        user name,
+        database name,
+        process ID,
+        client host:port number,
+        session ID,
+        per-session line number,
+        command tag,
+        session start time,
+        virtual transaction ID,
+        regular transaction ID,
+        error severity,
+        SQLSTATE code,
+        error message,
+        error message detail,
+        hint,
+        internal query that led to the error (if any),
+        character count of the error position therein,
+        error context,
+        user query that led to the error (if any and enabled by
+        <varname>log_min_error_statement</>),
+        character count of the error position therein,
+        location of the error in the PostgreSQL source code
+        (if <varname>log_error_verbosity</> is set to <literal>verbose</>),
+        and application name.
+        Here is a sample table definition for storing CSV-format log output:
+       -->
+       <varname>log_destination</>リストに<literal>csvlog</>を含めることは、ログファイルをデータベーステーブルにインポートする簡便な方法を提供します。このオプションはカンマ区切り値書式（<acronym>CSV</>）で以下の列を含むログ行を生成します。
+        ミリ秒単位のtimestamp、
+        ユーザ名、
+        データベース名、
+        プロセス識別子、
+        クライアントホスト：ポート番号、
+        セッション識別子、
+        セッション前行番号、
+        コマンドタグ、
+        セッション開始時間、
+        仮想トランザクション識別子、
+        通常トランザクション識別子、
+        エラーの深刻度、
+        SQL状態コード、
+        エラーメッセージ、
+        詳細エラーメッセージ、
+        ヒント、
+        エラーとなった内部的な問い合わせ（もしあれば）、
+        内部問い合わせにおけるエラー位置の文字数、
+        エラーの文脈、
+        PostgreSQLソースコード上のエラー発生場所（<varname>log_error_verbosity</>が<literal>verbose</>に設定されているならば）
+        アプリケーション名。
+以下にcsvlog出力を格納するためのテーブル定義のサンプルを示します。
+
+<programlisting>
+CREATE TABLE postgres_log
+(
+  log_time timestamp(3) with time zone,
+  user_name text,
+  database_name text,
+  process_id integer,
+  connection_from text,
+  session_id text,
+  session_line_num bigint,
+  command_tag text,
+  session_start_time timestamp with time zone,
+  virtual_transaction_id text,
+  transaction_id bigint,
+  error_severity text,
+  sql_state_code text,
+  message text,
+  detail text,
+  hint text,
+  internal_query text,
+  internal_query_pos integer,
+  context text,
+  query text,
+  query_pos integer,
+  location text,
+  application_name text,
+  PRIMARY KEY (session_id, session_line_num)
+);
+</programlisting>
+       </para>
+
+       <para>
+       <!--
+        To import a log file into this table, use the <command>COPY FROM</>
+        command:
+       -->
+       このテーブルにインポートするためには、<command>COPY FROM</>コマンドを使用してください。
+
+<programlisting>
+COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
+</programlisting>
+       </para>
+
+       <para>
+       <!--
+       There are a few things you need to do to simplify importing CSV log
+       files:
+       -->
+       CSVログファイルをインポートする作業を単純にするためにいくつか必要な作業があります。
+
+       <orderedlist>
+         <listitem>
+           <para>
+          <!--
+            Set <varname>log_filename</varname> and
+            <varname>log_rotation_age</> to provide a consistent,
+            predictable naming scheme for your log files.  This lets you
+            predict what the file name will be and know when an individual log
+            file is complete and therefore ready to be imported.
+           -->
+           一貫性があり、予測可能なログファイル命名機構を提供するために、<varname>log_filename</varname>および<varname>log_rotation_age</>を設定してください。
+これによりどのようなファイル名になると、個々のログファイルが完了しインポートする準備が整ったかが推測できるようになります。
+         </para>
+        </listitem>
+
+        <listitem>
+           <para>
+          <!--
+            Set <varname>log_rotation_size</varname> to 0 to disable
+            size-based log rotation, as it makes the log file name difficult
+            to predict.
+           -->
+           ログファイル名の予測が困難になりますので、<varname>log_rotation_size</varname>を0にして容量を基にしたログの回転を無効にしてください。
+           </para>
+        </listitem>
+
+        <listitem>
+          <para>
+<!--
+           Set <varname>log_truncate_on_rotation</varname> to <literal>on</> so
+           that old log data isn't mixed with the new in the same file.
+-->
+同じファイルに古いログデータと新しいログデータが混在しないようにするために、<varname>log_truncate_on_rotation</varname>を<literal>on</>に設定してください。
+          </para>
+        </listitem>
+
+        <listitem>
+          <para>
+         <!--
+           The table definition above includes a primary key specification.
+           This is useful to protect against accidentally importing the same
+           information twice.  The <command>COPY</> command commits all of the
+           data it imports at one time, so any error will cause the entire
+           import to fail.  If you import a partial log file and later import
+           the file again when it is complete, the primary key violation will
+           cause the import to fail.  Wait until the log is complete and
+           closed before importing.  This procedure will also protect against
+           accidentally importing a partial line that hasn't been completely
+           written, which would also cause <command>COPY</> to fail.
+          -->
+          上のテーブル定義には主キーの指定が含まれています。
+これにより、同じ情報が2回インポートされる事故を防止するために有用です。
+<command>COPY</>コマンドは、一度にインポートするすべてのデータをコミットしますので、何か1つでもエラーがあればインポート全体が失敗します。
+ログファイルの一部をインポートし、そのファイルが完了した後に再度インポートしようとした場合、主キー違反によりインポートが失敗します。
+インポートする前に、ログファイルの完了を待ち、閉じるまで待機してください。
+この手順は、<command>COPY</>が失敗する原因となる、完全に書き込まれなかった欠落した行をインポートするという事故も防止します。
+          </para>
+        </listitem>
+        </orderedlist>
+      </para>
+    </sect2>
+
+   <sect2>
+<!--
+    <title>Process Title</title>
+-->
+    <title>プロセスの表題</title>
+
+    <para>
+<!--
+     These settings control how process titles of server processes are
+     modified.  Process titles are typically viewed using programs like
+     <application>ps</> or, on Windows, <application>Process Explorer</>.
+     See <xref linkend="monitoring-ps"> for details.
+-->
+これらの設定項目は、<command>ps</command>で見えるサーバプロセスの表題を変更します。
+プロセスの表題は、典型的には<application>ps</>、あるいはWindowsにおいては<application>Process Explorer</>で見ることができます。
+詳細については、<xref linkend="monitoring-ps">を参照してください。
+    </para>
+
+    <variablelist>
+     <varlistentry id="guc-cluster-name" xreflabel="cluster_name">
+      <term><varname>cluster_name</varname> (<type>string</type>)
+      <indexterm>
+<!--
+       <primary><varname>cluster_name</> configuration parameter</primary>
+-->
+       <primary><varname>cluster_name</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Sets the cluster name that appears in the process title for all
+        server processes in this cluster. The name can be any string of less
+        than <symbol>NAMEDATALEN</> characters (64 characters in a standard
+        build). Only printable ASCII characters may be used in the
+        <varname>cluster_name</varname> value. Other characters will be
+        replaced with question marks (<literal>?</literal>).  No name is shown
+        if this parameter is set to the empty string <literal>''</> (which is
+        the default). This parameter can only be set at server start.
+-->
+このクラスタ内のすべてのサーバプロセス表題にクラスタ名を設定します。
+クラスタ名は<symbol>NAMEDATALEN</>文字(標準のビルドでは64文字)より少ない文字列です。
+表示可能なASCII文字だけが<varname>cluster_name</varname>の値として設定できます。
+他の文字は、疑問符(<literal>?</literal>)に置き換えられます。
+空文字<literal>''</>(これがデフォルト値です)が設定されると、クラスタ名は表示されません。
+このパラメータはサーバ起動時にのみ設定できます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-update-process-title" xreflabel="update_process_title">
+      <term><varname>update_process_title</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>update_process_title</> configuration parameter</primary>
+       -->
+       <primary><varname>update_process_title</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Enables updating of the process title every time a new SQL command
+        is received by the server.
+        This setting defaults to <literal>on</> on most platforms, but it
+        defaults to <literal>off</> on Windows due to that platform's larger
+        overhead for updating the process title.
+        Only superusers can change this setting.
+-->
+サーバが新しいSQLコマンドを受け取る時に毎回、プロセスタイトルを更新できるようにします。
+この設定値はたいていのプラットフォームで<literal>on</>がデフォルトになっていますが、Windowsではプロセスタイトルを更新するオーバヘッドが大きいため、<literal>off</>がデフォルトになっています。
+スーパーユーザのみがこの設定を変更することができます。
+       </para>
+      </listitem>
+     </varlistentry>
+    </variablelist>
+   </sect2>
+  </sect1>
+
+   <sect1 id="runtime-config-statistics">
+   <!--
+    <title>Run-time Statistics</title>
+    -->
+    <title>実行時統計情報</title>
+
+    <sect2 id="runtime-config-statistics-collector">
+    <!--
+     <title>Query and Index Statistics Collector</title>
+     -->
+     <title>問い合わせおよびインデックスに関する統計情報コレクタ</title>
+
+     <para>
+     <!--
+      These parameters control server-wide statistics collection features.
+      When statistics collection is enabled, the data that is produced can be
+      accessed via the <structname>pg_stat</structname> and
+      <structname>pg_statio</structname> family of system views.
+      Refer to <xref linkend="monitoring"> for more information.
+      -->
+      これらのパラメータは、サーバ全体の統計情報収集機能を制御します。
+統計情報収集が有効ならば、生成されるデータは<structname>pg_stat</structname>と<structname>pg_statio</structname>系のシステムビュー経由でアクセス可能です。
+詳細は<xref linkend="monitoring">を参照してください。
+     </para>
+
+     <variablelist>
+
+     <varlistentry id="guc-track-activities" xreflabel="track_activities">
+      <term><varname>track_activities</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>track_activities</> configuration parameter</primary>
+       -->
+       <primary><varname>track_activities</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables the collection of information on the currently
+        executing command of each session, along with the time when
+        that command began execution. This parameter is on by
+        default. Note that even when enabled, this information is not
+        visible to all users, only to superusers and the user owning
+        the session being reported on, so it should not represent a
+        security risk.
+        Only superusers can change this setting.
+       -->
+       各セッションで実行中のコマンドに関する情報とそのコマンドの実行開始時刻の収集を有効にします。
+このパラメータはデフォルトで有効です。
+有効な場合であっても、すべてのユーザがこの情報を見ることができず、スーパーユーザと報告されたセッションの所有者のみから可視である点に注意してください。
+このためセキュリティ上の危険性はありません。
+スーパーユーザのみがこの設定を変更することができます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-track-activity-query-size" xreflabel="track_activity_query_size">
+      <term><varname>track_activity_query_size</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>track_activity_query_size</> configuration parameter</primary>
+       -->
+       <primary><varname>track_activity_query_size</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+       Specifies the number of bytes reserved to track the currently
+       executing command for each active session, for the
+       <structname>pg_stat_activity</>.<structfield>query</> field.
+       The default value is 1024. This parameter can only be set at server
+       start.
+       -->
+       <structname>pg_stat_activity</>.<structfield>query</>フィールドに対し、それぞれの活動中のセッションで現在実行されているコマンドを追跡記録するため予約されるバイト数を指定します。デフォルトの値は1024です。このパラメータはサーバ起動時のみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-track-counts" xreflabel="track_counts">
+      <term><varname>track_counts</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>track_counts</> configuration parameter</primary>
+       -->
+       <primary><varname>track_counts</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables collection of statistics on database activity.
+        This parameter is on by default, because the autovacuum
+        daemon needs the collected information.
+        Only superusers can change this setting.
+       -->
+       データベースの活動についての統計情報の収集を有効にします。
+収集される情報を自動バキュームデーモンが必要とするため、このオプションはデフォルトで有効です。
+スーパーユーザのみがこの設定を変更することができます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-track-io-timing" xreflabel="track_io_timing">
+      <term><varname>track_io_timing</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>track_io_timing</> configuration parameter</primary>
+       -->
+       <primary><varname>track_io_timing</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables timing of database I/O calls.  This parameter is off by
+        default, because it will repeatedly query the operating system for
+        the current time, which may cause significant overhead on some
+        platforms.  You can use the <xref linkend="pgtesttiming"> tool to
+        measure the overhead of timing on your system.
+        I/O timing information is
+        displayed in <xref linkend="pg-stat-database-view">, in the output of
+        <xref linkend="sql-explain"> when the <literal>BUFFERS</> option is
+        used, and by <xref linkend="pgstatstatements">.  Only superusers can
+        change this setting.
+-->
+       データベースによるI/O呼び出しの時間的調節を可能にします。このパラメータはデフォルトで無効になっています。その理由は、現時点の時刻をオペレーティングシステムに繰り返し問い合わせるので、プラットフォームによっては深刻な負荷の原因になります。自身の使用している負荷のタイミングを計測するため<xref linkend="pgtesttiming">ツールが使用できます。
+       I/Oタイミング情報は、<literal>BUFFERS</> オプションが設定されている時<xref linkend="sql-explain"> の出力として、また<xref linkend="pgstatstatements">により表示されます。スーパーユーザのみこの設定を変更できます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-track-functions" xreflabel="track_functions">
+      <term><varname>track_functions</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>track_functions</> configuration parameter</primary>
+       -->
+       <primary><varname>track_functions</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables tracking of function call counts and time used. Specify
+        <literal>pl</literal> to track only procedural-language functions,
+        <literal>all</literal> to also track SQL and C language functions.
+        The default is <literal>none</literal>, which disables function
+        statistics tracking.  Only superusers can change this setting.
+       -->
+       関数の呼び出し数と費やされた時間の追跡を有効にします。
+       手続き言語関数のみを追跡するためには<literal>pl</literal>と指定してください。
+       SQL関数、C言語関数も追跡するためには<literal>all</literal>と指定してください。
+       デフォルトは、統計情報追跡機能を無効にする<literal>none</literal>です。
+       スーパーユーザのみがこの設定を変更できます。
+       </para>
+
+       <note>
+        <para>
+       <!--
+         SQL-language functions that are simple enough to be <quote>inlined</>
+         into the calling query will not be tracked, regardless of this
+         setting.
+        -->
+        呼び出す問い合わせ内に<quote>インライン化</>できる位単純なSQL言語関数は、この設定と関係なく、追跡されません。
+        </para>
+       </note>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-stats-temp-directory" xreflabel="stats_temp_directory">
+      <term><varname>stats_temp_directory</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>stats_temp_directory</> configuration parameter</primary>
+       -->
+       <primary><varname>stats_temp_directory</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the directory to store temporary statistics data in. This can be
+        a path relative to the data directory or an absolute path. The default
+        is <filename>pg_stat_tmp</filename>. Pointing this at a RAM-based
+        file system will decrease physical I/O requirements and can lead to
+        improved performance.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+       統計情報データを一時的に格納するディレクトリを設定します。
+       これをデータディレクトリからの相対パスとすることも絶対パスとすることもできます。
+       デフォルトは<filename>pg_stat_tmp</filename>です。
+       これをRAMベースのファイルシステムを指し示すようにすることで物理I/O要求が減り、性能を向上させることができます。
+       このパラメータは、<filename>postgresql.conf</>ファイルまたはサーバのコマンドラインのみで設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+    </sect2>
+
+    <sect2 id="runtime-config-statistics-monitor">
+    <!--
+     <title>Statistics Monitoring</title>
+     -->
+     <title>統計情報の監視</title>
+     <variablelist>
+
+     <varlistentry>
+      <term><varname>log_statement_stats</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_statement_stats</> configuration parameter</primary>
+       -->
+       <primary><varname>log_statement_stats</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <term><varname>log_parser_stats</varname> (<type>boolean</type>)
+      <indexterm>
+<!--
+       <primary><varname>log_parser_stats</> configuration parameter</primary>
+-->
+       <primary><varname>log_parser_stats</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <term><varname>log_planner_stats</varname> (<type>boolean</type>)
+      <indexterm>
+<!--
+       <primary><varname>log_planner_stats</> configuration parameter</primary>
+-->
+       <primary><varname>log_planner_stats</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <term><varname>log_executor_stats</varname> (<type>boolean</type>)
+      <indexterm>
+<!--
+       <primary><varname>log_executor_stats</> configuration parameter</primary>
+-->
+      <primary><varname>log_executor_stats</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        For each query, output performance statistics of the respective
+        module to the server log. This is a crude profiling
+        instrument, similar to the Unix <function>getrusage()</> operating
+        system facility.  <varname>log_statement_stats</varname> reports total
+        statement statistics, while the others report per-module statistics.
+        <varname>log_statement_stats</varname> cannot be enabled together with
+        any of the per-module options.  All of these options are disabled by
+        default.   Only superusers can change these settings.
+       -->
+       各問い合わせに対し、対応するモジュールの性能に関する統計情報をサーバログに出力します。
+これは、Unixの<function>getrusage()</>オペレーティングシステム機能に類似した、雑なプロファイリング手段です。
+<varname>log_statement_stats</varname>は文に関する統計情報全体を、この他はモジュール毎の統計情報を報告します。
+<varname>log_statement_stats</varname>とモジュール毎のオプションを一緒に有効にすることはできません。
+デフォルトでこれらのオプションはすべて無効です。
+スーパーユーザのみがこの設定を変更することができます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+
+    </sect2>
+   </sect1>
+
+   <sect1 id="runtime-config-autovacuum">
+   <!--
+    <title>Automatic Vacuuming</title>
+    -->
+    <title>自動Vacuum作業</title>
+
+    <indexterm>
+     <primary>autovacuum</primary>
+     <!--
+     <secondary>configuration parameters</secondary>
+     -->
+     <secondary>設定パラメータ</secondary>
+    </indexterm>
+
+     <para>
+     <!--
+      These settings control the behavior of the <firstterm>autovacuum</>
+      feature.  Refer to <xref linkend="autovacuum"> for more information.
+      Note that many of these settings can be overridden on a per-table
+      basis; see <xref linkend="sql-createtable-storage-parameters"
+      endterm="sql-createtable-storage-parameters-title">.
+      -->
+      以下に示す設定は<firstterm>自動バキューム</firstterm>機能の動作を制御します。詳細は<xref linkend="autovacuum">を参照してください。
+これらの設定の多くは、テーブル単位で変更できることに注意してください。
+<xref linkend="sql-createtable-storage-parameters" endterm="sql-createtable-storage-parameters-title">を参照してください。
+     </para>
+
+    <variablelist>
+
+     <varlistentry id="guc-autovacuum" xreflabel="autovacuum">
+      <term><varname>autovacuum</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>autovacuum</> configuration parameter</primary>
+       -->
+       <primary><varname>autovacuum</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Controls whether the server should run the
+        autovacuum launcher daemon.  This is on by default; however,
+        <xref linkend="guc-track-counts"> must also be enabled for
+        autovacuum to work.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line; however, autovacuuming can be
+        disabled for individual tables by changing table storage parameters.
+       -->
+       サーバがautovacuumランチャデーモンを実行すべきかどうかを管理します。
+デフォルトでは有効です。
+しかしautovacuumを作動させるためには<xref linkend="guc-track-counts">も有効でなければなりません。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+ただし、テーブルストレージパラメータを変更することにより、autovacuumは個々のテーブルに対して無効にできます。
+       </para>
+       <para>
+       <!--
+        Note that even when this parameter is disabled, the system
+        will launch autovacuum processes if necessary to
+        prevent transaction ID wraparound.  See <xref
+        linkend="vacuum-for-wraparound"> for more information.
+       -->
+       このパラメータが無効であったとしてもシステムは、トランザクションIDの周回を防止する必要があれば、autovacuumプロセスを起動することに注意してください。
+詳細は<xref linkend="vacuum-for-wraparound">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-log-autovacuum-min-duration" xreflabel="log_autovacuum_min_duration">
+      <term><varname>log_autovacuum_min_duration</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_autovacuum_min_duration</> configuration parameter</primary>
+       -->
+       <primary><varname>log_autovacuum_min_duration</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Causes each action executed by autovacuum to be logged if it ran for at
+        least the specified number of milliseconds.  Setting this to zero logs
+        all autovacuum actions. Minus-one (the default) disables logging
+        autovacuum actions.  For example, if you set this to
+        <literal>250ms</literal> then all automatic vacuums and analyzes that run
+        250ms or longer will be logged.  In addition, when this parameter is
+        set to any value other than <literal>-1</literal>, a message will be
+        logged if an autovacuum action is skipped due to the existence of a
+        conflicting lock.  Enabling this parameter can be helpful
+        in tracking autovacuum activity.  This parameter can only be set in
+        the <filename>postgresql.conf</> file or on the server command line;
+        but the setting can be overridden for individual tables by
+        changing table storage parameters.
+       -->
+       少なくとも指定ミリ秒実行した場合、autovacuumで実行される各活動がログに残るようになります。
+これをゼロに設定すると、すべてのautovacuumの活動がログに残ります。
+マイナス1（デフォルト）はautovacuum活動のログを無効にします。
+例えば、これを<literal>250ms</literal>に設定すると、250ms以上かかって実行されたautovacuumや解析はすべてログに残ります。
+        さらに、<literal>-1</literal>以外の値にこのパラメータが設定された場合、競合するロックの存在によりオートバキューム動作が省略されるとメッセージはログに記録されます。
+        このパラメータを有効にすることは、autovacuum活動の追跡に役に立ちます。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-autovacuum-max-workers" xreflabel="autovacuum_max_workers">
+      <term><varname>autovacuum_max_workers</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>autovacuum_max_workers</> configuration parameter</primary>
+       -->
+       <primary><varname>autovacuum_max_workers</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the maximum number of autovacuum processes (other than the
+        autovacuum launcher) that may be running at any one time.  The default
+        is three.  This parameter can only be set at server start.
+       -->
+       同時に実行することができるautovacuumプロセス（autovacuumランチャ以外）の最大数を指定します。
+デフォルトは3です。
+サーバ起動時のみで設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-autovacuum-naptime" xreflabel="autovacuum_naptime">
+      <term><varname>autovacuum_naptime</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>autovacuum_naptime</> configuration parameter</primary>
+       -->
+       <primary><varname>autovacuum_naptime</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the minimum delay between autovacuum runs on any given
+        database.  In each round the daemon examines the
+        database and issues <command>VACUUM</> and <command>ANALYZE</> commands
+        as needed for tables in that database.  The delay is measured
+        in seconds, and the default is one minute (<literal>1min</>).
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+       あるデータベースについて実行されるautovacuumデーモンの最小遅延を指定します。
+それぞれの周期で、デーモンはそのデータベースを試験し、そしてそのデータベース内のテーブルで必要性が認められると、<command>VACUUM</>および<command>ANALYZE</>コマンドを発行します。
+遅延は秒単位で計測され、デフォルトは1分（<literal>1min</>）です。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-autovacuum-vacuum-threshold" xreflabel="autovacuum_vacuum_threshold">
+      <term><varname>autovacuum_vacuum_threshold</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>autovacuum_vacuum_threshold</> configuration parameter</primary>
+       -->
+       <primary><varname>autovacuum_vacuum_threshold</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the minimum number of updated or deleted tuples needed
+        to trigger a <command>VACUUM</> in any one table.
+        The default is 50 tuples.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line;
+        but the setting can be overridden for individual tables by
+        changing table storage parameters.
+       -->
+どのテーブルに対しても<command>VACUUM</>を起動するために必要な、更新もしくは削除されたタプルの最小数を指定します。
+デフォルトは50タプルです。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-autovacuum-analyze-threshold" xreflabel="autovacuum_analyze_threshold">
+      <term><varname>autovacuum_analyze_threshold</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>autovacuum_analyze_threshold</> configuration parameter</primary>
+       -->
+       <primary><varname>autovacuum_analyze_threshold</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the minimum number of inserted, updated or deleted tuples
+        needed to trigger an <command>ANALYZE</> in any one table.
+        The default is 50 tuples.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line;
+        but the setting can be overridden for individual tables by
+        changing table storage parameters.
+       -->
+どのテーブルに対しても<command>ANALYZE</>を起動するのに必要な、挿入、更新、もしくは削除されたタプルの最小数を指定します。
+デフォルトは50タプルです。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-autovacuum-vacuum-scale-factor" xreflabel="autovacuum_vacuum_scale_factor">
+      <term><varname>autovacuum_vacuum_scale_factor</varname> (<type>floating point</type>)
+      <indexterm>
+      <!--
+       <primary><varname>autovacuum_vacuum_scale_factor</> configuration parameter</primary>
+       -->
+       <primary><varname>autovacuum_vacuum_scale_factor</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies a fraction of the table size to add to
+        <varname>autovacuum_vacuum_threshold</varname>
+        when deciding whether to trigger a <command>VACUUM</>.
+        The default is 0.2 (20% of table size).
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line;
+        but the setting can be overridden for individual tables by
+        changing table storage parameters.
+       -->
+       <command>VACUUM</>を起動するか否かを決定するときに、<varname>autovacuum_vacuum_threshold</varname>に足し算するテーブル容量の割合を指定します。
+デフォルトは0.2（テーブルサイズの20%）です。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きされます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-autovacuum-analyze-scale-factor" xreflabel="autovacuum_analyze_scale_factor">
+      <term><varname>autovacuum_analyze_scale_factor</varname> (<type>floating point</type>)
+      <indexterm>
+      <!--
+       <primary><varname>autovacuum_analyze_scale_factor</> configuration parameter</primary>
+       -->
+       <primary><varname>autovacuum_analyze_scale_factor</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies a fraction of the table size to add to
+        <varname>autovacuum_analyze_threshold</varname>
+        when deciding whether to trigger an <command>ANALYZE</>.
+        The default is 0.1 (10% of table size).
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line;
+        but the setting can be overridden for individual tables by
+        changing table storage parameters.
+       -->
+<command>ANALYZE</>を起動するか否かを決定するときに、<varname>autovacuum_analyze_threshold</varname>に足し算するテーブル容量の割合を指定します。
+デフォルトは0.1（テーブルサイズの10%）です。
+このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きされます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-autovacuum-freeze-max-age" xreflabel="autovacuum_freeze_max_age">
+      <term><varname>autovacuum_freeze_max_age</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>autovacuum_freeze_max_age</> configuration parameter</primary>
+       -->
+       <primary><varname>autovacuum_freeze_max_age</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the maximum age (in transactions) that a table's
+        <structname>pg_class</>.<structfield>relfrozenxid</> field can
+        attain before a <command>VACUUM</> operation is forced
+        to prevent transaction ID wraparound within the table.
+        Note that the system will launch autovacuum processes to
+        prevent wraparound even when autovacuum is otherwise disabled.
+       -->
+       トランザクションID周回を防ぐために<command>VACUUM</>操作が強制される前までにテーブルの<structname>pg_class</>.<structfield>relfrozenxid</> フィールドが到達できる最大（トランザクションにおける）年代を指定します。
+自動バキュームが無効であった時でも、システムは周回を防ぐために自動バキューム子プロセスを起動することに注意してください。
+       </para>
+
+       <para>
+       <!--
+        Vacuum also allows removal of old files from the
+        <filename>pg_xact</> subdirectory, which is why the default
+        is a relatively low 200 million transactions.
+        This parameter can only be set at server start, but the setting
+        can be reduced for individual tables by
+        changing table storage parameters.
+        For more information see <xref linkend="vacuum-for-wraparound">.
+       -->
+       vacuumは同時に<filename>pg_xact</>サブディレクトリから古いファイルの削除を許可します。
+       これが、比較的低い2億トランザクションがデフォルトである理由です。
+       このパラメータはサーバ起動時にのみ設定可能です。
+しかし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルで減らすことができます。
+詳細は<xref linkend="vacuum-for-wraparound">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-autovacuum-multixact-freeze-max-age" xreflabel="autovacuum_multixact_freeze_max_age">
+      <term><varname>autovacuum_multixact_freeze_max_age</varname> (<type>integer</type>)
+      <indexterm>
+<!--
+       <primary><varname>autovacuum_multixact_freeze_max_age</varname> configuration parameter</primary>
+-->
+       <primary><varname>autovacuum_multixact_freeze_max_age</varname>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Specifies the maximum age (in multixacts) that a table's
+        <structname>pg_class</>.<structfield>relminmxid</> field can
+        attain before a <command>VACUUM</> operation is forced to
+        prevent multixact ID wraparound within the table.
+        Note that the system will launch autovacuum processes to
+        prevent wraparound even when autovacuum is otherwise disabled.
+-->
+       トランザクションID周回を防ぐために<command>VACUUM</>操作が強制される前までにテーブルの<structname>pg_class</>.<structfield>relminmxid</> フィールドが到達できる最大（マルチトランザクションにおける）年代を指定します。
+自動バキュームが無効であった時でも、システムは周回を防ぐために自動バキューム子プロセスを起動することに注意してください。
+       </para>
+
+       <para>
+<!--
+        Vacuuming multixacts also allows removal of old files from the
+        <filename>pg_multixact/members</> and <filename>pg_multixact/offsets</>
+        subdirectories, which is why the default is a relatively low
+        400 million multixacts.
+        This parameter can only be set at server start, but the setting can
+        be reduced for individual tables by changing table storage parameters.
+        For more information see <xref linkend="vacuum-for-multixact-wraparound">.
+-->
+       またマルチトランザクションIDのvacuumは<filename>pg_multixact</>と<filename>pg_multixact/offsets</>サブディレクトリから古いファイルの削除します。
+       これがデフォルトが4億トランザクションをやや下回る理由です。
+       このパラメータはサーバ起動時にのみ設定可能です。
+しかし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルで減らすことができます。
+詳細は<xref linkend="vacuum-for-multixact-wraparound">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-autovacuum-vacuum-cost-delay" xreflabel="autovacuum_vacuum_cost_delay">
+      <term><varname>autovacuum_vacuum_cost_delay</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>autovacuum_vacuum_cost_delay</> configuration parameter</primary>
+       -->
+       <primary><varname>autovacuum_vacuum_cost_delay</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the cost delay value that will be used in automatic
+        <command>VACUUM</> operations.  If -1 is specified, the regular
+        <xref linkend="guc-vacuum-cost-delay"> value will be used.
+        The default value is 20 milliseconds.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line;
+        but the setting can be overridden for individual tables by
+        changing table storage parameters.
+       -->
+       自動<command>VACUUM</>操作に使用されるコスト遅延値を指定します。
+        -1に指定されると、一定の <xref linkend="guc-vacuum-cost-delay">の値が使用されます。
+デフォルト値は20ミリ秒です。
+このパラメータは<filename>postgresql.conf</>ファイル内、または、サーバのコマンドラインのみで設定可能です。
+この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-autovacuum-vacuum-cost-limit" xreflabel="autovacuum_vacuum_cost_limit">
+      <term><varname>autovacuum_vacuum_cost_limit</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>autovacuum_vacuum_cost_limit</> configuration parameter</primary>
+       -->
+       <primary><varname>autovacuum_vacuum_cost_limit</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the cost limit value that will be used in automatic
+        <command>VACUUM</> operations.  If -1 is specified (which is the
+        default), the regular
+        <xref linkend="guc-vacuum-cost-limit"> value will be used.  Note that
+        the value is distributed proportionally among the running autovacuum
+        workers, if there is more than one, so that the sum of the limits for
+        each worker does not exceed the value of this variable.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line;
+        but the setting can be overridden for individual tables by
+        changing table storage parameters.
+       -->
+       自動<command>VACUUM</>操作に使用されるコスト限界値を指定します。
+（デフォルトの）-1が指定されると、一定の <xref linkend="guc-vacuum-cost-limit">の値が使用されます。
+この値は、実行中の自動バキュームワーカが複数存在する場合ワーカすべてに比例分配されることに注意してください。
+したがって各ワーカの制限を足し合わせてもこの変数による制限を超えることはありません。
+このパラメータは<filename>postgresql.conf</>ファイル、または、サーバのコマンドラインのみで設定可能です。
+この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+    </variablelist>
+   </sect1>
+
+   <sect1 id="runtime-config-client">
+   <!--
+    <title>Client Connection Defaults</title>
+    -->
+    <title>クライアント接続デフォルト</title>
+
+    <sect2 id="runtime-config-client-statement">
+    <!--
+     <title>Statement Behavior</title>
+     -->
+     <title>文の動作</title>
+     <variablelist>
+
+     <varlistentry id="guc-search-path" xreflabel="search_path">
+      <term><varname>search_path</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>search_path</> configuration parameter</primary>
+       -->
+       <primary><varname>search_path</>設定パラメータ</primary>
+      </indexterm>
+      <!--
+      <indexterm><primary>path</><secondary>for schemas</></>
+      -->
+      <indexterm><primary>パス</><secondary>スキーマへの</></>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        This variable specifies the order in which schemas are searched
+        when an object (table, data type, function, etc.) is referenced by a
+        simple name with no schema specified.  When there are objects of
+        identical names in different schemas, the one found first
+        in the search path is used.  An object that is not in any of the
+        schemas in the search path can only be referenced by specifying
+        its containing schema with a qualified (dotted) name.
+       -->
+       この変数は、オブジェクト（テーブル、データ型、関数など）がスキーマを指定されていない単純な名前で参照されている場合に、スキーマを検索する順番を指定します。
+       異なるスキーマに同じ名前のオブジェクトがある場合、検索パスで最初に見つかったものが使用されます。
+       検索パス内のどのスキーマにも存在しないオブジェクトを参照するには、修飾名（ドット付き）でそのオブジェクトが含まれるスキーマを指定する必要があります。
+       </para>
+
+       <para>
+       <!--
+        The value for <varname>search_path</varname> must be a comma-separated
+        list of schema names.  Any name that is not an existing schema, or is
+        a schema for which the user does not have <literal>USAGE</>
+        permission, is silently ignored.
+       -->
+       <varname>search_path</varname>の値は、スキーマの名前をカンマで区切った一覧でなければなりません。
+       存在していないスキーマ、またはユーザが<literal>USAGE</>権限を所有していないスキーマは警告なしに無視されます。
+       </para>
+
+       <para>
+       <!--
+        If one of the list items is the special name
+        <literal>$user</literal>, then the schema having the name returned by
+        <function>SESSION_USER</> is substituted, if there is such a schema
+        and the user has <literal>USAGE</> permission for it.
+        (If not, <literal>$user</literal> is ignored.)
+       -->
+       もしそのようなスキーマが存在し、ユーザがそれにたいして<literal>USAGE</>権限を所有している場合、一覧内の項目の1つが特別な名前である<literal>$user</literal>の場合、<function>SESSION_USER</>と同じ名前を持つスキーマがあれば、そのスキーマが置換されます。
+       （このような名前空間がない場合は<literal>$user</literal>は無視されます。）
+       </para>
+
+       <para>
+       <!--
+        The system catalog schema, <literal>pg_catalog</>, is always
+        searched, whether it is mentioned in the path or not.  If it is
+        mentioned in the path then it will be searched in the specified
+        order.  If <literal>pg_catalog</> is not in the path then it will
+        be searched <emphasis>before</> searching any of the path items.
+       -->
+       システムカタログのスキーマである<literal>pg_catalog</>は、パスでの指定の有無にかかわらず、常に検索されます。
+パスで指定されている場合は、指定された順序で検索されます。
+<literal>pg_catalog</>がパスに含まれていない場合、パスに含まれる項目を検索する<emphasis>前に</>検索が行われます
+       </para>
+
+       <para>
+       <!--
+        Likewise, the current session's temporary-table schema,
+        <literal>pg_temp_<replaceable>nnn</></>, is always searched if it
+        exists.  It can be explicitly listed in the path by using the
+        alias <literal>pg_temp</><indexterm><primary>pg_temp</></>.  If it is not listed in the path then
+        it is searched first (even before <literal>pg_catalog</>).  However,
+        the temporary schema is only searched for relation (table, view,
+        sequence, etc) and data type names.  It is never searched for
+        function or operator names.
+       -->
+       同様に、現在のセッションの一時テーブルスキーマ<literal>pg_temp_<replaceable>nnn</></>も、存在すれば常に検索されます。
+これは<literal>pg_temp</><indexterm><primary>pg_temp</></>という別名を使用してパスに明示的に列挙させることができます。
+パスに列挙されていない場合、最初に（<literal>pg_catalog</>よりも前であっても）検索されます。
+しかし、一時スキーマはリレーション（テーブル、ビュー、シーケンスなど）とデータ型名に対してのみ検索されます。
+関数や演算子名に対してはまったく検索されません。
+       </para>
+
+       <para>
+       <!--
+        When objects are created without specifying a particular target
+        schema, they will be placed in the first valid schema named in
+        <varname>search_path</varname>.  An error is reported if the search
+        path is empty.
+       -->
+       対象となる特定のスキーマを指定せずにオブジェクトが作成された場合、それらのオブジェクトは<varname>search_path</varname>で名前を付けられた最初に有効となっているスキーマに配置されます。
+検索パスが空の場合、エラーが報告されます。
+       </para>
+
+       <para>
+       <!--
+        The default value for this parameter is
+        <literal>"$user", public</literal>.
+        This setting supports shared use of a database (where no users
+        have private schemas, and all share use of <literal>public</>),
+        private per-user schemas, and combinations of these.  Other
+        effects can be obtained by altering the default search path
+        setting, either globally or per-user.
+       -->
+       このパラメータのデフォルト値は<literal>"$user", public</literal>です。
+この設定はデータベースの共有（どのユーザも非公開のスキーマを持たず、全員が<literal>public</>を共有）、ユーザごとの非公開のスキーマ、およびこれらの組み合わせがサポートします。
+デフォルトの検索パスの設定を全体的またはユーザごとに変更することで、その他の効果を得ることもできます。
+       </para>
+
+       <para>
+<!--
+        For more information on schema handling, see
+        <xref linkend="ddl-schemas">.  In particular, the default
+        configuration is suitable only when the database has a single user or
+        a few mutually-trusting users.
+-->
+スキーマの扱いについての詳細は、<xref linkend="ddl-schemas">をご覧ください。
+とりわけ、デフォルトの設定はデータベースのユーザが、一人あるいはお互いに信頼できる少数のユーザだけである場合にのみ適切です。
+       </para>
+
+       <para>
+       <!--
+        The current effective value of the search path can be examined
+        via the <acronym>SQL</acronym> function
+        <function>current_schemas</>
+        (see <xref linkend="functions-info">).
+        This is not quite the same as
+        examining the value of <varname>search_path</varname>, since
+        <function>current_schemas</> shows how the items
+        appearing in <varname>search_path</varname> were resolved.
+       -->
+       <acronym>SQL</acronym>関数の<function>current_schemas</> によって、検索パスの現在の有効な値を調べることができます（<xref linkend="functions-info">を参照してください）。
+これは、<varname>search_path</varname> の値を調べるのとは異なります。
+<function>current_schemas</>は、<varname>search_path</varname>に現れる項目がどのように解決されたかを表すからです。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-row-security" xreflabel="row_security">
+      <term><varname>row_security</varname> (<type>boolean</type>)
+      <indexterm>
+<!--
+       <primary><varname>row_security</> configuration parameter</primary>
+-->
+       <primary><varname>row_security</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        This variable controls whether to raise an error in lieu of applying a
+        row security policy.  When set to <literal>on</>, policies apply
+        normally.  When set to <literal>off</>, queries fail which would
+        otherwise apply at least one policy.  The default is <literal>on</>.
+        Change to <literal>off</> where limited row visibility could cause
+        incorrect results; for example, <application>pg_dump</> makes that
+        change by default.  This variable has no effect on roles which bypass
+        every row security policy, to wit, superusers and roles with
+        the <literal>BYPASSRLS</> attribute.
+-->
+この設定値は、行セキュリティポリシーの適用によってエラーを生じさせるかどうかを制御します。
+<literal>on</>に設定すると、通常通りポリシーが適用されます。
+<literal>off</>にすると、少なくともひとつのポリシーが適用されたクエリは失敗します。
+デフォルトは<literal>on</>です。
+行の可視性が制限されている場合、<literal>off</>にすると不正な結果を招くことがあります。
+たとえば、<application>pg_dump</>はデフォルトで<literal>off</>にしています。
+この設定値は、行セキュリティポリシーを迂回するロールには効果がありません。
+それはすなわち、<literal>BYPASSRLS</>アトリビュートを持つスーパーユーザです。
+       </para>
+
+       <para>
+<!--
+        For more information on row security policies,
+        see <xref linkend="SQL-CREATEPOLICY">.
+-->
+行セキュリティポリシーについての更なる情報は<xref linkend="SQL-CREATEPOLICY">をご覧ください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-default-tablespace" xreflabel="default_tablespace">
+      <term><varname>default_tablespace</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>default_tablespace</> configuration parameter</primary>
+       -->
+       <primary><varname>default_tablespace</>設定パラメータ</primary>
+      </indexterm>
+      <!--
+      <indexterm><primary>tablespace</><secondary>default</></>
+      -->
+      <indexterm><primary>テーブル空間</><secondary>デフォルト</></>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        This variable specifies the default tablespace in which to create
+        objects (tables and indexes) when a <command>CREATE</> command does
+        not explicitly specify a tablespace.
+       -->
+       この変数は、<command>CREATE</>コマンドで明示的にテーブル空間を指定していない場合にオブジェクトの作成先となるデフォルトのテーブル空間を指定します。
+       </para>
+
+       <para>
+       <!--
+        The value is either the name of a tablespace, or an empty string
+        to specify using the default tablespace of the current database.
+        If the value does not match the name of any existing tablespace,
+        <productname>PostgreSQL</> will automatically use the default
+        tablespace of the current database.  If a nondefault tablespace
+        is specified, the user must have <literal>CREATE</> privilege
+        for it, or creation attempts will fail.
+       -->
+       値はテーブル空間名、もしくは現在のデータベースのデフォルトのテーブル空間を使用することを意味する空文字列です。
+この値が既存のテーブル空間名と一致しない場合、<productname>PostgreSQL</>は自動的に現在のデータベースのデフォルトのテーブル空間を使用します。
+デフォルト以外のテーブル空間が指定された場合、ユーザはそのテーブル空間で<literal>CREATE</>権限を持たなければなりません。
+さもなくば作成に失敗します。
+       </para>
+
+       <para>
+       <!--
+        This variable is not used for temporary tables; for them,
+        <xref linkend="guc-temp-tablespaces"> is consulted instead.
+       -->
+       この変数は一時テーブル向けには使用されません。
+一時テーブル向けには代わりに<xref linkend="guc-temp-tablespaces">が考慮されます。
+       </para>
+
+       <para>
+       <!--
+        This variable is also not used when creating databases.
+        By default, a new database inherits its tablespace setting from
+        the template database it is copied from.
+       -->
+       同時に、この変数はデータベース作成時には使用されません。
+       </para>
+
+       <para>
+       <!--
+        For more information on tablespaces,
+        see <xref linkend="manage-ag-tablespaces">.
+       -->
+       テーブル空間に付いてより詳細な情報は<xref linkend="manage-ag-tablespaces">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-temp-tablespaces" xreflabel="temp_tablespaces">
+      <term><varname>temp_tablespaces</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>temp_tablespaces</> configuration parameter</primary>
+       -->
+       <primary><varname>temp_tablespaces</>設定パラメータ</primary>
+      </indexterm>
+      <!--
+      <indexterm><primary>tablespace</><secondary>temporary</></>
+      -->
+      <indexterm><primary>テーブル空間</><secondary>一時的</></>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        This variable specifies tablespaces in which to create temporary
+        objects (temp tables and indexes on temp tables) when a
+        <command>CREATE</> command does not explicitly specify a tablespace.
+        Temporary files for purposes such as sorting large data sets
+        are also created in these tablespaces.
+       -->
+       この変数は、<command>CREATE</>コマンドで明示的にテーブル空間が指定されない場合に、生成する一時オブジェクト（一時テーブルと一時テーブル上のインデックス）を格納するテーブル空間（複数可）を指定します。
+大規模データ集合のソートなどを目的とした一時ファイルもまた、このテーブル空間（複数可）に作成されます。
+       </para>
+
+       <para>
+       <!--
+        The value is a list of names of tablespaces.  When there is more than
+        one name in the list, <productname>PostgreSQL</> chooses a random
+        member of the list each time a temporary object is to be created;
+        except that within a transaction, successively created temporary
+        objects are placed in successive tablespaces from the list.
+        If the selected element of the list is an empty string,
+        <productname>PostgreSQL</> will automatically use the default
+        tablespace of the current database instead.
+       -->
+       この値はテーブル空間名のリストです。
+リストに複数の名前が存在する場合、一時オブジェクトが作成される度に<productname>PostgreSQL</>は無作為にリストから要素を選択します。
+トランザクションの内側は例外で、連続して作成される一時オブジェクトはそのリストで連続するテーブル空間に格納されます。
+リスト内の選択された要素が空文字列だった場合、<productname>PostgreSQL</>は自動的に現在のデータベースのデフォルトのテーブル空間を代わりに使用します。
+       </para>
+
+       <para>
+       <!--
+        When <varname>temp_tablespaces</> is set interactively, specifying a
+        nonexistent tablespace is an error, as is specifying a tablespace for
+        which the user does not have <literal>CREATE</> privilege.  However,
+        when using a previously set value, nonexistent tablespaces are
+        ignored, as are tablespaces for which the user lacks
+        <literal>CREATE</> privilege.  In particular, this rule applies when
+        using a value set in <filename>postgresql.conf</>.
+       -->
+       <varname>temp_tablespaces</>を対話式に設定する場合、存在しないテーブル空間を指定するとエラーになります。
+ユーザが<literal>CREATE</>権限を持たないテーブル空間を指定した場合も同様です。
+しかし事前に設定された値を使用する場合、存在しないテーブル空間は無視されます。
+ユーザが<literal>CREATE</>権限を持たないテーブル空間も同様です。
+具体的には、この規則は<filename>postgresql.conf</>内で設定した値を使用する場合に適用されます。
+       </para>
+
+       <para>
+       <!--
+        The default value is an empty string, which results in all temporary
+        objects being created in the default tablespace of the current
+        database.
+       -->
+       デフォルト値は空文字列です。
+この結果、すべての一時オブジェクトは現在のデータベースのデフォルトのテーブル空間内に作成されます。
+       </para>
+
+       <para>
+       <!--
+        See also <xref linkend="guc-default-tablespace">.
+       -->
+       <xref linkend="guc-default-tablespace">も参照してください
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-check-function-bodies" xreflabel="check_function_bodies">
+      <term><varname>check_function_bodies</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>check_function_bodies</> configuration parameter</primary>
+       -->
+       <primary><varname>check_function_bodies</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        This parameter is normally on. When set to <literal>off</>, it
+        disables validation of the function body string during <xref
+        linkend="sql-createfunction">.  Disabling validation avoids side
+        effects of the validation process and avoids false positives due
+        to problems such as forward references.  Set this parameter
+        to <literal>off</> before loading functions on behalf of other
+        users; <application>pg_dump</> does so automatically.
+       -->
+       このパラメータは通常オンです。<literal>off</>に設定すると、<xref
+       linkend="sql-createfunction">の間で関数本体文字列の妥当性検証を無効にします。
+       妥当性検証を無効にするとその妥当性検証処理の副作用を避け、前方参照による問題から起こる擬陽性(false positive)を避けることができます。
+関数をロードする前にこのパラメータを他のユーザとして<literal>off</>にします。
+<application>pg_dump</>はこれを自動的に行います。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-default-transaction-isolation" xreflabel="default_transaction_isolation">
+      <term><varname>default_transaction_isolation</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary>transaction isolation level</primary>
+       -->
+       <primary>トランザクション隔離レベル</primary>
+       <!--
+       <secondary>setting default</secondary>
+       -->
+       <secondary>デフォルト設定</secondary>
+      </indexterm>
+      <indexterm>
+      <!--
+       <primary><varname>default_transaction_isolation</> configuration parameter</primary>
+       -->
+       <primary><varname>default_transaction_isolation</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Each SQL transaction has an isolation level, which can be
+        either <quote>read uncommitted</quote>, <quote>read
+        committed</quote>, <quote>repeatable read</quote>, or
+        <quote>serializable</quote>.  This parameter controls the
+        default isolation level of each new transaction. The default
+        is <quote>read committed</quote>.
+       -->
+       SQLトランザクションはそれぞれ、<quote>read uncommitted</quote>、<quote>read committed</quote>、<quote>repeatable read</quote>、または<quote>serializable</quote>のいずれかの隔離レベルを持ちます。
+このパラメータは各新規トランザクションのデフォルトの隔離レベルを制御します。
+デフォルトは<quote>read committed</quote>です。
+       </para>
+
+       <para>
+       <!--
+        Consult <xref linkend="mvcc"> and <xref
+        linkend="sql-set-transaction"> for more information.
+       -->
+       より詳細は <xref linkend="mvcc"> および <xref
+        linkend="sql-set-transaction"> を調べてください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+<!-- split-config2-end -->

--- a/doc/src/sgml/config3.sgml
+++ b/doc/src/sgml/config3.sgml
@@ -1,0 +1,3209 @@
+<!-- 警告：このファイルは直接編集しないでください！
+1. config.sgmlを編集したら、split-config.shを起動します。
+2. するとconfig[0-3].sgmlが生成されます。
+3. config.sgmlとともにconfig[0-3].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
+4. レビューはconfig[0-3].sgmlに対して行います。
+5. 指摘された点があればconfig.sgmlに反映し、1に戻ります。
+6. config.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
+-->
+<!-- split-config3-start -->
+
+     <varlistentry id="guc-default-transaction-read-only" xreflabel="default_transaction_read_only">
+      <term><varname>default_transaction_read_only</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary>read-only transaction</primary>
+       -->
+       <primary>読み取り専用トランザクション</primary>
+       <!--
+       <secondary>setting default</secondary>
+       -->
+       <secondary>デフォルト設定</secondary>
+      </indexterm>
+      <indexterm>
+      <!--
+       <primary><varname>default_transaction_read_only</> configuration parameter</primary>
+       -->
+       <primary><varname>default_transaction_read_only</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        A read-only SQL transaction cannot alter non-temporary tables.
+        This parameter controls the default read-only status of each new
+        transaction. The default is <literal>off</> (read/write).
+       -->
+       読み取り専用のSQLトランザクションでは、非一時的テーブルを変更することができません。
+このパラメータは、各新規トランザクションのデフォルトの読み取りのみ状況を制御します。
+デフォルト<literal>off</>（読み書き）です。
+       </para>
+
+       <para>
+       <!--
+        Consult <xref linkend="sql-set-transaction"> for more information.
+       -->
+       より詳細な情報は<xref linkend="sql-set-transaction">を調べてください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-default-transaction-deferrable" xreflabel="default_transaction_deferrable">
+      <term><varname>default_transaction_deferrable</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary>deferrable transaction</primary>
+       <secondary>setting default</secondary>
+       -->
+       <primary>遅延トランザクション</primary>
+       <secondary>デフォルト設定</secondary>
+      </indexterm>
+      <indexterm>
+      <!--
+       <primary><varname>default_transaction_deferrable</> configuration parameter</primary>
+       -->
+       <primary><varname>default_transaction_deferrable</> 設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        When running at the <literal>serializable</> isolation level,
+        a deferrable read-only SQL transaction may be delayed before
+        it is allowed to proceed.  However, once it begins executing
+        it does not incur any of the overhead required to ensure
+        serializability; so serialization code will have no reason to
+        force it to abort because of concurrent updates, making this
+        option suitable for long-running read-only transactions.
+       -->
+       <literal>シリアライザブル</>隔離レベルで運用されている場合、繰り延べ読み取り専用SQLトランザクションは、その処理の許可の前に遅延されることがあります。
+       しかし、ひとたび処理が開始されるとシリアライザブル可能性を保障するために必要ないかなるオーバヘッドも発生させません。
+       従って、シリアル化（直列化）のコードは、このオプションを長期間にわたる読み取り専用トランザクションに対して適切な処置と位置づけ、同時実行の更新の観点から中断を強制する理由はありません。
+        </para>
+
+        <para>
+       <!--
+        This parameter controls the default deferrable status of each
+        new transaction.  It currently has no effect on read-write
+        transactions or those operating at isolation levels lower
+        than <literal>serializable</>. The default is <literal>off</>.
+       -->
+       このパラメータはそれぞれの新規トランザクションのデフォルトでの繰り延べ状態を制御します。
+       現時点では、読み取り専用トランザクション、または<literal>シリアライザブル</>より低位の隔離レベルの運用に対して効果はありません。
+       </para>
+
+       <para>
+       <!--
+        Consult <xref linkend="sql-set-transaction"> for more information.
+       -->
+       より詳細は<xref linkend="sql-set-transaction">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+
+     <varlistentry id="guc-session-replication-role" xreflabel="session_replication_role">
+      <term><varname>session_replication_role</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>session_replication_role</> configuration parameter</primary>
+       -->
+       <primary><varname>session_replication_role</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Controls firing of replication-related triggers and rules for the
+        current session.  Setting this variable requires
+        superuser privilege and results in discarding any previously cached
+        query plans.  Possible values are <literal>origin</> (the default),
+        <literal>replica</> and <literal>local</>.
+        See <xref linkend="sql-altertable"> for
+        more information.
+       -->
+       現在のセッションでのレプリケーションに関連したトリガおよびルールの発行を制御します。
+この変数を設定するにはスーパーユーザ権限が必要で、かつ、これまでにキャッシュされた問い合わせ計画が破棄されることになります。
+取り得る値は、<literal>origin</>（デフォルト）、<literal>replica</>、<literal>local</>です。
+詳細については<xref linkend="sql-altertable">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-statement-timeout" xreflabel="statement_timeout">
+      <term><varname>statement_timeout</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>statement_timeout</> configuration parameter</primary>
+       -->
+       <primary><varname>statement_timeout</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Abort any statement that takes more than the specified number of
+        milliseconds, starting from the time the command arrives at the server
+        from the client.  If <varname>log_min_error_statement</> is set to
+        <literal>ERROR</> or lower, the statement that timed out will also be
+        logged.  A value of zero (the default) turns this off.
+       -->
+コマンドがクライアントからサーバに届いた時から数えて、実行時間が指定されたミリ秒を越えた文を停止します。
+<varname>log_min_error_statement</>が<literal>ERROR</>もしくはそれ以下に設定されている場合は、タイムアウトした文はログに書き込まれます。
+値がゼロ（デフォルト）の場合、これを無効にします。
+       </para>
+
+       <para>
+       <!--
+        Setting <varname>statement_timeout</> in
+        <filename>postgresql.conf</> is not recommended because it would
+        affect all sessions.
+       -->
+       すべてのセッションに影響することがあるので、<filename>postgresql.conf</>内で<varname>statement_timeout</>を設定することは推奨されません。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-lock-timeout" xreflabel="lock_timeout">
+      <term><varname>lock_timeout</varname> (<type>integer</type>)
+      <indexterm>
+<!--
+       <primary><varname>lock_timeout</> configuration parameter</primary>
+-->
+       <primary><varname>lock_timeout</> 設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Abort any statement that waits longer than the specified number of
+        milliseconds while attempting to acquire a lock on a table, index,
+        row, or other database object.  The time limit applies separately to
+        each lock acquisition attempt.  The limit applies both to explicit
+        locking requests (such as <command>LOCK TABLE</>, or <command>SELECT
+        FOR UPDATE</> without <literal>NOWAIT</>) and to implicitly-acquired
+        locks.  If <varname>log_min_error_statement</> is set to
+        <literal>ERROR</> or lower, the statement that timed out will be
+        logged.  A value of zero (the default) turns this off.
+       -->
+       テーブル、インデックス、行、またはその他のデータベースオブジェクトに対してロック獲得を試みている最中、指定されたミリ秒数を超えて待機するいかなる命令も停止されます。
+       時間制限はそれぞれのロック取得の試みに対し個別に適応されます。
+       制限は明示的ロック要求（例えば<command>LOCK TABLE</>、または<command>SELECT FOR UPDATE</> without <literal>NOWAIT</>など）および暗黙的に取得されるロックに適用されます。
+       <varname>log_min_error_statement</>が<literal>ERROR</>またはそれより低く設定されると、時間制限を超えた命令はログに記録されます。値ゼロ（デフォルト）はこの機能を無効にします。
+       </para>
+
+       <para>
+       <!--
+        Unlike <varname>statement_timeout</>, this timeout can only occur
+        while waiting for locks.  Note that if <varname>statement_timeout</>
+        is nonzero, it is rather pointless to set <varname>lock_timeout</> to
+        the same or larger value, since the statement timeout would always
+        trigger first.
+       -->
+       <varname>statement_timeout</>と異なり、このタイムアウトはロックを待機しているときのみ発生します。
+       命令によるタイムアウトは常に第一に起動されるため、もし<varname>statement_timeout</>が非ゼロであれば<varname>lock_timeout</>を同一、もしくはより大きい値に設定するのは的を得ていません。
+       </para>
+
+       <para>
+       <!--
+        Setting <varname>lock_timeout</> in
+        <filename>postgresql.conf</> is not recommended because it would
+        affect all sessions.
+       -->
+       <varname>lock_timeout</>を<filename>postgresql.conf</>にて設定することは、すべてのセッションに影響を与える可能性があるため推奨されません。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-idle-in-transaction-session-timeout" xreflabel="idle_in_transaction_session_timeout">
+      <term><varname>idle_in_transaction_session_timeout</varname> (<type>integer</type>)
+      <indexterm>
+<!--
+       <primary><varname>idle_in_transaction_session_timeout</> configuration parameter</primary>
+-->
+       <primary><varname>idle_in_transaction_session_timeout</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+       Terminate any session with an open transaction that has been idle for
+       longer than the specified duration in milliseconds. This allows any
+       locks held by that session to be released and the connection slot to be reused;
+       it also allows tuples visible only to this transaction to be vacuumed.  See
+       <xref linkend="routine-vacuuming"> for more details about this.
+-->
+開いたトランザクションが、指定された時間（単位はミリ秒）を超えてアイドルだった場合に、セッションを終了します。
+これにより、そのセッションが獲得したロックを解放し、コネクションスロットを再利用できるようになります。
+また、このトランザクションからのみ見えるタプルがVACUUMできるようになります。
+更なる詳細は<xref linkend="routine-vacuuming">を見てください。
+       </para>
+       <para>
+<!--
+       The default value of 0 disables this feature.
+-->
+値がゼロ（デフォルト）の場合、この機能は無効になります。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-vacuum-freeze-table-age" xreflabel="vacuum_freeze_table_age">
+      <term><varname>vacuum_freeze_table_age</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>vacuum_freeze_table_age</> configuration parameter</primary>
+       -->
+       <primary><varname>vacuum_freeze_table_age</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        <command>VACUUM</> performs an aggressive scan if the table's
+        <structname>pg_class</>.<structfield>relfrozenxid</> field has reached
+        the age specified by this setting.  An aggressive scan differs from
+        a regular <command>VACUUM</> in that it visits every page that might
+        contain unfrozen XIDs or MXIDs, not just those that might contain dead
+        tuples.  The default is 150 million transactions.  Although users can
+        set this value anywhere from zero to two billions, <command>VACUUM</>
+        will silently limit the effective value to 95% of
+        <xref linkend="guc-autovacuum-freeze-max-age">, so that a
+        periodical manual <command>VACUUM</> has a chance to run before an
+        anti-wraparound autovacuum is launched for the table. For more
+        information see
+        <xref linkend="vacuum-for-wraparound">.
+-->
+テーブルの<structname>pg_class</>.<structfield>relfrozenxid</>フィールドがこの設定で指定した時期に達すると、<command>VACUUM</>は積極的なテーブル走査を行います。
+積極的な走査は、無効タプルを含む可能性のあるページだけではなく、凍結されていないXIDあるいはMXIDを含むすべてのページを読む点で通常の<command>VACUUM</>とは異なります。
+デフォルトは1.5億トランザクションです。
+ユーザはこの値をゼロから20億までの任意の値に設定することができますが、<command>VACUUM</>は警告することなく、周回問題対策のautovacuumがテーブルに対して起動する前に定期的な手動<command>VACUUM</>が実行する機会を持つように、<xref linkend="guc-autovacuum-freeze-max-age">の95%に実効値を制限します。
+詳細は<xref linkend="vacuum-for-wraparound">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-vacuum-freeze-min-age" xreflabel="vacuum_freeze_min_age">
+      <term><varname>vacuum_freeze_min_age</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>vacuum_freeze_min_age</> configuration parameter</primary>
+       -->
+       <primary><varname>vacuum_freeze_min_age</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Specifies the cutoff age (in transactions) that <command>VACUUM</>
+        should use to decide whether to freeze row versions
+        while scanning a table.
+        The default is 50 million transactions.  Although
+        users can set this value anywhere from zero to one billion,
+        <command>VACUUM</> will silently limit the effective value to half
+        the value of <xref linkend="guc-autovacuum-freeze-max-age">, so
+        that there is not an unreasonably short time between forced
+        autovacuums.  For more information see <xref
+        linkend="vacuum-for-wraparound">.
+       -->
+       <command>VACUUM</>がテーブルスキャン時に行バージョンをフリーズするかどうかを決定する際に使用する、カットオフ（トランザクション）年代を指定します。
+デフォルトは5千万トランザクションです。
+ユーザはこの値を0から10億までの間で任意の値に設定することができますが、<command>VACUUM</>は警告なく<xref linkend="guc-autovacuum-freeze-max-age">の半分までの値に値を制限します。
+このため、強制的なautovacuumの間隔が不合理に短くなることはありません。
+詳細は<xref linkend="vacuum-for-wraparound">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-vacuum-multixact-freeze-table-age" xreflabel="vacuum_multixact_freeze_table_age">
+      <term><varname>vacuum_multixact_freeze_table_age</varname> (<type>integer</type>)
+      <indexterm>
+<!--
+       <primary><varname>vacuum_multixact_freeze_table_age</> configuration parameter</primary>
+-->
+       <primary><varname>vacuum_multixact_freeze_table_age</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        <command>VACUUM</> performs an aggressive scan if the table's
+        <structname>pg_class</>.<structfield>relminmxid</> field has reached
+        the age specified by this setting.  An aggressive scan differs from
+        a regular <command>VACUUM</> in that it visits every page that might
+        contain unfrozen XIDs or MXIDs, not just those that might contain dead
+        tuples.  The default is 150 million multixacts.
+        Although users can set this value anywhere from zero to two billions,
+        <command>VACUUM</> will silently limit the effective value to 95% of
+        <xref linkend="guc-autovacuum-multixact-freeze-max-age">, so that a
+        periodical manual <command>VACUUM</> has a chance to run before an
+        anti-wraparound is launched for the table.
+        For more information see <xref linkend="vacuum-for-multixact-wraparound">.
+-->
+<structname>pg_class</>.<structfield>relminmxid</>フィールドがこの設定値で指定した年代に達すると<command>VACUUM</>はテーブルの積極的なスキャンを行います。
+積極的なスキャンは、無効タプルを含む可能性のあるページだけではなく、凍結XIDあるいはMXIDを含むすべてのページを読む点で通常の<command>VACUUM</>とは異なります。
+デフォルトは1億5千万トランザクションです。
+ユーザは0から20億まで任意の値を設定できますが、テーブルに対してラップアラウンド防止処理が起動される前に定期的な手動<command>VACUUM</>が走ることができるように、<command>VACUUM</>は<xref linkend="guc-autovacuum-multixact-freeze-max-age">の95%に暗黙的に制限します。
+詳細は<xref linkend="vacuum-for-multixact-wraparound">をご覧ください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-vacuum-multixact-freeze-min-age" xreflabel="vacuum_multixact_freeze_min_age">
+      <term><varname>vacuum_multixact_freeze_min_age</varname> (<type>integer</type>)
+      <indexterm>
+<!--
+       <primary><varname>vacuum_multixact_freeze_min_age</> configuration parameter</primary>
+-->
+       <primary><varname>vacuum_multixact_freeze_min_age</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Specifies the cutoff age (in multixacts) that <command>VACUUM</>
+        should use to decide whether to replace multixact IDs with a newer
+        transaction ID or multixact ID while scanning a table.  The default
+        is 5 million multixacts.
+        Although users can set this value anywhere from zero to one billion,
+        <command>VACUUM</> will silently limit the effective value to half
+        the value of <xref linkend="guc-autovacuum-multixact-freeze-max-age">,
+        so that there is not an unreasonably short time between forced
+        autovacuums.
+        For more information see <xref linkend="vacuum-for-multixact-wraparound">.
+-->
+        <command>VACUUM</>がテーブルをスキャンする際に、マルチトランザクションIDをより新しいトランザクションIDまたはマルチトランザクションIDに置き換えるかどうかを決める下限値をマルチトランザクション単位で指定します。
+ユーザは0から10億まで任意の値を設定できますが、強制的な自動バキュームの間隔が短くなり過ぎないように、<command>VACUUM</>は<xref linkend="guc-autovacuum-multixact-freeze-max-age">の半分に暗黙的に実効的な値を制限します。
+詳細は<xref linkend="vacuum-for-multixact-wraparound">をご覧ください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-bytea-output" xreflabel="bytea_output">
+      <term><varname>bytea_output</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>bytea_output</> configuration parameter</primary>
+       -->
+       <primary><varname>bytea_output</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the output format for values of type <type>bytea</type>.
+        Valid values are <literal>hex</literal> (the default)
+        and <literal>escape</literal> (the traditional PostgreSQL
+        format).  See <xref linkend="datatype-binary"> for more
+        information.  The <type>bytea</type> type always
+        accepts both formats on input, regardless of this setting.
+       -->
+       <type>bytea</type>型の値の出力形式を設定します。
+       有効な値は<literal>hex</literal>（デフォルト）、および<literal>escape</literal>（PostgreSQLの伝統的な書式）です。
+       より詳細は<xref linkend="datatype-binary">を参照してください。
+       <type>bytea</type>型は常にこの設定に係わらず、入力時に双方の書式を受け付けます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-xmlbinary" xreflabel="xmlbinary">
+      <term><varname>xmlbinary</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>xmlbinary</> configuration parameter</primary>
+       -->
+       <primary><varname>xmlbinary</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets how binary values are to be encoded in XML.  This applies
+        for example when <type>bytea</type> values are converted to
+        XML by the functions <function>xmlelement</function> or
+        <function>xmlforest</function>.  Possible values are
+        <literal>base64</literal> and <literal>hex</literal>, which
+        are both defined in the XML Schema standard.  The default is
+        <literal>base64</literal>.  For further information about
+        XML-related functions, see <xref linkend="functions-xml">.
+       -->
+       バイナリデータをXMLに符号化する方法を設定します。
+例えばこれは、<function>xmlelement</function>や<function>xmlforest</function>関数で<type>bytea</type>値をXMLに変換する際に適用されます。
+取り得る値は<literal>base64</literal>と<literal>hex</literal>です。
+どちらもXMLスキーマ標準で定義されています。
+デフォルトは<literal>base64</literal>です。
+XMLに関連した関数については<xref linkend="functions-xml">を参照してください。
+       </para>
+
+       <para>
+       <!--
+        The actual choice here is mostly a matter of taste,
+        constrained only by possible restrictions in client
+        applications.  Both methods support all possible values,
+        although the hex encoding will be somewhat larger than the
+        base64 encoding.
+       -->
+       実のところこの選択はほとんど趣味の問題で、クライアントアプリケーションで起こり得る制限のみに制約されます。
+どちらの方法もすべての値をサポートしますが、hex符号化方式はbase64符号化方式より少し大きくなります。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-xmloption" xreflabel="xmloption">
+      <term><varname>xmloption</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>xmloption</> configuration parameter</primary>
+       -->
+       <primary><varname>xmloption</>設定パラメータ</primary>
+      </indexterm>
+      <indexterm>
+       <primary><varname>SET XML OPTION</></primary>
+      </indexterm>
+      <indexterm>
+      <!--
+       <primary>XML option</primary>
+       -->
+       <primary>XMLオプション</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets whether <literal>DOCUMENT</literal> or
+        <literal>CONTENT</literal> is implicit when converting between
+        XML and character string values.  See <xref
+        linkend="datatype-xml"> for a description of this.  Valid
+        values are <literal>DOCUMENT</literal> and
+        <literal>CONTENT</literal>.  The default is
+        <literal>CONTENT</literal>.
+       -->
+       XMLと文字列値との変換時に<literal>DOCUMENT</literal>とするか<literal>CONTENT</literal>とするかを設定します。
+この説明については<xref linkend="datatype-xml">を参照してください。
+有効な値は<literal>DOCUMENT</literal>と<literal>CONTENT</literal>です。
+デフォルトは<literal>CONTENT</literal>です。
+       </para>
+
+       <para>
+       <!--
+        According to the SQL standard, the command to set this option is
+       -->
+       標準SQLに従うと、このオプションを設定するコマンドは以下のようになります。
+<synopsis>
+SET XML OPTION { DOCUMENT | CONTENT };
+</synopsis>
+       <!--
+        This syntax is also available in PostgreSQL.
+       -->
+       この構文はPostgreSQLでも使用可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-gin-pending-list-limit" xreflabel="gin_pending_list_limit">
+      <term><varname>gin_pending_list_limit</varname> (<type>integer</type>)
+      <indexterm>
+<!--
+       <primary><varname>gin_pending_list_limit</> configuration parameter</primary>
+-->
+       <primary><varname>gin_pending_list_limit</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Sets the maximum size of the GIN pending list which is used
+        when <literal>fastupdate</> is enabled. If the list grows
+        larger than this maximum size, it is cleaned up by moving
+        the entries in it to the main GIN data structure in bulk.
+        The default is four megabytes (<literal>4MB</>). This setting
+        can be overridden for individual GIN indexes by changing
+        index storage parameters.
+         See <xref linkend="gin-fast-update"> and <xref linkend="gin-tips">
+         for more information.
+-->
+<literal>fastupdate</>が有効なときに使用されるGINペンディングリストの最大サイズを設定します。
+リストがこの設定値よりも大きくなったら、エントリをGINの主データ構造に一括転送してリストはクリアされます。
+デフォルトは4メガバイト(<literal>4MB</>)です。
+この設定は、個々のGINインデックスに対してインデックスストレージパラメータを変更することにより、上書きできます。
+更なる情報については、<xref linkend="gin-fast-update">と<xref linkend="gin-tips">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+    </sect2>
+     <sect2 id="runtime-config-client-format">
+     <!--
+     <title>Locale and Formatting</title>
+     -->
+     <title>ロケールと書式設定</title>
+
+     <variablelist>
+
+     <varlistentry id="guc-datestyle" xreflabel="DateStyle">
+      <term><varname>DateStyle</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>DateStyle</> configuration parameter</primary>
+       -->
+       <primary><varname>DateStyle</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the display format for date and time values, as well as the
+        rules for interpreting ambiguous date input values. For
+        historical reasons, this variable contains two independent
+        components: the output format specification (<literal>ISO</>,
+        <literal>Postgres</>, <literal>SQL</>, or <literal>German</>)
+        and the input/output specification for year/month/day ordering
+        (<literal>DMY</>, <literal>MDY</>, or <literal>YMD</>). These
+        can be set separately or together. The keywords <literal>Euro</>
+        and <literal>European</> are synonyms for <literal>DMY</>; the
+        keywords <literal>US</>, <literal>NonEuro</>, and
+        <literal>NonEuropean</> are synonyms for <literal>MDY</>. See
+        <xref linkend="datatype-datetime"> for more information. The
+        built-in default is <literal>ISO, MDY</>, but
+        <application>initdb</application> will initialize the
+        configuration file with a setting that corresponds to the
+        behavior of the chosen <varname>lc_time</varname> locale.
+       -->
+       日付時刻値の表示書式を設定し、曖昧な日付入力の解釈規則を設定します。
+歴史的な理由により、この変数には2つの独立した要素が含まれています。
+出力書式指定（<literal>ISO</>、<literal>Postgres</>、<literal>SQL</>、<literal>German</>）と年/月/日の順序の入出力指定（<literal>DMY</>、<literal>MDY</>、<literal>YMD</>）です。
+これらは分けて設定することもまとめて設定することもできます。
+<literal>Euro</>および<literal>European</>キーワードは<literal>DMY</>の同義語であり、<literal>US</>、<literal>NonEuro</>、<literal>NonEuropean</>は<literal>MDY</>の同義語です。
+詳細は<xref linkend="datatype-datetime">を参照してください。
+組み込みのデフォルトは<literal>ISO, MDY</>ですが、<application>initdb</application>により、選択された<varname>lc_time</varname>ロケールの動作に対応した設定で設定ファイルが初期化されます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-intervalstyle" xreflabel="IntervalStyle">
+      <term><varname>IntervalStyle</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>IntervalStyle</> configuration parameter</primary>
+       -->
+       <primary><varname>IntervalStyle</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the display format for interval values.
+        The value <literal>sql_standard</> will produce
+        output matching <acronym>SQL</acronym> standard interval literals.
+        The value <literal>postgres</> (which is the default) will produce
+        output matching <productname>PostgreSQL</> releases prior to 8.4
+        when the <xref linkend="guc-datestyle">
+        parameter was set to <literal>ISO</>.
+        The value <literal>postgres_verbose</> will produce output
+        matching <productname>PostgreSQL</> releases prior to 8.4
+        when the <varname>DateStyle</>
+        parameter was set to non-<literal>ISO</> output.
+        The value <literal>iso_8601</> will produce output matching the time
+        interval <quote>format with designators</> defined in section
+        4.4.3.2 of ISO 8601.
+       -->
+       間隔の値の表示形式を設定します。<literal>sql_standard</>値は、<acronym>SQL</acronym>標準間隔リテラルに一致する出力を生成します。
+       （デフォルトの）値<literal>postgres</>は、<xref linkend="guc-datestyle">パラメータが<literal>ISO</>に設定されている場合、リリース8.4以前の<productname>PostgreSQL</>に一致する出力を生成します。
+       値<literal>postgres_verbose</>は、<varname>DateStyle</>パラメータが非<literal>ISO</>出力に設定されている場合、リリース8.4以前の<productname>PostgreSQL</>に一致する出力を生成します。
+       値<literal>iso_8601</>は、ISO 8601の4.4.3.2節で定義されている時間間隔<quote>format with designators</>に一致する出力を生成します。
+       </para>
+       <para>
+       <!--
+        The <varname>IntervalStyle</> parameter also affects the
+        interpretation of ambiguous interval input.  See
+        <xref linkend="datatype-interval-input"> for more information.
+       -->
+       また<varname>IntervalStyle</>パラメータはあいまいに入力された時間間隔の解釈に影響を与えます。
+       詳細については<xref linkend="datatype-interval-input">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-timezone" xreflabel="TimeZone">
+      <term><varname>TimeZone</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>TimeZone</> configuration parameter</primary>
+       -->
+       <primary><varname>TimeZone</>設定パラメータ</primary>
+      </indexterm>
+      <!--
+      <indexterm><primary>time zone</></>
+      -->
+      <indexterm><primary><!--time zone-->時間帯</></>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the time zone for displaying and interpreting time stamps.
+        The built-in default is <literal>GMT</>, but that is typically
+        overridden in <filename>postgresql.conf</>; <application>initdb</>
+        will install a setting there corresponding to its system environment.
+        See <xref linkend="datatype-timezones"> for more information.
+       -->
+       表示用およびタイムスタンプ解釈用の時間帯を設定します。
+       組み込まれているデフォルトは<literal>GMT</>ですが、通常は<filename>postgresql.conf</>により上書きされます。<application>initdb</>によりこれらと関連した設定をシステム環境にインストールされます。
+        詳細は<xref linkend="datatype-timezones">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-timezone-abbreviations" xreflabel="timezone_abbreviations">
+      <term><varname>timezone_abbreviations</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>timezone_abbreviations</> configuration parameter</primary>
+       -->
+       <primary><varname>timezone_abbreviations</>設定パラメータ</primary>
+      </indexterm>
+      <!--
+      <indexterm><primary>time zone names</></>
+      -->
+      <indexterm><primary>時間帯名</></>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the collection of time zone abbreviations that will be accepted
+        by the server for datetime input.  The default is <literal>'Default'</>,
+        which is a collection that works in most of the world; there are
+        also <literal>'Australia'</literal> and <literal>'India'</literal>,
+        and other collections can be defined for a particular installation.
+        See <xref linkend="datetime-config-files"> for more information.
+       -->
+       サーバで日付時刻の入力として受付け可能となる時間帯省略形の集合を設定します。
+デフォルトは<literal>'Default'</>です。
+これはほぼ全世界で通じる集合です。
+また、<literal>Australia</literal>、<literal>India</literal>、その他特定のインストレーションで定義可能な集合が存在します。
+詳細は<xref linkend="datetime-appendix">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-extra-float-digits" xreflabel="extra_float_digits">
+      <term><varname>extra_float_digits</varname> (<type>integer</type>)
+      <indexterm>
+     <!--
+       <primary>significant digits</primary>
+       -->
+       <primary>有効数字</primary>
+      </indexterm>
+      <indexterm>
+      <!--
+       <primary>floating-point</primary>
+       -->
+       <primary>浮動小数点</primary>
+       <!--
+       <secondary>display</secondary>
+       -->
+       <secondary>表示</secondary>
+      </indexterm>
+      <indexterm>
+      <!--
+       <primary><varname>extra_float_digits</> configuration parameter</primary>
+       -->
+       <primary><varname>extra_float_digits</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        This parameter adjusts the number of digits displayed for
+        floating-point values, including <type>float4</>, <type>float8</>,
+        and geometric data types.  The parameter value is added to the
+        standard number of digits (<literal>FLT_DIG</> or <literal>DBL_DIG</>
+        as appropriate).  The value can be set as high as 3, to include
+        partially-significant digits; this is especially useful for dumping
+        float data that needs to be restored exactly.  Or it can be set
+        negative to suppress unwanted digits.
+        See also <xref linkend="datatype-float">.
+       -->
+       このパラメータは、<type>float4</>、<type>float8</>、幾何データ型などの浮動小数点値の表示桁数を調整します。
+パラメータ値が標準的な桁数（<literal>FLT_DIG</>もしくは<literal>DBL_DIG</>どちらか適切な方）に追加されます。
+この値は、部分有効数を含めるために3まで設定することができます。
+これは基本的に、正確にリストアする必要がある浮動小数点データをダンプするために有用です。
+もしくは、不要な桁を抑制するために負の値を設定することもできます。
+       <xref linkend="datatype-float">も参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-client-encoding" xreflabel="client_encoding">
+      <term><varname>client_encoding</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>client_encoding</> configuration parameter</primary>
+       -->
+       <primary><varname>client_encoding</>設定パラメータ</primary>
+      </indexterm>
+      <!--
+      <indexterm><primary>character set</></>
+      -->
+      <indexterm><primary>文字セット</></>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the client-side encoding (character set).
+        The default is to use the database encoding.
+        The character sets supported by the <productname>PostgreSQL</productname>
+        server are described in <xref linkend="multibyte-charset-supported">.
+       -->
+       クライアント側符号化方式（文字セット）を設定します。デフォルトはデータベース符号化方式を使用します。
+       <productname>PostgreSQL</productname>サーバでサポートされている文字セットは<xref linkend="multibyte-charset-supported">に記載されています。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-lc-messages" xreflabel="lc_messages">
+      <term><varname>lc_messages</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>lc_messages</> configuration parameter</primary>
+       -->
+       <primary><varname>lc_messages</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the language in which messages are displayed.  Acceptable
+        values are system-dependent; see <xref linkend="locale"> for
+        more information.  If this variable is set to the empty string
+        (which is the default) then the value is inherited from the
+        execution environment of the server in a system-dependent way.
+       -->
+       メッセージが表示される言語を設定します。使用可能な値はシステムに依存します。詳細については<xref linkend="locale">を参照してください。
+       この変数が空に設定された場合（これがデフォルトです）、値はシステムに依存する方法でサーバの実行環境から継承されます。
+       </para>
+
+       <para>
+       <!--
+        On some systems, this locale category does not exist.  Setting
+        this variable will still work, but there will be no effect.
+        Also, there is a chance that no translated messages for the
+        desired language exist.  In that case you will continue to see
+        the English messages.
+       -->
+       システムによっては、このロケールのカテゴリが存在しません。この変数を設定することはできますが、実効性はありません。
+       また、指定の言語に翻訳されたメッセージが存在しないこともあります。
+       その場合は、引き続き英語のメッセージが表示されます。
+       </para>
+
+       <para>
+       <!--
+        Only superusers can change this setting, because it affects the
+        messages sent to the server log as well as to the client, and
+        an improper value might obscure the readability of the server
+        logs.
+       -->
+       サーバログやクライアントに送信されるメッセージに影響するため、および、全ての不適切な値がサーバログの信頼性を損ねる可能性があるため、スーパーユーザのみがこの設定を変更することができます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-lc-monetary" xreflabel="lc_monetary">
+      <term><varname>lc_monetary</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>lc_monetary</> configuration parameter</primary>
+       -->
+       <primary><varname>lc_monetary</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the locale to use for formatting monetary amounts, for
+        example with the <function>to_char</function> family of
+        functions.  Acceptable values are system-dependent; see <xref
+        linkend="locale"> for more information.  If this variable is
+        set to the empty string (which is the default) then the value
+        is inherited from the execution environment of the server in a
+        system-dependent way.
+       -->
+       通貨書式で使用するロケールを設定します。
+例えば、<function>to_char()</function>系の関数で使用します。
+使用可能な値はシステムに依存します。
+詳細については<xref linkend="locale">を参照してください。
+この変数が空に設定された場合（これがデフォルトです）、値はシステムに依存する方法でサーバの実行環境から継承されます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-lc-numeric" xreflabel="lc_numeric">
+      <term><varname>lc_numeric</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>lc_numeric</> configuration parameter</primary>
+       -->
+       <primary><varname>lc_numeric</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the locale to use for formatting numbers, for example
+        with the <function>to_char</function> family of
+        functions. Acceptable values are system-dependent; see <xref
+        linkend="locale"> for more information.  If this variable is
+        set to the empty string (which is the default) then the value
+        is inherited from the execution environment of the server in a
+        system-dependent way.
+       -->
+       数字の書式で使用するロケールを設定します。
+例えば、<function>to_char</function>系の関数で使用します。
+使用可能な値はシステムに依存します。
+詳細については<xref linkend="locale">を参照してください。
+この変数が空に設定された場合（これがデフォルトです）、値はシステムに依存する方法でサーバの実行環境から継承されます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-lc-time" xreflabel="lc_time">
+      <term><varname>lc_time</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>lc_time</> configuration parameter</primary>
+       -->
+       <primary><varname>lc_time</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Sets the locale to use for formatting dates and times, for example
+        with the <function>to_char</function> family of
+        functions. Acceptable values are system-dependent; see <xref
+        linkend="locale"> for more information.  If this variable is
+        set to the empty string (which is the default) then the value
+        is inherited from the execution environment of the server in a
+        system-dependent way.
+       -->
+       例えば<function>to_char</function>系関数における、日付と時間の書式で使用するロケールを設定します。
+       使用可能な値はシステムに依存します。
+       詳細については<xref linkend="locale">を参照してください。
+この変数が空に設定された場合（これがデフォルトです）、値はシステムに依存する方法でサーバの実行環境から継承されます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-default-text-search-config" xreflabel="default_text_search_config">
+      <term><varname>default_text_search_config</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>default_text_search_config</> configuration parameter</primary>
+       -->
+       <primary><varname>default_text_search_config</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Selects the text search configuration that is used by those variants
+        of the text search functions that do not have an explicit argument
+        specifying the configuration.
+        See <xref linkend="textsearch"> for further information.
+        The built-in default is <literal>pg_catalog.simple</>, but
+        <application>initdb</application> will initialize the
+        configuration file with a setting that corresponds to the
+        chosen <varname>lc_ctype</varname> locale, if a configuration
+        matching that locale can be identified.
+       -->
+       明示的な設定指定引数を持たないテキスト検索関数の亜種で使用される、テキスト検索設定を選択します。
+詳細は<xref linkend="textsearch">を参照してください。
+組み込みのデフォルトは<literal>pg_catalog.simple</>ですが、<application>initdb</application>は、ロケールに合う設定を認識することができれば、選択された<varname>lc_ctype</varname>ロケールに対応した設定で設定ファイルを初期化します。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+
+    </sect2>
+
+    <sect2 id="runtime-config-client-preload">
+<!--
+     <title>Shared Library Preloading</title>
+-->
+     <title>共有ライブラリのプリロード</title>
+
+     <para>
+<!--
+      Several settings are available for preloading shared libraries into the
+      server, in order to load additional functionality or achieve performance
+      benefits.  For example, a setting of
+      <literal>'$libdir/mylib'</literal> would cause
+      <literal>mylib.so</> (or on some platforms,
+      <literal>mylib.sl</>) to be preloaded from the installation's standard
+      library directory.  The differences between the settings are when they
+      take effect and what privileges are required to change them.
+-->
+      追加機能や性能改良の目的で共有ライブラリをプリロードするいくつかの設定があります。
+たとえば<literal>'$libdir/mylib'</literal>を設定すると<literal>mylib.so</>(あるいは他のプラットフォームでは<literal>mylib.sl</>)を導入設定したの標準ディレクトリからプリロードします。
+各設定の違いは、設定変更を行うためにいつ、どのような権限が必要かにあります。
+     </para>
+
+     <para>
+<!--
+      <productname>PostgreSQL</productname> procedural language libraries can
+      be preloaded in this way, typically by using the
+      syntax <literal>'$libdir/plXXX'</literal> where
+      <literal>XXX</literal> is <literal>pgsql</>, <literal>perl</>,
+      <literal>tcl</>, or <literal>python</>.
+-->
+      典型的には<literal>'$libdir/plXXX'</literal>のような構文を用いて<productname>PostgreSQL</productname>手続き言語ライブラリをこの方法でプリロードできます。
+<literal>XXX</literal>は<literal>pgsql</>、<literal>perl</>、<literal>tcl</>、<literal>python</>です。
+     </para>
+
+     <para>
+<!--
+      Only shared libraries specifically intended to be used with PostgreSQL
+      can be loaded this way.  Every PostgreSQL-supported library has
+      a <quote>magic block</> that is checked to guarantee compatibility.  For
+      this reason, non-PostgreSQL libraries cannot be loaded in this way.  You
+      might be able to use operating-system facilities such
+      as <envar>LD_PRELOAD</envar> for that.
+-->
+      PostgreSQLで使用することを意図したライブラリだけがこの方法でロードできます。
+すべてのPostgreSQL用のライブラリは<quote>magic block</>を持ち、互換性を保証するためにチェックされます。
+ですからPostgreSQL用ではないライブラリはこの方法ではロードできません。
+<envar>LD_PRELOAD</envar>のようなOSの機能を使えばあるいは使用できるかもしれません。
+     </para>
+
+     <para>
+<!--
+      In general, refer to the documentation of a specific module for the
+      recommended way to load that module.
+-->
+      一般的に言ってモジュールのドキュメントを参照し、推奨される方法でロードしてください。
+     </para>
+
+     <variablelist>
+     <varlistentry id="guc-local-preload-libraries" xreflabel="local_preload_libraries">
+      <term><varname>local_preload_libraries</varname> (<type>string</type>)
+      <indexterm>
+<!--
+       <primary><varname>local_preload_libraries</> configuration parameter</primary>
+-->
+       <primary><varname>local_preload_libraries</>設定パラメータ</primary>
+      </indexterm>
+      <indexterm>
+       <primary><filename>$libdir/plugins</></primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        This variable specifies one or more shared libraries that are to be
+        preloaded at connection start.
+        It contains a comma-separated list of library names, where each name
+        is interpreted as for the <xref linkend="SQL-LOAD"> command.
+        Whitespace between entries is ignored; surround a library name with
+        double quotes if you need to include whitespace or commas in the name.
+        The parameter value only takes effect at the start of the connection.
+        Subsequent changes have no effect.  If a specified library is not
+        found, the connection attempt will fail.
+-->
+この変数は、接続時に事前読み込みされる、1つまたは複数の共有ライブラリを指定します。
+ここにはカンマ区切りでライブラリ名のリストを格納し、各々の名前は<xref linkend="SQL-LOAD">コマンドと同じように解釈されます。
+項目の間の空白は無視されます。
+名前の中に空白あるいはカンマを含める場合は、二重引用符で囲ってください。
+このパラメータは、接続の開始時にのみ効果があります。
+以降の変更は効果がありません。
+もし指定したライブラリが見つからない場合は、接続は失敗します。
+       </para>
+
+       <para>
+<!--
+        This option can be set by any user.  Because of that, the libraries
+        that can be loaded are restricted to those appearing in the
+        <filename>plugins</> subdirectory of the installation's
+        standard library directory.  (It is the database administrator's
+        responsibility to ensure that only <quote>safe</> libraries
+        are installed there.)  Entries in <varname>local_preload_libraries</>
+        can specify this directory explicitly, for example
+        <literal>$libdir/plugins/mylib</literal>, or just specify
+        the library name &mdash; <literal>mylib</literal> would have
+        the same effect as <literal>$libdir/plugins/mylib</literal>.
+-->
+        このオプションはすべてのユーザが設定できます。
+この理由で、読み込み可能なライブラリはインストレーションの共有ライブラリディレクトリのサブディレクトリ<filename>plugins</>内にあるものに制限されています。
+（確実に<quote>安全</>なライブラリのみをここにインストールすることはデータベース管理者の責任です。）
+ <varname>local_preload_libraries</>内の項目で、たとえば<literal>$libdir/plugins/mylib</literal>のようにこのディレクトリを明示的に指定することも、単にライブラリ名を指定することも可能です。
+<literal>mylib</literal> は<literal>$libdir/plugins/mylib</literal>と同じ効果です。
+       </para>
+
+       <para>
+<!--
+        The intent of this feature is to allow unprivileged users to load
+        debugging or performance-measurement libraries into specific sessions
+        without requiring an explicit <command>LOAD</> command.  To that end,
+        it would be typical to set this parameter using
+        the <envar>PGOPTIONS</envar> environment variable on the client or by
+        using
+        <command>ALTER ROLE SET</>.
+-->
+この機能の意図するところは、明示的な<command>LOAD</>コマンドを使わずに、特定のセッションにおいて非特権ユーザがデバッグ用あるいは性能計測用のライブラリをロードできるようにすることにあります。
+そのためにも、クライアント側で<envar>PGOPTIONS</envar>環境変数を使う、あるいは<command>ALTER ROLE SET</>を使うことが典型的になるでしょう。
+       </para>
+
+       <para>
+<!--
+        However, unless a module is specifically designed to be used in this way by
+        non-superusers, this is usually not the right setting to use.  Look
+        at <xref linkend="guc-session-preload-libraries"> instead.
+-->
+しかし、モジュールが特にスーパーユーザ以外に使われることを意図しているのでない限り、通常この方法は正しい使い方ではありません。
+代わりに<xref linkend="guc-session-preload-libraries">を見てください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+
+     <varlistentry id="guc-session-preload-libraries" xreflabel="session_preload_libraries">
+      <term><varname>session_preload_libraries</varname> (<type>string</type>)
+      <indexterm>
+<!--
+       <primary><varname>session_preload_libraries</> configuration parameter</primary>
+-->
+       <primary><varname>session_preload_libraries</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        This variable specifies one or more shared libraries that are to be
+        preloaded at connection start.
+        It contains a comma-separated list of library names, where each name
+        is interpreted as for the <xref linkend="SQL-LOAD"> command.
+        Whitespace between entries is ignored; surround a library name with
+        double quotes if you need to include whitespace or commas in the name.
+        The parameter value only takes effect at the start of the connection.
+        Subsequent changes have no effect.  If a specified library is not
+        found, the connection attempt will fail.
+        Only superusers can change this setting.
+-->
+この変数は接続開始時にプリロードされる一つ以上の共有ライブラリを指定します。
+ここにはカンマ区切りでライブラリ名のリストを格納し、各々の名前は<xref linkend="SQL-LOAD">コマンドで解釈されます。
+名前の中に空白あるいはカンマを含める場合は、二重引用符で囲ってください。
+スーパーユーザだけがこの設定を変更できます。
+このパラメータは接続開始時にのみ有効です。
+以降の変更は効果がありません。
+もし指定したライブラリが見つからない場合は、接続は失敗します。
+スーパーユーザだけがこの設定を変えられます。
+       </para>
+
+       <para>
+<!--
+        The intent of this feature is to allow debugging or
+        performance-measurement libraries to be loaded into specific sessions
+        without an explicit
+        <command>LOAD</> command being given.  For
+        example, <xref linkend="auto-explain"> could be enabled for all
+        sessions under a given user name by setting this parameter
+        with <command>ALTER ROLE SET</>.  Also, this parameter can be changed
+        without restarting the server (but changes only take effect when a new
+        session is started), so it is easier to add new modules this way, even
+        if they should apply to all sessions.
+-->
+        この機能は、デバッグや性能測定の目的で<command>LOAD</>コマンドを使わずに特定のセッションでライブラリをロードする目的で使われます。
+たとえば<command>ALTER ROLE SET</>で設定することにより、特定のユーザが開始するすべてのセッションで<xref linkend="auto-explain">が有効になります。
+また、このパラメータはサーバを再起動せずに変更できます(しかし変更は新しいセッションが開始するときにのみ有効となります)。すべてのセッションで有効にしたいのであれば、この方法で新しいモジュールを容易に追加できます。
+       </para>
+
+       <para>
+<!--
+        Unlike <xref linkend="guc-shared-preload-libraries">, there is no large
+        performance advantage to loading a library at session start rather than
+        when it is first used.  There is some advantage, however, when
+        connection pooling is used.
+-->
+        <xref linkend="guc-shared-preload-libraries">と違って、ライブラリがはじめて使われるときにロードする方法と比べてセッションが開始するときにライブラリをロードする方法には大きな性能的な優位性はありません。
+しかし、コネクションプーリングを使うのであれば、いくらか優位性があります。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-shared-preload-libraries" xreflabel="shared_preload_libraries">
+      <term><varname>shared_preload_libraries</varname> (<type>string</type>)
+      <indexterm>
+<!--
+       <primary><varname>shared_preload_libraries</> configuration parameter</primary>
+-->
+       <primary><varname>shared_preload_libraries</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        This variable specifies one or more shared libraries to be preloaded at
+        server start.
+        It contains a comma-separated list of library names, where each name
+        is interpreted as for the <xref linkend="SQL-LOAD"> command.
+        Whitespace between entries is ignored; surround a library name with
+        double quotes if you need to include whitespace or commas in the name.
+        This parameter can only be set at server start.  If a specified
+        library is not found, the server will fail to start.
+-->
+        この変数はサーバ起動時にプリロードされる一つ以上の共有ライブラリを指定します。
+スーパーユーザだけがこの設定を変更できます。
+このパラメータはサーバ起動時にのみ有効です。
+もし指定したライブラリが見つからない場合は、起動は失敗します。
+       </para>
+
+       <para>
+<!--
+        Some libraries need to perform certain operations that can only take
+        place at postmaster start, such as allocating shared memory, reserving
+        light-weight locks, or starting background workers.  Those libraries
+        must be loaded at server start through this parameter.  See the
+        documentation of each library for details.
+-->
+        ライブラリによってはpostmaster起動時にのみ可能な操作を実行する必要があるものがあります。
+たとえば、共有メモリの獲得、軽量ロックの予約、バックグラウンドワーカの起動などです。
+このようなライブラリはこのパラメータを使ってサーバ起動時にロードしなければなりません。
+詳細は各ライブラリのドキュメントを見てください。
+       </para>
+
+       <para>
+<!--
+        Other libraries can also be preloaded.  By preloading a shared library,
+        the library startup time is avoided when the library is first used.
+        However, the time to start each new server process might increase
+        slightly, even if that process never uses the library.  So this
+        parameter is recommended only for libraries that will be used in most
+        sessions.  Also, changing this parameter requires a server restart, so
+        this is not the right setting to use for short-term debugging tasks,
+        say.  Use <xref linkend="guc-session-preload-libraries"> for that
+        instead.
+-->
+        これ以外のライブラリもプリロードできます。
+共有ライブラリをプリロードすることにより、最初にライブラリが使われる際にライブラリが起動する時間を避けることができます。
+しかし、そのライブラリが使われないとしても、サーバプロセスが起動する時間がわずかに長くなる可能性があります。
+したがって、この方法は、ほとんどのセッションで使われるライブラリにのみ使用することを推奨します。
+また、パラメータの変更にはサーバの再起動が必要になります。
+ですから、たとえば短期のデバッグ仕事にこの設定を使うのは適当とは言えません。
+<xref linkend="guc-session-preload-libraries">を代わりに使ってください。
+       </para>
+
+      <note>
+       <para>
+<!--
+        On Windows hosts, preloading a library at server start will not reduce
+        the time required to start each new server process; each server process
+        will re-load all preload libraries.  However, <varname>shared_preload_libraries
+        </varname> is still useful on Windows hosts for libraries that need to
+        perform operations at postmaster start time.
+-->
+        Windowsのホストでは、ライブラリのプリロードは、新しいサーバプロセスの起動に要する時間を短縮しません。
+個々のサーバプロセスは、すべてのプリロードライブラリを再読み込みします。
+それでもpostmaster起動時に操作を実行しなければならないライブラリを使用するWindowsホストにとっては<varname>shared_preload_libraries</varname>は有用です。
+       </para>
+      </note>
+      </listitem>
+     </varlistentry>
+    </variablelist>
+   </sect2>
+
+     <sect2 id="runtime-config-client-other">
+     <!--
+     <title>Other Defaults</title>
+     -->
+     <title>その他のデフォルト</title>
+
+     <variablelist>
+
+     <varlistentry id="guc-dynamic-library-path" xreflabel="dynamic_library_path">
+      <term><varname>dynamic_library_path</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>dynamic_library_path</> configuration parameter</primary>
+       -->
+       <primary><varname>dynamic_library_path</>設定パラメータ</primary>
+      </indexterm>
+      <!--
+      <indexterm><primary>dynamic loading</></>
+      -->
+      <indexterm><primary>動的ロード</></>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        If a dynamically loadable module needs to be opened and the
+        file name specified in the <command>CREATE FUNCTION</command> or
+        <command>LOAD</command> command
+        does not have a directory component (i.e., the
+        name does not contain a slash), the system will search this
+        path for the required file.
+       -->
+       オープンする必要がある動的ロード可能なモジュールについて、その<command>CREATE FUNCTION</command>や<command>LOAD</command>コマンドで指定されたファイル名にディレクトリ要素がなく（つまり、名前にスラッシュが含まれずに）指定された場合、システムは必要なファイルをこのパスから検索します。
+       </para>
+
+       <para>
+       <!--
+        The value for <varname>dynamic_library_path</varname> must be a
+        list of absolute directory paths separated by colons (or semi-colons
+        on Windows).  If a list element starts
+        with the special string <literal>$libdir</literal>, the
+        compiled-in <productname>PostgreSQL</productname> package
+        library directory is substituted for <literal>$libdir</literal>; this
+        is where the modules provided by the standard
+        <productname>PostgreSQL</productname> distribution are installed.
+        (Use <literal>pg_config &#045;-pkglibdir</literal> to find out the name of
+        this directory.) For example:
+       -->
+       <varname>dynamic_library_path</varname>の値は、絶対パスのディレクトリ名をコロン（Windowsの場合はセミコロン）で区切った一覧です。
+この一覧の要素が特別な<literal>$libdir</literal>という値から始まる場合、コンパイルされた<productname>PostgreSQL</productname>パッケージのライブラリディレクトリで<literal>$libdir</literal>は置換されます。
+ここには、<productname>PostgreSQL</productname>の標準配布物により提供されるモジュールがインストールされます
+（このディレクトリ名を表示するには、<literal>pg_config --pkglibdir</literal> を使用してください）。
+例を以下に示します。
+<programlisting>
+dynamic_library_path = '/usr/local/lib/postgresql:/home/my_project/lib:$libdir'
+</programlisting>
+<!--
+        or, in a Windows environment:
+-->
+Windows環境の場合は以下です。
+<programlisting>
+dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
+</programlisting>
+       </para>
+
+       <para>
+       <!--
+        The default value for this parameter is
+        <literal>'$libdir'</literal>. If the value is set to an empty
+        string, the automatic path search is turned off.
+       -->
+       このパラメータのデフォルト値は<literal>'$libdir'</literal>です。
+この値が空に設定された場合、自動的なパス検索は無効になります。
+       </para>
+
+       <para>
+       <!--
+        This parameter can be changed at run time by superusers, but a
+        setting done that way will only persist until the end of the
+        client connection, so this method should be reserved for
+        development purposes. The recommended way to set this parameter
+        is in the <filename>postgresql.conf</filename> configuration
+        file.
+       -->
+       このパラメータはスーパーユーザによって実行時に変更することができますが、この方法での設定は、そのクライアント接続が終わるまでしか有効になりません。
+ですので、この方法は開発目的でのみ使用すべきです。
+推奨方法はこのパラメータを<filename>postgresql.conf</filename>設定ファイル内で設定することです。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-gin-fuzzy-search-limit" xreflabel="gin_fuzzy_search_limit">
+      <term><varname>gin_fuzzy_search_limit</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>gin_fuzzy_search_limit</> configuration parameter</primary>
+       -->
+       <primary><varname>gin_fuzzy_search_limit</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Soft upper limit of the size of the set returned by GIN index scans. For more
+        information see <xref linkend="gin-tips">.
+       -->
+       GINインデックス走査により返されるセットのソフトな上限サイズです。
+詳細は<xref linkend="gin-tips">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+    </sect2>
+   </sect1>
+
+   <sect1 id="runtime-config-locks">
+   <!--
+    <title>Lock Management</title>
+    -->
+    <title>ロック管理</title>
+
+     <variablelist>
+
+     <varlistentry id="guc-deadlock-timeout" xreflabel="deadlock_timeout">
+      <term><varname>deadlock_timeout</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary>deadlock</primary>
+       -->
+       <primary><!--deadlock-->デッドロック</primary>
+       <!--
+       <secondary>timeout during</secondary>
+       -->
+       <secondary>間のタイムアウト</secondary>
+      </indexterm>
+      <indexterm>
+      <!--
+       <primary>timeout</primary>
+       -->
+       <primary>タイムアウト</primary>
+       <!--
+       <secondary>deadlock</secondary>
+       -->
+       <secondary>デッドロック</secondary>
+      </indexterm>
+      <indexterm>
+      <!--
+       <primary><varname>deadlock_timeout</> configuration parameter</primary>
+       -->
+       <primary><varname>deadlock_timeout</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        This is the amount of time, in milliseconds, to wait on a lock
+        before checking to see if there is a deadlock condition. The
+        check for deadlock is relatively expensive, so the server doesn't run
+        it every time it waits for a lock. We optimistically assume
+        that deadlocks are not common in production applications and
+        just wait on the lock for a while before checking for a
+        deadlock. Increasing this value reduces the amount of time
+        wasted in needless deadlock checks, but slows down reporting of
+        real deadlock errors. The default is one second (<literal>1s</>),
+        which is probably about the smallest value you would want in
+        practice. On a heavily loaded server you might want to raise it.
+        Ideally the setting should exceed your typical transaction time,
+        so as to improve the odds that a lock will be released before
+        the waiter decides to check for deadlock.  Only superusers can change
+        this setting.
+-->
+これは、デッドロック状態があるかどうかを調べる前にロックを待つ時間をミリ秒で計算したものです。
+デッドロックの検査は比較的高価なので、サーバはロックを待つ度にこれを実行するわけではありません。
+楽天的ですがデッドロックは実用レベルのアプリケーションでは頻繁に発生しないと仮定し、デッドロックの検査の前にしばらくはロック待ちをします。
+この値を増やすことにより必要のないデッドロックの検査で無駄にされる時間は減りますが、本当にデッドロックがあった場合の報告が遅れます。
+デフォルトは1秒（<literal>1s</>）で、おそらく実用の際にはこれ以上は必要でしょう。
+負荷の大きいサーバではもっと必要かもしれません。
+理想としてはこの設定は通常のトランザクションにかかる時間を超えているべきです。
+そうすればロック待ちトランザクションがデッドロックの検査をする前にロックが解除される可能性が改善されます。
+スーパーユーザのみこの設定を変更できます。
+       </para>
+
+       <para>
+       <!--
+        When <xref linkend="guc-log-lock-waits"> is set,
+        this parameter also determines the length of time to wait before
+        a log message is issued about the lock wait.  If you are trying
+        to investigate locking delays you might want to set a shorter than
+        normal <varname>deadlock_timeout</varname>.
+       -->
+       <xref linkend="guc-log-lock-waits">が設定された場合、このパラメータはロック待機に関するログメッセージを出力する前の待機時間を決定します。
+ロック遅延の調査を行う場合は、通常の<varname>deadlock_timeout</varname>よりも短い値を設定することを勧めます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-max-locks-per-transaction" xreflabel="max_locks_per_transaction">
+      <term><varname>max_locks_per_transaction</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>max_locks_per_transaction</> configuration parameter</primary>
+       -->
+       <primary><varname>max_locks_per_transaction</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        The shared lock table tracks locks on
+        <varname>max_locks_per_transaction</varname> * (<xref
+        linkend="guc-max-connections"> + <xref
+        linkend="guc-max-prepared-transactions">) objects (e.g.,  tables);
+        hence, no more than this many distinct objects can be locked at
+        any one time.  This parameter controls the average number of object
+        locks allocated for each transaction;  individual transactions
+        can lock more objects as long as the locks of all transactions
+        fit in the lock table.  This is <emphasis>not</> the number of
+        rows that can be locked; that value is unlimited.  The default,
+        64, has historically proven sufficient, but you might need to
+        raise this value if you have queries that touch many different
+        tables in a single transaction, e.g. query of a parent table with
+        many children.  This parameter can only be set at server start.
+       -->
+       共有ロックテーブルは、<varname>max_locks_per_transaction</varname> * （<xref linkend="guc-max-connections"> + <xref linkend="guc-max-prepared-transactions">）オブジェクト（例えばテーブル）上のロック追跡します。
+したがって、ある時点でこの数以上の個々のオブジェクトをロックすることはできません。
+このパラメータは各トランザクションで割り当てられるオブジェクトロックの平均値を制御します。
+個々のトランザクションでは、このロックテーブルにすべてのトランザクションのロックが収まる限りオブジェクトのロックを獲得できます。
+これは、ロックできる行数では<emphasis>ありません</>。この値には制限がありません。
+デフォルトの64は、経験的に十分であると証明されていますが、単一のトランザクションで数多くの異なるテーブルをいじる問い合わせがいる場合、たとえば、数多くの子テーブルを持つ親テーブルの問い合わせなど、この値を大きくする必要があるかも知れません。
+このパラメータはサーバ起動時のみ設定されます。
+       </para>
+
+       <para>
+       <!--
+        When running a standby server, you must set this parameter to the
+        same or higher value than on the master server. Otherwise, queries
+        will not be allowed in the standby server.
+       -->
+       スタンバイサーバを稼動するとき、このパラメータをマスターサーバと同じか、より高い値に設定しなければなりません。
+       そうしないと、問い合わせはスタンバイサーバでは許可されません。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-max-pred-locks-per-transaction" xreflabel="max_pred_locks_per_transaction">
+      <term><varname>max_pred_locks_per_transaction</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>max_pred_locks_per_transaction</> configuration parameter</primary>
+       -->
+       <primary><varname>max_pred_locks_per_transaction</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        The shared predicate lock table tracks locks on
+        <varname>max_pred_locks_per_transaction</varname> * (<xref
+        linkend="guc-max-connections"> + <xref
+        linkend="guc-max-prepared-transactions">) objects (e.g., tables);
+        hence, no more than this many distinct objects can be locked at
+        any one time.  This parameter controls the average number of object
+        locks allocated for each transaction;  individual transactions
+        can lock more objects as long as the locks of all transactions
+        fit in the lock table.  This is <emphasis>not</> the number of
+        rows that can be locked; that value is unlimited.  The default,
+        64, has generally been sufficient in testing, but you might need to
+        raise this value if you have clients that touch many different
+        tables in a single serializable transaction. This parameter can
+        only be set at server start.
+       -->
+       共有記述ロックテーブル（shared predicate lock table）は、<varname>max_pred_locks_per_transaction</varname> * (<xref
+        linkend="guc-max-connections"> + <xref
+        linkend="guc-max-prepared-transactions">)オブジェクト（例えば諸テーブル）のロックを追跡します。
+       従って、この数以上の明確なオブジェクトは同時にロックされません。
+       このパラメータはそれぞれのトランザクションに対して割り当てられたオブジェクトのロックの平均数を管理します。
+       個別のトランザクションはロックテーブル内の全てのトランザクションのロックが適合する限り、より多くのオブジェクトをロックできます。
+       これはロック可能な行数では<emphasis>ありません</>。その値は無制限です。
+       デフォルトは64で、テストでは一般的に充分ですが、単一のシリアライザブルトランザクションで数多くの異なるテーブルに触れるクライアントが存在する場合、この値を大きくする必要があることがあります。
+       このパラメータはサーバ起動時のみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-max-pred-locks-per-relation" xreflabel="max_pred_locks_per_relation">
+      <term><varname>max_pred_locks_per_relation</varname> (<type>integer</type>)
+      <indexterm>
+<!--
+       <primary><varname>max_pred_locks_per_relation</> configuration parameter</primary>
+-->
+       <primary><varname>max_pred_locks_per_relation</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        This controls how many pages or tuples of a single relation can be
+        predicate-locked before the lock is promoted to covering the whole
+        relation.  Values greater than or equal to zero mean an absolute
+        limit, while negative values
+        mean <xref linkend="guc-max-pred-locks-per-transaction"> divided by
+        the absolute value of this setting.  The default is -2, which keeps
+        the behavior from previous versions of <productname>PostgreSQL</>.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+-->
+リレーション全体をカバーするロックに昇格する前に、一つリレーションの中で述語ロックできるページ数あるいはタプル数を指定します。
+0以上の値は、絶対的な制限を表し、負の数は<xref linkend="guc-max-pred-locks-per-transaction">をその絶対値で割ったものを表します。
+  デフォルトは-2で、以前のバージョンの<productname>PostgreSQL</>の振る舞いを維持します。
+このパラメータは<filename>postgresql.conf</>ファイル、または、サーバのコマンドラインのみで設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-max-pred-locks-per-page" xreflabel="max_pred_locks_per_page">
+      <term><varname>max_pred_locks_per_page</varname> (<type>integer</type>)
+      <indexterm>
+       <primary><varname>max_pred_locks_per_page</> configuration parameter</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        This controls how many rows on a single page can be predicate-locked
+        before the lock is promoted to covering the whole page.  The default
+        is 2.  This parameter can only be set in
+        the <filename>postgresql.conf</> file or on the server command line.
+-->
+ページ全体をカバーするロックに昇格する前に、一つページの中で述語ロックできる行数を指定します。
+デフォルトは2です。
+このパラメータは<filename>postgresql.conf</>ファイル、または、サーバのコマンドラインのみで設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+   </sect1>
+
+   <sect1 id="runtime-config-compatible">
+   <!--
+    <title>Version and Platform Compatibility</title>
+    -->
+    <title>バージョンとプラットフォーム互換性</title>
+
+    <sect2 id="runtime-config-compatible-version">
+    <!--
+     <title>Previous PostgreSQL Versions</title>
+     -->
+     <title>以前のPostgreSQLバージョン</title>
+
+     <variablelist>
+
+     <varlistentry id="guc-array-nulls" xreflabel="array_nulls">
+      <term><varname>array_nulls</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>array_nulls</> configuration parameter</primary>
+       -->
+       <primary><varname>array_nulls</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        This controls whether the array input parser recognizes
+        unquoted <literal>NULL</> as specifying a null array element.
+        By default, this is <literal>on</>, allowing array values containing
+        null values to be entered.  However, <productname>PostgreSQL</> versions
+        before 8.2 did not support null values in arrays, and therefore would
+        treat <literal>NULL</> as specifying a normal array element with
+        the string value <quote>NULL</>.  For backward compatibility with
+        applications that require the old behavior, this variable can be
+        turned <literal>off</>.
+       -->
+       これは、配列入力パーサが引用符のない<literal>NULL</>をNULL配列要素として認識するかどうかを制御します。
+デフォルトでは、これは<literal>on</>で、NULL値を持つ配列値を入力することができます。
+しかし、8.2より前のバージョンの<productname>PostgreSQL</>では、配列内のNULL値をサポートしておらず、<literal>NULL</>を<quote>NULL</>という値の文字列を持つ通常の配列要素として扱っていました。
+古い動作を必要とするアプリケーションの後方互換性のため、この変数を<literal>off</>にすることができます。
+       </para>
+
+       <para>
+       <!--
+        Note that it is possible to create array values containing null values
+        even when this variable is <literal>off</>.
+       -->
+       この変数が<literal>off</>であっても、NULL値を含む配列値を作成することができることに注意してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-backslash-quote" xreflabel="backslash_quote">
+      <term><varname>backslash_quote</varname> (<type>enum</type>)
+      <!--
+      <indexterm><primary>strings</><secondary>backslash quotes</></>
+      -->
+      <indexterm><primary>文字列</><secondary>バックスラッシュによる引用</></>
+      <indexterm>
+      <!--
+       <primary><varname>backslash_quote</> configuration parameter</primary>
+       -->
+       <primary><varname>backslash_quote</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        This controls whether a quote mark can be represented by
+        <literal>\'</> in a string literal.  The preferred, SQL-standard way
+        to represent a quote mark is by doubling it (<literal>''</>) but
+        <productname>PostgreSQL</> has historically also accepted
+        <literal>\'</>. However, use of <literal>\'</> creates security risks
+        because in some client character set encodings, there are multibyte
+        characters in which the last byte is numerically equivalent to ASCII
+        <literal>\</>.  If client-side code does escaping incorrectly then a
+        SQL-injection attack is possible.  This risk can be prevented by
+        making the server reject queries in which a quote mark appears to be
+        escaped by a backslash.
+        The allowed values of <varname>backslash_quote</> are
+        <literal>on</> (allow <literal>\'</> always),
+        <literal>off</> (reject always), and
+        <literal>safe_encoding</> (allow only if client encoding does not
+        allow ASCII <literal>\</> within a multibyte character).
+        <literal>safe_encoding</> is the default setting.
+       -->
+       文字列リテラルの中で引用符が<literal>\'</>で表現されるかどうかを管理します。
+       引用符の表現としてSQL準拠の方式では二重化（<literal>''</>）ですが、<productname>PostgreSQL</>は歴史的に<literal>\'</>も受け付けます。
+       とは言っても、いくつかのクライアント文字集合符号化方式において、最終バイトが数値的にASCIIの<literal>\</>に等しいマルチバイト文字があり、<literal>\'</>を使用するとセキュリティ上問題を引き起こす可能性があります。
+       クライアント側のコードが事実上エスケープを正しく扱わない場合、SQLインジェクション攻撃が可能になります。この危険性の回避は、サーバが逆スラッシュでエスケープされた引用符を含む問い合わせを拒絶するようにします。
+       許可される<varname>backslash_quote</>の値は、
+        <literal>on</> （常に <literal>\'</> を許可）,
+        <literal>off</> （常に拒否）、および
+        <literal>safe_encoding</> （クライアント符号化方式がASCIIの<literal>\</>を許可しないときのみ、マルチバイト文字内で許可）。
+        <literal>safe_encoding</> がデフォルトの設定。
+       </para>
+
+       <para>
+       <!--
+        Note that in a standard-conforming string literal, <literal>\</> just
+        means <literal>\</> anyway.  This parameter only affects the handling of
+        non-standard-conforming literals, including
+        escape string syntax (<literal>E'...'</>).
+       -->
+       標準に従った文字列リテラルでは、<literal>\</>は単に<literal>\</>を意味するものです。
+このパラメータのみが、エスケープ文字列構文（<literal>E'...'</>）を含む標準に従わないリテラルの取り扱いに影響します。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-default-with-oids" xreflabel="default_with_oids">
+      <term><varname>default_with_oids</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>default_with_oids</> configuration parameter</primary>
+       -->
+       <primary><varname>default_with_oids</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        This controls whether <command>CREATE TABLE</command> and
+        <command>CREATE TABLE AS</command> include an OID column in
+        newly-created tables, if neither <literal>WITH OIDS</literal>
+        nor <literal>WITHOUT OIDS</literal> is specified. It also
+        determines whether OIDs will be included in tables created by
+        <command>SELECT INTO</command>. The parameter is <literal>off</>
+        by default; in <productname>PostgreSQL</> 8.0 and earlier, it
+        was <literal>on</> by default.
+       -->
+       もし<literal>WITH OIDS</literal>もしくは<literal>WITHOUT OIDS</literal>のいずれも指定されていない場合、<command>CREATE TABLE</command>および<command>CREATE TABLE AS</command>がオブジェクト識別子（OID）列を新規作成のテーブルに含めるか否かを管理します。
+同時に<command>SELECT INTO</command>で作成されたテーブルにOIDが含まれるか否かも決定します。
+このパラメータはデフォルトで<literal>off</>です。<productname>PostgreSQL</> 8.0およびそれ以前ではデフォルトで<literal>on</>でした。
+       </para>
+
+       <para>
+       <!--
+        The use of OIDs in user tables is considered deprecated, so
+        most installations should leave this variable disabled.
+        Applications that require OIDs for a particular table should
+        specify <literal>WITH OIDS</literal> when creating the
+        table. This variable can be enabled for compatibility with old
+        applications that do not follow this behavior.
+       -->
+       ユーザテーブルでのOID使用は良くないと考えられるため、ほとんどのインストレーションはこの変数を無効にしたままになっています。
+       特定のテーブルに対してOIDを必要とするアプリケーションは、テーブル作成にあたって<literal>WITH OIDS</literal>を指定しなければなりません。
+       この変数は、この動作を行わない古いアプリケーションとの互換性を有効にします。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-escape-string-warning" xreflabel="escape_string_warning">
+      <term><varname>escape_string_warning</varname> (<type>boolean</type>)
+      <!--
+      <indexterm><primary>strings</><secondary>escape warning</></>
+      -->
+      <indexterm><primary>文字列</><secondary>エスケープに関する警告</></>
+      <indexterm>
+      <!--
+       <primary><varname>escape_string_warning</> configuration parameter</primary>
+       -->
+       <primary><varname>escape_string_warning</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        When on, a warning is issued if a backslash (<literal>\</>)
+        appears in an ordinary string literal (<literal>'...'</>
+        syntax) and <varname>standard_conforming_strings</varname> is off.
+        The default is <literal>on</>.
+       -->
+       有効の場合、通常の文字列リテラル（<literal>'...'</>構文）にバックスラッシュ（<literal>\</>）があり、<varname>standard_conforming_strings</varname>が無効な場合、警告が発せられます。
+デフォルトは<literal>on</>です。
+       </para>
+       <para>
+       <!--
+        Applications that wish to use backslash as escape should be
+        modified to use escape string syntax (<literal>E'...'</>),
+        because the default behavior of ordinary strings is now to treat
+        backslash as an ordinary character, per SQL standard.  This variable
+        can be enabled to help locate code that needs to be changed.
+       -->
+       通常文字列のデフォルトの振る舞いは、SQL標準ではバックスラッシュを通常文字として取り扱うため、バックスラッシュをエスケープとして使用したいアプリケーションは、エスケープ文字列構文(<literal>E'...'</>)を使用するように変更すべきです。
+        この変数は変更すべきコードを突き止めるのに役立つよう、有効にすることができます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-lo-compat-privileges" xreflabel="lo_compat_privileges">
+      <term><varname>lo_compat_privileges</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>lo_compat_privileges</> configuration parameter</primary>
+       -->
+       <primary><varname>lo-compat-privileges</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        In <productname>PostgreSQL</> releases prior to 9.0, large objects
+        did not have access privileges and were, therefore, always readable
+        and writable by all users.  Setting this variable to <literal>on</>
+        disables the new privilege checks, for compatibility with prior
+        releases.  The default is <literal>off</>.
+        Only superusers can change this setting.
+       -->
+       9.0以前の<productname>PostgreSQL</>リリースでは、ラージオブジェクトはアクセス権限が無く、従って全てのユーザが常に読み込み、書き込みが可能でした。
+       この変数を<literal>on</>にすると、以前のリリースとの互換性のため、新規の権限チェックが無効になります。
+       デフォルトは<literal>off</>です。
+        スーパーユーザのみこの設定を変更できます。
+       </para>
+       <para>
+<!--
+        Setting this variable does not disable all security checks related to
+        large objects &mdash; only those for which the default behavior has
+        changed in <productname>PostgreSQL</> 9.0.
+        For example, <literal>lo_import()</literal> and
+        <literal>lo_export()</literal> need superuser privileges regardless
+        of this setting.
+-->
+この変数を設定しても、ラージオブジェクトに関連した全ての安全性チェックを無効にする訳ではありません。
+<productname>PostgreSQL</> 9.0で変更されたデフォルトの動きに対してのみです。
+例えば、<literal>lo_import()</literal>と<literal>lo_export()</literal>はこの設定に係わらずスーパーユーザの権限を必要とします。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-operator-precedence-warning" xreflabel="operator_precedence_warning">
+      <term><varname>operator_precedence_warning</varname> (<type>boolean</type>)
+      <indexterm>
+<!--
+       <primary><varname>operator_precedence_warning</> configuration parameter</primary>
+-->
+       <primary><varname>operator_precedence_warning</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        When on, the parser will emit a warning for any construct that might
+        have changed meanings since <productname>PostgreSQL</> 9.4 as a result
+        of changes in operator precedence.  This is useful for auditing
+        applications to see if precedence changes have broken anything; but it
+        is not meant to be kept turned on in production, since it will warn
+        about some perfectly valid, standard-compliant SQL code.
+        The default is <literal>off</>.
+-->
+onの場合、演算子の優先順位の変更の結果、<productname>PostgreSQL</> 9.4以降で意味が変わる可能性のある構文に対して、パーサは警告を出力します。
+これは、優先順位の変更によりアプリケーションに何か不具合が起きないか監視するのに役立ちます。
+しかし、これはプロダクション環境でオンにしたままにしておくためのものではありません。
+なぜなら、完全に正しいSQL標準準拠コードに対しても警告を発するからです。
+デフォルトは<literal>off</>です。
+       </para>
+
+       <para>
+<!--
+        See <xref linkend="sql-precedence"> for more information.
+-->
+詳細は<xref linkend="sql-precedence">を見てください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+    <varlistentry id="guc-quote-all-identifiers" xreflabel="quote-all-identifiers">
+      <term><varname>quote_all_identifiers</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>quote_all_identifiers</> configuration parameter</primary>
+       -->
+       <primary><varname>quote_all_identifiers</> 設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        When the database generates SQL, force all identifiers to be quoted,
+        even if they are not (currently) keywords.  This will affect the
+        output of <command>EXPLAIN</> as well as the results of functions
+        like <function>pg_get_viewdef</>.  See also the
+        <option>&#045;-quote-all-identifiers</option> option of
+        <xref linkend="app-pgdump"> and <xref linkend="app-pg-dumpall">.
+-->
+データベースがSQLを生成する時、たとえ（現在）キーワードになっていなくても、全ての識別子を引用符で囲むことを強制します。
+これは <command>EXPLAIN</>の出力に影響を与えるのみならず、<function>pg_get_viewdef</>のような関数の結果にも影響します。
+<xref linkend="app-pgdump"> および <xref linkend="app-pg-dumpall">の<option>--quote-all-identifiers</option>オプションも参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-standard-conforming-strings" xreflabel="standard_conforming_strings">
+      <term><varname>standard_conforming_strings</varname> (<type>boolean</type>)
+      <!--
+      <indexterm><primary>strings</><secondary>standard conforming</></>
+      -->
+      <indexterm><primary>文字列</><secondary>標準に従う</></>
+      <indexterm>
+      <!--
+       <primary><varname>standard_conforming_strings</> configuration parameter</primary>
+       -->
+       <primary><varname>standard_conforming_strings</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        This controls whether ordinary string literals
+        (<literal>'...'</>) treat backslashes literally, as specified in
+        the SQL standard.
+        Beginning in <productname>PostgreSQL</productname> 9.1, the default is
+        <literal>on</> (prior releases defaulted to <literal>off</>).
+        Applications can check this
+        parameter to determine how string literals will be processed.
+        The presence of this parameter can also be taken as an indication
+        that the escape string syntax (<literal>E'...'</>) is supported.
+        Escape string syntax (<xref linkend="sql-syntax-strings-escape">)
+        should be used if an application desires
+        backslashes to be treated as escape characters.
+       -->
+       標準SQLで規定されたように、通常の文字列リテラル（<literal>'...'</>）がバックスラッシュをそのまま取り扱うか否かを制御します。
+       <productname>PostgreSQL</productname> 9.1からデフォルトは<literal>on</>になっています（それ以前のリリースでは<literal>off</>がデフォルトでした）。
+       どのように文字列リテラルが処理されるかを決めるこのパラメータを、アプリケーションで検査することができます。
+このパラメータの存在は、エスケープ文字列構文（<literal>E'...'</>）がサポートされているかどうかを示すものとも考えられます。
+エスケープ文字列構文 (<xref linkend="sql-syntax-strings-escape">)は、アプリケーションでバックスラッシュをエスケープ文字として扱いたい場合に使用すべきです。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-synchronize-seqscans" xreflabel="synchronize_seqscans">
+      <term><varname>synchronize_seqscans</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>synchronize_seqscans</> configuration parameter</primary>
+       -->
+       <primary><varname>synchronize_seqscans</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        This allows sequential scans of large tables to synchronize with each
+        other, so that concurrent scans read the same block at about the
+        same time and hence share the I/O workload.  When this is enabled,
+        a scan might start in the middle of the table and then <quote>wrap
+        around</> the end to cover all rows, so as to synchronize with the
+        activity of scans already in progress.  This can result in
+        unpredictable changes in the row ordering returned by queries that
+        have no <literal>ORDER BY</> clause.  Setting this parameter to
+        <literal>off</> ensures the pre-8.3 behavior in which a sequential
+        scan always starts from the beginning of the table.  The default
+        is <literal>on</>.
+       -->
+       これにより、同時実行スキャンがほぼ同じ時間に同じブロックを読み取り、I/Oへの負荷を分散できるように、互いに同期して、大規模テーブルをシーケンシャルスキャンすることができます。
+これが有効な場合、スキャンはテーブルの途中から始まり、進行中のスキャンの活動と同期するように、行全体を覆うように終端を<quote>巻き上げる</>可能性があります。
+これにより、<literal>ORDER BY</>句を持たない問い合わせが返す行の順序は予想できない程変わってしまいます。
+このパラメータを<literal>off</>にすることで、シーケンシャルスキャンが常にテーブルの先頭から始まるという、8.3より前の動作を保証します。
+デフォルトは<literal>on</>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+    </sect2>
+
+    <sect2 id="runtime-config-compatible-clients">
+    <!--
+     <title>Platform and Client Compatibility</title>
+     -->
+     <title>プラットフォームとクライアント互換性</title>
+     <variablelist>
+
+     <varlistentry id="guc-transform-null-equals" xreflabel="transform_null_equals">
+      <term><varname>transform_null_equals</varname> (<type>boolean</type>)
+      <indexterm><primary>IS NULL</></>
+      <indexterm>
+      <!--
+       <primary><varname>transform_null_equals</> configuration parameter</primary>
+       -->
+       <primary><varname>transform_null_equals</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        When on, expressions of the form <literal><replaceable>expr</> =
+        NULL</literal> (or <literal>NULL =
+        <replaceable>expr</></literal>) are treated as
+        <literal><replaceable>expr</> IS NULL</literal>, that is, they
+        return true if <replaceable>expr</> evaluates to the null value,
+        and false otherwise. The correct SQL-spec-compliant behavior of
+        <literal><replaceable>expr</> = NULL</literal> is to always
+        return null (unknown). Therefore this parameter defaults to
+        <literal>off</>.
+       -->
+       有効の場合、<literal><replaceable>expr</> = NULL</literal>（もしくは<literal>NULL = <replaceable>expr</></literal>）形式の式は<literal><replaceable>expr</> IS NULL</literal>として取り扱われ、それは、もし<replaceable>expr</>がNULL値と評価すれば真を返し、そうでなければ偽を返します。
+<literal><replaceable>expr</> = NULL</literal>の正しいSQL仕様準拠の動作は常にNULL（判らない）を返すことです。
+従って、このパラメータのデフォルトは<literal>off</>になっています。
+       </para>
+
+       <para>
+<!--
+        However, filtered forms in <productname>Microsoft
+        Access</productname> generate queries that appear to use
+        <literal><replaceable>expr</> = NULL</literal> to test for
+        null values, so if you use that interface to access the database you
+        might want to turn this option on.  Since expressions of the
+        form <literal><replaceable>expr</> = NULL</literal> always
+        return the null value (using the SQL standard interpretation), they are not
+        very useful and do not appear often in normal applications so
+        this option does little harm in practice.  But new users are
+        frequently confused about the semantics of expressions
+        involving null values, so this option is off by default.
+-->
+しかし、<productname>Microsoft Access</productname>のフィルタ形式はNULL値を検査するために<literal><replaceable>expr</> = NULL</literal>を使用する問い合わせを生成しますので、そのインタフェースを使用してデータベースにアクセスする場合は、このオプションを有効にする方が良いでしょう。
+<literal><replaceable>expr</> = NULL</literal>という形の式は（SQL標準解釈を使用した結果）常にNULL値を返しますので、通常のアプリケーションでは意味がほとんどなく、滅多に使用されません。
+ですので、このオプションは実際は害はありません。
+しかし、慣れていないユーザはしばしばNULL値に関する式の意味に戸惑いますので、デフォルトでこのオプションはoffです。
+       </para>
+
+       <para>
+       <!--
+        Note that this option only affects the exact form <literal>= NULL</>,
+        not other comparison operators or other expressions
+        that are computationally equivalent to some expression
+        involving the equals operator (such as <literal>IN</literal>).
+        Thus, this option is not a general fix for bad programming.
+       -->
+       このオプションは<literal>= NULL</>という形式にのみ影響することに注意してください。
+他の比較演算子や等価演算子を呼び出す他の（<literal>IN</literal>のような）式と計算する上で等価となる式には影響を与えません。
+したがって、このオプションは間違ったプログラミングの汎用的な問題解決を行いません。
+       </para>
+
+       <para>
+       <!--
+        Refer to <xref linkend="functions-comparison"> for related information.
+       -->
+       関連する情報は<xref linkend="functions-comparison">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     </variablelist>
+    </sect2>
+   </sect1>
+
+   <sect1 id="runtime-config-error-handling">
+   <!--
+    <title>Error Handling</title>
+    -->
+    <title>エラー処理</title>
+
+    <variablelist>
+
+     <varlistentry id="guc-exit-on-error" xreflabel="exit_on_error">
+      <term><varname>exit_on_error</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>exit_on_error</> configuration parameter</primary>
+       -->
+       <primary><varname>exit_on_error</> 設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        If true, any error will terminate the current session.  By default,
+        this is set to false, so that only FATAL errors will terminate the
+        session.
+       -->
+       真の場合、全てのエラーは現在のセッションを中止させます。
+       デフォルトでこれは偽に設定されますので、 FATALエラーのみがセッションを中止させます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-restart-after-crash" xreflabel="restart_after_crash">
+      <term><varname>restart_after_crash</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>restart_after_crash</> configuration parameter</primary>
+       -->
+       <primary><varname>restart_after_crash</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        When set to true, which is the default, <productname>PostgreSQL</>
+        will automatically reinitialize after a backend crash.  Leaving this
+        value set to true is normally the best way to maximize the availability
+        of the database.  However, in some circumstances, such as when
+        <productname>PostgreSQL</> is being invoked by clusterware, it may be
+        useful to disable the restart so that the clusterware can gain
+        control and take any actions it deems appropriate.
+       -->
+       真の場合、これがデフォルトですが、<productname>PostgreSQL</>はバックエンドのクラッシュの後、自動的に再初期化を行います。
+       この値を真のままにしておくことは通常データベースの可用性を最大化する最適の方法です。
+       しかし、 <productname>PostgreSQL</>がクラスタウェアにより起動された時のような状況により、クラスタウェアが制御を獲得し、適切とみなされるいかなる振る舞いをも行えるように再起動を無効にすることも有益です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+    </variablelist>
+
+   </sect1>
+
+   <sect1 id="runtime-config-preset">
+   <!--
+    <title>Preset Options</title>
+    -->
+    <title>設定済みのオプション</title>
+
+    <para>
+    <!--
+     The following <quote>parameters</> are read-only, and are determined
+     when <productname>PostgreSQL</productname> is compiled or when it is
+     installed. As such, they have been excluded from the sample
+     <filename>postgresql.conf</> file.  These options report
+     various aspects of <productname>PostgreSQL</productname> behavior
+     that might be of interest to certain applications, particularly
+     administrative front-ends.
+     -->
+     以下の<quote>パラメータ</>は読み取り専用で、<productname>PostgreSQL</productname>のコンパイル時、もしくはインストール時に決定されます。
+そのため、これらは<filename>postgresql.conf</>のサンプルから除かれています。
+このオプションは、特定のアプリケーション、特に管理用フロントエンドによって注目される可能性がある<productname>PostgreSQL</productname>の様々な部分の振舞いを報告します。
+    </para>
+
+    <variablelist>
+
+     <varlistentry id="guc-block-size" xreflabel="block_size">
+      <term><varname>block_size</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>block_size</> configuration parameter</primary>
+       -->
+       <primary><varname>block_size</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Reports the size of a disk block.  It is determined by the value
+        of <literal>BLCKSZ</> when building the server. The default
+        value is 8192 bytes.  The meaning of some configuration
+        variables (such as <xref linkend="guc-shared-buffers">) is
+        influenced by <varname>block_size</varname>. See <xref
+        linkend="runtime-config-resource"> for information.
+       -->
+       ディスクブロックの容量を報告します。
+       サーバ構築の際に<literal>BLCKSZ</>の値で決定されます。デフォルトの値は8192バイトです。
+       （<xref linkend="guc-shared-buffers">の様な）いくつかの構成変数の意味は<varname>block_size</varname>によって影響されます。
+       これに関しての情報は<xref
+        linkend="runtime-config-resource">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-data-checksums" xreflabel="data_checksums">
+      <term><varname>data_checksums</varname> (<type>boolean</type>)
+      <indexterm>
+<!--
+       <primary><varname>data_checksums</> configuration parameter</primary>
+-->
+       <primary><varname>data_checksums</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Reports whether data checksums are enabled for this cluster.
+        See <xref linkend="app-initdb-data-checksums"> for more information.
+-->
+        このクラスタでデータチェックサムが有効になっているかどうかを報告します。
+        詳細は<xref linkend="app-initdb-data-checksums">を見てください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-debug-assertions" xreflabel="debug_assertions">
+      <term><varname>debug_assertions</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>debug_assertions</> configuration parameter</primary>
+       -->
+       <primary><varname>debug_assertions</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Reports whether <productname>PostgreSQL</productname> has been built
+        with assertions enabled. That is the case if the
+        macro <symbol>USE_ASSERT_CHECKING</symbol> is defined
+        when <productname>PostgreSQL</productname> is built (accomplished
+        e.g. by the <command>configure</command> option
+        <option>&#045;-enable-cassert</option>). By
+        default <productname>PostgreSQL</productname> is built without
+        assertions.
+-->
+<productname>PostgreSQL</productname>がアサーションを有効にしてビルドされているかどうかを報告します。
+これは、<symbol>USE_ASSERT_CHECKING</symbol>マクロが<productname>PostgreSQL</productname>をビルドされた際に定義されている場合(つまり、<command>configure</command>オプションの<option>--enable-cassert</option>)が適用されている)に該当します。
+デフォルトでは<productname>PostgreSQL</productname>は、アサーションなしにビルドされます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-integer-datetimes" xreflabel="integer_datetimes">
+      <term><varname>integer_datetimes</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>integer_datetimes</> configuration parameter</primary>
+       -->
+       <primary><varname>integer_datetimes</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        Reports whether <productname>PostgreSQL</> was built with support for
+        64-bit-integer dates and times.  As of <productname>PostgreSQL</> 10,
+        this is always <literal>on</literal>.
+-->
+<productname>PostgreSQL</>が64ビット整数による日付と時刻のサポート付きで構築されたかどうかを報告します。
+<productname>PostgreSQL</> 10では、これは常に<literal>on</literal>です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-lc-collate" xreflabel="lc_collate">
+      <term><varname>lc_collate</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>lc_collate</> configuration parameter</primary>
+       -->
+       <primary><varname>lc_collate</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Reports the locale in which sorting of textual data is done.
+        See <xref linkend="locale"> for more information.
+        This value is determined when a database is created.
+       -->
+       テキストデータの並び替えが行なわれるロケールを報告します。
+       詳細は<xref linkend="locale"> を参照してください。
+       この値はデータベースが作成されたときに決定されます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-lc-ctype" xreflabel="lc_ctype">
+      <term><varname>lc_ctype</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>lc_ctype</> configuration parameter</primary>
+       -->
+       <primary><varname>lc_ctype</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Reports the locale that determines character classifications.
+        See <xref linkend="locale"> for more information.
+        This value is determined when a database is created.
+        Ordinarily this will be the same as <varname>lc_collate</varname>,
+        but for special applications it might be set differently.
+       -->
+       文字分類を決定するロケールを報告します。
+       詳細は<xref linkend="locale">を参照してください。
+       この値はデータベースが作成されたときに決定されます。
+       通常、これは<varname>lc_collate</varname>と同一ですが、特殊なアプリケーションでは異なって設定されることがあります。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-max-function-args" xreflabel="max_function_args">
+      <term><varname>max_function_args</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>max_function_args</> configuration parameter</primary>
+       -->
+       <primary><varname>max_function_args</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Reports the maximum number of function arguments. It is determined by
+        the value of <literal>FUNC_MAX_ARGS</> when building the server. The
+        default value is 100 arguments.
+       -->
+       関数の引数の最大数を報告します。
+サーバを構築する時、<literal>FUNC_MAX_ARGS</>の値で決定されます。
+デフォルトの値は100引数です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-max-identifier-length" xreflabel="max_identifier_length">
+      <term><varname>max_identifier_length</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>max_identifier_length</> configuration parameter</primary>
+       -->
+       <primary><varname>max_identifier_length</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Reports the maximum identifier length. It is determined as one
+        less than the value of <literal>NAMEDATALEN</> when building
+        the server. The default value of <literal>NAMEDATALEN</> is
+        64; therefore the default
+        <varname>max_identifier_length</varname> is 63 bytes, which
+        can be less than 63 characters when using multibyte encodings.
+       -->
+       最長の識別子の長さを報告します。
+サーバ構築時の<literal>NAMEDATALEN</>の値より一つ少なく設定されます。
+デフォルトの<literal>NAMEDATALEN</>の値は64ですので、デフォルトの<varname>max_identifier_length</varname>は63バイトで、マルチバイト符号化方式を使用している場合、63文字以下になることがあります。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-max-index-keys" xreflabel="max_index_keys">
+      <term><varname>max_index_keys</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>max_index_keys</> configuration parameter</primary>
+       -->
+       <primary><varname>max_index_keys</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Reports the maximum number of index keys. It is determined by
+        the value of <literal>INDEX_MAX_KEYS</> when building the server. The
+        default value is 32 keys.
+       -->
+       インデックスキーの最大数を報告します。サーバをビルドする際に<literal>INDEX_MAX_KEYS</>の値で決定されます。デフォルトの値は32キーです。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-segment-size" xreflabel="segment_size">
+      <term><varname>segment_size</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>segment_size</> configuration parameter</primary>
+       -->
+       <primary><varname>segment_size</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Reports the number of blocks (pages) that can be stored within a file
+        segment.  It is determined by the value of <literal>RELSEG_SIZE</>
+        when building the server.  The maximum size of a segment file in bytes
+        is equal to <varname>segment_size</> multiplied by
+        <varname>block_size</>; by default this is 1GB.
+       -->
+       あるファイルセグメントの中に格納できるブロック数（ページ数）を報告します。
+       サーバ構築時に<literal>RELSEG_SIZE</>の値で決定されます。
+       バイト単位の一セグメントファイルの最大容量は、<varname>block_size</>倍の<varname>segment_size</>と等しくなります。デフォルトでは1GBです。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-server-encoding" xreflabel="server_encoding">
+      <term><varname>server_encoding</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>server_encoding</> configuration parameter</primary>
+       -->
+       <primary><varname>server_encoding</>設定パラメータ</primary>
+      </indexterm>
+      <!--
+      <indexterm><primary>character set</></>
+      -->
+      <indexterm><primary>文字セット</></>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Reports the database encoding (character set).
+        It is determined when the database is created.  Ordinarily,
+        clients need only be concerned with the value of <xref
+        linkend="guc-client-encoding">.
+       -->
+       データベース符号化方式（文字セット）を報告します。
+       データベースが作成された時に決定されます。通常クライアントは<xref
+        linkend="guc-client-encoding">の値にのみ注意する必要があります。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-server-version" xreflabel="server_version">
+      <term><varname>server_version</varname> (<type>string</type>)
+      <indexterm>
+      <!--
+       <primary><varname>server_version</> configuration parameter</primary>
+       -->
+       <primary><varname>server_version</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Reports the version number of the server. It is determined by the
+        value of <literal>PG_VERSION</> when building the server.
+       -->
+       サーバのバージョン番号を報告します。
+       サーバ構築の際の<literal>PG_VERSION</>の値によって決定されます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-server-version-num" xreflabel="server_version_num">
+      <term><varname>server_version_num</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>server_version_num</> configuration parameter</primary>
+       -->
+       <primary><varname>server_version_num</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Reports the version number of the server as an integer. It is determined
+        by the value of <literal>PG_VERSION_NUM</> when building the server.
+       -->
+       サーバのバージョン番号を整数として返します。
+       この値は、サーバ構築時の<literal>PG_VERSION_NUM</>の値により決まります。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-wal-block-size" xreflabel="wal_block_size">
+      <term><varname>wal_block_size</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>wal_block_size</> configuration parameter</primary>
+       -->
+       <primary><varname>wal_block_size</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Reports the size of a WAL disk block.  It is determined by the value
+        of <literal>XLOG_BLCKSZ</> when building the server. The default value
+        is 8192 bytes.
+       -->
+       WALディスクブロックの容量を報告します。
+       サーバ構築時に<literal>XLOG_BLCKSZ</>の値で決定されます。デフォルトの値は8192バイトです。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-wal-segment-size" xreflabel="wal_segment_size">
+      <term><varname>wal_segment_size</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>wal_segment_size</> configuration parameter</primary>
+       -->
+       <primary><varname>wal_segment_size</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Reports the number of blocks (pages) in a WAL segment file.
+        The total size of a WAL segment file in bytes is equal to
+        <varname>wal_segment_size</> multiplied by <varname>wal_block_size</>;
+        by default this is 16MB.  See <xref linkend="wal-configuration"> for
+        more information.
+       -->
+       WALセグメントファイルのブロック数（ページ数）を報告します。
+       バイト単位のWALセグメント総容量は<varname>wal_block_size</>倍の<varname>wal_segment_size</>に等しくなります。
+       デフォルトでは16MBです。より詳細は<xref linkend="wal-configuration">を参照してください。
+       </para>
+      </listitem>
+     </varlistentry>
+
+    </variablelist>
+   </sect1>
+
+   <sect1 id="runtime-config-custom">
+   <!--
+    <title>Customized Options</title>
+    -->
+    <title>独自のオプション</title>
+
+    <para>
+    <!--
+     This feature was designed to allow parameters not normally known to
+     <productname>PostgreSQL</productname> to be added by add-on modules
+     (such as procedural languages).  This allows extension modules to be
+     configured in the standard ways.
+     -->
+     この機能は追加モジュール（手続き言語など）によって追加される<productname>PostgreSQL</productname>が識別できないパラメータを使えるように設計されたものです。
+これにより拡張モジュールは標準の方法で構成されます。
+    </para>
+
+    <para>
+    <!--
+     Custom options have two-part names: an extension name, then a dot, then
+     the parameter name proper, much like qualified names in SQL.  An example
+     is <literal>plpgsql.variable_conflict</>.
+    -->
+    カスタムオプションには２つに分かれた名称があります。拡張名につづいてドット、そして特定のパラメータ名です。SQLの修飾名に良く似ています。例として<literal>plpgsql.variable_conflict</>が挙げられます。
+    </para>
+
+    <para>
+    <!--
+     Because custom options may need to be set in processes that have not
+     loaded the relevant extension module, <productname>PostgreSQL</>
+     will accept a setting for any two-part parameter name.  Such variables
+     are treated as placeholders and have no function until the module that
+     defines them is loaded. When an extension module is loaded, it will add
+     its variable definitions, convert any placeholder values according to
+     those definitions, and issue warnings for any unrecognized placeholders
+     that begin with its extension name.
+     -->
+     カスタムオプションは読み込まれていない関連性のある拡張モジュールのプロセスに設定される必要がある場合があるので、<productname>PostgreSQL</>はどんな２つの部分のパラメータ名による設定を受け付けます。これらの変数は代替物として取り扱われ、それらを定義したモジュールが読み込まれるまで機能しません。
+     拡張モジュールが読み込まれた時、その変数定義が追加され、それら定義に基づいた代替値が変換され、そしてその拡張名の確認されない代替物に対して警告が発せられます。
+    </para>
+   </sect1>
+
+   <sect1 id="runtime-config-developer">
+   <!--
+    <title>Developer Options</title>
+    -->
+    <title>開発者向けのオプション</title>
+
+    <para>
+    <!--
+     The following parameters are intended for work on the
+     <productname>PostgreSQL</productname> source code, and in some cases
+     to assist with recovery of severely damaged databases.  There
+     should be no reason to use them on a production database.
+     As such, they have been excluded from the sample
+     <filename>postgresql.conf</> file.  Note that many of these
+     parameters require special source compilation flags to work at all.
+     -->
+     以下のパラメータは、<productname>PostgreSQL</productname>のソースコードに対する作業用のものです。
+中には深刻な損傷を負ったデータベースの復旧に役立つものもあります。
+実運用のデータベースでこれらを設定する理由はないはずです。
+したがって、これらはサンプルの<filename>postgresql.conf</>からは除外されています。
+これらのパラメータの多くは、それを動作させるために特殊なソースコンパイルを必要としていることに注意してください。
+    </para>
+
+    <variablelist>
+     <varlistentry id="guc-allow-system-table-mods" xreflabel="allow_system_table_mods">
+      <term><varname>allow_system_table_mods</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+        <primary><varname>allow_system_table_mods</varname> configuration parameter</primary>
+       -->
+       <primary><varname>allow_system_table_mods</varname>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Allows modification of the structure of system tables.
+        This is used by <command>initdb</command>.
+        This parameter can only be set at server start.
+       -->
+       システムテーブルの構造変更を許可します。
+これは<command>initdb</command>で使用されます。
+このパラメータはサーバ起動時にのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-ignore-system-indexes" xreflabel="ignore_system_indexes">
+      <term><varname>ignore_system_indexes</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+        <primary><varname>ignore_system_indexes</varname> configuration parameter</primary>
+       -->
+       <primary><varname>ignore_system_indexes</varname>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Ignore system indexes when reading system tables (but still
+        update the indexes when modifying the tables).  This is useful
+        when recovering from damaged system indexes.
+        This parameter cannot be changed after session start.
+       -->
+       システムテーブルの読み込み時にシステムインデックスを無視します（しかしテーブルが更新された時はインデックスを更新します）。
+障害があるシステムインデックスを復旧する時、これは有用です。
+セッションが始まった後に、このパラメータを変更することはできません。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-post-auth-delay" xreflabel="post_auth_delay">
+      <term><varname>post_auth_delay</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>post_auth_delay</> configuration parameter</primary>
+       -->
+       <primary><varname>post_auth_delay</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        If nonzero, a delay of this many seconds occurs when a new
+        server process is started, after it conducts the
+        authentication procedure.  This is intended to give developers an
+        opportunity to attach to the server process with a debugger.
+        This parameter cannot be changed after session start.
+       -->
+       非ゼロの場合、サーバプロセスが始まり認証手続きが終わった後に、指定した秒数の遅延が発生します。
+これは、デバッガを使用してサーバプロセスに接続する機会を開発者に提供することを目的としています。
+セッションが始まった後に、このパラメータを変更することはできません。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-pre-auth-delay" xreflabel="pre_auth_delay">
+      <term><varname>pre_auth_delay</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>pre_auth_delay</> configuration parameter</primary>
+       -->
+       <primary><varname>pre_auth_delay</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        If nonzero, a delay of this many seconds occurs just after a
+        new server process is forked, before it conducts the
+        authentication procedure.  This is intended to give developers an
+        opportunity to attach to the server process with a debugger to
+        trace down misbehavior in authentication.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+       非ゼロの場合、ここで指定した秒数分の遅延が新しくサーバプロセスがforkした後、認証手続きに入る前に発生します。
+これは、認証における誤動作を追跡するために、デバッガを使用してサーバプロセスに接続する機会を開発者に提供することを目的としたものです。
+このパラメータは<filename>postgresql.conf</>ファイル内、または、サーバのコマンドラインでのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-trace-notify" xreflabel="trace_notify">
+      <term><varname>trace_notify</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>trace_notify</> configuration parameter</primary>
+       -->
+       <primary><varname>trace_notify</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Generates a great amount of debugging output for the
+        <command>LISTEN</command> and <command>NOTIFY</command>
+        commands.  <xref linkend="guc-client-min-messages"> or
+        <xref linkend="guc-log-min-messages"> must be
+        <literal>DEBUG1</literal> or lower to send this output to the
+        client or server logs, respectively.
+       -->
+       <command>LISTEN</command>と<command>NOTIFY</command>コマンドのための大量なデバッグ出力を生成します。
+この出力をクライアントもしくはサーバログに送信するためには、それぞれ、<xref linkend="guc-client-min-messages">もしくは<xref linkend="guc-log-min-messages">は<literal>DEBUG1</literal>以下でなければなりません。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-trace-recovery-messages" xreflabel="trace_recovery_messages">
+      <term><varname>trace_recovery_messages</varname> (<type>enum</type>)
+      <indexterm>
+      <!--
+       <primary><varname>trace_recovery_messages</> configuration parameter</primary>
+       -->
+       <primary><varname>trace_recovery_messages</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Enables logging of recovery-related debugging output that otherwise
+        would not be logged. This parameter allows the user to override the
+        normal setting of <xref linkend="guc-log-min-messages">, but only for
+        specific messages. This is intended for use in debugging Hot Standby.
+        Valid values are <literal>DEBUG5</>, <literal>DEBUG4</>,
+        <literal>DEBUG3</>, <literal>DEBUG2</>, <literal>DEBUG1</>, and
+        <literal>LOG</>.  The default, <literal>LOG</>, does not affect
+        logging decisions at all.  The other values cause recovery-related
+        debug messages of that priority or higher to be logged as though they
+        had <literal>LOG</> priority; for common settings of
+        <varname>log_min_messages</> this results in unconditionally sending
+        them to the server log.
+        This parameter can only be set in the <filename>postgresql.conf</>
+        file or on the server command line.
+       -->
+       復旧関連のデバッグ出力のログ取得を有効にします。さもないとログは取られません。
+       このパラメータはユーザに対し、<xref linkend="guc-log-min-messages">の通常設定を上書きすることを許可します。
+       しかし、特定のメッセージに対してのみです。これはホットスタンバイのデバッグを意図したものです。
+       有効な値は、<literal>DEBUG5</>、<literal>DEBUG4</>、
+        <literal>DEBUG3</>、<literal>DEBUG2</>、<literal>DEBUG1</>、および
+        <literal>LOG</>です。
+       デフォルトの<literal>LOG</>は、ログ取得の決定に全く影響しません。
+       その他の値は、あたかも<literal>LOG</>優先度を所有しているごとく、それ、またはより高い優先度でログ取得される復旧関連デバッグメッセージの要因となります。
+       <varname>log_min_messages</>の通常設定に対し、これは無条件にそれらをサーバログに送り込みます。
+       このパラメータは<filename>postgresql.conf</>ファイル内、または、サーバコマンドラインでのみ設定可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-trace-sort" xreflabel="trace_sort">
+      <term><varname>trace_sort</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>trace_sort</> configuration parameter</primary>
+       -->
+       <primary><varname>trace_sort</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        If on, emit information about resource usage during sort operations.
+        This parameter is only available if the <symbol>TRACE_SORT</symbol> macro
+        was defined when <productname>PostgreSQL</productname> was compiled.
+        (However, <symbol>TRACE_SORT</symbol> is currently defined by default.)
+       -->
+       もしも有効であれば、並び替え操作の間のリソース使用についての情報を放出します。
+このパラメータは <productname>PostgreSQL</productname>がコンパイルされた時、<symbol>TRACE_SORT</symbol>マクロが定義されている場合にのみ有効です。
+（とは言っても、現在<symbol>TRACE_SORT</symbol>はデフォルトで定義されています。）
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
+      <term><varname>trace_locks</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>trace_locks</> configuration parameter</primary>
+       -->
+       <primary><varname>trace_locks</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        If on, emit information about lock usage.  Information dumped
+        includes the type of lock operation, the type of lock and the unique
+        identifier of the object being locked or unlocked.  Also included
+        are bit masks for the lock types already granted on this object as
+        well as for the lock types awaited on this object.  For each lock
+        type a count of the number of granted locks and waiting locks is
+        also dumped as well as the totals.  An example of the log file output
+        is shown here:
+       -->
+       有効な場合、ロックの使用状況に関する情報を出力します。
+       出力される情報には、ロック操作の種類、ロックの種類、ロックまたはロック解除されているオブジェクトの一意な識別子が含まれます。
+       また、このオブジェクトに既に与えられているロック種類やこのオブジェクトで待機しているロック種類を表すビットマスクも含まれます。
+       ロック種類それぞれについて、与えられているロック数、待機中のロック数がその総数と共に出力されます。
+       ログファイル出力例を以下に示します。
+<screen>
+LOG:  LockAcquire: new: lock(0xb7acd844) id(24688,24696,0,0,0,1)
+      grantMask(0) req(0,0,0,0,0,0,0)=0 grant(0,0,0,0,0,0,0)=0
+      wait(0) type(AccessShareLock)
+LOG:  GrantLock: lock(0xb7acd844) id(24688,24696,0,0,0,1)
+      grantMask(2) req(1,0,0,0,0,0,0)=1 grant(1,0,0,0,0,0,0)=1
+      wait(0) type(AccessShareLock)
+LOG:  UnGrantLock: updated: lock(0xb7acd844) id(24688,24696,0,0,0,1)
+      grantMask(0) req(0,0,0,0,0,0,0)=0 grant(0,0,0,0,0,0,0)=0
+      wait(0) type(AccessShareLock)
+LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
+      grantMask(0) req(0,0,0,0,0,0,0)=0 grant(0,0,0,0,0,0,0)=0
+      wait(0) type(INVALID)
+</screen>
+       <!--
+        Details of the structure being dumped may be found in
+        <filename>src/include/storage/lock.h</filename>.
+       -->
+       ダンプされる構造の詳細は、<filename>src/include/storage/lock.h</filename> にあります。
+       </para>
+       <para>
+       <!--
+        This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
+        macro was defined when <productname>PostgreSQL</productname> was
+        compiled.
+       -->
+       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
+      <term><varname>trace_lwlocks</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>trace_lwlocks</> configuration parameter</primary>
+       -->
+       <primary><varname>trace_lwlocks</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        If on, emit information about lightweight lock usage.  Lightweight
+        locks are intended primarily to provide mutual exclusion of access
+        to shared-memory data structures.
+       -->
+       有効な場合、軽量ロックの使用状況に関する情報を出力します。
+       軽量ロックは主に、共有メモリ上のデータ構造へのアクセスに関する排他制御機能を提供することを意図したものです。
+       </para>
+       <para>
+       <!--
+        This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
+        macro was defined when <productname>PostgreSQL</productname> was
+        compiled.
+       -->
+       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
+      <term><varname>trace_userlocks</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>trace_userlocks</> configuration parameter</primary>
+       -->
+       <primary><varname>trace_userlocks</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        If on, emit information about user lock usage.  Output is the same
+        as for <symbol>trace_locks</symbol>, only for advisory locks.
+       -->
+       有効な場合、ユーザロックの使用状況に関する情報を出力します。
+       出力は<symbol>trace_locks</symbol>と同じですが、勧告的ロックに関するもののみを出力します。
+       </para>
+       <para>
+       <!--
+        This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
+        macro was defined when <productname>PostgreSQL</productname> was
+        compiled.
+       -->
+       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
+      <term><varname>trace_lock_oidmin</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>trace_lock_oidmin</> configuration parameter</primary>
+       -->
+       <primary><varname>trace_lock_oidmin</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        If set, do not trace locks for tables below this OID. (use to avoid
+        output on system tables)
+       -->
+       設定すると、このOID未満のテーブルに関するロックの追跡を行いません。
+       （システムテーブルに関する出力を抑えるために使用します。）
+       </para>
+       <para>
+       <!--
+        This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
+        macro was defined when <productname>PostgreSQL</productname> was
+        compiled.
+       -->
+       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
+      <term><varname>trace_lock_table</varname> (<type>integer</type>)
+      <indexterm>
+      <!--
+       <primary><varname>trace_lock_table</> configuration parameter</primary>
+       -->
+       <primary><varname>trace_lock_table</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Unconditionally trace locks on this table (OID).
+       -->
+       このテーブル（OID）に対し無条件でロックを追跡します。
+       </para>
+       <para>
+       <!--
+        This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
+        macro was defined when <productname>PostgreSQL</productname> was
+        compiled.
+       -->
+       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
+      <term><varname>debug_deadlocks</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>debug_deadlocks</> configuration parameter</primary>
+       -->
+       <primary><varname>debug_deadlocks</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        If set, dumps information about all current locks when a
+        deadlock timeout occurs.
+       -->
+       設定すると、デッドロックタイムアウトが発生した時全ての進行中のロックについての情報がダンプされます。
+       </para>
+       <para>
+       <!--
+        This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
+        macro was defined when <productname>PostgreSQL</productname> was
+        compiled.
+       -->
+       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
+      <term><varname>log_btree_build_stats</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>log_btree_build_stats</> configuration parameter</primary>
+       -->
+       <primary><varname>log_btree_build_stats</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        If set, logs system resource usage statistics (memory and CPU) on
+        various B-tree operations.
+       -->
+       設定すると、各種B-tree操作に関するシステムリソース（メモリとCPU）の使用についての統計情報をログに出力します。
+       </para>
+       <para>
+       <!--
+        This parameter is only available if the <symbol>BTREE_BUILD_STATS</symbol>
+        macro was defined when <productname>PostgreSQL</productname> was
+        compiled.
+       -->
+       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>BTREE_BUILD_STATS</symbol>マクロが定義された場合のみ有効です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-wal-consistency-checking" xreflabel="wal_consistency_checking">
+      <term><varname>wal_consistency_checking</varname> (<type>string</type>)
+      <indexterm>
+<!--
+       <primary><varname>wal_consistency_checking</> configuration parameter</primary>
+-->
+       <primary><varname>wal_consistency_checking</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+<!--
+        This parameter is intended to be used to check for bugs in the WAL
+        redo routines.  When enabled, full-page images of any buffers modified
+        in conjunction with the WAL record are added to the record.
+        If the record is subsequently replayed, the system will first apply
+        each record and then test whether the buffers modified by the record
+        match the stored images.  In certain cases (such as hint bits), minor
+        variations are acceptable, and will be ignored.  Any unexpected
+        differences will result in a fatal error, terminating recovery.
+-->
+このパラメータは、WALのREDOルーチンのバグをチェックするために使うことを意図しています。
+有効にすると、WALレコードと一緒に変更されたバッファのフルページイメージをレコードに追加します。
+後でそのレコードがリプレイされるときは、システムはまず各々のレコードを適用し、次にレコードによって変更されたバッファが、格納したイメージと一致するかどうかをテストします。
+ある種のケース（たとえばヒントビット）では、些細な変化は許容され、無視されます。
+予期しない差異は、致命的エラーを引き起こし、リカバリが中断されます。
+       </para>
+
+       <para>
+<!--
+        The default value of this setting is the empty string, which disables
+        the feature.  It can be set to <literal>all</literal> to check all
+        records, or to a comma-separated list of resource managers to check
+        only records originating from those resource managers.  Currently,
+        the supported resource managers are <literal>heap</>,
+        <literal>heap2</>, <literal>btree</>, <literal>hash</>,
+        <literal>gin</>, <literal>gist</>, <literal>sequence</>,
+        <literal>spgist</>, <literal>brin</>, and <literal>generic</>. Only
+        superusers can change this setting.
+-->
+デフォルト値は空文字で、この機能を無効にします。
+すべてのレコードをチェックするために、<literal>all</literal>にすることができます。
+カンマ区切りのリストにすると、対応するリソースマネージャに由来するレコードのみをチェックします。
+今のところ、サポートされているリソースマネージャは、<literal>heap</>、<literal>heap2</>、<literal>btree</>、<literal>hash</>、<literal>gin</>、<literal>gist</>、<literal>sequence</>、<literal>spgist</>、<literal>brin</>、<literal>generic</>です。
+スーパーユーザだけがこの設定を変更できます。
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry id="guc-wal-debug" xreflabel="wal_debug">
+      <term><varname>wal_debug</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>wal_debug</> configuration parameter</primary>
+       -->
+       <primary><varname>wal_debug</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        If on, emit WAL-related debugging output. This parameter is
+        only available if the <symbol>WAL_DEBUG</symbol> macro was
+        defined when <productname>PostgreSQL</productname> was
+        compiled.
+       -->
+       もしonであれば、WALに関連したデバッグ出力が有効になります。このパラメータは<symbol>WAL_DEBUG</symbol>マクロが <productname>PostgreSQL</productname>のコンパイルの時に定義された場合にのみ有効です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+    <varlistentry id="guc-ignore-checksum-failure" xreflabel="ignore_checksum_failure">
+      <term><varname>ignore_checksum_failure</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>ignore_checksum_failure</> configuration parameter</primary>
+       -->
+       <primary><varname>ignore_checksum_failure</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Only has effect if <xref linkend="app-initdb-data-checksums"> are enabled.
+       -->
+       <xref linkend="app-initdb-data-checksums">が有効の時のみ効果があります。
+       </para>
+       <para>
+       <!--
+        Detection of a checksum failure during a read normally causes
+        <productname>PostgreSQL</> to report an error, aborting the current
+        transaction.  Setting <varname>ignore_checksum_failure</> to on causes
+        the system to ignore the failure (but still report a warning), and
+        continue processing.  This behavior may <emphasis>cause crashes, propagate
+        or hide corruption, or other serious problems</>.  However, it may allow
+        you to get past the error and retrieve undamaged tuples that might still be
+        present in the table if the block header is still sane. If the header is
+        corrupt an error will be reported even if this option is enabled. The
+        default setting is <literal>off</>, and it can only be changed by a superuser.
+       -->
+       読み込み過程でチェックサム障害が検出されると、通常<productname>PostgreSQL</>はエラーを報告し、現時点のトランザクションを停止します。
+       <varname>ignore_checksum_failure</>を有効（on）に設定するとシステムはその障害を無視し（しかし警告は報告をします）、処理を継続します。
+       この振る舞いはたぶん<emphasis>クラッシュの原因、破損の伝播や隠ぺい、もしくはその他の深刻な問題</>の原因になることがあります。
+       とは言っても、エラーを切り抜け、ブロックヘッダが健全に存在するテーブルにある障害を受けていないタプルの回収は行えます。
+       もしヘッダーが破損されたら、オプションが有効になっていたとしても報告はなされます。
+       デフォルトの設定は<literal>off</>で、スーパーユーザのみが変更可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+
+    <varlistentry id="guc-zero-damaged-pages" xreflabel="zero_damaged_pages">
+      <term><varname>zero_damaged_pages</varname> (<type>boolean</type>)
+      <indexterm>
+      <!--
+       <primary><varname>zero_damaged_pages</> configuration parameter</primary>
+       -->
+       <primary><varname>zero_damaged_pages</>設定パラメータ</primary>
+      </indexterm>
+      </term>
+      <listitem>
+       <para>
+       <!--
+        Detection of a damaged page header normally causes
+        <productname>PostgreSQL</> to report an error, aborting the current
+        transaction.  Setting <varname>zero_damaged_pages</> to on causes
+        the system to instead report a warning, zero out the damaged
+        page in memory, and continue processing.  This behavior <emphasis>will destroy data</>,
+        namely all the rows on the damaged page.  However, it does allow you to get
+        past the error and retrieve rows from any undamaged pages that might
+        be present in the table.  It is useful for recovering data if
+        corruption has occurred due to a hardware or software error.  You should
+        generally not set this on until you have given up hope of recovering
+        data from the damaged pages of a table.  Zeroed-out pages are not
+        forced to disk so it is recommended to recreate the table or
+        the index before turning this parameter off again.  The
+        default setting is <literal>off</>, and it can only be changed
+        by a superuser.
+       -->
+       ページヘッダの障害がわかると、通常<productname>PostgreSQL</>はエラーの報告を行い、現在のトランザクションを中断させます。
+<varname>zero_damaged_pages</>をonに設定することにより、システムは代わりに警告を報告し、障害のあるメモリ内のページをゼロで埋め、処理を継続します。
+この動作により、障害のあったページ上にある全ての行の<emphasis>データが破壊</>されます。
+しかし、これによりエラーを確実に無視し、正常なページに存在するテーブル内の行を取り出すことができます。
+        ハードウェアまたはソフトウェアのエラーによって破損が発生した場合のデータの復旧時に有用です。
+障害のあるページからのテーブルのデータの復旧をあきらめた場合を除き、通常はこれをonにしてはいけません。
+        ゼロで埋められたページはディスクに書き込みを強要されないため、このパラメータを再び無効にする以前にテーブル、またはインデックスを再作成することを勧めます。
+        デフォルトは<literal>off</>であり、スーパーユーザのみ変更可能です。
+       </para>
+      </listitem>
+     </varlistentry>
+   </variablelist>
+  </sect1>
+  <sect1 id="runtime-config-short">
+  <!--
+   <title>Short Options</title>
+   -->
+   <title>短いオプション</title>
+
+   <para>
+   <!--
+    For convenience there are also single letter command-line option
+    switches available for some parameters.  They are described in
+    <xref linkend="runtime-config-short-table">.  Some of these
+    options exist for historical reasons, and their presence as a
+    single-letter option does not necessarily indicate an endorsement
+    to use the option heavily.
+    -->
+    簡便性のために、一文字のコマンドラインオプションスイッチも、幾つかのパラメータのために用意されています。
+それらは<xref linkend="runtime-config-short-table">に解説されています。
+一部のオプションは歴史的な理由のために存在します。
+また、この一文字オプションが存在することが、このオプションを多く使用することを支持することを示しているわけではありません。
+   </para>
+
+    <table id="runtime-config-short-table">
+    <!--
+     <title>Short Option Key</title>
+     -->
+     <title>短いオプションキー</title>
+     <tgroup cols="2">
+      <thead>
+       <row>
+       <!--
+        <entry>Short Option</entry>
+       -->
+       <entry>短いオプション</entry>
+       <!--
+        <entry>Equivalent</entry>
+       -->
+       <entry>同義</entry>
+       </row>
+      </thead>
+
+      <tbody>
+       <row>
+        <entry><option>-B <replaceable>x</replaceable></option></entry>
+        <entry><literal>shared_buffers = <replaceable>x</replaceable></></entry>
+       </row>
+       <row>
+        <entry><option>-d <replaceable>x</replaceable></option></entry>
+        <entry><literal>log_min_messages = DEBUG<replaceable>x</replaceable></></entry>
+       </row>
+       <row>
+        <entry><option>-e</option></entry>
+        <entry><literal>datestyle = euro</></entry>
+       </row>
+       <row>
+        <entry>
+          <option>-fb</option>, <option>-fh</option>, <option>-fi</option>,
+          <option>-fm</option>, <option>-fn</option>, <option>-fo</option>,
+          <option>-fs</option>, <option>-ft</option>
+         </entry>
+         <entry>
+          <literal>enable_bitmapscan = off</>,
+          <literal>enable_hashjoin = off</>,
+          <literal>enable_indexscan = off</>,
+          <literal>enable_mergejoin = off</>,
+          <literal>enable_nestloop = off</>,
+          <literal>enable_indexonlyscan = off</>,
+          <literal>enable_seqscan = off</>,
+          <literal>enable_tidscan = off</>
+         </entry>
+       </row>
+       <row>
+        <entry><option>-F</option></entry>
+        <entry><literal>fsync = off</></entry>
+       </row>
+       <row>
+        <entry><option>-h <replaceable>x</replaceable></option></entry>
+        <entry><literal>listen_addresses = <replaceable>x</replaceable></></entry>
+       </row>
+       <row>
+        <entry><option>-i</option></entry>
+        <entry><literal>listen_addresses = '*'</></entry>
+       </row>
+       <row>
+        <entry><option>-k <replaceable>x</replaceable></option></entry>
+        <entry><literal>unix_socket_directories = <replaceable>x</replaceable></></entry>
+       </row>
+       <row>
+        <entry><option>-l</option></entry>
+        <entry><literal>ssl = on</></entry>
+       </row>
+       <row>
+        <entry><option>-N <replaceable>x</replaceable></option></entry>
+        <entry><literal>max_connections = <replaceable>x</replaceable></></entry>
+       </row>
+       <row>
+        <entry><option>-O</option></entry>
+        <entry><literal>allow_system_table_mods = on</></entry>
+       </row>
+       <row>
+        <entry><option>-p <replaceable>x</replaceable></option></entry>
+        <entry><literal>port = <replaceable>x</replaceable></></entry>
+       </row>
+       <row>
+        <entry><option>-P</option></entry>
+        <entry><literal>ignore_system_indexes = on</></entry>
+       </row>
+       <row>
+        <entry><option>-s</option></entry>
+        <entry><literal>log_statement_stats = on</></entry>
+       </row>
+       <row>
+        <entry><option>-S <replaceable>x</replaceable></option></entry>
+        <entry><literal>work_mem = <replaceable>x</replaceable></></entry>
+       </row>
+       <row>
+        <entry><option>-tpa</option>, <option>-tpl</option>, <option>-te</option></entry>
+        <entry><literal>log_parser_stats = on</>,
+        <literal>log_planner_stats = on</>,
+        <literal>log_executor_stats = on</></entry>
+       </row>
+       <row>
+        <entry><option>-W <replaceable>x</replaceable></option></entry>
+        <entry><literal>post_auth_delay = <replaceable>x</replaceable></></entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </table>
+
+  </sect1>
+
+<!-- split-config3-end -->

--- a/doc/src/sgml/split-config.sh
+++ b/doc/src/sgml/split-config.sh
@@ -1,0 +1,29 @@
+#! /bin/sh
+# This script splits config.sgml into 3 files: namely config[0-3].sgml.
+# config.sgml remains untouched. config0.sgml should be included by
+# postgres.sgml instead of config.sgml.
+# "<!-- split-config1-start --> and <!-- split-config1-end --> etc. must be in config.sgml
+# in order to get this script working.
+
+comment='
+<!-- 警告：このファイルは直接編集しないでください！
+1. config.sgmlを編集したら、split-config.shを起動します。
+2. するとconfig[0-3].sgmlが生成されます。
+3. config.sgmlとともにconfig[0-3].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
+4. レビューはconfig[0-3].sgmlに対して行います。
+5. 指摘された点があればconfig.sgmlに反映し、1に戻ります。
+6. config.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
+-->
+'
+
+echo "$comment"|sed -e '/^$/d'  > config0.sgml
+sed -e '/^<!-- split-config1-start -->$/,/^<!-- split-config3-end -->$/d' \
+    -e '/<!-- split-config0-end -->/i&config1;\n&config2;\n&config3;' \
+    config.sgml >> config0.sgml
+echo "$comment"|sed -e '/^$/d' > config1.sgml
+sed -n -e '/^<!-- split-config1-start -->$/,/^<!-- split-config1-end -->$/p' config.sgml >> config1.sgml
+echo "$comment"|sed -e '/^$/d' > config2.sgml
+sed -n -e '/^<!-- split-config2-start -->$/,/^<!-- split-config2-end -->$/p' config.sgml >> config2.sgml
+echo "$comment"|sed -e '/^$/d' > config3.sgml
+sed -n -e '/^<!-- split-config3-start -->$/,/^<!-- split-config3-end -->$/p' config.sgml >> config3.sgml
+

--- a/doc/src/sgml/split-config.sh
+++ b/doc/src/sgml/split-config.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-# This script splits config.sgml into 3 files: namely config[0-3].sgml.
+# This script splits config.sgml into 4 files: namely config[0-3].sgml.
 # config.sgml remains untouched. config0.sgml should be included by
 # postgres.sgml instead of config.sgml.
 # "<!-- split-config1-start --> and <!-- split-config1-end --> etc. must be in config.sgml


### PR DESCRIPTION
split-config.shを起動することにより、config.sgmlはconfig[0-3].sgmlに分割されます。
また、config.sgmlに分割用のマーカーを追加しました。
split-config.shは分割用のスクリプトです。