### PR TITLE
func.sgmlのPostgreSQL 11対応です。

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -23464,7 +23464,7 @@ SELECT pg_type_is_visible('myschema.widget'::regtype);
 <!--
        <entry>get <literal>RETURNS</literal> clause for function (returns null for a procedure)</entry>
 -->
-       <entry>関数に対する<literal>RETURNS</literal>句の取得（手続きに対してはNULLを返します）</entry>
+       <entry>関数に対する<literal>RETURNS</literal>句の取得（プロシージャに対してはNULLを返します）</entry>
       </row>
       <row>
        <entry><literal><function>pg_get_indexdef(<parameter>index_oid</parameter>)</function></literal></entry>

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -3084,7 +3084,10 @@ POSIX正規表現を区切り文字に使って<parameter>string</parameter>を�
        </entry>
        <entry><type>bool</type></entry>
        <entry>
+<!--
         Returns true if <parameter>string</parameter> starts with <parameter>prefix</parameter>.
+-->
+<parameter>string</parameter>が<parameter>prefix</parameter>で始まっていれば真を返します。
        </entry>
        <entry><literal>starts_with('alphabet', 'alph')</literal></entry>
        <entry><literal>t</literal></entry>
@@ -4722,7 +4725,10 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
        </entry>
        <entry><type>bytea</type></entry>
        <entry>
+<!--
         SHA-224 hash
+-->
+SHA-224ハッシュ
        </entry>
        <entry><literal>sha224('abc')</literal></entry>
        <entry><literal>\x23097d223405d8228642a477bda2&#x200B;55b32aadbce4bda0b3f7e36c9da7</literal></entry>
@@ -4737,7 +4743,10 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
        </entry>
        <entry><type>bytea</type></entry>
        <entry>
+<!--
         SHA-256 hash
+-->
+SHA-256ハッシュ
        </entry>
        <entry><literal>sha256('abc')</literal></entry>
        <entry><literal>\xba7816bf8f01cfea414140de5dae2223&#x200B;b00361a396177a9cb410ff61f20015ad</literal></entry>
@@ -4752,7 +4761,10 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
        </entry>
        <entry><type>bytea</type></entry>
        <entry>
+<!--
         SHA-384 hash
+-->
+SHA-384ハッシュ
        </entry>
        <entry><literal>sha384('abc')</literal></entry>
        <entry><literal>\xcb00753f45a35e8bb5a03d699ac65007&#x200B;272c32ab0eded1631a8b605a43ff5bed&#x200B;8086072ba1e7cc2358baeca134c825a7</literal></entry>
@@ -4767,7 +4779,10 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
        </entry>
        <entry><type>bytea</type></entry>
        <entry>
+<!--
         SHA-512 hash
+-->
+SHA-512ハッシュ
        </entry>
        <entry><literal>sha512('abc')</literal></entry>
        <entry><literal>\xddaf35a193617abacc417349ae204131&#x200B;12e6fa4e89a97ea20a9eeee64b55d39a&#x200B;2192992a274fc1a836ba3c23a3feebbd&#x200B;454d4423643ce80e2a9ac94fa54ca49f</literal></entry>
@@ -4789,12 +4804,16 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
   </para>
 
   <para>
+<!--
    Note that for historic reasons, the function <function>md5</function>
    returns a hex-encoded value of type <type>text</type> whereas the SHA-2
    functions return type <type>bytea</type>.  Use the functions
    <function>encode</function> and <function>decode</function> to convert
    between the two, for example <literal>encode(sha256('abc'),
    'hex')</literal> to get a hex-encoded text representation.
+-->
+歴史的な理由により、<function>md5</function>は16進のエンコード値を返すのに対し、SHA-2関数は<type>bytea</type>を返すことに注意してください。
+両者の間の変換を行うには、関数<function>encode</function>と<function>decode</function>を使ってください。たとえば、16進のエンコードのテキスト表現を得るには、<literal>encode(sha256('abc'),'hex')</literal>としてください。
   </para>
 
   <para>
@@ -5212,9 +5231,12 @@ cast(-44 as bit(12))           <lineannotation>111111010100</lineannotation>
    </para>
 
    <para>
+<!--
     There is also the prefix operator <literal>^@</literal> and corresponding
     <function>starts_with</function> function which covers cases when only
     searching by beginning of the string is needed.
+-->
+単に文字列の先頭からの開始が必要なだけのケースであれば、接頭辞演算子<literal>^@</literal>とそれに対応する<function>starts_with</function>関数があります。
    </para>
   </sect2>
 
@@ -7952,6 +7974,7 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
 <function>to_char</function>用の出力テンプレート文字列には、値に基づいて認識され、適切に整形されたデータで置き換えられるパターンがあります。
 テンプレートパターンではない全てのテキストは単にそのままコピーされます。
 同様に、（その他の関数用の）入力テンプレート文字列では、テンプレートパターンは入力されたデータ文字列で供給される値を特定します。
+テンプレート文字列中にテンプレートパターンではない文字があれば、（テンプレート文字列と同じかどうかにかかわらず）入力文字列データ中の該当文字は単にスキップされます。
    </para>
 
   <para>
@@ -8348,11 +8371,17 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
        </row>
        <row>
        <entry><literal>TZH</literal></entry>
+<!--
         <entry>time-zone hours</entry>
+-->
+        <entry>time-zoneの時間</entry>
        </row>
        <row>
        <entry><literal>TZM</literal></entry>
+<!--
         <entry>time-zone minutes</entry>
+-->
+        <entry>time-zoneの分</entry>
        </row>
        <row>
         <entry><literal>OF</literal></entry>
@@ -8541,9 +8570,9 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
        (whether or not they are <literal>XX</literal>).
 -->
 <function>to_char</function>テンプレートには、通常のテキストを入れることができ、それはそのまま出力されます。
-部分文字列を二重引用符で括ることで、部分文字列にパターン用のキーワードがあったとしても、強制的にリテラルテキストとして解釈させることができます。
+部分文字列を二重引用符で括ることで、部分文字列にテンプレートパターンがあったとしても、強制的にリテラルテキストとして解釈させることができます。
 例えば、<literal>'"Hello Year "YYYY'</literal>では<literal>YYYY</literal>は年データに置換されてしまいますが、<literal>Year</literal>内の<literal>Y</literal>は置換されません。
-<function>to_date</function>、<function>to_number</function>、<function>to_timestamp</function>では、二重引用符で括られた文字の数だけ入力された文字をスキップします。例えば<literal>"XX"</literal>が指定された場合は2文字がスキップされます。
+<function>to_date</function>、<function>to_number</function>、<function>to_timestamp</function>では、二重引用符で括られた文字の数だけ入力された文字をスキップします。例えば<literal>"XX"</literal>は2文字の入力文字（それが<literal>XX</literal>であるかどうかにかかわらず)をスキップします。
       </para>
      </listitem>
 
@@ -8560,6 +8589,9 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
        or another backslash).
 -->
 出力に二重引用符を付けたい場合、<literal>'\"YYYY Month\"'</literal>のようにその前にバックスラッシュを付けなければなりません。
+バックスラッシュは、二重引用符の外側では特別扱いされません。
+二重引用符の内側では、バックスラッシュによって次の文字が何であれ文字通りに扱われるようになります。
+（しかし、次の文字が二重引用符であるか、あるいは別のバックスラッシュでない限り、これは特別な効果をもたらしません。）
       </para>
      </listitem>
 
@@ -8913,12 +8945,17 @@ ISO 8601週番号年の文脈では、<quote>月</quote>、あるいは<quote>�
     <itemizedlist>
      <listitem>
       <para>
+<!--
        <literal>0</literal> specifies a digit position that will always be printed,
        even if it contains a leading/trailing zero.  <literal>9</literal> also
        specifies a digit position, but if it is a leading zero then it will
        be replaced by a space, while if it is a trailing zero and fill mode
        is specified then it will be deleted.  (For <function>to_number()</function>,
        these two pattern characters are equivalent.)
+-->
+<literal>0</literal>は、それが先頭あるいは末尾のゼロであっても必ず表示する数字の位置を指定します。
+<literal>9</literal>も数字の位置を指定しますが、先頭のゼロであればそれは空白で置換され、また末尾のゼロで字詰めモードが指定されているときは削除されます。
+（<function>to_number()</function>では、これら2つのパターン文字は同じ意味になります。）
       </para>
      </listitem>
 
@@ -8994,12 +9031,15 @@ ISO 8601週番号年の文脈では、<quote>月</quote>、あるいは<quote>�
 
      <listitem>
       <para>
+<!--
        In <function>to_number</function>, if non-data template patterns such
        as <literal>L</literal> or <literal>TH</literal> are used, the
        corresponding number of input characters are skipped, whether or not
        they match the template pattern, unless they are data characters
        (that is, digits, sign, decimal point, or comma).  For
        example, <literal>TH</literal> would skip two non-data characters.
