### PR TITLE
pg_rewindのソースサーバがリカバリ中の時のエラーメッセージ和訳を修正

### DIFF
--- a/src/bin/pg_rewind/po/ja.po
+++ b/src/bin/pg_rewind/po/ja.po
@@ -268,7 +268,7 @@ msgstr "search_pathを消去できませんでした: %s"
 #: libpq_fetch.c:71
 #, c-format
 msgid "source server must not be in recovery mode\n"
-msgstr "ソースサーバはリカバリモードでなければなりません\n"
+msgstr "ソースサーバはリカバリモードであってはなりません\n"
 
 #: libpq_fetch.c:81
 #, c-format


### PR DESCRIPTION
pg_rewindのソースサーバがリカバリ中の時のエラーメッセージの日本語の意味が逆