### PR TITLE
update plpgsql for 10.5

### DIFF
--- a/doc/src/sgml/plpgsql.sgml
+++ b/doc/src/sgml/plpgsql.sgml
@@ -4651,6 +4651,7 @@ FETCH <optional> <replaceable>direction</replaceable> { FROM | IN } </optional> 
      with the <literal>SCROLL</> option.
 -->
 <replaceable>direction</replaceable>句の省略は、<literal>NEXT</>の指定と同じです。
+<replaceable>count</replaceable>を使う形式では、<replaceable>count</replaceable>はいかなる整数値の式も可能です。(SQL <command>FETCH</command>コマンドとは異なります。あちらは整数定数のみを受け付けます。)
 <literal>SCROLL</>オプションを用いてカーソルを宣言または開かないと、<replaceable>direction</replaceable>の値による逆方向への移動の要求は失敗します。
     </para>
 
@@ -4698,6 +4699,9 @@ MOVE <optional> <replaceable>direction</replaceable> { FROM | IN } </optional> <
     </para>
 
     <para>
+<!--
+     Examples:
+-->
 例:
 <programlisting>
 MOVE curs1;


### PR DESCRIPTION
plpgsql.sgml の10.5対応です。

Exampleが追加されているように見えますけど、これはマージ時の削除し過ぎを戻しているということだと思います。