+-->
+<function>to_number</function>において、<literal>L</literal>あるいは<literal>TH</literal>のように非データテンプレートが使われた場合には、それがデータ文字（すなわち、数字、符号、10進小数点あるいはカンマ）でない限りテンプレートパターンにマッチするかどうかにかかわらず、該当する数分だけの入力文字がスキップされます。
       </para>
      </listitem>
 
@@ -10850,7 +10890,7 @@ SELECT date_trunc('year', TIMESTAMP '2001-02-16 20:38:40');
     <emphasis>time</emphasis> values to different time zones. <xref
     linkend="functions-datetime-zoneconvert-table"/> shows its variants.
 -->
-<function>AT TIME ZONE</function>構文を使用することにより、タイムスタンプを異なる時間帯に変換することができます。
+<function>AT TIME ZONE</function>構文を使用することにより、time stamp <emphasis>without time zone</emphasis>からtime stamp <emphasis>with time zone</emphasis>へ、あるいはtime stamp <emphasis>with time zone</emphasis>からtime stamp <emphasis>without time zone</emphasis>へ変換でき、また<emphasis>時刻</emphasis>値を異なる時間帯に変換することができます。
 <xref linkend="functions-datetime-zoneconvert-table"/>にその種類を示します。
    </para>
 
@@ -10919,7 +10959,7 @@ SELECT date_trunc('year', TIMESTAMP '2001-02-16 20:38:40');
     In the text case, a time zone name can be specified in any of the ways
     described in <xref linkend="datatype-timezones"/>.
 -->
-これらの式では、設定する時間帯<replaceable>zone</replaceable>は、（<literal>'PST'</literal>のような）テキスト文字列、または（<literal>INTERVAL '-08:00'</literal>のような）時間間隔で指定することができます。
+これらの式では、設定する時間帯<replaceable>zone</replaceable>は、（<literal>'America/Los_Angeles'</literal>のような）テキスト文字列、または（<literal>INTERVAL '-08:00'</literal>のような）時間間隔で指定することができます。
 テキストの場合、<xref linkend="datatype-timezones"/>に示した方法で時間帯名称を指定することができます。
    </para>
 
@@ -10927,7 +10967,7 @@ SELECT date_trunc('year', TIMESTAMP '2001-02-16 20:38:40');
 <!--
     Examples (assuming the local time zone is <literal>America/Los_Angeles</literal>):
 -->
-以下に例を示します（ローカル時間帯を<literal>PST8PDT</literal>と想定しています）。
+以下に例を示します（ローカル時間帯を<literal>America/Los_Angeles</literal>と想定しています）。
 <screen>
 SELECT TIMESTAMP '2001-02-16 20:38:40' AT TIME ZONE 'America/Denver';
 <lineannotation>Result: </lineannotation><computeroutput>2001-02-16 19:38:40-08</computeroutput>
@@ -10949,8 +10989,11 @@ SELECT TIMESTAMP '2001-02-16 20:38:40-05' AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE
     values to other time zones uses the currently active time zone rules
     since no date is supplied.
 -->
-最初の例は、時間帯のないタイムスタンプを使用し、それをMST時間（UTC-7）として解釈し、そして表示用にPST（UTC-7）に変換します。
-2番目の例は、EST（UTC-5）で指定されたタイムスタンプを使用し、MST（UTC-7）でのローカル時間に変換しています。
+最初の例は、時間帯のない値に時間帯を追加し、現在の<varname>TimeZone</varname>設定を使ってその値を表示します。
+2番目の例は、time stamp with time zone値を指定したタイムゾーンに変換し、その値をwithout a time zoneで返しています。
+これは、<varname>TimeZone</varname>設定とは異なる値の格納と表示を可能にします。
+3番目の例は、東京時間をシカゴ時間に変換します。
+データが与えられていないので、現在有効なタイムゾーンルールを使って、<emphasis>時刻</emphasis>値を変換しています。
    </para>
 
    <para>
@@ -13084,7 +13127,10 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
           <literal><function>websearch_to_tsquery(<optional> <replaceable class="parameter">config</replaceable> <type>regconfig</type> , </optional> <replaceable class="parameter">query</replaceable> <type>text</type>)</function></literal>
          </entry>
         <entry><type>tsquery</type></entry>
+<!--
         <entry>produce <type>tsquery</type> from a web search style query</entry>
+-->
+        <entry>web検索形式の問い合わせから<type>tsquery</type>を生成</entry>
         <entry><literal>websearch_to_tsquery('english', '"fat rat" or rat')</literal></entry>
         <entry><literal>'fat' &lt;-&gt; 'rat' | 'rat'</literal></entry>
        </row>
@@ -13205,6 +13251,7 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
         </entry>
         <entry><type>tsvector</type></entry>
         <entry>
+<!--
           reduce each value in the document, specified by <replaceable class="parameter">filter</replaceable> to a <type>tsvector</type>,
           and then concatenate those in document order to produce a single <type>tsvector</type>.
           <replaceable class="parameter">filter</replaceable> is a <type>jsonb</type> array, that enumerates what kind of elements need to be included
@@ -13213,6 +13260,11 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
           <literal>"boolean"</literal> (to include all Boolean values in the string format <literal>"true"</literal>/<literal>"false"</literal>),
           <literal>"key"</literal> (to include all keys) or <literal>"all"</literal> (to include all above). These values
           can be combined together to include, e.g. all string and numeric values.
+-->
+<replaceable class="parameter">filter</replaceable>によって指定された文書中の各々の値を<type>tsvector</type>にまとめ、次に文書にあらわれる順にそれらを結合して単一の<type>tsvector</type>を生成します。
+<replaceable class="parameter">filter</replaceable>は<type>jsonb</type>の配列で、結果の<type>tsvector</type>にどの種類の要素を含める必要があるのかを列挙します。
+<replaceable class="parameter">filter</replaceable>に指定可能な値は、<literal>"string"</literal> (すべての文字列値を含める)、<literal>"numeric"</literal> (すべての文字列形式の数値を含める)、<literal>"key"</literal> (すべてのキーを含める)、<literal>"all"</literal> (それらすべてを含める)です。
+これらの値は、たとえば文字列と数値のように、結合することができます。
         </entry>
         <entry><literal>json_to_tsvector('english', '{"a": "The Fat Rats", "b": 123}'::json, '["string", "numeric"]')</literal></entry>
         <entry><literal>'123':5 'fat':2 'rat':3</literal></entry>
@@ -20219,7 +20271,7 @@ NULL値は<literal>ORDER BY</literal>節で指定されるルールに従って�
 <function>first_value</function>、<function>last_value</function>、<function>nth_value</function>関数は<quote>ウィンドウフレーム</quote>内の行のみを考慮することに注意してください。
 デフォルトで、ウィンドウフレームにはパーティションの先頭から現在の行の最終ピアまでの行が含まれます。
 これは<function>last_value</function>、または時々<function>nth_value</function>では有用ではない結果を得ることになりがちです。
-<literal>OVER</literal>句に適切なフレーム指定(<literal>RANGE</literal>もしくは<literal>ROWS</literal>)を加えることで、フレームを再定義することができます。
+<literal>OVER</literal>句に適切なフレーム指定(<literal>RANGE</literal>、<literal>GROUP</literal>、もしくは<literal>ROWS</literal>)を加えることで、フレームを再定義することができます。
 フレーム指定についての詳細は<xref linkend="syntax-window-functions"/>を参照してください。
   </para>
 
@@ -20639,7 +20691,7 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
 左辺の式は副問い合わせの結果のそれぞれの行に対し、与えられた<replaceable>operator</replaceable>を使用して行に関する評価、比較が行われます。
 比較の結果、副問い合わせの行のどれかに対して真となる場合、<token>ANY</token>の結果は<quote>true（真）</quote>です。
 比較の結果、副問い合わせの全ての行に対して偽となる場合（副問い合わせが行を返さないという場合も含む）、結果は<quote>false（偽）</quote>です。
-比較の結果、いかなる行でも真を返さず、かつ、少なくとも１つの行がNULLを返す場合、結果はNULLになります。
+いかなる副問合せ行との比較の結果も偽を返さず、かつ、少なくとも１つの比較がNULLを返す場合、結果はNULLになります。
   </para>
 
   <para>
@@ -21842,9 +21894,13 @@ SELECT * FROM pg_ls_dir('.') WITH ORDINALITY AS t(ls,n);
       <row>
        <entry><literal><function>pg_jit_available()</function></literal></entry>
        <entry><type>boolean</type></entry>
+<!--
        <entry>is <acronym>JIT</acronym> compilation available in this session
        (see <xref linkend="jit"/>)? Returns <literal>false</literal> if <xref
        linkend="guc-jit"/> is set to false.</entry>
