### PR TITLE
translate standalone-install for 11.1

### DIFF
--- a/doc/src/sgml/standalone-install.xml
+++ b/doc/src/sgml/standalone-install.xml
@@ -54,7 +54,7 @@ in the stand-alone version.
 -->
 <productname>PostgreSQL</productname>サーバ用にユーザアカウントを作成してください。
 これはサーバを動作させるユーザです。
-本番利用向けには、別の非特権アカウント(一般に<quote>postgres</quote>が使われます)を作成すべきです。
+本番利用向けには、別の非特権アカウント(一般的に<quote>postgres</quote>が使われます)を分けて作成すべきです。
 root権限を持っていなかったり、ちょっと試してみたいだけなら、自分のユーザアカウントで十分ですが、rootとしてサーバを動かすことはセキュリティリスクですので動作しないでしょう。
 <screen><userinput>adduser postgres</userinput></screen>
     </para>
@@ -176,6 +176,7 @@ postgres$ <userinput>/usr/local/pgsql/bin/initdb -D /usr/local/pgsql/data</useri
       changed the installation directories.
 -->
 <productname>PostgreSQL</productname>配布物には幅広い文書が含まれており、時々は読むべきです。
+インストール後は、その文書は、インストールディレクトリを変更していなければ<filename>/usr/local/pgsql/doc/html/index.html</filename>をブラウザで開くことでアクセスできます。
      </para>
 
      <para>

--- a/doc/src/sgml/standalone-install.xml
+++ b/doc/src/sgml/standalone-install.xml
@@ -7,11 +7,17 @@ instructions in the main documentation with some material that only appears
 in the stand-alone version.
 -->
 <article id="installation">
+<!--
  <title><productname>PostgreSQL</productname> Installation from Source Code</title>
+-->
+ <title>ソースコードからの<productname>PostgreSQL</productname>のインストール</title>
 
  <para>
+<!--
   This document describes the installation of
   <productname>PostgreSQL</productname> using this source code distribution.
+-->
+この文書はこのソースコード配布物を使用した<productname>PostgreSQL</productname>のインストール方法について説明します。
  </para>
 
  <xi:include href="postgres.sgml" xpointer="install-short" xmlns:xi="http://www.w3.org/2001/XInclude"/>
@@ -20,16 +26,24 @@ in the stand-alone version.
  <xi:include href="postgres.sgml" xpointer="install-post" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 
  <sect1 id="install-getting-started">
+<!--
   <title>Getting Started</title>
+-->
+  <title>さあ、はじめましょう</title>
 
   <para>
+<!--
    The following is a quick summary of how to get <productname>PostgreSQL</productname> up and
    running once installed. The main documentation contains more information.
+-->
+以下は<productname>PostgreSQL</productname>を用意しインストールして動作させる方法の概略です。
+本編の文書にはより多くの情報があります。
   </para>
 
   <procedure>
    <step>
     <para>
+<!--
      Create a user account for the <productname>PostgreSQL</productname>
      server. This is the user the server will run as. For production
      use you should create a separate, unprivileged account
@@ -37,16 +51,26 @@ in the stand-alone version.
      access or just want to play around, your own user account is
      enough, but running the server as root is a security risk and
      will not work.
+-->
+<productname>PostgreSQL</productname>サーバ用にユーザアカウントを作成してください。
+これはサーバを動作させるユーザです。
+本番利用向けには、別の非特権アカウント(一般に<quote>postgres</quote>が使われます)を作成すべきです。
+root権限を持っていなかったり、ちょっと試してみたいだけなら、自分のユーザアカウントで十分ですが、rootとしてサーバを動かすことはセキュリティリスクですので動作しないでしょう。
 <screen><userinput>adduser postgres</userinput></screen>
     </para>
    </step>
 
    <step>
     <para>
+<!--
      Create a database installation with the <command>initdb</command>
      command. To run <command>initdb</command> you must be logged in to your
      <productname>PostgreSQL</productname> server account. It will not work as
      root.
+-->
+<command>initdb</command>コマンドでデータベースインストレーションを作成してください。
+<command>initdb</command>を動かすには、<productname>PostgreSQL</productname>サーバアカウントでログインしてください。
+rootでは動作しません。
 <screen>root# <userinput>mkdir /usr/local/pgsql/data</userinput>
 root# <userinput>chown postgres /usr/local/pgsql/data</userinput>
 root# <userinput>su - postgres</userinput>
@@ -54,99 +78,149 @@ postgres$ <userinput>/usr/local/pgsql/bin/initdb -D /usr/local/pgsql/data</useri
     </para>
 
     <para>
