### PR TITLE
pgcrypto.sgmlの11.1対応です。

### DIFF
--- a/doc/src/sgml/pgcrypto.sgml
+++ b/doc/src/sgml/pgcrypto.sgml
@@ -1458,7 +1458,7 @@ PGP関数にこれらのキーを渡す前に<function>dearmor()</function>を�
    Privacy Handbook</ulink> and other documentation on
    <ulink url="https://www.gnupg.org/"></ulink>.
 -->
-詳細は<literal>man gpg</literal>、<ulink url="https://www.gnupg.org/gph/en/manual.html">The GNU Privacy Handbook</ulink>、<ulink url="https://www.gnupg.org"></ulink>サイトの各種文書を参照してください。
+詳細は<literal>man gpg</literal>、<ulink url="https://www.gnupg.org/gph/en/manual.html">The GNU Privacy Handbook</ulink>、<ulink url="https://www.gnupg.org/"></ulink>サイトの各種文書を参照してください。
   </para>
  </sect3>
 


### PR DESCRIPTION
URLは既に変更していたため、修正漏れのみです。