+-->
+<entry>is <acronym>JIT</acronym>コンパイルがこのセッションで可能か？(<xref linkend="jit"/>参照)
+<xref linkend="guc-jit"/>がfalseなら、<literal>false</literal>を返します。</entry>
       </row>
 
       <row>
@@ -23163,6 +23219,7 @@ SELECT relname FROM pg_class WHERE pg_table_is_visible(oid);
 -->
 それぞれの関数はデータベースオブジェクトの１つの型に対して可視性の検査を行います。
 <function>pg_table_is_visible</function>がビュー、マテリアライズドビュー、インデックス、シーケンス、外部テーブルに対しても使用できること、<function>pg_type_is_visible</function>がドメインに対しても使用できることに注意してください。
+<function>pg_function_is_visible</function>は手続きと集約にも使えます。
 関数および演算子では、パスの前方に同じ名前かつ同じ<emphasis>引数のデータ型</emphasis>を持つオブジェクトが存在しなければ、検索パス内のオブジェクトは可視です。
 演算子クラスでは、名前と関連するインデックスアクセスメソッドが考慮されます。
    </para>
@@ -23383,7 +23440,7 @@ SELECT pg_type_is_visible('myschema.widget'::regtype);
 <!--
        <entry>get definition of a function or procedure</entry>
 -->
-       <entry>関数定義の取得</entry>
+       <entry>関数あるいは手続きの定義の取得</entry>
       </row>
       <row>
        <entry><literal><function>pg_get_function_arguments(<parameter>func_oid</parameter>)</function></literal></entry>
@@ -23391,7 +23448,7 @@ SELECT pg_type_is_visible('myschema.widget'::regtype);
 <!--
        <entry>get argument list of function's or procedure's definition (with default values)</entry>
 -->
-       <entry>関数定義の引数リスト（デフォルト値付き）を取得</entry>
+       <entry>関数あるいは手続きの定義の引数リスト（デフォルト値付き）を取得</entry>
       </row>
       <row>
        <entry><literal><function>pg_get_function_identity_arguments(<parameter>func_oid</parameter>)</function></literal></entry>
@@ -23399,7 +23456,7 @@ SELECT pg_type_is_visible('myschema.widget'::regtype);
 <!--
        <entry>get argument list to identify a function or procedure (without default values)</entry>
 -->
-       <entry>関数を特定するための引数リスト（デフォルト値なし）を取得</entry>
+       <entry>関数あるいは手続きを特定するための引数リスト（デフォルト値なし）を取得</entry>
       </row>
       <row>
        <entry><literal><function>pg_get_function_result(<parameter>func_oid</parameter>)</function></literal></entry>
@@ -23407,7 +23464,7 @@ SELECT pg_type_is_visible('myschema.widget'::regtype);
 <!--
        <entry>get <literal>RETURNS</literal> clause for function (returns null for a procedure)</entry>
 -->
-       <entry>関数に対する<literal>RETURNS</literal>句の取得</entry>
+       <entry>関数に対する<literal>RETURNS</literal>句の取得（手続きに対してはNULLを返します）</entry>
       </row>
       <row>
        <entry><literal><function>pg_get_indexdef(<parameter>index_oid</parameter>)</function></literal></entry>
@@ -24009,9 +24066,12 @@ SELECT currval(pg_get_serial_sequence('sometable', 'id'));
      </row>
      <row>
       <entry><literal>can_include</literal></entry>
+<!--
       <entry>Does the access method support the <literal>INCLUDE</literal>
         clause of <literal>CREATE INDEX</literal>?
       </entry>
+-->
+      <entry>アクセスメソッドが<literal>CREATE INDEX</literal>の<literal>INCLUDE</literal>句をサポートしているか</entry>
      </row>
     </tbody>
    </tgroup>
@@ -24211,7 +24271,7 @@ SELECT collation for ('foo' COLLATE "de_DE");
    This is useful to determine the identity of an object as stored in the
    <structname>pg_depend</structname> catalog.
 -->
-<function>pg_describe_object</function>はカタログOID、オブジェクトOID、もしくはサブオブジェクトOID（0のこともある）で指定されたデータベースオブジェクトのテキストによる説明を返します。
+<function>pg_describe_object</function>はカタログOID、オブジェクトOID、もしくはサブオブジェクトOID（たとえばテーブル中の列番号。オブジェクト全体を参照している場合は0）で指定されたデータベースオブジェクトのテキストによる説明を返します。
 この説明はサーバの設定に依存しますが、人が読んでわかる、そして翻訳も可能になることを目的としたのもです。
 これは<structname>pg_depend</structname>カタログに格納されたオブジェクトの識別判断の際に有用です。
   </para>
@@ -24232,7 +24292,7 @@ SELECT collation for ('foo' COLLATE "de_DE");
    precise format depending on object type, and each name within the format
    being schema-qualified and quoted as necessary.
 -->
-<function>pg_identify_object</function>はカタログOID、オブジェクトOID、そしてサブオブジェクトID（0のこともある）により指定されるデータベースオブジェクトを一意に特定するために十分な情報を含む行を返します。
+<function>pg_identify_object</function>はカタログOID、オブジェクトOID、そしてサブオブジェクトIDにより指定されるデータベースオブジェクトを一意に特定するために十分な情報を含む行を返します。
 この情報は機械による読み取りを目的としており、決して翻訳されません。
 <parameter>type</parameter>はデータベースオブジェクトの型を識別するものです。
 <parameter>schema</parameter>はオブジェクトが所属するスキーマの名前ですが、スキーマに所属しないオブジェクト型の場合は<literal>NULL</literal>になります。
@@ -24256,12 +24316,12 @@ SELECT collation for ('foo' COLLATE "de_DE");
    of the object.
    This function is the inverse of <function>pg_get_object_address</function>.
 -->
-<function>pg_identify_object_as_address</function>はカタログOID、オブジェクトOID、そしてサブオブジェクトID（0のこともある）により指定されるデータベースオブジェクトを一意に特定するために充分な情報を含む行を返します。
+<function>pg_identify_object_as_address</function>はカタログOID、オブジェクトOID、そしてサブオブジェクトIDにより指定されるデータベースオブジェクトを一意に特定するために充分な情報を含む行を返します。
 返される情報は現在のサーバに依存しません。
 つまり、他のサーバで全く同じ名前を付けられたオブジェクトを識別するために使うことができます。
 <parameter>type</parameter>はデータベースオブジェクトの型を識別するものです。
-<parameter>name</parameter>と<parameter>args</parameter>は文字列の配列で、それらが組み合わされてオブジェクトへの参照を構成します。
-これらの3つの列は、オブジェクトの内部アドレスを取得するために<function>pg_get_object_address</function>に渡すことができます。
+<parameter>object_names</parameter>と<parameter>object_args</parameter>は文字列の配列で、それらが組み合わされてオブジェクトへの参照を構成します。
+これらの3つの値は、オブジェクトの内部アドレスを取得するために<function>pg_get_object_address</function>に渡すことができます。
 この関数は<function>pg_get_object_address</function>の逆関数です。
   </para>
 
@@ -24281,9 +24341,9 @@ SELECT collation for ('foo' COLLATE "de_DE");
 -->
 <function>pg_get_object_address</function>は、型、オブジェクト名および引数の配列で指定されたデータベースオブジェクトを一意に特定するために十分な情報を含む行を返します。
 返される値は、<structname>pg_depend</structname>などのシステムカタログで使用されるもので、<function>pg_identify_object</function>や<function>pg_describe_object</function>など他のシステム関数に渡すことができます。
-<parameter>catalog_id</parameter>はオブジェクトを含むシステムカタログのOIDです。
-<parameter>object_id</parameter>はオブジェクト自体のOIDです。
-<parameter>object_sub_id</parameter>はオブジェクトのサブID、なければ0です。
+<parameter>classid</parameter>はオブジェクトを含むシステムカタログのOIDです。
+<parameter>objid</parameter>はオブジェクト自体のOIDです。
+<parameter>objsubid</parameter>はオブジェクトのサブID、なければ0です。
 この関数は<function>pg_identify_object_as_address</function>の逆関数です。
   </para>
 
@@ -26429,10 +26489,15 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         <type>bool</type>
        </entry>
        <entry>
+<!--
         Advances the current confirmed position of a replication slot named
         <parameter>slot_name</parameter>. The slot will not be moved backwards,
         and it will not be moved beyond the current insert location.  Returns
         name of the slot and real position to which it was advanced to.
+-->
+<parameter>slot_name</parameter>という名前のレプリケーションスロットの現在の確認された位置を進めます。
+スロットは後方には動きませんし、現在の挿入位置を超えて進むこともありません。
+スロットの名前と前に進んだ実際の位置を返します。
        </entry>
       </row>
 
@@ -27456,12 +27521,13 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
     configuration setting for log files.
 -->
 <xref linkend="functions-admin-genfile-table"/>で示されている関数はサーバをホスティングしているマシン上のファイルに対し、ネイティブのアクセスを提供します。