+<!--
      The <option>-D</option> option specifies the location where the data
      will be stored. You can use any path you want, it does not have
      to be under the installation directory. Just make sure that the
      server account can write to the directory (or create it, if it
      doesn't already exist) before starting <command>initdb</command>, as
      illustrated here.
+-->
+<option>-D</option>オプションはデータが保存される場所を指定します。
+好きなパスを使えます。インストールディレクトリの下である必要はありません。
+ここで示すように、<command>initdb</command>を開始する前にサーバアカウントがそのディレクトリに書き込めることを確実にしておいてください(ディレクトリが存在していなければ、作成してください)。
     </para>
    </step>
 
    <step>
     <para>
+<!---
      At this point, if you did not use the <command>initdb</command> <literal>-A</literal>
      option, you might want to modify <filename>pg_hba.conf</filename> to control
      local access to the server before you start it.  The default is to
      trust all local users.
+-->
+この時点で、<command>initdb</command> <literal>-A</literal>オプションを使っていなければ、サーバへのローカルアクセスを制御するためにサーバを開始する前に<filename>pg_hba.conf</filename>を修正したいかもしれません。
+デフォルトでは全ローカルユーザを信頼します。
     </para>
    </step>
 
    <step>
     <para>
+<!--
      The previous <command>initdb</command> step should have told you how to
      start up the database server. Do so now. The command should look
      something like:
+-->
+前の<command>initdb</command>ステップでデータベースサーバを起動する方法を説明しておくべきでした。
+今、起動してください。
+コマンドは以下のようになります。
 <programlisting>/usr/local/pgsql/bin/postgres -D /usr/local/pgsql/data</programlisting>
+<!--
      This will start the server in the foreground. To put the server
      in the background use something like:
+-->
+これはサーバをフォアグラウンドで開始します。
+サーバをバックグラウンドで動作させるには以下のようにしてください。
 <programlisting>nohup /usr/local/pgsql/bin/postgres -D /usr/local/pgsql/data \
     &lt;/dev/null &gt;&gt;server.log 2&gt;&amp;1 &lt;/dev/null &amp;</programlisting>
     </para>
 
     <para>
+<!--
      To stop a server running in the background you can type:
+-->
+バックグラウンドで動作しているサーバを停止するには、以下のようにタイプします。
 <programlisting>kill `cat /usr/local/pgsql/data/postmaster.pid`</programlisting>
     </para>
    </step>
 
    <step>
     <para>
+<!--
      Create a database:
+-->
+データベースを作成してください。
 <screen><userinput>createdb testdb</userinput></screen>
+<!--
      Then enter:
+-->
+次にそのデータベースに接続するために以下のように入力します。
 <screen><userinput>psql testdb</userinput></screen>
+<!--
      to connect to that database. At the prompt you can enter SQL
      commands and start experimenting.
+-->
+プロンプトでSQLコマンドを入力し、試し始めることができます。
     </para>
    </step>
   </procedure>
  </sect1>
 
  <sect1 id="install-whatnow">
+<!--
   <title>What Now?</title>
+-->
+  <title>その次に</title>
 
   <para>
    <itemizedlist>
     <listitem>
      <para>
+<!--
       The <productname>PostgreSQL</productname> distribution contains a
       comprehensive documentation set, which you should read sometime.
       After installation, the documentation can be accessed by
       pointing your browser to
       <filename>/usr/local/pgsql/doc/html/index.html</filename>, unless you
       changed the installation directories.
+-->
+<productname>PostgreSQL</productname>配布物には幅広い文書が含まれており、時々は読むべきです。
      </para>
 
      <para>
+<!--
       The first few chapters of the main documentation are the Tutorial,
       which should be your first reading if you are completely new to
       <acronym>SQL</acronym> databases.  If you are familiar with database
       concepts then you want to proceed with part on server
       administration, which contains information about how to set up
       the database server, database users, and authentication.
+-->
+本編の文書の始めの2、3章はチュートリアルで、もしあなたが<acronym>SQL</acronym>データベースは全く初めてであるなら最初に読むべきものです。
+データベースの概念に慣れているのであれば、サーバ管理に関する部分から始めてください。そこには、データベースサーバやデータベースユーザ、認証の情報があります。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Usually, you will want to modify your computer so that it will
       automatically start the database server whenever it boots. Some
       suggestions for this are in the documentation.
+-->
+通常、コンピュータが起動する時には必ず自動的にデータベースサーバを開始するよう修正したいでしょう。
+文書中に、このことに関する提案がいくつかあります。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Run the regression tests against the installed server (using
       <command>make installcheck</command>). If you didn't run the
       tests before installation, you should definitely do it now. This
       is also explained in the documentation.
+-->
+(<command>make installcheck</command>を使って)インストールしたサーバに対してリグレッションテストをしてください。
+インストール前にテストをしていなければ、絶対に今すべきです。
+これも文書中で説明しています。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       By default, <productname>PostgreSQL</productname> is configured to run on
       minimal hardware.  This allows it to start up with almost any
       hardware configuration. The default configuration is, however,
@@ -156,6 +230,12 @@ postgres$ <userinput>/usr/local/pgsql/bin/initdb -D /usr/local/pgsql/data</useri
       <varname>work_mem</varname>.
       Other parameters mentioned in the documentation also affect
       performance.
+-->
+デフォルトでは<productname>PostgreSQL</productname>は最低限のハードウェアで動作するよう構成されています。
+このため、ほぼすべてのハードウェア構成で始められます。
+しかしながら、デフォルト構成は、最適なパフォーマンスのためには設計されていません。
+最適なパフォーマンスを達成するには、サーバパラメータをいくつか調整しなければなりません。よくある2つは<varname>shared_buffers</varname>と<varname>work_mem</varname>です。
+文書で述べている他のパラメータもパフォーマンスに影響します。
      </para>
     </listitem>
    </itemizedlist>


### PR DESCRIPTION
standalone-install.xmlの訳です。
ファイルとしては以前のstandalone-install.sgmlに対応するもののようですが、対応する英文はほとんどなかったため、一から訳す形になっています。