-データベースクラスタディレクトリと<varname>log_directory</varname>に存在するファイルのみがアクセス可能です。
+ユーザが<literal>pg_read_server_files</literal>ロールを与えられていない限り、データベースクラスタディレクトリと<varname>log_directory</varname>に存在するファイルのみがアクセス可能です。
 クラスタディレクトリ内のファイルに対して相対パスを、そしてログファイルに対しては<varname>log_directory</varname>構成設定に一致するパスを使用してください。
 これらの関数は特に記述がある場合を除き、スーパーユーザだけが使用できます。
    </para>
 
    <para>
+<!--
     Note that granting users the EXECUTE privilege on the
     <function>pg_read_file()</function>, or related, functions allows them the
     ability to read any file on the server which the database can read and
@@ -27470,6 +27536,10 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
     <literal>pg_authid</literal> table where authentication information is contained,
     as well as read any file in the database.  Therefore, granting access to these
     functions should be carefully considered.
+-->
+ユーザに対して<function>pg_read_file()</function>あるいは関連する関数へのEXECUTE権限を許可することは、サーバ上のデータベースが読むことのできるすべてのファイルに対して読み出し許可を与えることになること、こうした読み出しについてはデータベース内のあらゆる権限チェックがすり抜けられることに注意してください。
+これはつまり、この権限を持っているユーザは、とりわけ認証情報が含まれる<literal>pg_authid</literal>テーブルの内容を読むことができることを意味します。
+ですから、これらの関数には注意深くアクセス許可を与えるべきです。
    </para>
 
    <table id="functions-admin-genfile-table">
@@ -27496,7 +27566,7 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
 <!--
         List the contents of a directory.  Restricted to superusers by default, but other users can be granted EXECUTE to run the function.
 -->
-ディレクトリの内容を一覧表示する
+ディレクトリの内容を一覧表示する。デフォルトではスーパーユーザに制限されるが、他のユーザにEXECUTEを許可することによりこの関数を実行できる
        </entry>
       </row>
       <row>
@@ -27538,7 +27608,7 @@ WALディレクトリ内のファイルの名前、サイズ、最終更新時�
 <!--
         Return the contents of a text file.  Restricted to superusers by default, but other users can be granted EXECUTE to run the function.
 -->
-テキストファイルの内容を返す
+テキストファイルの内容を返す。デフォルトではスーパーユーザに制限されるが、他のユーザにEXECUTEを許可することによりこの関数を実行できる
        </entry>
       </row>
       <row>
@@ -27550,7 +27620,7 @@ WALディレクトリ内のファイルの名前、サイズ、最終更新時�
 <!--
         Return the contents of a file.  Restricted to superusers by default, but other users can be granted EXECUTE to run the function.
 -->
-ファイルの内容を返す
+ファイルの内容を返す。デフォルトではスーパーユーザに制限されるが、他のユーザにEXECUTEを許可することによりこの関数を実行できる
        </entry>
       </row>
       <row>
@@ -27562,7 +27632,7 @@ WALディレクトリ内のファイルの名前、サイズ、最終更新時�
 <!--
         Return information about a file.  Restricted to superusers by default, but other users can be granted EXECUTE to run the function.
 -->
-ファイルについての情報を返す
+ファイルについての情報を返す。デフォルトではスーパーユーザに制限されるが、他のユーザにEXECUTEを許可することによりこの関数を実行できる
        </entry>
       </row>
      </tbody>
@@ -28301,7 +28371,7 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
          identifier included in the identity is quoted if necessary.
 -->
 オブジェクトの識別をテキスト表現したもので、スキーマ修飾される。
-識別内に存在するすべての識別子は、必要なら引用符で括られる。
+識別内に存在する各識別子は、必要なら引用符で括られる。
         </entry>
        </row>
        <row>
@@ -28310,7 +28380,7 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
 <!--
         <entry>True if the command is part of an extension script</entry>
 -->
-        <entry>コマンドが拡張のスクリプトの一部かどうか</entry>
+        <entry>コマンドが拡張のスクリプトの一部なら真</entry>
        </row>
        <row>
         <entry><literal>command</literal></entry>
@@ -28400,7 +28470,7 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
 <!--
         <entry>True if this was one of the root object(s) of the deletion</entry>
 -->
-        <entry>削除のルートオブジェクトを特定するために使われるフラグ</entry>
+        <entry>これが削除のルートオブジェクトの一つなら真</entry>
        </row>
        <row>
         <entry><literal>normal</literal></entry>
@@ -28410,7 +28480,7 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
          True if there was a normal dependency relationship
          in the dependency graph leading to this object
 -->
-このオブジェクトへと至る依存関係グラフで、通常の依存があることを示すフラグ
+このオブジェクトへと至る依存関係グラフで、通常の依存があるなら真
         </entry>
        </row>
        <row>
@@ -28420,7 +28490,7 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
 <!--
          True if this was a temporary object
 -->
-オブジェクトが一時オブジェクトであったことを示すフラグ
+オブジェクトが一時オブジェクトであったなら真
         </entry>
        </row>
        <row>
@@ -28466,7 +28536,7 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
          identifier included in the identity is quoted if necessary.
 -->
 オブジェクト識別のテキスト表現で、スキーマ修飾される。
-権限のなかにあるそれぞれ全ての識別子は必要であれば引用符で括られる。
+権限のなかにある各識別子は必要であれば引用符で括られる。
         </entry>
        </row>
        <row>
@@ -28490,7 +28560,7 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
 <!--
          Complement for <literal>address_names</literal>
 -->
-上記<literal>address_names</literal>の補足。
+<literal>address_names</literal>の補足。
         </entry>
        </row>
       </tbody>

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -5236,7 +5236,7 @@ cast(-44 as bit(12))           <lineannotation>111111010100</lineannotation>
     <function>starts_with</function> function which covers cases when only
     searching by beginning of the string is needed.
 -->
-単に文字列の先頭からの開始が必要なだけのケースであれば、接頭辞演算子<literal>^@</literal>とそれに対応する<function>starts_with</function>関数があります。
+単に文字列の先頭からの開始が必要なだけのケースであれば、接頭辞演算子<literal>^@</literal>とそれに対応する<function>starts_with</function>関数もあります。
    </para>
   </sect2>
 
@@ -7974,7 +7974,7 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
 <function>to_char</function>用の出力テンプレート文字列には、値に基づいて認識され、適切に整形されたデータで置き換えられるパターンがあります。
 テンプレートパターンではない全てのテキストは単にそのままコピーされます。
 同様に、（その他の関数用の）入力テンプレート文字列では、テンプレートパターンは入力されたデータ文字列で供給される値を特定します。
-テンプレート文字列中にテンプレートパターンではない文字があれば、（テンプレート文字列と同じかどうかにかかわらず）入力文字列データ中の該当文字は単にスキップされます。
+テンプレート文字列中にテンプレートパターンではない文字があれば、（テンプレート文字列の文字と同じかどうかにかかわらず）入力文字列データ中の該当文字は単にスキップされます。
    </para>
 
   <para>
@@ -13264,7 +13264,7 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
 <replaceable class="parameter">filter</replaceable>によって指定された文書中の各々の値を<type>tsvector</type>にまとめ、次に文書にあらわれる順にそれらを結合して単一の<type>tsvector</type>を生成します。
 <replaceable class="parameter">filter</replaceable>は<type>jsonb</type>の配列で、結果の<type>tsvector</type>にどの種類の要素を含める必要があるのかを列挙します。
 <replaceable class="parameter">filter</replaceable>に指定可能な値は、<literal>"string"</literal> (すべての文字列値を含める)、<literal>"numeric"</literal> (すべての文字列形式の数値を含める)、<literal>"key"</literal> (すべてのキーを含める)、<literal>"all"</literal> (それらすべてを含める)です。
-これらの値は、たとえば文字列と数値のように、結合することができます。
+これらの値は、たとえばすべての文字列と数値、のように組み合わせることができます。
         </entry>
         <entry><literal>json_to_tsvector('english', '{"a": "The Fat Rats", "b": 123}'::json, '["string", "numeric"]')</literal></entry>
         <entry><literal>'123':5 'fat':2 'rat':3</literal></entry>
@@ -28536,7 +28536,7 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
          identifier included in the identity is quoted if necessary.
 -->
 オブジェクト識別のテキスト表現で、スキーマ修飾される。
-権限のなかにある各識別子は必要であれば引用符で括られる。
+識別内に存在する各識別子は必要であれば引用符で括られる。
         </entry>
        </row>
        <row>

--- a/doc/src/sgml/func1.sgml
+++ b/doc/src/sgml/func1.sgml
@@ -5188,7 +5188,7 @@ cast(-44 as bit(12))           <lineannotation>111111010100</lineannotation>
     <function>starts_with</function> function which covers cases when only
     searching by beginning of the string is needed.
 -->
-単に文字列の先頭からの開始が必要なだけのケースであれば、接頭辞演算子<literal>^@</literal>とそれに対応する<function>starts_with</function>関数があります。
+単に文字列の先頭からの開始が必要なだけのケースであれば、接頭辞演算子<literal>^@</literal>とそれに対応する<function>starts_with</function>関数もあります。
    </para>
   </sect2>
 

--- a/doc/src/sgml/func1.sgml
+++ b/doc/src/sgml/func1.sgml
@@ -3036,7 +3036,10 @@ POSIX正規表現を区切り文字に使って<parameter>string</parameter>を�
        </entry>
        <entry><type>bool</type></entry>
        <entry>
+<!--
         Returns true if <parameter>string</parameter> starts with <parameter>prefix</parameter>.
+-->
+<parameter>string</parameter>が<parameter>prefix</parameter>で始まっていれば真を返します。
        </entry>
        <entry><literal>starts_with('alphabet', 'alph')</literal></entry>
        <entry><literal>t</literal></entry>
@@ -4674,7 +4677,10 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
        </entry>
        <entry><type>bytea</type></entry>
        <entry>
+<!--
         SHA-224 hash
+-->
+SHA-224ハッシュ
        </entry>
        <entry><literal>sha224('abc')</literal></entry>
        <entry><literal>\x23097d223405d8228642a477bda2&#x200B;55b32aadbce4bda0b3f7e36c9da7</literal></entry>
@@ -4689,7 +4695,10 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
        </entry>
        <entry><type>bytea</type></entry>
        <entry>
+<!--
         SHA-256 hash
+-->
+SHA-256ハッシュ
        </entry>
        <entry><literal>sha256('abc')</literal></entry>
        <entry><literal>\xba7816bf8f01cfea414140de5dae2223&#x200B;b00361a396177a9cb410ff61f20015ad</literal></entry>
@@ -4704,7 +4713,10 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
        </entry>
        <entry><type>bytea</type></entry>
        <entry>
+<!--
         SHA-384 hash
+-->
+SHA-384ハッシュ
        </entry>
        <entry><literal>sha384('abc')</literal></entry>
        <entry><literal>\xcb00753f45a35e8bb5a03d699ac65007&#x200B;272c32ab0eded1631a8b605a43ff5bed&#x200B;8086072ba1e7cc2358baeca134c825a7</literal></entry>
@@ -4719,7 +4731,10 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
        </entry>
        <entry><type>bytea</type></entry>
        <entry>
+<!--
         SHA-512 hash
+-->
+SHA-512ハッシュ
        </entry>
        <entry><literal>sha512('abc')</literal></entry>
        <entry><literal>\xddaf35a193617abacc417349ae204131&#x200B;12e6fa4e89a97ea20a9eeee64b55d39a&#x200B;2192992a274fc1a836ba3c23a3feebbd&#x200B;454d4423643ce80e2a9ac94fa54ca49f</literal></entry>
@@ -4741,12 +4756,16 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
   </para>
 
   <para>
+<!--
    Note that for historic reasons, the function <function>md5</function>
    returns a hex-encoded value of type <type>text</type> whereas the SHA-2
    functions return type <type>bytea</type>.  Use the functions
    <function>encode</function> and <function>decode</function> to convert
    between the two, for example <literal>encode(sha256('abc'),
    'hex')</literal> to get a hex-encoded text representation.
+-->
+歴史的な理由により、<function>md5</function>は16進のエンコード値を返すのに対し、SHA-2関数は<type>bytea</type>を返すことに注意してください。
+両者の間の変換を行うには、関数<function>encode</function>と<function>decode</function>を使ってください。たとえば、16進のエンコードのテキスト表現を得るには、<literal>encode(sha256('abc'),'hex')</literal>としてください。
   </para>
 
   <para>
@@ -5164,9 +5183,12 @@ cast(-44 as bit(12))           <lineannotation>111111010100</lineannotation>
    </para>
 
    <para>
+<!--
     There is also the prefix operator <literal>^@</literal> and corresponding
     <function>starts_with</function> function which covers cases when only
     searching by beginning of the string is needed.
+-->
+単に文字列の先頭からの開始が必要なだけのケースであれば、接頭辞演算子<literal>^@</literal>とそれに対応する<function>starts_with</function>関数があります。
    </para>
   </sect2>
 

--- a/doc/src/sgml/func2.sgml
+++ b/doc/src/sgml/func2.sgml
@@ -197,6 +197,7 @@
 <function>to_char</function>用の出力テンプレート文字列には、値に基づいて認識され、適切に整形されたデータで置き換えられるパターンがあります。
 テンプレートパターンではない全てのテキストは単にそのままコピーされます。
 同様に、（その他の関数用の）入力テンプレート文字列では、テンプレートパターンは入力されたデータ文字列で供給される値を特定します。
+テンプレート文字列中にテンプレートパターンではない文字があれば、（テンプレート文字列と同じかどうかにかかわらず）入力文字列データ中の該当文字は単にスキップされます。
    </para>
 
   <para>
@@ -593,11 +594,17 @@
        </row>
        <row>
        <entry><literal>TZH</literal></entry>
+<!--
         <entry>time-zone hours</entry>
+-->
+        <entry>time-zoneの時間</entry>
        </row>
        <row>
        <entry><literal>TZM</literal></entry>
+<!--
         <entry>time-zone minutes</entry>
+-->
+        <entry>time-zoneの分</entry>
        </row>
        <row>
         <entry><literal>OF</literal></entry>
@@ -786,9 +793,9 @@
        (whether or not they are <literal>XX</literal>).
 -->
 <function>to_char</function>テンプレートには、通常のテキストを入れることができ、それはそのまま出力されます。
-部分文字列を二重引用符で括ることで、部分文字列にパターン用のキーワードがあったとしても、強制的にリテラルテキストとして解釈させることができます。
+部分文字列を二重引用符で括ることで、部分文字列にテンプレートパターンがあったとしても、強制的にリテラルテキストとして解釈させることができます。
 例えば、<literal>'"Hello Year "YYYY'</literal>では<literal>YYYY</literal>は年データに置換されてしまいますが、<literal>Year</literal>内の<literal>Y</literal>は置換されません。
-<function>to_date</function>、<function>to_number</function>、<function>to_timestamp</function>では、二重引用符で括られた文字の数だけ入力された文字をスキップします。例えば<literal>"XX"</literal>が指定された場合は2文字がスキップされます。
+<function>to_date</function>、<function>to_number</function>、<function>to_timestamp</function>では、二重引用符で括られた文字の数だけ入力された文字をスキップします。例えば<literal>"XX"</literal>は2文字の入力文字（それが<literal>XX</literal>であるかどうかにかかわらず)をスキップします。
       </para>
      </listitem>
 
@@ -805,6 +812,9 @@
        or another backslash).
 -->
 出力に二重引用符を付けたい場合、<literal>'\"YYYY Month\"'</literal>のようにその前にバックスラッシュを付けなければなりません。
+バックスラッシュは、二重引用符の外側では特別扱いされません。
+二重引用符の内側では、バックスラッシュによって次の文字が何であれ文字通りに扱われるようになります。
+（しかし、次の文字が二重引用符であるか、あるいは別のバックスラッシュでない限り、これは特別な効果をもたらしません。）
       </para>
      </listitem>
 
@@ -1158,12 +1168,17 @@ ISO 8601週番号年の文脈では、<quote>月</quote>、あるいは<quote>�
     <itemizedlist>
      <listitem>
       <para>
+<!--
        <literal>0</literal> specifies a digit position that will always be printed,
        even if it contains a leading/trailing zero.  <literal>9</literal> also
        specifies a digit position, but if it is a leading zero then it will
        be replaced by a space, while if it is a trailing zero and fill mode
        is specified then it will be deleted.  (For <function>to_number()</function>,
        these two pattern characters are equivalent.)
+-->
+<literal>0</literal>は、それが先頭あるいは末尾のゼロであっても必ず表示する数字の位置を指定します。
+<literal>9</literal>も数字の位置を指定しますが、先頭のゼロであればそれは空白で置換され、また末尾のゼロで字詰めモードが指定されているときは削除されます。
+（<function>to_number()</function>では、これら2つのパターン文字は同じ意味になります。）
       </para>
      </listitem>
 
@@ -1239,12 +1254,15 @@ ISO 8601週番号年の文脈では、<quote>月</quote>、あるいは<quote>�
 
      <listitem>
       <para>
+<!--
        In <function>to_number</function>, if non-data template patterns such
        as <literal>L</literal> or <literal>TH</literal> are used, the
        corresponding number of input characters are skipped, whether or not
        they match the template pattern, unless they are data characters
        (that is, digits, sign, decimal point, or comma).  For
        example, <literal>TH</literal> would skip two non-data characters.
+-->
+<function>to_number</function>において、<literal>L</literal>あるいは<literal>TH</literal>のように非データテンプレートが使われた場合には、それがデータ文字（すなわち、数字、符号、10進小数点あるいはカンマ）でない限りテンプレートパターンにマッチするかどうかにかかわらず、該当する数分だけの入力文字がスキップされます。
       </para>
      </listitem>
 
@@ -3095,7 +3113,7 @@ SELECT date_trunc('year', TIMESTAMP '2001-02-16 20:38:40');
     <emphasis>time</emphasis> values to different time zones. <xref
     linkend="functions-datetime-zoneconvert-table"/> shows its variants.
 -->
-<function>AT TIME ZONE</function>構文を使用することにより、タイムスタンプを異なる時間帯に変換することができます。
+<function>AT TIME ZONE</function>構文を使用することにより、time stamp <emphasis>without time zone</emphasis>からtime stamp <emphasis>with time zone</emphasis>へ、あるいはtime stamp <emphasis>with time zone</emphasis>からtime stamp <emphasis>without time zone</emphasis>へ変換でき、また<emphasis>時刻</emphasis>値を異なる時間帯に変換することができます。
 <xref linkend="functions-datetime-zoneconvert-table"/>にその種類を示します。
    </para>
 
@@ -3164,7 +3182,7 @@ SELECT date_trunc('year', TIMESTAMP '2001-02-16 20:38:40');
     In the text case, a time zone name can be specified in any of the ways
     described in <xref linkend="datatype-timezones"/>.
 -->
-これらの式では、設定する時間帯<replaceable>zone</replaceable>は、（<literal>'PST'</literal>のような）テキスト文字列、または（<literal>INTERVAL '-08:00'</literal>のような）時間間隔で指定することができます。
+これらの式では、設定する時間帯<replaceable>zone</replaceable>は、（<literal>'America/Los_Angeles'</literal>のような）テキスト文字列、または（<literal>INTERVAL '-08:00'</literal>のような）時間間隔で指定することができます。
 テキストの場合、<xref linkend="datatype-timezones"/>に示した方法で時間帯名称を指定することができます。
    </para>
 
@@ -3172,7 +3190,7 @@ SELECT date_trunc('year', TIMESTAMP '2001-02-16 20:38:40');
 <!--
     Examples (assuming the local time zone is <literal>America/Los_Angeles</literal>):
 -->
-以下に例を示します（ローカル時間帯を<literal>PST8PDT</literal>と想定しています）。
+以下に例を示します（ローカル時間帯を<literal>America/Los_Angeles</literal>と想定しています）。
 <screen>
 SELECT TIMESTAMP '2001-02-16 20:38:40' AT TIME ZONE 'America/Denver';
 <lineannotation>Result: </lineannotation><computeroutput>2001-02-16 19:38:40-08</computeroutput>
@@ -3194,8 +3212,11 @@ SELECT TIMESTAMP '2001-02-16 20:38:40-05' AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE
     values to other time zones uses the currently active time zone rules
     since no date is supplied.
 -->
-最初の例は、時間帯のないタイムスタンプを使用し、それをMST時間（UTC-7）として解釈し、そして表示用にPST（UTC-7）に変換します。
-2番目の例は、EST（UTC-5）で指定されたタイムスタンプを使用し、MST（UTC-7）でのローカル時間に変換しています。
+最初の例は、時間帯のない値に時間帯を追加し、現在の<varname>TimeZone</varname>設定を使ってその値を表示します。
+2番目の例は、time stamp with time zone値を指定したタイムゾーンに変換し、その値をwithout a time zoneで返しています。
+これは、<varname>TimeZone</varname>設定とは異なる値の格納と表示を可能にします。
+3番目の例は、東京時間をシカゴ時間に変換します。
+データが与えられていないので、現在有効なタイムゾーンルールを使って、<emphasis>時刻</emphasis>値を変換しています。
    </para>
 
    <para>
@@ -5329,7 +5350,10 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
           <literal><function>websearch_to_tsquery(<optional> <replaceable class="parameter">config</replaceable> <type>regconfig</type> , </optional> <replaceable class="parameter">query</replaceable> <type>text</type>)</function></literal>
          </entry>
         <entry><type>tsquery</type></entry>
+<!--
         <entry>produce <type>tsquery</type> from a web search style query</entry>
+-->
+        <entry>web検索形式の問い合わせから<type>tsquery</type>を生成</entry>
         <entry><literal>websearch_to_tsquery('english', '"fat rat" or rat')</literal></entry>
         <entry><literal>'fat' &lt;-&gt; 'rat' | 'rat'</literal></entry>
        </row>
@@ -5450,6 +5474,7 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
         </entry>
         <entry><type>tsvector</type></entry>
         <entry>
+<!--
           reduce each value in the document, specified by <replaceable class="parameter">filter</replaceable> to a <type>tsvector</type>,
           and then concatenate those in document order to produce a single <type>tsvector</type>.
           <replaceable class="parameter">filter</replaceable> is a <type>jsonb</type> array, that enumerates what kind of elements need to be included
@@ -5458,6 +5483,11 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
           <literal>"boolean"</literal> (to include all Boolean values in the string format <literal>"true"</literal>/<literal>"false"</literal>),
           <literal>"key"</literal> (to include all keys) or <literal>"all"</literal> (to include all above). These values
           can be combined together to include, e.g. all string and numeric values.
+-->
+<replaceable class="parameter">filter</replaceable>によって指定された文書中の各々の値を<type>tsvector</type>にまとめ、次に文書にあらわれる順にそれらを結合して単一の<type>tsvector</type>を生成します。
+<replaceable class="parameter">filter</replaceable>は<type>jsonb</type>の配列で、結果の<type>tsvector</type>にどの種類の要素を含める必要があるのかを列挙します。
+<replaceable class="parameter">filter</replaceable>に指定可能な値は、<literal>"string"</literal> (すべての文字列値を含める)、<literal>"numeric"</literal> (すべての文字列形式の数値を含める)、<literal>"key"</literal> (すべてのキーを含める)、<literal>"all"</literal> (それらすべてを含める)です。
+これらの値は、たとえば文字列と数値のように、結合することができます。
         </entry>
         <entry><literal>json_to_tsvector('english', '{"a": "The Fat Rats", "b": 123}'::json, '["string", "numeric"]')</literal></entry>
         <entry><literal>'123':5 'fat':2 'rat':3</literal></entry>

--- a/doc/src/sgml/func2.sgml
+++ b/doc/src/sgml/func2.sgml
@@ -197,7 +197,7 @@
 <function>to_char</function>用の出力テンプレート文字列には、値に基づいて認識され、適切に整形されたデータで置き換えられるパターンがあります。
 テンプレートパターンではない全てのテキストは単にそのままコピーされます。
 同様に、（その他の関数用の）入力テンプレート文字列では、テンプレートパターンは入力されたデータ文字列で供給される値を特定します。
-テンプレート文字列中にテンプレートパターンではない文字があれば、（テンプレート文字列と同じかどうかにかかわらず）入力文字列データ中の該当文字は単にスキップされます。
+テンプレート文字列中にテンプレートパターンではない文字があれば、（テンプレート文字列の文字と同じかどうかにかかわらず）入力文字列データ中の該当文字は単にスキップされます。
    </para>
 
   <para>
@@ -5487,7 +5487,7 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
 <replaceable class="parameter">filter</replaceable>によって指定された文書中の各々の値を<type>tsvector</type>にまとめ、次に文書にあらわれる順にそれらを結合して単一の<type>tsvector</type>を生成します。
 <replaceable class="parameter">filter</replaceable>は<type>jsonb</type>の配列で、結果の<type>tsvector</type>にどの種類の要素を含める必要があるのかを列挙します。
 <replaceable class="parameter">filter</replaceable>に指定可能な値は、<literal>"string"</literal> (すべての文字列値を含める)、<literal>"numeric"</literal> (すべての文字列形式の数値を含める)、<literal>"key"</literal> (すべてのキーを含める)、<literal>"all"</literal> (それらすべてを含める)です。
-これらの値は、たとえば文字列と数値のように、結合することができます。
+これらの値は、たとえばすべての文字列と数値、のように組み合わせることができます。
         </entry>
         <entry><literal>json_to_tsvector('english', '{"a": "The Fat Rats", "b": 123}'::json, '["string", "numeric"]')</literal></entry>
         <entry><literal>'123':5 'fat':2 'rat':3</literal></entry>

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -5143,7 +5143,7 @@ NULL値は<literal>ORDER BY</literal>節で指定されるルールに従って�
 <function>first_value</function>、<function>last_value</function>、<function>nth_value</function>関数は<quote>ウィンドウフレーム</quote>内の行のみを考慮することに注意してください。
 デフォルトで、ウィンドウフレームにはパーティションの先頭から現在の行の最終ピアまでの行が含まれます。
 これは<function>last_value</function>、または時々<function>nth_value</function>では有用ではない結果を得ることになりがちです。
-<literal>OVER</literal>句に適切なフレーム指定(<literal>RANGE</literal>もしくは<literal>ROWS</literal>)を加えることで、フレームを再定義することができます。
+<literal>OVER</literal>句に適切なフレーム指定(<literal>RANGE</literal>、<literal>GROUP</literal>、もしくは<literal>ROWS</literal>)を加えることで、フレームを再定義することができます。
 フレーム指定についての詳細は<xref linkend="syntax-window-functions"/>を参照してください。
   </para>
 

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -8215,7 +8215,7 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
          identifier included in the identity is quoted if necessary.
 -->
 オブジェクト識別のテキスト表現で、スキーマ修飾される。
-権限のなかにある各識別子は必要であれば引用符で括られる。
+識別内に存在する各識別子は必要であれば引用符で括られる。
         </entry>
        </row>
        <row>

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -3143,7 +3143,7 @@ SELECT pg_type_is_visible('myschema.widget'::regtype);
 <!--
        <entry>get <literal>RETURNS</literal> clause for function (returns null for a procedure)</entry>
 -->
-       <entry>関数に対する<literal>RETURNS</literal>句の取得（手続きに対してはNULLを返します）</entry>
+       <entry>関数に対する<literal>RETURNS</literal>句の取得（プロシージャに対してはNULLを返します）</entry>
       </row>
       <row>
        <entry><literal><function>pg_get_indexdef(<parameter>index_oid</parameter>)</function></literal></entry>

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -370,7 +370,7 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
 左辺の式は副問い合わせの結果のそれぞれの行に対し、与えられた<replaceable>operator</replaceable>を使用して行に関する評価、比較が行われます。
 比較の結果、副問い合わせの行のどれかに対して真となる場合、<token>ANY</token>の結果は<quote>true（真）</quote>です。
 比較の結果、副問い合わせの全ての行に対して偽となる場合（副問い合わせが行を返さないという場合も含む）、結果は<quote>false（偽）</quote>です。
-比較の結果、いかなる行でも真を返さず、かつ、少なくとも１つの行がNULLを返す場合、結果はNULLになります。
+いかなる副問合せ行との比較の結果も偽を返さず、かつ、少なくとも１つの比較がNULLを返す場合、結果はNULLになります。
   </para>
 
   <para>
@@ -1573,9 +1573,13 @@ SELECT * FROM pg_ls_dir('.') WITH ORDINALITY AS t(ls,n);
       <row>
        <entry><literal><function>pg_jit_available()</function></literal></entry>
        <entry><type>boolean</type></entry>
+<!--
        <entry>is <acronym>JIT</acronym> compilation available in this session
        (see <xref linkend="jit"/>)? Returns <literal>false</literal> if <xref
        linkend="guc-jit"/> is set to false.</entry>
+-->
+<entry>is <acronym>JIT</acronym>コンパイルがこのセッションで可能か？(<xref linkend="jit"/>参照)
+<xref linkend="guc-jit"/>がfalseなら、<literal>false</literal>を返します。</entry>
       </row>
 
       <row>
@@ -2894,6 +2898,7 @@ SELECT relname FROM pg_class WHERE pg_table_is_visible(oid);
 -->
 それぞれの関数はデータベースオブジェクトの１つの型に対して可視性の検査を行います。
 <function>pg_table_is_visible</function>がビュー、マテリアライズドビュー、インデックス、シーケンス、外部テーブルに対しても使用できること、<function>pg_type_is_visible</function>がドメインに対しても使用できることに注意してください。
+<function>pg_function_is_visible</function>は手続きと集約にも使えます。
 関数および演算子では、パスの前方に同じ名前かつ同じ<emphasis>引数のデータ型</emphasis>を持つオブジェクトが存在しなければ、検索パス内のオブジェクトは可視です。
 演算子クラスでは、名前と関連するインデックスアクセスメソッドが考慮されます。
    </para>
@@ -3114,7 +3119,7 @@ SELECT pg_type_is_visible('myschema.widget'::regtype);
 <!--
        <entry>get definition of a function or procedure</entry>
 -->
-       <entry>関数定義の取得</entry>
+       <entry>関数あるいは手続きの定義の取得</entry>
       </row>
       <row>
        <entry><literal><function>pg_get_function_arguments(<parameter>func_oid</parameter>)</function></literal></entry>
@@ -3122,7 +3127,7 @@ SELECT pg_type_is_visible('myschema.widget'::regtype);
 <!--
        <entry>get argument list of function's or procedure's definition (with default values)</entry>
 -->
-       <entry>関数定義の引数リスト（デフォルト値付き）を取得</entry>
+       <entry>関数あるいは手続きの定義の引数リスト（デフォルト値付き）を取得</entry>
       </row>
       <row>
        <entry><literal><function>pg_get_function_identity_arguments(<parameter>func_oid</parameter>)</function></literal></entry>
@@ -3130,7 +3135,7 @@ SELECT pg_type_is_visible('myschema.widget'::regtype);
 <!--
        <entry>get argument list to identify a function or procedure (without default values)</entry>
 -->
-       <entry>関数を特定するための引数リスト（デフォルト値なし）を取得</entry>
+       <entry>関数あるいは手続きを特定するための引数リスト（デフォルト値なし）を取得</entry>
       </row>
       <row>
        <entry><literal><function>pg_get_function_result(<parameter>func_oid</parameter>)</function></literal></entry>
@@ -3138,7 +3143,7 @@ SELECT pg_type_is_visible('myschema.widget'::regtype);
 <!--
        <entry>get <literal>RETURNS</literal> clause for function (returns null for a procedure)</entry>
 -->
-       <entry>関数に対する<literal>RETURNS</literal>句の取得</entry>
+       <entry>関数に対する<literal>RETURNS</literal>句の取得（手続きに対してはNULLを返します）</entry>
       </row>
       <row>
        <entry><literal><function>pg_get_indexdef(<parameter>index_oid</parameter>)</function></literal></entry>
@@ -3740,9 +3745,12 @@ SELECT currval(pg_get_serial_sequence('sometable', 'id'));
      </row>
      <row>
       <entry><literal>can_include</literal></entry>
+<!--
       <entry>Does the access method support the <literal>INCLUDE</literal>
         clause of <literal>CREATE INDEX</literal>?
       </entry>
+-->
+      <entry>アクセスメソッドが<literal>CREATE INDEX</literal>の<literal>INCLUDE</literal>句をサポートしているか</entry>
      </row>
     </tbody>
    </tgroup>
@@ -3942,7 +3950,7 @@ SELECT collation for ('foo' COLLATE "de_DE");
    This is useful to determine the identity of an object as stored in the
    <structname>pg_depend</structname> catalog.
 -->
-<function>pg_describe_object</function>はカタログOID、オブジェクトOID、もしくはサブオブジェクトOID（0のこともある）で指定されたデータベースオブジェクトのテキストによる説明を返します。
+<function>pg_describe_object</function>はカタログOID、オブジェクトOID、もしくはサブオブジェクトOID（たとえばテーブル中の列番号。オブジェクト全体を参照している場合は0）で指定されたデータベースオブジェクトのテキストによる説明を返します。
 この説明はサーバの設定に依存しますが、人が読んでわかる、そして翻訳も可能になることを目的としたのもです。
 これは<structname>pg_depend</structname>カタログに格納されたオブジェクトの識別判断の際に有用です。
   </para>
@@ -3963,7 +3971,7 @@ SELECT collation for ('foo' COLLATE "de_DE");
    precise format depending on object type, and each name within the format
    being schema-qualified and quoted as necessary.
 -->
-<function>pg_identify_object</function>はカタログOID、オブジェクトOID、そしてサブオブジェクトID（0のこともある）により指定されるデータベースオブジェクトを一意に特定するために十分な情報を含む行を返します。
+<function>pg_identify_object</function>はカタログOID、オブジェクトOID、そしてサブオブジェクトIDにより指定されるデータベースオブジェクトを一意に特定するために十分な情報を含む行を返します。
 この情報は機械による読み取りを目的としており、決して翻訳されません。
 <parameter>type</parameter>はデータベースオブジェクトの型を識別するものです。
 <parameter>schema</parameter>はオブジェクトが所属するスキーマの名前ですが、スキーマに所属しないオブジェクト型の場合は<literal>NULL</literal>になります。
@@ -3987,12 +3995,12 @@ SELECT collation for ('foo' COLLATE "de_DE");
    of the object.
    This function is the inverse of <function>pg_get_object_address</function>.
 -->
-<function>pg_identify_object_as_address</function>はカタログOID、オブジェクトOID、そしてサブオブジェクトID（0のこともある）により指定されるデータベースオブジェクトを一意に特定するために充分な情報を含む行を返します。
+<function>pg_identify_object_as_address</function>はカタログOID、オブジェクトOID、そしてサブオブジェクトIDにより指定されるデータベースオブジェクトを一意に特定するために充分な情報を含む行を返します。
 返される情報は現在のサーバに依存しません。
 つまり、他のサーバで全く同じ名前を付けられたオブジェクトを識別するために使うことができます。
 <parameter>type</parameter>はデータベースオブジェクトの型を識別するものです。
-<parameter>name</parameter>と<parameter>args</parameter>は文字列の配列で、それらが組み合わされてオブジェクトへの参照を構成します。
-これらの3つの列は、オブジェクトの内部アドレスを取得するために<function>pg_get_object_address</function>に渡すことができます。
+<parameter>object_names</parameter>と<parameter>object_args</parameter>は文字列の配列で、それらが組み合わされてオブジェクトへの参照を構成します。
+これらの3つの値は、オブジェクトの内部アドレスを取得するために<function>pg_get_object_address</function>に渡すことができます。
 この関数は<function>pg_get_object_address</function>の逆関数です。
   </para>
 
@@ -4012,9 +4020,9 @@ SELECT collation for ('foo' COLLATE "de_DE");
 -->
 <function>pg_get_object_address</function>は、型、オブジェクト名および引数の配列で指定されたデータベースオブジェクトを一意に特定するために十分な情報を含む行を返します。
 返される値は、<structname>pg_depend</structname>などのシステムカタログで使用されるもので、<function>pg_identify_object</function>や<function>pg_describe_object</function>など他のシステム関数に渡すことができます。
-<parameter>catalog_id</parameter>はオブジェクトを含むシステムカタログのOIDです。
-<parameter>object_id</parameter>はオブジェクト自体のOIDです。
-<parameter>object_sub_id</parameter>はオブジェクトのサブID、なければ0です。
+<parameter>classid</parameter>はオブジェクトを含むシステムカタログのOIDです。
+<parameter>objid</parameter>はオブジェクト自体のOIDです。
+<parameter>objsubid</parameter>はオブジェクトのサブID、なければ0です。
 この関数は<function>pg_identify_object_as_address</function>の逆関数です。
   </para>
 
@@ -6160,10 +6168,15 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         <type>bool</type>
        </entry>
        <entry>
+<!--
         Advances the current confirmed position of a replication slot named
         <parameter>slot_name</parameter>. The slot will not be moved backwards,
         and it will not be moved beyond the current insert location.  Returns
         name of the slot and real position to which it was advanced to.
+-->
+<parameter>slot_name</parameter>という名前のレプリケーションスロットの現在の確認された位置を進めます。
+スロットは後方には動きませんし、現在の挿入位置を超えて進むこともありません。
+スロットの名前と前に進んだ実際の位置を返します。
        </entry>
       </row>
 
@@ -7187,12 +7200,13 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
     configuration setting for log files.
 -->
 <xref linkend="functions-admin-genfile-table"/>で示されている関数はサーバをホスティングしているマシン上のファイルに対し、ネイティブのアクセスを提供します。
-データベースクラスタディレクトリと<varname>log_directory</varname>に存在するファイルのみがアクセス可能です。
+ユーザが<literal>pg_read_server_files</literal>ロールを与えられていない限り、データベースクラスタディレクトリと<varname>log_directory</varname>に存在するファイルのみがアクセス可能です。
 クラスタディレクトリ内のファイルに対して相対パスを、そしてログファイルに対しては<varname>log_directory</varname>構成設定に一致するパスを使用してください。
 これらの関数は特に記述がある場合を除き、スーパーユーザだけが使用できます。
    </para>
 
    <para>
+<!--
     Note that granting users the EXECUTE privilege on the
     <function>pg_read_file()</function>, or related, functions allows them the
     ability to read any file on the server which the database can read and
@@ -7201,6 +7215,10 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
     <literal>pg_authid</literal> table where authentication information is contained,
     as well as read any file in the database.  Therefore, granting access to these
     functions should be carefully considered.
+-->
+ユーザに対して<function>pg_read_file()</function>あるいは関連する関数へのEXECUTE権限を許可することは、サーバ上のデータベースが読むことのできるすべてのファイルに対して読み出し許可を与えることになること、こうした読み出しについてはデータベース内のあらゆる権限チェックがすり抜けられることに注意してください。
+これはつまり、この権限を持っているユーザは、とりわけ認証情報が含まれる<literal>pg_authid</literal>テーブルの内容を読むことができることを意味します。
+ですから、これらの関数には注意深くアクセス許可を与えるべきです。
    </para>
 
    <table id="functions-admin-genfile-table">
@@ -7227,7 +7245,7 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
 <!--
         List the contents of a directory.  Restricted to superusers by default, but other users can be granted EXECUTE to run the function.
 -->
-ディレクトリの内容を一覧表示する
+ディレクトリの内容を一覧表示する。デフォルトではスーパーユーザに制限されるが、他のユーザにEXECUTEを許可することによりこの関数を実行できる
        </entry>
       </row>
       <row>
@@ -7269,7 +7287,7 @@ WALディレクトリ内のファイルの名前、サイズ、最終更新時�
 <!--
         Return the contents of a text file.  Restricted to superusers by default, but other users can be granted EXECUTE to run the function.
 -->
-テキストファイルの内容を返す
+テキストファイルの内容を返す。デフォルトではスーパーユーザに制限されるが、他のユーザにEXECUTEを許可することによりこの関数を実行できる
        </entry>
       </row>
       <row>
@@ -7281,7 +7299,7 @@ WALディレクトリ内のファイルの名前、サイズ、最終更新時�
 <!--
         Return the contents of a file.  Restricted to superusers by default, but other users can be granted EXECUTE to run the function.
 -->
-ファイルの内容を返す
+ファイルの内容を返す。デフォルトではスーパーユーザに制限されるが、他のユーザにEXECUTEを許可することによりこの関数を実行できる
        </entry>
       </row>
       <row>
@@ -7293,7 +7311,7 @@ WALディレクトリ内のファイルの名前、サイズ、最終更新時�
 <!--
         Return information about a file.  Restricted to superusers by default, but other users can be granted EXECUTE to run the function.
 -->
-ファイルについての情報を返す
+ファイルについての情報を返す。デフォルトではスーパーユーザに制限されるが、他のユーザにEXECUTEを許可することによりこの関数を実行できる
        </entry>
       </row>
      </tbody>
@@ -8032,7 +8050,7 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
          identifier included in the identity is quoted if necessary.
 -->
 オブジェクトの識別をテキスト表現したもので、スキーマ修飾される。
-識別内に存在するすべての識別子は、必要なら引用符で括られる。
+識別内に存在する各識別子は、必要なら引用符で括られる。
         </entry>
        </row>
        <row>
@@ -8041,7 +8059,7 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
 <!--
         <entry>True if the command is part of an extension script</entry>
 -->
-        <entry>コマンドが拡張のスクリプトの一部かどうか</entry>
+        <entry>コマンドが拡張のスクリプトの一部なら真</entry>
        </row>
        <row>
         <entry><literal>command</literal></entry>
@@ -8131,7 +8149,7 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
 <!--
         <entry>True if this was one of the root object(s) of the deletion</entry>
 -->
-        <entry>削除のルートオブジェクトを特定するために使われるフラグ</entry>
+        <entry>これが削除のルートオブジェクトの一つなら真</entry>
        </row>
        <row>
         <entry><literal>normal</literal></entry>
@@ -8141,7 +8159,7 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
          True if there was a normal dependency relationship
          in the dependency graph leading to this object
 -->
-このオブジェクトへと至る依存関係グラフで、通常の依存があることを示すフラグ
+このオブジェクトへと至る依存関係グラフで、通常の依存があるなら真
         </entry>
        </row>
        <row>
@@ -8151,7 +8169,7 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
 <!--
          True if this was a temporary object
 -->
-オブジェクトが一時オブジェクトであったことを示すフラグ
+オブジェクトが一時オブジェクトであったなら真
         </entry>
        </row>
        <row>
@@ -8197,7 +8215,7 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
          identifier included in the identity is quoted if necessary.
 -->
 オブジェクト識別のテキスト表現で、スキーマ修飾される。
-権限のなかにあるそれぞれ全ての識別子は必要であれば引用符で括られる。
+権限のなかにある各識別子は必要であれば引用符で括られる。
         </entry>
        </row>
        <row>
@@ -8221,7 +8239,7 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
 <!--
          Complement for <literal>address_names</literal>
 -->
-上記<literal>address_names</literal>の補足。
+<literal>address_names</literal>の補足。
         </entry>
        </row>
       </tbody>


### PR DESCRIPTION
レビューは、func[1-4].sgmlで行ってください。

27,531行からの文は原文に文法的な誤りがあったため、本家に報告、修正を
PostgreSQL 11の安定ブランチにコミットしています。訳は修正後の原文に基
づいています。詳細はコミット "Doc: fix typo in "Generic File Access
Functions" section." (84fcc2ce56962a82e4da633b5ba2bd68c4960cd8) を参照。