### PR TITLE
Translate release note 9.3.25 to 9.6.11

### DIFF
--- a/doc/src/sgml/release-9.3.sgml
+++ b/doc/src/sgml/release-9.3.sgml
@@ -2,292 +2,459 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-3-25">
+<!--
   <title>Release 9.3.25</title>
+-->
+  <title>リリース9.3.25</title>
 
   <formalpara>
+<!--
   <title>Release date:</title>
+-->
+  <title>リリース日:</title>
   <para>2018-11-08</para>
   </formalpara>
 
   <para>
+<!--
    This release contains a variety of fixes from 9.3.24.
    For information about new features in the 9.3 major release, see
    <xref linkend="release-9-3"/>.
+-->
+このリリースは9.3.24に対し、様々な不具合を修正したものです。
+9.3メジャーリリースにおける新機能については、<xref linkend="release-9-3"/>を参照してください。
   </para>
 
   <para>
+<!--
    This is expected to be the last <productname>PostgreSQL</productname>
    release in the 9.3.X series.  Users are encouraged to update to a newer
    release branch soon.
+-->
+本リリースは<productname>PostgreSQL</productname>の9.3.Xシリーズの最後のリリース
+となる予定です。
+早めに新しいリリースのブランチに更新することを推奨します。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.3.25</title>
+-->
+   <title>9.3.25への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.3.X.
+-->
+9.3.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if you are upgrading from a version earlier than 9.3.23,
     see <xref linkend="release-9-3-23"/>.
+-->
+しかしながら、9.3.23よりも前のバージョンからアップグレードする場合は、<xref linkend="release-9-3-23"/>を参照して下さい。
    </para>
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Fix corner-case failures
       in <function>has_<replaceable>foo</replaceable>_privilege()</function>
       family of functions (Tom Lane)
+-->
+<function>has_<replaceable>foo</replaceable>_privilege()</function>関数群での稀な場合のエラーを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Return NULL rather than throwing an error when an invalid object OID
       is provided.  Some of these functions got that right already, but not
       all.  <function>has_column_privilege()</function> was additionally
       capable of crashing on some platforms.
+-->
+無効なオブジェクトOIDが与えられたとき、エラーを投げるのでなくNULLを返すようにしました。
+これら関数の一部は既にその通りになっていましたが、全てがそうではありませんでした。
+加えて、<function>has_column_privilege()</function>は一部プラットフォーム上でクラッシュするおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid O(N^2) slowdown in regular expression match/split functions on
       long strings (Andrew Gierth)
+-->
+長い文字列に対する正規表現でのマッチ/分割の関数でO(N^2)の速度低下を回避しました。
+(Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid O(N^3) slowdown in lexer for long strings
       of <literal>+</literal> or <literal>-</literal> characters
       (Andrew Gierth)
+-->
+<literal>+</literal>や<literal>-</literal>文字からなる長い文字列に対する字句解析でO(N^3)の速度低下を回避しました。
+(Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix mis-execution of SubPlans when the outer query is being scanned
       backwards (Andrew Gierth)
+-->
+外側の問い合わせが逆向きスキャンされているときの誤ったSubPlans実行を修正しました。
+(Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix failure of <command>UPDATE/DELETE ... WHERE CURRENT OF ...</command>
       after rewinding the referenced cursor (Tom Lane)
+-->
+参照されているカーソルを巻き戻した後の<command>UPDATE/DELETE ... WHERE CURRENT OF ...</command>のエラーを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       A cursor that scans multiple relations (particularly an inheritance
       tree) could produce wrong behavior if rewound to an earlier relation.
+-->
+複数リレーション（具体的には継承ツリー）を走査するカーソルは、最初の方のリレーションまで巻き戻された場合に、誤った振る舞いをする可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <function>EvalPlanQual</function> to handle conditionally-executed
       InitPlans properly (Andrew Gierth, Tom Lane)
+-->
+<function>EvalPlanQual</function>が条件実行されるInitPlansを適切に処理するように修正しました。
+(Andrew Gierth, Tom Lane)
      </para>
 
      <para>
+<!--
       This resulted in hard-to-reproduce crashes or wrong answers in
       concurrent updates, if they contained code such as an uncorrelated
       sub-<literal>SELECT</literal> inside a <literal>CASE</literal>
       construct.
+-->
+<literal>CASE</literal>構造内の無関係な副<literal>SELECT</literal>といったコードが含まれている場合に、同時更新で再現困難なクラッシュや誤った応答をもたらしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix character-class checks to not fail on Windows for Unicode
       characters above U+FFFF (Tom Lane, Kenji Uno)
+-->
+WindowsでU+FFFFより上のユニコード文字でエラーを起こさないように文字クラス検査を修正しました。
+(Tom Lane, Kenji Uno)
      </para>
 
      <para>
+<!--
       This bug affected full-text-search operations, as well
       as <filename>contrib/ltree</filename>
       and <filename>contrib/pg_trgm</filename>.
+-->
+このバグは全文検索演算子や<filename>contrib/ltree</filename>、<filename>contrib/pg_trgm</filename>に影響があります。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that sequences owned by a foreign table are processed
       by <literal>ALTER OWNER</literal> on the table (Peter Eisentraut)
+-->
+外部テーブルが所有するシーケンスがそのテーブルに対する<literal>ALTER OWNER</literal>で確実に処理されるようにしました。
+(Peter Eisentraut)
      </para>
 
      <para>
+<!--
       The ownership change should propagate to such sequences as well, but
       this was missed for foreign tables.
+-->
+所有者変更はこのようなシーケンスにも伝播すべきでしたが、外部テーブルに対しては漏れていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix over-allocation of space for <function>array_out()</function>'s
       result string (Keiichi Hirobe)
+-->
+<function>array_out()</function>の結果文字列に対する空間の超過割り当てを修正しました。
+(Keiichi Hirobe)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix memory leak in repeated SP-GiST index scans (Tom Lane)
+-->
+SP-GiSTインデックスのスキャンを繰り返すときのメモリリークを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This is only known to amount to anything significant in cases where
       an exclusion constraint using SP-GiST receives many new index entries
       in a single command.
+-->
+著しいリーク量になるのはSP-GiSTを使った排他制約が一つのコマンドで多数の新たなインデックスエントリを受け入れる場合のみが知られています。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid crash if a utility command causes infinite recursion (Tom Lane)
+-->
+ユーティリティコマンドが無限再帰をひき起こした場合のクラッシュを回避しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       When initializing a hot standby, cope with duplicate XIDs caused by
       two-phase transactions on the master
       (Michael Paquier, Konstantin Knizhnik)
+-->
+ホットスタンバイを初期化するとき、マスタ上の二相トランザクションで生じた重複するXIDをうまく処理するようにしました。
+(Michael Paquier, Konstantin Knizhnik)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Randomize the <function>random()</function> seed in bootstrap and
       standalone backends, and in <application>initdb</application>
       (Noah Misch)
+-->
+
+ブートストラップとスタンドアローンバックエンドで、また、<application>initdb</application>で、<function>random()</function>のシードをランダム化するようにしました。
+(Noah Misch)
      </para>
 
      <para>
+<!--
       The main practical effect of this change is that it avoids a scenario
       where <application>initdb</application> might mistakenly conclude that
       POSIX shared memory is not available, due to name collisions caused by
       always using the same random seed.
+-->
+この変更の主たる実用的効果は、<application>initdb</application>が同じランダムシードを常に使うことによる名前の衝突でPOSIX共有メモリが使用できないと誤判断するシナリオを回避することです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that hot standby processes use the correct WAL consistency
       point (Alexander Kukushkin, Michael Paquier)
+-->
+ホットスタンバイプロセスが確実に正しいWALの一貫性のある地点を用いるようにしました。
+(Alexander Kukushkin, Michael Paquier)
      </para>
 
      <para>
+<!--
       This prevents possible misbehavior just after a standby server has
       reached a consistent database state during WAL replay.
+-->
+これによりスタンバイサーバがWALリプレイ中に一貫性のあるデータベース状態に到達した直後に起こりうる誤動作を防ぎます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Don't run atexit callbacks when servicing <literal>SIGQUIT</literal>
       (Heikki Linnakangas)
+-->
+<literal>SIGQUIT</literal>を処理するときにatexitコールバックを実行しないようにしました。
+(Heikki Linnakangas)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Don't record foreign-server user mappings as members of extensions
       (Tom Lane)
+-->
+外部サーバのユーザマッピングを拡張のメンバーとして記録しないようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       If <command>CREATE USER MAPPING</command> is executed in an extension
       script, an extension dependency was created for the user mapping,
       which is unexpected.  Roles can't be extension members, so user
       mappings shouldn't be either.
+-->
+拡張のスクリプトで<command>CREATE USER MAPPING</command>が実行された場合、ユーザマッピングに対して拡張の依存性が作られますが、これは予期せぬものです。
+ロールは拡張のメンバーになれませんので、ユーザマッピングもなれないべきです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Make syslogger more robust against failures in opening CSV log files
       (Tom Lane)
+-->
+CSVログファイルを開くときの失敗に対してsysloggerをより頑健にしました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible inconsistency in <application>pg_dump</application>'s
       sorting of dissimilar object names (Jacob Champion)
+-->
+<application>pg_dump</application>の異なるオブジェクト名のソートでおこりうる一貫性の欠如を修正しました。
+(Jacob Champion)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that <application>pg_restore</application> will schema-qualify
       the table name when
       emitting <literal>DISABLE</literal>/<literal>ENABLE TRIGGER</literal>
       commands (Tom Lane)
+-->
+<application>pg_restore</application>が<literal>DISABLE</literal>/<literal>ENABLE TRIGGER</literal>コマンドを出力するときにテーブル名を確実にスキーマ修飾するようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This avoids failures due to the new policy of running restores with
       restrictive search path.
+-->
+これにより制限的なサーチパスを用いるリストア実行の新たな方針のための失敗を回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_upgrade</application> to handle event triggers in
       extensions correctly (Haribabu Kommi)
+-->
+<application>pg_upgrade</application>を拡張でイベントトリガを適切に処理するように修正しました。
+(Haribabu Kommi)
      </para>
 
      <para>
+<!--
       <application>pg_upgrade</application> failed to preserve an event
       trigger's extension-membership status.
+-->
+<application>pg_upgrade</application>はイベントトリガの拡張への所属状態を維持しませんでした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_upgrade</application>'s cluster state check to
       work correctly on a standby server (Bruce Momjian)
+-->
+<application>pg_upgrade</application>のクラスタ状態検査をスタンバイサーバで正しく動作するように修正しました。
+(Bruce Momjian)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Enforce type <type>cube</type>'s dimension limit in
       all <filename>contrib/cube</filename> functions (Andrey Borodin)
+-->
+全ての<filename>contrib/cube</filename>の関数で、<type>cube</type>型の次元制限に従わせるようにしました。
+(Andrey Borodin)
      </para>
 
      <para>
+<!--
       Previously, some cube-related functions could construct values that
       would be rejected by <function>cube_in()</function>, leading to
       dump/reload failures.
+-->
+これまでは、一部のcube関連の関数は<function>cube_in()</function>で拒否される値を生成する可能性があり、ダンプ/リロードの失敗をもたらしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <filename>contrib/unaccent</filename>'s
       <function>unaccent()</function> function to use
       the <literal>unaccent</literal> text search dictionary that is in the
       same schema as the function (Tom Lane)
+-->
+<filename>contrib/unaccent</filename>の<function>unaccent()</function>関数を関数と同じスキーマの<literal>unaccent</literal>テキスト検索辞書を使うように修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Previously it tried to look up the dictionary using the search path,
       which could fail if the search path has a restrictive value.
+-->
+これまではサーチパスを使って辞書を探そうとしていましたが、サーチパスが制限的な値であると失敗する可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix build problems on macOS 10.14 (Mojave) (Tom Lane)
+-->
+macOS 10.14 でのビルド問題を修正しました。
+(Mojave) (Tom Lane)
      </para>
 
      <para>
+<!--
       Adjust <application>configure</application> to add
       an <option>-isysroot</option> switch to <varname>CPPFLAGS</varname>;
       without this, PL/Perl and PL/Tcl fail to configure or build on macOS
@@ -295,49 +462,75 @@
       or build time by setting the <varname>PG_SYSROOT</varname> variable in
       the arguments of <application>configure</application>
       or <application>make</application>.
+-->
+<varname>CPPFLAGS</varname>に<option>-isysroot</option>スイッチを加えるように<application>configure</application>を調整しました。
+これが無いとPL/PerlとPL/TclがmacOS 10.14でconfigureやビルドで失敗します。
+このsysroot指定はconfigure時またはビルド時に<application>configure</application>または<application>make</application>の引数で<varname>PG_SYSROOT</varname>変数を設定することで上書きできます。
      </para>
 
      <para>
+<!--
       It is now recommended that Perl-related extensions
       write <literal>$(perl_includespec)</literal> rather
       than <literal>-I$(perl_archlibexp)/CORE</literal> in their compiler
       flags.  The latter continues to work on most platforms, but not recent
       macOS.
+-->
+これからはPerl関連の拡張はコンパイラフラグの<literal>-I$(perl_archlibexp)/CORE</literal>ではなく<literal>$(perl_includespec)</literal>を書くことが推奨されます。
      </para>
 
      <para>
+<!--
       Also, it should no longer be necessary to
-      specify <option>--with-tclconfig</option> manually to get PL/Tcl to
+      specify <option>&#045;-with-tclconfig</option> manually to get PL/Tcl to
       build on recent macOS releases.
+-->
+また、最近のmacOSリリースではPL/Tclをビルドさせるのに、もはや<option>--with-tclconfig</option>を手動で指定する必要がありません。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix MSVC build and regression-test scripts to work on recent Perl
       versions (Andrew Dunstan)
+-->
+最近のPerlバージョンで動作するようにMSVCでのビルドとリグレッションテストスクリプトを修正しました。
+(Andrew Dunstan)
      </para>
 
      <para>
+<!--
       Perl no longer includes the current directory in its search path
       by default; work around that.
+-->
+Perlはもはやカレントディレクトリをデフォルトではサーチパスに含めず、このことに対応しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Support building on Windows with Visual Studio 2015 or Visual Studio 2017
       (Michael Paquier, Haribabu Kommi)
+-->
+WindowsでVisual Studio 2015またはVisual Studio 2017でのビルドに対応しました。
+(Michael Paquier, Haribabu Kommi)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Allow btree comparison functions to return <literal>INT_MIN</literal>
       (Tom Lane)
+-->
+Btreeの比較関数で<literal>INT_MIN</literal>を返せるようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Up to now, we've forbidden datatype-specific comparison functions from
       returning <literal>INT_MIN</literal>, which allows callers to invert
       the sort order just by negating the comparison result.  However, this
@@ -349,116 +542,179 @@
       Hence, we've removed this restriction.  Callers must now use
       the <literal>INVERT_COMPARE_RESULT()</literal> macro if they wish to
       invert the sort order.
+-->
+これまでは比較結果を逆転するだけで呼び出し元がソート順を逆にできるように、特定データ型の比較関数が<literal>INT_MIN</literal>を返すのを禁止していました。
+しかしながら、これは<function>memcmp()</function>、<function>strcmp()</function>等の結果を直接返す比較関数については、POSIXがそのような制限をこれら関数に設けていないため、全く安全ではありませんでした。
+少なくとも<function>memcmp()</function>の最近の一部バージョンは<literal>INT_MIN</literal>を返すことがあり、不適切なソート順をもたらしました。
+それゆえ、これら制限を取り除きました。
+これからは呼び出し元は、ソート順を反転させたい場合には<literal>INVERT_COMPARE_RESULT()</literal>マクロを使わなければなりません。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix recursion hazard in shared-invalidation message processing
       (Tom Lane)
+-->
+共有の無効化メッセージの生成で再帰障害を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This error could, for example, result in failure to access a system
       catalog or index that had just been processed by <command>VACUUM
       FULL</command>.
+-->
+この誤りは、例えば、<command>VACUUM FULL</command>で処理された直後のシステムカタログやシステムインデックスへのアクセス失敗をもたらします。
      </para>
 
      <para>
+<!--
       This change adds a new result code
       for <function>LockAcquire</function>, which might possibly affect
       external callers of that function, though only very unusual usage
       patterns would have an issue with it.  The API
       of <function>LockAcquireExtended</function> is also changed.
+-->
+この変更では、とても稀な使用パターンでのみ出るものですが<function>LockAcquire</function>の新たな結果コードを追加しており、この関数の外部呼び出し元に影響があるかもしれません。
+<function>LockAcquireExtended</function>のAPIも変更されました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Save and restore SPI's global variables
       during <function>SPI_connect()</function>
       and <function>SPI_finish()</function> (Chapman Flack, Tom Lane)
+-->
+<function>SPI_connect()</function>と<function>SPI_finish()</function>のときにSPIのグローバル変数を退避し、復旧するようにしました。
+(Chapman Flack, Tom Lane)
      </para>
 
      <para>
+<!--
       This prevents possible interference when one SPI-using function calls
       another.
+-->
+これは、あるSPI使用関数が他を呼び出すときに起こりうる干渉を防止します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Provide <literal>ALLOCSET_DEFAULT_SIZES</literal> and sibling macros
       in back branches (Tom Lane)
+-->
+<literal>ALLOCSET_DEFAULT_SIZES</literal>と関連するマクロを旧バージョン系列にも提供しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       These macros have existed since 9.6, but there were requests to add
       them to older branches to allow extensions to rely on them without
       branch-specific coding.
+-->
+これらのマクロは9.6から導入されましたが、旧バージョン系列にも追加して、拡張がバージョン毎のコードを書くことなく、マクロに依存できるようにする要望がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid using potentially-under-aligned page buffers (Tom Lane)
+-->
+潜在的にアライメント調整されたページバッファの使用を回避しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Invent new union types <type>PGAlignedBlock</type>
       and <type>PGAlignedXLogBlock</type>, and use these in place of plain
       char arrays, ensuring that the compiler can't place the buffer at a
       misaligned start address.  This fixes potential core dumps on
       alignment-picky platforms, and may improve performance even on
       platforms that allow misalignment.
+-->
+新たなunion型の<type>PGAlignedBlock</type>と<type>PGAlignedXLogBlock</type>を導入し、単なる文字配列に替えてこれらを使用して、コンパイラがバッファをアライメントを外れた開始アドレスに置くことがないようにしました。
+これはアライメントに厳しいプラットフォームでの潜在的なコアダンプを修正し、また、アライメント外れを許すプラットフォームであっても性能を改善すると考えられます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Make <filename>src/port/snprintf.c</filename> follow the C99
       standard's definition of <function>snprintf()</function>'s result
       value (Tom Lane)
+-->
+<filename>src/port/snprintf.c</filename>がC99標準の<function>snprintf()</function>の戻り値の定義に従うようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       On platforms where this code is used (mostly Windows), its pre-C99
       behavior could lead to failure to detect buffer overrun, if the
       calling code assumed C99 semantics.
+-->
+このコードが使われるプラットフォーム（大部分はWindows）では、C99のセマンティクスを想定したコードを呼び出した場合に、このC99より前の振る舞いがバッファオーバラン検知の失敗をひき起こすおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       When building on i386 with the <application>clang</application>
       compiler, require <option>-msse2</option> to be used (Andres Freund)
+-->
+<application>clang</application>コンパイラでi386でビルドするときに、<option>-msse2</option>使用を必須としました。
+(Andres Freund)
      </para>
 
      <para>
+<!--
       This avoids problems with missed floating point overflow checks.
+-->
+これは浮動小数点オーバーフロー検査の問題を防ぎます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>configure</application>'s detection of the result
       type of <function>strerror_r()</function> (Tom Lane)
+-->
+<application>configure</application>の<function>strerror_r()</function>の戻り型の検出を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       The previous coding got the wrong answer when building
       with <application>icc</application> on Linux (and perhaps in other
       cases), leading to <application>libpq</application> not returning
       useful error messages for system-reported errors.
+-->
+これまでのコーディングはLinux上の<application>icc</application>（と、おそらくは他のケースで）でビルドするときに誤った答を得ていて、<application>libpq</application>がシステムから報告されるエラーについて役立つエラーメッセージを返しませんでした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Update time zone data files to <application>tzdata</application>
       release 2018g for DST law changes in Chile, Fiji, Morocco, and Russia
       (Volgograd), plus historical corrections for China, Hawaii, Japan,
       Macau, and North Korea.
+-->
+タイムゾーンデータファイルを<application>tzdata</application> release 2018gに更新しました。チリ、フィジー、モロッコ、ロシア（ヴォルゴグラード）の夏時間法の変更、中国、ハワイ、日本、マカオ、北朝鮮の歴史的修正が含まれます。
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.4.sgml
+++ b/doc/src/sgml/release-9.4.sgml
@@ -2,342 +2,534 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-4-20">
+<!--
   <title>Release 9.4.20</title>
+-->
+  <title>リリース9.4.20</title>
 
   <formalpara>
+<!--
   <title>Release date:</title>
+-->
+  <title>リリース日:</title>
   <para>2018-11-08</para>
   </formalpara>
 
   <para>
+<!--
    This release contains a variety of fixes from 9.4.19.
    For information about new features in the 9.4 major release, see
    <xref linkend="release-9-4"/>.
+-->
+このリリースは9.4.19に対し、様々な不具合を修正したものです。
+9.4メジャーリリースにおける新機能については、<xref linkend="release-9-4"/>を参照してください。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.4.20</title>
+-->
+   <title>9.4.20への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.4.X.
+-->
+9.4.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if you are upgrading from a version earlier than 9.4.18,
     see <xref linkend="release-9-4-18"/>.
+-->
+しかしながら、9.4.18よりも前のバージョンからアップグレードする場合は、<xref linkend="release-9-4-18"/>を参照して下さい。
    </para>
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Fix corner-case failures
       in <function>has_<replaceable>foo</replaceable>_privilege()</function>
       family of functions (Tom Lane)
+-->
+<function>has_<replaceable>foo</replaceable>_privilege()</function>関数群での稀な場合のエラーを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Return NULL rather than throwing an error when an invalid object OID
       is provided.  Some of these functions got that right already, but not
       all.  <function>has_column_privilege()</function> was additionally
       capable of crashing on some platforms.
+-->
+無効なオブジェクトOIDが与えられたとき、エラーを投げるのでなくNULLを返すようにしました。
+これら関数の一部は既にその通りになっていましたが、全てがそうではありませんでした。
+加えて、<function>has_column_privilege()</function>は一部プラットフォーム上でクラッシュするおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid O(N^2) slowdown in regular expression match/split functions on
       long strings (Andrew Gierth)
+-->
+長い文字列に対する正規表現でのマッチ/分割の関数でO(N^2)の速度低下を回避しました。
+(Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid O(N^3) slowdown in lexer for long strings
       of <literal>+</literal> or <literal>-</literal> characters
       (Andrew Gierth)
+-->
+<literal>+</literal>や<literal>-</literal>文字からなる長い文字列に対する字句解析でO(N^3)の速度低下を回避しました。
+(Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix mis-execution of SubPlans when the outer query is being scanned
       backwards (Andrew Gierth)
+-->
+外側の問い合わせが逆向きスキャンされているときの誤ったSubPlans実行を修正しました。
+(Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix failure of <command>UPDATE/DELETE ... WHERE CURRENT OF ...</command>
       after rewinding the referenced cursor (Tom Lane)
+-->
+参照されているカーソルを巻き戻した後の<command>UPDATE/DELETE ... WHERE CURRENT OF ...</command>のエラーを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       A cursor that scans multiple relations (particularly an inheritance
       tree) could produce wrong behavior if rewound to an earlier relation.
+-->
+複数リレーション（具体的には継承ツリー）を走査するカーソルは、最初の方のリレーションまで巻き戻された場合に、誤った振る舞いをする可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <function>EvalPlanQual</function> to handle conditionally-executed
       InitPlans properly (Andrew Gierth, Tom Lane)
+-->
+<function>EvalPlanQual</function>が条件実行されるInitPlansを適切に処理するように修正しました。
+(Andrew Gierth, Tom Lane)
      </para>
 
      <para>
+<!--
       This resulted in hard-to-reproduce crashes or wrong answers in
       concurrent updates, if they contained code such as an uncorrelated
       sub-<literal>SELECT</literal> inside a <literal>CASE</literal>
       construct.
+-->
+<literal>CASE</literal>構造内の無関係な副<literal>SELECT</literal>といったコードが含まれている場合に、同時更新で再現困難なクラッシュや誤った応答をもたらしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix character-class checks to not fail on Windows for Unicode
       characters above U+FFFF (Tom Lane, Kenji Uno)
+-->
+WindowsでU+FFFFより上のユニコード文字でエラーを起こさないように文字クラス検査を修正しました。
+(Tom Lane, Kenji Uno)
      </para>
 
      <para>
+<!--
       This bug affected full-text-search operations, as well
       as <filename>contrib/ltree</filename>
       and <filename>contrib/pg_trgm</filename>.
+-->
+このバグは全文検索演算子や<filename>contrib/ltree</filename>、<filename>contrib/pg_trgm</filename>に影響があります。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that sequences owned by a foreign table are processed
       by <literal>ALTER OWNER</literal> on the table (Peter Eisentraut)
+-->
+外部テーブルが所有するシーケンスがそのテーブルに対する<literal>ALTER OWNER</literal>で確実に処理されるようにしました。
+(Peter Eisentraut)
      </para>
 
      <para>
+<!--
       The ownership change should propagate to such sequences as well, but
       this was missed for foreign tables.
+-->
+所有者変更はこのようなシーケンスにも伝播すべきでしたが、外部テーブルに対しては漏れていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix over-allocation of space for <function>array_out()</function>'s
       result string (Keiichi Hirobe)
+-->
+<function>array_out()</function>の結果文字列に対する空間の超過割り当てを修正しました。
+(Keiichi Hirobe)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix memory leak in repeated SP-GiST index scans (Tom Lane)
+-->
+SP-GiSTインデックスのスキャンを繰り返すときのメモリリークを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This is only known to amount to anything significant in cases where
       an exclusion constraint using SP-GiST receives many new index entries
       in a single command.
+-->
+著しいリーク量になるのはSP-GiSTを使った排他制約が一つのコマンドで多数の新たなインデックスエントリを受け入れる場合のみが知られています。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that <function>ApplyLogicalMappingFile()</function> closes the
       mapping file when done with it (Tomas Vondra)
+-->
+<function>ApplyLogicalMappingFile()</function>がマッピングファイルを伴って実行されたときに、確実にマッピングファイルを閉じるようにしました。
+(Tomas Vondra)
      </para>
 
      <para>
+<!--
       Previously, the file descriptor was leaked, eventually resulting in
       failures during logical decoding.
+-->
+これまでファイルディスクリプタがリークしていて、最終的にロジカルデコーディングのときにエラーをひき起こしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix logical decoding to handle cases where a mapped catalog table is
       repeatedly rewritten, e.g. by <literal>VACUUM FULL</literal>
       (Andres Freund)
+-->
+例えば<literal>VACUUM FULL</literal>によって、関連付けられたカタログテーブルが繰り返し書き換えられる場合をうまく扱うようにロジカルデコーディングを修正しました。
+(Andres Freund)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent starting the server with <varname>wal_level</varname> set
       to too low a value to support an existing replication slot (Andres
       Freund)
+-->
+既存レプリケーションスロットに対応するには低すぎる値に設定された<varname>wal_level</varname>でのサーバ起動をできなくしました。
+(Andres Freund)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid crash if a utility command causes infinite recursion (Tom Lane)
+-->
+ユーティリティコマンドが無限再帰をひき起こした場合のクラッシュを回避しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       When initializing a hot standby, cope with duplicate XIDs caused by
       two-phase transactions on the master
       (Michael Paquier, Konstantin Knizhnik)
+-->
+ホットスタンバイを初期化するとき、マスタ上の二相トランザクションで生じた重複するXIDをうまく処理するようにしました。
+(Michael Paquier, Konstantin Knizhnik)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Randomize the <function>random()</function> seed in bootstrap and
       standalone backends, and in <application>initdb</application>
       (Noah Misch)
+-->
+
+ブートストラップとスタンドアローンバックエンドで、また、<application>initdb</application>で、<function>random()</function>のシードをランダム化するようにしました。
+(Noah Misch)
      </para>
 
      <para>
+<!--
       The main practical effect of this change is that it avoids a scenario
       where <application>initdb</application> might mistakenly conclude that
       POSIX shared memory is not available, due to name collisions caused by
       always using the same random seed.
+-->
+この変更の主たる実用的効果は、<application>initdb</application>が同じランダムシードを常に使うことによる名前の衝突でPOSIX共有メモリが使用できないと誤判断するシナリオを回避することです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Allow DSM allocation to be interrupted (Chris Travers)
+-->
+DSM割り当てを割り込み可能にしました。
+(Chris Travers)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid possible buffer overrun when replaying GIN page recompression
       from WAL (Alexander Korotkov, Sivasubramanian Ramasubramanian)
+-->
+GINページ再圧縮をWALからリプレイするときにバッファオーバーランの可能性があり、回避しました。
+(Alexander Korotkov, Sivasubramanian Ramasubramanian)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix missed fsync of a replication slot's directory (Konstantin
       Knizhnik, Michael Paquier)
+-->
+レプリケーションスロットのディレクトリのfsyncが行われていなかったのを修正しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix unexpected timeouts when
       using <varname>wal_sender_timeout</varname> on a slow server
       (Noah Misch)
+-->
+遅いサーバで<varname>wal_sender_timeout</varname>を使ったときの予期せぬタイムアウトを修正しました。
+(Noah Misch)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that hot standby processes use the correct WAL consistency
       point (Alexander Kukushkin, Michael Paquier)
+-->
+ホットスタンバイプロセスが確実に正しいWALの一貫性のある地点を用いるようにしました。
+(Alexander Kukushkin, Michael Paquier)
      </para>
 
      <para>
+<!--
       This prevents possible misbehavior just after a standby server has
       reached a consistent database state during WAL replay.
+-->
+これによりスタンバイサーバがWALリプレイ中に一貫性のあるデータベース状態に到達した直後に起こりうる誤動作を防ぎます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Don't run atexit callbacks when servicing <literal>SIGQUIT</literal>
       (Heikki Linnakangas)
+-->
+<literal>SIGQUIT</literal>を処理するときにatexitコールバックを実行しないようにしました。
+(Heikki Linnakangas)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Don't record foreign-server user mappings as members of extensions
       (Tom Lane)
+-->
+外部サーバのユーザマッピングを拡張のメンバーとして記録しないようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       If <command>CREATE USER MAPPING</command> is executed in an extension
       script, an extension dependency was created for the user mapping,
       which is unexpected.  Roles can't be extension members, so user
       mappings shouldn't be either.
+-->
+拡張のスクリプトで<command>CREATE USER MAPPING</command>が実行された場合、ユーザマッピングに対して拡張の依存性が作られますが、これは予期せぬものです。
+ロールは拡張のメンバーになれませんので、ユーザマッピングもなれないべきです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Make syslogger more robust against failures in opening CSV log files
       (Tom Lane)
+-->
+CSVログファイルを開くときの失敗に対してsysloggerをより頑健にしました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible inconsistency in <application>pg_dump</application>'s
       sorting of dissimilar object names (Jacob Champion)
+-->
+<application>pg_dump</application>の異なるオブジェクト名のソートでおこりうる一貫性の欠如を修正しました。
+(Jacob Champion)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that <application>pg_restore</application> will schema-qualify
       the table name when
       emitting <literal>DISABLE</literal>/<literal>ENABLE TRIGGER</literal>
       commands (Tom Lane)
+-->
+<application>pg_restore</application>が<literal>DISABLE</literal>/<literal>ENABLE TRIGGER</literal>コマンドを出力するときにテーブル名を確実にスキーマ修飾するようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This avoids failures due to the new policy of running restores with
       restrictive search path.
+-->
+これにより制限的なサーチパスを用いるリストア実行の新たな方針のための失敗を回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_upgrade</application> to handle event triggers in
       extensions correctly (Haribabu Kommi)
+-->
+<application>pg_upgrade</application>を拡張でイベントトリガを適切に処理するように修正しました。
+(Haribabu Kommi)
      </para>
 
      <para>
+<!--
       <application>pg_upgrade</application> failed to preserve an event
       trigger's extension-membership status.
+-->
+<application>pg_upgrade</application>はイベントトリガの拡張への所属状態を維持しませんでした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_upgrade</application>'s cluster state check to
       work correctly on a standby server (Bruce Momjian)
+-->
+<application>pg_upgrade</application>のクラスタ状態検査をスタンバイサーバで正しく動作するように修正しました。
+(Bruce Momjian)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Enforce type <type>cube</type>'s dimension limit in
       all <filename>contrib/cube</filename> functions (Andrey Borodin)
+-->
+全ての<filename>contrib/cube</filename>の関数で、<type>cube</type>型の次元制限に従わせるようにしました。
+(Andrey Borodin)
      </para>
 
      <para>
+<!--
       Previously, some cube-related functions could construct values that
       would be rejected by <function>cube_in()</function>, leading to
       dump/reload failures.
+-->
+これまでは、一部のcube関連の関数は<function>cube_in()</function>で拒否される値を生成する可能性があり、ダンプ/リロードの失敗をもたらしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <filename>contrib/unaccent</filename>'s
       <function>unaccent()</function> function to use
       the <literal>unaccent</literal> text search dictionary that is in the
       same schema as the function (Tom Lane)
+-->
+<filename>contrib/unaccent</filename>の<function>unaccent()</function>関数を関数と同じスキーマの<literal>unaccent</literal>テキスト検索辞書を使うように修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Previously it tried to look up the dictionary using the search path,
       which could fail if the search path has a restrictive value.
+-->
+これまではサーチパスを使って辞書を探そうとしていましたが、サーチパスが制限的な値であると失敗する可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix build problems on macOS 10.14 (Mojave) (Tom Lane)
+-->
+macOS 10.14 でのビルド問題を修正しました。
+(Mojave) (Tom Lane)
      </para>
 
      <para>
+<!--
       Adjust <application>configure</application> to add
       an <option>-isysroot</option> switch to <varname>CPPFLAGS</varname>;
       without this, PL/Perl and PL/Tcl fail to configure or build on macOS
@@ -345,49 +537,75 @@
       or build time by setting the <varname>PG_SYSROOT</varname> variable in
       the arguments of <application>configure</application>
       or <application>make</application>.
+-->
+<varname>CPPFLAGS</varname>に<option>-isysroot</option>スイッチを加えるように<application>configure</application>を調整しました。
+これが無いとPL/PerlとPL/TclがmacOS 10.14でconfigureやビルドで失敗します。
+このsysroot指定はconfigure時またはビルド時に<application>configure</application>または<application>make</application>の引数で<varname>PG_SYSROOT</varname>変数を設定することで上書きできます。
      </para>
 
      <para>
+<!--
       It is now recommended that Perl-related extensions
       write <literal>$(perl_includespec)</literal> rather
       than <literal>-I$(perl_archlibexp)/CORE</literal> in their compiler
       flags.  The latter continues to work on most platforms, but not recent
       macOS.
+-->
+これからはPerl関連の拡張はコンパイラフラグの<literal>-I$(perl_archlibexp)/CORE</literal>ではなく<literal>$(perl_includespec)</literal>を書くことが推奨されます。
      </para>
 
      <para>
+<!--
       Also, it should no longer be necessary to
-      specify <option>--with-tclconfig</option> manually to get PL/Tcl to
+      specify <option>&#045;-with-tclconfig</option> manually to get PL/Tcl to
       build on recent macOS releases.
+-->
+また、最近のmacOSリリースではPL/Tclをビルドさせるのに、もはや<option>--with-tclconfig</option>を手動で指定する必要がありません。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix MSVC build and regression-test scripts to work on recent Perl
       versions (Andrew Dunstan)
+-->
+最近のPerlバージョンで動作するようにMSVCでのビルドとリグレッションテストスクリプトを修正しました。
+(Andrew Dunstan)
      </para>
 
      <para>
+<!--
       Perl no longer includes the current directory in its search path
       by default; work around that.
+-->
+Perlはもはやカレントディレクトリをデフォルトではサーチパスに含めず、このことに対応しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Support building on Windows with Visual Studio 2015 or Visual Studio 2017
       (Michael Paquier, Haribabu Kommi)
+-->
+WindowsでVisual Studio 2015またはVisual Studio 2017でのビルドに対応しました。
+(Michael Paquier, Haribabu Kommi)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Allow btree comparison functions to return <literal>INT_MIN</literal>
       (Tom Lane)
+-->
+Btreeの比較関数で<literal>INT_MIN</literal>を返せるようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Up to now, we've forbidden datatype-specific comparison functions from
       returning <literal>INT_MIN</literal>, which allows callers to invert
       the sort order just by negating the comparison result.  However, this
@@ -399,116 +617,179 @@
       Hence, we've removed this restriction.  Callers must now use
       the <literal>INVERT_COMPARE_RESULT()</literal> macro if they wish to
       invert the sort order.
+-->
+これまでは比較結果を逆転するだけで呼び出し元がソート順を逆にできるように、特定データ型の比較関数が<literal>INT_MIN</literal>を返すのを禁止していました。
+しかしながら、これは<function>memcmp()</function>、<function>strcmp()</function>等の結果を直接返す比較関数については、POSIXがそのような制限をこれら関数に設けていないため、全く安全ではありませんでした。
+少なくとも<function>memcmp()</function>の最近の一部バージョンは<literal>INT_MIN</literal>を返すことがあり、不適切なソート順をもたらしました。
+それゆえ、これら制限を取り除きました。
+これからは呼び出し元は、ソート順を反転させたい場合には<literal>INVERT_COMPARE_RESULT()</literal>マクロを使わなければなりません。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix recursion hazard in shared-invalidation message processing
       (Tom Lane)
+-->
+共有の無効化メッセージの生成で再帰障害を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This error could, for example, result in failure to access a system
       catalog or index that had just been processed by <command>VACUUM
       FULL</command>.
+-->
+この誤りは、例えば、<command>VACUUM FULL</command>で処理された直後のシステムカタログやシステムインデックスへのアクセス失敗をもたらします。
      </para>
 
      <para>
+<!--
       This change adds a new result code
       for <function>LockAcquire</function>, which might possibly affect
       external callers of that function, though only very unusual usage
       patterns would have an issue with it.  The API
       of <function>LockAcquireExtended</function> is also changed.
+-->
+この変更では、とても稀な使用パターンでのみ出るものですが<function>LockAcquire</function>の新たな結果コードを追加しており、この関数の外部呼び出し元に影響があるかもしれません。
+<function>LockAcquireExtended</function>のAPIも変更されました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Save and restore SPI's global variables
       during <function>SPI_connect()</function>
       and <function>SPI_finish()</function> (Chapman Flack, Tom Lane)
+-->
+<function>SPI_connect()</function>と<function>SPI_finish()</function>のときにSPIのグローバル変数を退避し、復旧するようにしました。
+(Chapman Flack, Tom Lane)
      </para>
 
      <para>
+<!--
       This prevents possible interference when one SPI-using function calls
       another.
+-->
+これは、あるSPI使用関数が他を呼び出すときに起こりうる干渉を防止します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Provide <literal>ALLOCSET_DEFAULT_SIZES</literal> and sibling macros
       in back branches (Tom Lane)
+-->
+<literal>ALLOCSET_DEFAULT_SIZES</literal>と関連するマクロを旧バージョン系列にも提供しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       These macros have existed since 9.6, but there were requests to add
       them to older branches to allow extensions to rely on them without
       branch-specific coding.
+-->
+これらのマクロは9.6から導入されましたが、旧バージョン系列にも追加して、拡張がバージョン毎のコードを書くことなく、マクロに依存できるようにする要望がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid using potentially-under-aligned page buffers (Tom Lane)
+-->
+潜在的にアライメント調整されたページバッファの使用を回避しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Invent new union types <type>PGAlignedBlock</type>
       and <type>PGAlignedXLogBlock</type>, and use these in place of plain
       char arrays, ensuring that the compiler can't place the buffer at a
       misaligned start address.  This fixes potential core dumps on
       alignment-picky platforms, and may improve performance even on
       platforms that allow misalignment.
+-->
+新たなunion型の<type>PGAlignedBlock</type>と<type>PGAlignedXLogBlock</type>を導入し、単なる文字配列に替えてこれらを使用して、コンパイラがバッファをアライメントを外れた開始アドレスに置くことがないようにしました。
+これはアライメントに厳しいプラットフォームでの潜在的なコアダンプを修正し、また、アライメント外れを許すプラットフォームであっても性能を改善すると考えられます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Make <filename>src/port/snprintf.c</filename> follow the C99
       standard's definition of <function>snprintf()</function>'s result
       value (Tom Lane)
+-->
+<filename>src/port/snprintf.c</filename>がC99標準の<function>snprintf()</function>の戻り値の定義に従うようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       On platforms where this code is used (mostly Windows), its pre-C99
       behavior could lead to failure to detect buffer overrun, if the
       calling code assumed C99 semantics.
+-->
+このコードが使われるプラットフォーム（大部分はWindows）では、C99のセマンティクスを想定したコードを呼び出した場合に、このC99より前の振る舞いがバッファオーバラン検知の失敗をひき起こすおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       When building on i386 with the <application>clang</application>
       compiler, require <option>-msse2</option> to be used (Andres Freund)
+-->
+<application>clang</application>コンパイラでi386でビルドするときに、<option>-msse2</option>使用を必須としました。
+(Andres Freund)
      </para>
 
      <para>
+<!--
       This avoids problems with missed floating point overflow checks.
+-->
+これは浮動小数点オーバーフロー検査の問題を防ぎます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>configure</application>'s detection of the result
       type of <function>strerror_r()</function> (Tom Lane)
+-->
+<application>configure</application>の<function>strerror_r()</function>の戻り型の検出を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       The previous coding got the wrong answer when building
       with <application>icc</application> on Linux (and perhaps in other
       cases), leading to <application>libpq</application> not returning
       useful error messages for system-reported errors.
+-->
+これまでのコーディングはLinux上の<application>icc</application>（と、おそらくは他のケースで）でビルドするときに誤った答を得ていて、<application>libpq</application>がシステムから報告されるエラーについて役立つエラーメッセージを返しませんでした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Update time zone data files to <application>tzdata</application>
       release 2018g for DST law changes in Chile, Fiji, Morocco, and Russia
       (Volgograd), plus historical corrections for China, Hawaii, Japan,
       Macau, and North Korea.
+-->
+タイムゾーンデータファイルを<application>tzdata</application> release 2018gに更新しました。チリ、フィジー、モロッコ、ロシア（ヴォルゴグラード）の夏時間法の変更、中国、ハワイ、日本、マカオ、北朝鮮の歴史的修正が含まれます。
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.5.sgml
+++ b/doc/src/sgml/release-9.5.sgml
@@ -2,438 +2,681 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-5-15">
+<!--
   <title>Release 9.5.15</title>
+-->
+  <title>リリース9.5.15</title>
 
   <formalpara>
+<!--
   <title>Release date:</title>
+-->
+  <title>リリース日:</title>
   <para>2018-11-08</para>
   </formalpara>
 
   <para>
+<!--
    This release contains a variety of fixes from 9.5.14.
    For information about new features in the 9.5 major release, see
    <xref linkend="release-9-5"/>.
+-->
+このリリースは9.5.14に対し、様々な不具合を修正したものです。
+9.5メジャーリリースにおける新機能については、<xref linkend="release-9-5"/>を参照してください。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.5.15</title>
+-->
+   <title>9.5.15への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.5.X.
+-->
+9.5.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if you are upgrading from a version earlier than 9.5.13,
     see <xref linkend="release-9-5-13"/>.
+-->
+しかしながら、9.5.13よりも前のバージョンからアップグレードする場合は、<xref linkend="release-9-5-13"/>を参照して下さい。
    </para>
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Fix corner-case failures
       in <function>has_<replaceable>foo</replaceable>_privilege()</function>
       family of functions (Tom Lane)
+-->
+<function>has_<replaceable>foo</replaceable>_privilege()</function>関数群での稀な場合のエラーを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Return NULL rather than throwing an error when an invalid object OID
       is provided.  Some of these functions got that right already, but not
       all.  <function>has_column_privilege()</function> was additionally
       capable of crashing on some platforms.
+-->
+無効なオブジェクトOIDが与えられたとき、エラーを投げるのでなくNULLを返すようにしました。
+これら関数の一部は既にその通りになっていましたが、全てがそうではありませんでした。
+加えて、<function>has_column_privilege()</function>は一部プラットフォーム上でクラッシュするおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid O(N^2) slowdown in regular expression match/split functions on
       long strings (Andrew Gierth)
+-->
+長い文字列に対する正規表現でのマッチ/分割の関数でO(N^2)の速度低下を回避しました。
+(Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix parsing of standard multi-character operators that are immediately
       followed by a comment or <literal>+</literal> or <literal>-</literal>
       (Andrew Gierth)
+-->
+コメントや<literal>+</literal>、<literal>-</literal>の直後にある複数文字の標準演算子の解析を修正しました。
+(Andrew Gierth)
      </para>
 
      <para>
+<!--
       This oversight could lead to parse errors, or to incorrect assignment
       of precedence.
+-->
+この見落としでパースエラーや不正な優先順位割り当てをひき起こす可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid O(N^3) slowdown in lexer for long strings
       of <literal>+</literal> or <literal>-</literal> characters
       (Andrew Gierth)
+-->
+<literal>+</literal>や<literal>-</literal>文字からなる長い文字列に対する字句解析でO(N^3)の速度低下を回避しました。
+(Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix mis-execution of SubPlans when the outer query is being scanned
       backwards (Andrew Gierth)
+-->
+外側の問い合わせが逆向きスキャンされているときの誤ったSubPlans実行を修正しました。
+(Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix failure of <command>UPDATE/DELETE ... WHERE CURRENT OF ...</command>
       after rewinding the referenced cursor (Tom Lane)
+-->
+参照されているカーソルを巻き戻した後の<command>UPDATE/DELETE ... WHERE CURRENT OF ...</command>のエラーを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       A cursor that scans multiple relations (particularly an inheritance
       tree) could produce wrong behavior if rewound to an earlier relation.
+-->
+複数リレーション（具体的には継承ツリー）を走査するカーソルは、最初の方のリレーションまで巻き戻された場合に、誤った振る舞いをする可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <function>EvalPlanQual</function> to handle conditionally-executed
       InitPlans properly (Andrew Gierth, Tom Lane)
+-->
+<function>EvalPlanQual</function>が条件実行されるInitPlansを適切に処理するように修正しました。
+(Andrew Gierth, Tom Lane)
      </para>
 
      <para>
+<!--
       This resulted in hard-to-reproduce crashes or wrong answers in
       concurrent updates, if they contained code such as an uncorrelated
       sub-<literal>SELECT</literal> inside a <literal>CASE</literal>
       construct.
+-->
+<literal>CASE</literal>構造内の無関係な副<literal>SELECT</literal>といったコードが含まれている場合に、同時更新で再現困難なクラッシュや誤った応答をもたらしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix character-class checks to not fail on Windows for Unicode
       characters above U+FFFF (Tom Lane, Kenji Uno)
+-->
+WindowsでU+FFFFより上のユニコード文字でエラーを起こさないように文字クラス検査を修正しました。
+(Tom Lane, Kenji Uno)
      </para>
 
      <para>
+<!--
       This bug affected full-text-search operations, as well
       as <filename>contrib/ltree</filename>
       and <filename>contrib/pg_trgm</filename>.
+-->
+このバグは全文検索演算子や<filename>contrib/ltree</filename>、<filename>contrib/pg_trgm</filename>に影響があります。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that sequences owned by a foreign table are processed
       by <literal>ALTER OWNER</literal> on the table (Peter Eisentraut)
+-->
+外部テーブルが所有するシーケンスがそのテーブルに対する<literal>ALTER OWNER</literal>で確実に処理されるようにしました。
+(Peter Eisentraut)
      </para>
 
      <para>
+<!--
       The ownership change should propagate to such sequences as well, but
       this was missed for foreign tables.
+-->
+所有者変更はこのようなシーケンスにも伝播すべきでしたが、外部テーブルに対しては漏れていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that the server will process
       already-received <literal>NOTIFY</literal>
       and <literal>SIGTERM</literal> interrupts before waiting for client
       input (Jeff Janes, Tom Lane)
+-->
+サーバがクライアント入力を待つ前に受信済みの<literal>NOTIFY</literal>と<literal>SIGTERM</literal>割り込みを処理することを保証しました。
+(Jeff Janes, Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix over-allocation of space for <function>array_out()</function>'s
       result string (Keiichi Hirobe)
+-->
+<function>array_out()</function>の結果文字列に対する空間の超過割り当てを修正しました。
+(Keiichi Hirobe)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix memory leak in repeated SP-GiST index scans (Tom Lane)
+-->
+SP-GiSTインデックスのスキャンを繰り返すときのメモリリークを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This is only known to amount to anything significant in cases where
       an exclusion constraint using SP-GiST receives many new index entries
       in a single command.
+-->
+著しいリーク量になるのはSP-GiSTを使った排他制約が一つのコマンドで多数の新たなインデックスエントリを受け入れる場合のみが知られています。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that <function>ApplyLogicalMappingFile()</function> closes the
       mapping file when done with it (Tomas Vondra)
+-->
+<function>ApplyLogicalMappingFile()</function>がマッピングファイルを伴って実行されたときに、確実にマッピングファイルを閉じるようにしました。
+(Tomas Vondra)
      </para>
 
      <para>
+<!--
       Previously, the file descriptor was leaked, eventually resulting in
       failures during logical decoding.
+-->
+これまでファイルディスクリプタがリークしていて、最終的にロジカルデコーディングのときにエラーをひき起こしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix logical decoding to handle cases where a mapped catalog table is
       repeatedly rewritten, e.g. by <literal>VACUUM FULL</literal>
       (Andres Freund)
+-->
+例えば<literal>VACUUM FULL</literal>によって、関連付けられたカタログテーブルが繰り返し書き換えられる場合をうまく扱うようにロジカルデコーディングを修正しました。
+(Andres Freund)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent starting the server with <varname>wal_level</varname> set
       to too low a value to support an existing replication slot (Andres
       Freund)
+-->
+既存レプリケーションスロットに対応するには低すぎる値に設定された<varname>wal_level</varname>でのサーバ起動をできなくしました。
+(Andres Freund)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid crash if a utility command causes infinite recursion (Tom Lane)
+-->
+ユーティリティコマンドが無限再帰をひき起こした場合のクラッシュを回避しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       When initializing a hot standby, cope with duplicate XIDs caused by
       two-phase transactions on the master
       (Michael Paquier, Konstantin Knizhnik)
+-->
+ホットスタンバイを初期化するとき、マスタ上の二相トランザクションで生じた重複するXIDをうまく処理するようにしました。
+(Michael Paquier, Konstantin Knizhnik)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix event triggers to handle nested <command>ALTER TABLE</command>
       commands (Michael Paquier, &Aacute;lvaro Herrera)
+-->
+イベントトリガが入れ子の<command>ALTER TABLE</command>コマンドを処理するように修正しました。
+(Michael Paquier, &Aacute;lvaro Herrera)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Propagate parent process's transaction and statement start timestamps
       to parallel workers (Konstantin Knizhnik)
+-->
+親プロセスの、トランザクションと文の開始タイムスタンプがパラレルワーカに伝播するようにしました。
+(Konstantin Knizhnik)
      </para>
 
      <para>
+<!--
       This prevents misbehavior of functions such
       as <function>transaction_timestamp()</function> when executed in a
       worker.
+-->
+ワーカで実行されるときに<function>transaction_timestamp()</function>のような関数の誤動作を防ぎます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix WAL file recycling logic to work correctly on standby servers
       (Michael Paquier)
+-->
+スタンバイサーバで正しく働くようにWALファイル再利用のロジックを修正しました。
+(Michael Paquier)
      </para>
 
      <para>
+<!--
       Depending on the setting of <varname>archive_mode</varname>, a standby
       might fail to remove some WAL files that could be removed.
+-->
+<varname>archive_mode</varname>設定によっては、スタンバイが一部の削除してよいWALファイルの削除に失敗するかもしれませんでした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix handling of commit-timestamp tracking during recovery
       (Masahiko Sawasa, Michael Paquier)
+-->
+リカバリ中のコミットタイムスタンプ追跡の処理を修正しました。
+(Masahiko Sawasa, Michael Paquier)
      </para>
 
      <para>
+<!--
       If commit timestamp tracking has been turned on or off, recovery might
       fail due to trying to fetch the commit timestamp for a transaction
       that did not record it.
+-->
+コミットタイムスタンプ追跡が有効または無効に変更されると、それを記録していないトランザクションに対してコミットタイムスタンプを取得しようと試みるため、リカバリに失敗するかもしれませんでした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Randomize the <function>random()</function> seed in bootstrap and
       standalone backends, and in <application>initdb</application>
       (Noah Misch)
+-->
+
+ブートストラップとスタンドアローンバックエンドで、また、<application>initdb</application>で、<function>random()</function>のシードをランダム化するようにしました。
+(Noah Misch)
      </para>
 
      <para>
+<!--
       The main practical effect of this change is that it avoids a scenario
       where <application>initdb</application> might mistakenly conclude that
       POSIX shared memory is not available, due to name collisions caused by
       always using the same random seed.
+-->
+この変更の主たる実用的効果は、<application>initdb</application>が同じランダムシードを常に使うことによる名前の衝突でPOSIX共有メモリが使用できないと誤判断するシナリオを回避することです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Allow DSM allocation to be interrupted (Chris Travers)
+-->
+DSM割り当てを割り込み可能にしました。
+(Chris Travers)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Properly handle turning <varname>full_page_writes</varname> on
       dynamically (Kyotaro Horiguchi)
+-->
+動的な<varname>full_page_writes</varname>の変更を適切に処理するようにしました。
+(Kyotaro Horiguchi)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid possible buffer overrun when replaying GIN page recompression
       from WAL (Alexander Korotkov, Sivasubramanian Ramasubramanian)
+-->
+GINページ再圧縮をWALからリプレイするときにバッファオーバーランの可能性があり、回避しました。
+(Alexander Korotkov, Sivasubramanian Ramasubramanian)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix missed fsync of a replication slot's directory (Konstantin
       Knizhnik, Michael Paquier)
+-->
+レプリケーションスロットのディレクトリのfsyncが行われていなかったのを修正しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix unexpected timeouts when
       using <varname>wal_sender_timeout</varname> on a slow server
       (Noah Misch)
+-->
+遅いサーバで<varname>wal_sender_timeout</varname>を使ったときの予期せぬタイムアウトを修正しました。
+(Noah Misch)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that hot standby processes use the correct WAL consistency
       point (Alexander Kukushkin, Michael Paquier)
+-->
+ホットスタンバイプロセスが確実に正しいWALの一貫性のある地点を用いるようにしました。
+(Alexander Kukushkin, Michael Paquier)
      </para>
 
      <para>
+<!--
       This prevents possible misbehavior just after a standby server has
       reached a consistent database state during WAL replay.
+-->
+これによりスタンバイサーバがWALリプレイ中に一貫性のあるデータベース状態に到達した直後に起こりうる誤動作を防ぎます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure background workers are stopped properly when the postmaster
       receives a fast-shutdown request before completing database startup
       (Alexander Kukushkin)
+-->
+データベース起動が完了する前にポストマスタがfastシャットダウン要求を受けたときにバックエンドワーカが適切に停止されることを保証しました。
+(Alexander Kukushkin)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Don't run atexit callbacks when servicing <literal>SIGQUIT</literal>
       (Heikki Linnakangas)
+-->
+<literal>SIGQUIT</literal>を処理するときにatexitコールバックを実行しないようにしました。
+(Heikki Linnakangas)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Don't record foreign-server user mappings as members of extensions
       (Tom Lane)
+-->
+外部サーバのユーザマッピングを拡張のメンバーとして記録しないようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       If <command>CREATE USER MAPPING</command> is executed in an extension
       script, an extension dependency was created for the user mapping,
       which is unexpected.  Roles can't be extension members, so user
       mappings shouldn't be either.
+-->
+拡張のスクリプトで<command>CREATE USER MAPPING</command>が実行された場合、ユーザマッピングに対して拡張の依存性が作られますが、これは予期せぬものです。
+ロールは拡張のメンバーになれませんので、ユーザマッピングもなれないべきです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Make syslogger more robust against failures in opening CSV log files
       (Tom Lane)
+-->
+CSVログファイルを開くときの失敗に対してsysloggerをより頑健にしました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>psql</application>, as well as documentation
       examples, to call <function>PQconsumeInput()</function> before
       each <function>PQnotifies()</function> call (Tom Lane)
+-->
+各<function>PQnotifies()</function>呼び出しの前に<function>PQconsumeInput()</function>を呼ぶように<application>psql</application>および文書のサンプルを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fixes cases in which <application>psql</application> would not
       report receipt of a <literal>NOTIFY</literal> message until after the
       next command.
+-->
+これは、<application>psql</application>が次コマンド後まで<literal>NOTIFY</literal>メッセージ受領を報告しない場合について修正します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible inconsistency in <application>pg_dump</application>'s
       sorting of dissimilar object names (Jacob Champion)
+-->
+<application>pg_dump</application>の異なるオブジェクト名のソートでおこりうる一貫性の欠如を修正しました。
+(Jacob Champion)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that <application>pg_restore</application> will schema-qualify
       the table name when
       emitting <literal>DISABLE</literal>/<literal>ENABLE TRIGGER</literal>
       commands (Tom Lane)
+-->
+<application>pg_restore</application>が<literal>DISABLE</literal>/<literal>ENABLE TRIGGER</literal>コマンドを出力するときにテーブル名を確実にスキーマ修飾するようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This avoids failures due to the new policy of running restores with
       restrictive search path.
+-->
+これにより制限的なサーチパスを用いるリストア実行の新たな方針のための失敗を回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_upgrade</application> to handle event triggers in
       extensions correctly (Haribabu Kommi)
+-->
+<application>pg_upgrade</application>を拡張でイベントトリガを適切に処理するように修正しました。
+(Haribabu Kommi)
      </para>
 
      <para>
+<!--
       <application>pg_upgrade</application> failed to preserve an event
       trigger's extension-membership status.
+-->
+<application>pg_upgrade</application>はイベントトリガの拡張への所属状態を維持しませんでした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_upgrade</application>'s cluster state check to
       work correctly on a standby server (Bruce Momjian)
+-->
+<application>pg_upgrade</application>のクラスタ状態検査をスタンバイサーバで正しく動作するように修正しました。
+(Bruce Momjian)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Enforce type <type>cube</type>'s dimension limit in
       all <filename>contrib/cube</filename> functions (Andrey Borodin)
+-->
+全ての<filename>contrib/cube</filename>の関数で、<type>cube</type>型の次元制限に従わせるようにしました。
+(Andrey Borodin)
      </para>
 
      <para>
+<!--
       Previously, some cube-related functions could construct values that
       would be rejected by <function>cube_in()</function>, leading to
       dump/reload failures.
+-->
+これまでは、一部のcube関連の関数は<function>cube_in()</function>で拒否される値を生成する可能性があり、ダンプ/リロードの失敗をもたらしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <filename>contrib/unaccent</filename>'s
       <function>unaccent()</function> function to use
       the <literal>unaccent</literal> text search dictionary that is in the
       same schema as the function (Tom Lane)
+-->
+<filename>contrib/unaccent</filename>の<function>unaccent()</function>関数を関数と同じスキーマの<literal>unaccent</literal>テキスト検索辞書を使うように修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Previously it tried to look up the dictionary using the search path,
       which could fail if the search path has a restrictive value.
+-->
+これまではサーチパスを使って辞書を探そうとしていましたが、サーチパスが制限的な値であると失敗する可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix build problems on macOS 10.14 (Mojave) (Tom Lane)
+-->
+macOS 10.14 でのビルド問題を修正しました。
+(Mojave) (Tom Lane)
      </para>
 
      <para>
+<!--
       Adjust <application>configure</application> to add
       an <option>-isysroot</option> switch to <varname>CPPFLAGS</varname>;
       without this, PL/Perl and PL/Tcl fail to configure or build on macOS
@@ -441,44 +684,68 @@
       or build time by setting the <varname>PG_SYSROOT</varname> variable in
       the arguments of <application>configure</application>
       or <application>make</application>.
+-->
+<varname>CPPFLAGS</varname>に<option>-isysroot</option>スイッチを加えるように<application>configure</application>を調整しました。
+これが無いとPL/PerlとPL/TclがmacOS 10.14でconfigureやビルドで失敗します。
+このsysroot指定はconfigure時またはビルド時に<application>configure</application>または<application>make</application>の引数で<varname>PG_SYSROOT</varname>変数を設定することで上書きできます。
      </para>
 
      <para>
+<!--
       It is now recommended that Perl-related extensions
       write <literal>$(perl_includespec)</literal> rather
       than <literal>-I$(perl_archlibexp)/CORE</literal> in their compiler
       flags.  The latter continues to work on most platforms, but not recent
       macOS.
+-->
+これからはPerl関連の拡張はコンパイラフラグの<literal>-I$(perl_archlibexp)/CORE</literal>ではなく<literal>$(perl_includespec)</literal>を書くことが推奨されます。
      </para>
 
      <para>
+<!--
       Also, it should no longer be necessary to
-      specify <option>--with-tclconfig</option> manually to get PL/Tcl to
+      specify <option>&#045;-with-tclconfig</option> manually to get PL/Tcl to
       build on recent macOS releases.
+-->
+また、最近のmacOSリリースではPL/Tclをビルドさせるのに、もはや<option>--with-tclconfig</option>を手動で指定する必要がありません。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix MSVC build and regression-test scripts to work on recent Perl
       versions (Andrew Dunstan)
+-->
+最近のPerlバージョンで動作するようにMSVCでのビルドとリグレッションテストスクリプトを修正しました。
+(Andrew Dunstan)
      </para>
 
      <para>
+<!--
       Perl no longer includes the current directory in its search path
       by default; work around that.
+-->
+Perlはもはやカレントディレクトリをデフォルトではサーチパスに含めず、このことに対応しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       On Windows, allow the regression tests to be run by an Administrator
       account (Andrew Dunstan)
+-->
+Windowsで、リグレッションテストをAdministratorアカウントで実行できるようにしました。
+(Andrew Dunstan)
      </para>
 
      <para>
+<!--
       To do this safely, <application>pg_regress</application> now gives up
       any such privileges at startup.
+-->
+安全に行えるように、<application>pg_regress</application>は起動時に管理者の権限を手放すようになりました。
      </para>
     </listitem>
 
@@ -494,18 +761,27 @@ Branch: REL9_4_STABLE [86e247583] 2018-09-12 12:24:11 -0400
 Branch: REL9_3_STABLE [520711d6e] 2018-09-12 12:25:57 -0400
 -->
      <para>
+<!--
       Support building on Windows with Visual Studio 2015 or Visual Studio 2017
       (Michael Paquier, Haribabu Kommi)
+-->
+WindowsでVisual Studio 2015またはVisual Studio 2017でのビルドに対応しました。
+(Michael Paquier, Haribabu Kommi)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Allow btree comparison functions to return <literal>INT_MIN</literal>
       (Tom Lane)
+-->
+Btreeの比較関数で<literal>INT_MIN</literal>を返せるようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Up to now, we've forbidden datatype-specific comparison functions from
       returning <literal>INT_MIN</literal>, which allows callers to invert
       the sort order just by negating the comparison result.  However, this
@@ -517,40 +793,64 @@ Branch: REL9_3_STABLE [520711d6e] 2018-09-12 12:25:57 -0400
       Hence, we've removed this restriction.  Callers must now use
       the <literal>INVERT_COMPARE_RESULT()</literal> macro if they wish to
       invert the sort order.
+-->
+これまでは比較結果を逆転するだけで呼び出し元がソート順を逆にできるように、特定データ型の比較関数が<literal>INT_MIN</literal>を返すのを禁止していました。
+しかしながら、これは<function>memcmp()</function>、<function>strcmp()</function>等の結果を直接返す比較関数については、POSIXがそのような制限をこれら関数に設けていないため、全く安全ではありませんでした。
+少なくとも<function>memcmp()</function>の最近の一部バージョンは<literal>INT_MIN</literal>を返すことがあり、不適切なソート順をもたらしました。
+それゆえ、これら制限を取り除きました。
+これからは呼び出し元は、ソート順を反転させたい場合には<literal>INVERT_COMPARE_RESULT()</literal>マクロを使わなければなりません。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix recursion hazard in shared-invalidation message processing
       (Tom Lane)
+-->
+共有の無効化メッセージの生成で再帰障害を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This error could, for example, result in failure to access a system
       catalog or index that had just been processed by <command>VACUUM
       FULL</command>.
+-->
+この誤りは、例えば、<command>VACUUM FULL</command>で処理された直後のシステムカタログやシステムインデックスへのアクセス失敗をもたらします。
      </para>
 
      <para>
+<!--
       This change adds a new result code
       for <function>LockAcquire</function>, which might possibly affect
       external callers of that function, though only very unusual usage
       patterns would have an issue with it.  The API
       of <function>LockAcquireExtended</function> is also changed.
+-->
+この変更では、とても稀な使用パターンでのみ出るものですが<function>LockAcquire</function>の新たな結果コードを追加しており、この関数の外部呼び出し元に影響があるかもしれません。
+<function>LockAcquireExtended</function>のAPIも変更されました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Save and restore SPI's global variables
       during <function>SPI_connect()</function>
       and <function>SPI_finish()</function> (Chapman Flack, Tom Lane)
+-->
+<function>SPI_connect()</function>と<function>SPI_finish()</function>のときにSPIのグローバル変数を退避し、復旧するようにしました。
+(Chapman Flack, Tom Lane)
      </para>
 
      <para>
+<!--
       This prevents possible interference when one SPI-using function calls
       another.
+-->
+これは、あるSPI使用関数が他を呼び出すときに起こりうる干渉を防止します。
      </para>
     </listitem>
 
@@ -562,77 +862,116 @@ Branch: REL9_4_STABLE [ec185747a] 2018-10-12 14:49:33 -0400
 Branch: REL9_3_STABLE [01187f32c] 2018-10-12 14:49:33 -0400
 -->
      <para>
+<!--
       Provide <literal>ALLOCSET_DEFAULT_SIZES</literal> and sibling macros
       in back branches (Tom Lane)
+-->
+<literal>ALLOCSET_DEFAULT_SIZES</literal>と関連するマクロを旧バージョン系列にも提供しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       These macros have existed since 9.6, but there were requests to add
       them to older branches to allow extensions to rely on them without
       branch-specific coding.
+-->
+これらのマクロは9.6から導入されましたが、旧バージョン系列にも追加して、拡張がバージョン毎のコードを書くことなく、マクロに依存できるようにする要望がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid using potentially-under-aligned page buffers (Tom Lane)
+-->
+潜在的にアライメント調整されたページバッファの使用を回避しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Invent new union types <type>PGAlignedBlock</type>
       and <type>PGAlignedXLogBlock</type>, and use these in place of plain
       char arrays, ensuring that the compiler can't place the buffer at a
       misaligned start address.  This fixes potential core dumps on
       alignment-picky platforms, and may improve performance even on
       platforms that allow misalignment.
+-->
+新たなunion型の<type>PGAlignedBlock</type>と<type>PGAlignedXLogBlock</type>を導入し、単なる文字配列に替えてこれらを使用して、コンパイラがバッファをアライメントを外れた開始アドレスに置くことがないようにしました。
+これはアライメントに厳しいプラットフォームでの潜在的なコアダンプを修正し、また、アライメント外れを許すプラットフォームであっても性能を改善すると考えられます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Make <filename>src/port/snprintf.c</filename> follow the C99
       standard's definition of <function>snprintf()</function>'s result
       value (Tom Lane)
+-->
+<filename>src/port/snprintf.c</filename>がC99標準の<function>snprintf()</function>の戻り値の定義に従うようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       On platforms where this code is used (mostly Windows), its pre-C99
       behavior could lead to failure to detect buffer overrun, if the
       calling code assumed C99 semantics.
+-->
+このコードが使われるプラットフォーム（大部分はWindows）では、C99のセマンティクスを想定したコードを呼び出した場合に、このC99より前の振る舞いがバッファオーバラン検知の失敗をひき起こすおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       When building on i386 with the <application>clang</application>
       compiler, require <option>-msse2</option> to be used (Andres Freund)
+-->
+<application>clang</application>コンパイラでi386でビルドするときに、<option>-msse2</option>使用を必須としました。
+(Andres Freund)
      </para>
 
      <para>
+<!--
       This avoids problems with missed floating point overflow checks.
+-->
+これは浮動小数点オーバーフロー検査の問題を防ぎます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>configure</application>'s detection of the result
       type of <function>strerror_r()</function> (Tom Lane)
+-->
+<application>configure</application>の<function>strerror_r()</function>の戻り型の検出を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       The previous coding got the wrong answer when building
       with <application>icc</application> on Linux (and perhaps in other
       cases), leading to <application>libpq</application> not returning
       useful error messages for system-reported errors.
+-->
+これまでのコーディングはLinux上の<application>icc</application>（と、おそらくは他のケースで）でビルドするときに誤った答を得ていて、<application>libpq</application>がシステムから報告されるエラーについて役立つエラーメッセージを返しませんでした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Update time zone data files to <application>tzdata</application>
       release 2018g for DST law changes in Chile, Fiji, Morocco, and Russia
       (Volgograd), plus historical corrections for China, Hawaii, Japan,
       Macau, and North Korea.
+-->
+タイムゾーンデータファイルを<application>tzdata</application> release 2018gに更新しました。チリ、フィジー、モロッコ、ロシア（ヴォルゴグラード）の夏時間法の変更、中国、ハワイ、日本、マカオ、北朝鮮の歴史的修正が含まれます。
      </para>
     </listitem>
 

--- a/doc/src/sgml/release-9.6.sgml
+++ b/doc/src/sgml/release-9.6.sgml
@@ -2,516 +2,801 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-9-6-11">
+<!--
   <title>Release 9.6.11</title>
+-->
+  <title>リリース9.6.11</title>
 
   <formalpara>
+<!--
   <title>Release date:</title>
+-->
+  <title>リリース日:</title>
   <para>2018-11-08</para>
   </formalpara>
 
   <para>
+<!--
    This release contains a variety of fixes from 9.6.10.
    For information about new features in the 9.6 major release, see
    <xref linkend="release-9-6"/>.
+-->
+このリリースは9.6.10に対し、様々な不具合を修正したものです。
+9.6メジャーリリースにおける新機能については、<xref linkend="release-9-6"/>を参照してください。
   </para>
 
   <sect2>
+<!--
    <title>Migration to Version 9.6.11</title>
+-->
+   <title>バージョン9.6.11への移行</title>
 
    <para>
+<!--
     A dump/restore is not required for those running 9.6.X.
+-->
+9.6.Xからの移行ではダンプ/リストアは不要です。
    </para>
 
    <para>
+<!--
     However, if you are upgrading from a version earlier than 9.6.9,
     see <xref linkend="release-9-6-9"/>.
+-->
+しかしながら、9.6.9よりも前のバージョンからアップグレードする場合は、<xref linkend="release-9-6-9"/>を参照して下さい。
    </para>
   </sect2>
 
   <sect2>
+<!--
    <title>Changes</title>
+-->
+   <title>変更点</title>
 
    <itemizedlist>
 
     <listitem>
      <para>
+<!--
       Fix corner-case failures
       in <function>has_<replaceable>foo</replaceable>_privilege()</function>
       family of functions (Tom Lane)
+-->
+<function>has_<replaceable>foo</replaceable>_privilege()</function>関数群での稀な場合のエラーを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Return NULL rather than throwing an error when an invalid object OID
       is provided.  Some of these functions got that right already, but not
       all.  <function>has_column_privilege()</function> was additionally
       capable of crashing on some platforms.
+-->
+無効なオブジェクトOIDが与えられたとき、エラーを投げるのでなくNULLを返すようにしました。
+これら関数の一部は既にその通りになっていましたが、全てがそうではありませんでした。
+加えて、<function>has_column_privilege()</function>は一部プラットフォーム上でクラッシュするおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid O(N^2) slowdown in regular expression match/split functions on
       long strings (Andrew Gierth)
+-->
+長い文字列に対する正規表現でのマッチ/分割の関数でO(N^2)の速度低下を回避しました。
+(Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix parsing of standard multi-character operators that are immediately
       followed by a comment or <literal>+</literal> or <literal>-</literal>
       (Andrew Gierth)
+-->
+コメントや<literal>+</literal>、<literal>-</literal>の直後にある複数文字の標準演算子の解析を修正しました。
+(Andrew Gierth)
      </para>
 
      <para>
+<!--
       This oversight could lead to parse errors, or to incorrect assignment
       of precedence.
+-->
+この見落としでパースエラーや不正な優先順位割り当てをひき起こす可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid O(N^3) slowdown in lexer for long strings
       of <literal>+</literal> or <literal>-</literal> characters
       (Andrew Gierth)
+-->
+<literal>+</literal>や<literal>-</literal>文字からなる長い文字列に対する字句解析でO(N^3)の速度低下を回避しました。
+(Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix mis-execution of SubPlans when the outer query is being scanned
       backwards (Andrew Gierth)
+-->
+外側の問い合わせが逆向きスキャンされているときの誤ったSubPlans実行を修正しました。
+(Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix failure of <command>UPDATE/DELETE ... WHERE CURRENT OF ...</command>
       after rewinding the referenced cursor (Tom Lane)
+-->
+参照されているカーソルを巻き戻した後の<command>UPDATE/DELETE ... WHERE CURRENT OF ...</command>のエラーを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       A cursor that scans multiple relations (particularly an inheritance
       tree) could produce wrong behavior if rewound to an earlier relation.
+-->
+複数リレーション（具体的には継承ツリー）を走査するカーソルは、最初の方のリレーションまで巻き戻された場合に、誤った振る舞いをする可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <function>EvalPlanQual</function> to handle conditionally-executed
       InitPlans properly (Andrew Gierth, Tom Lane)
+-->
+<function>EvalPlanQual</function>が条件実行されるInitPlansを適切に処理するように修正しました。
+(Andrew Gierth, Tom Lane)
      </para>
 
      <para>
+<!--
       This resulted in hard-to-reproduce crashes or wrong answers in
       concurrent updates, if they contained code such as an uncorrelated
       sub-<literal>SELECT</literal> inside a <literal>CASE</literal>
       construct.
+-->
+<literal>CASE</literal>構造内の無関係な副<literal>SELECT</literal>といったコードが含まれている場合に、同時更新で再現困難なクラッシュや誤った応答をもたらしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix character-class checks to not fail on Windows for Unicode
       characters above U+FFFF (Tom Lane, Kenji Uno)
+-->
+WindowsでU+FFFFより上のユニコード文字でエラーを起こさないように文字クラス検査を修正しました。
+(Tom Lane, Kenji Uno)
      </para>
 
      <para>
+<!--
       This bug affected full-text-search operations, as well
       as <filename>contrib/ltree</filename>
       and <filename>contrib/pg_trgm</filename>.
+-->
+このバグは全文検索演算子や<filename>contrib/ltree</filename>、<filename>contrib/pg_trgm</filename>に影響があります。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Disallow pushing sub-<literal>SELECT</literal>s containing window
       functions, <literal>LIMIT</literal>, or <literal>OFFSET</literal> to
       parallel workers (Amit Kapila)
+-->
+ウィンドウ関数や<literal>LIMIT</literal>、<literal>OFFSET</literal>を含む副<literal>SELECT</literal>をパラレルワーカにプッシュできなくしました。
+(Amit Kapila)
      </para>
 
      <para>
+<!--
       Such cases could result in inconsistent behavior due to different
       workers getting different answers, as a result of indeterminacy
       due to row-ordering variations.
+-->
+このような場合は、行順序の変動による不確定性の結果ゆえにワーカ間で異なる応答を得ることから、一貫性の無い振る舞いが生じる可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that sequences owned by a foreign table are processed
       by <literal>ALTER OWNER</literal> on the table (Peter Eisentraut)
+-->
+外部テーブルが所有するシーケンスがそのテーブルに対する<literal>ALTER OWNER</literal>で確実に処理されるようにしました。
+(Peter Eisentraut)
      </para>
 
      <para>
+<!--
       The ownership change should propagate to such sequences as well, but
       this was missed for foreign tables.
+-->
+所有者変更はこのようなシーケンスにも伝播すべきでしたが、外部テーブルに対しては漏れていました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that the server will process
       already-received <literal>NOTIFY</literal>
       and <literal>SIGTERM</literal> interrupts before waiting for client
       input (Jeff Janes, Tom Lane)
+-->
+サーバがクライアント入力を待つ前に受信済みの<literal>NOTIFY</literal>と<literal>SIGTERM</literal>割り込みを処理することを保証しました。
+(Jeff Janes, Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix over-allocation of space for <function>array_out()</function>'s
       result string (Keiichi Hirobe)
+-->
+<function>array_out()</function>の結果文字列に対する空間の超過割り当てを修正しました。
+(Keiichi Hirobe)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix memory leak in repeated SP-GiST index scans (Tom Lane)
+-->
+SP-GiSTインデックスのスキャンを繰り返すときのメモリリークを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This is only known to amount to anything significant in cases where
       an exclusion constraint using SP-GiST receives many new index entries
       in a single command.
+-->
+著しいリーク量になるのはSP-GiSTを使った排他制約が一つのコマンドで多数の新たなインデックスエントリを受け入れる場合のみが知られています。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that <function>ApplyLogicalMappingFile()</function> closes the
       mapping file when done with it (Tomas Vondra)
+-->
+<function>ApplyLogicalMappingFile()</function>がマッピングファイルを伴って実行されたときに、確実にマッピングファイルを閉じるようにしました。
+(Tomas Vondra)
      </para>
 
      <para>
+<!--
       Previously, the file descriptor was leaked, eventually resulting in
       failures during logical decoding.
+-->
+これまでファイルディスクリプタがリークしていて、最終的にロジカルデコーディングのときにエラーをひき起こしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix logical decoding to handle cases where a mapped catalog table is
       repeatedly rewritten, e.g. by <literal>VACUUM FULL</literal>
       (Andres Freund)
+-->
+例えば<literal>VACUUM FULL</literal>によって、関連付けられたカタログテーブルが繰り返し書き換えられる場合をうまく扱うようにロジカルデコーディングを修正しました。
+(Andres Freund)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Prevent starting the server with <varname>wal_level</varname> set
       to too low a value to support an existing replication slot (Andres
       Freund)
+-->
+既存レプリケーションスロットに対応するには低すぎる値に設定された<varname>wal_level</varname>でのサーバ起動をできなくしました。
+(Andres Freund)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid crash if a utility command causes infinite recursion (Tom Lane)
+-->
+ユーティリティコマンドが無限再帰をひき起こした場合のクラッシュを回避しました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       When initializing a hot standby, cope with duplicate XIDs caused by
       two-phase transactions on the master
       (Michael Paquier, Konstantin Knizhnik)
+-->
+ホットスタンバイを初期化するとき、マスタ上の二相トランザクションで生じた重複するXIDをうまく処理するようにしました。
+(Michael Paquier, Konstantin Knizhnik)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix event triggers to handle nested <command>ALTER TABLE</command>
       commands (Michael Paquier, &Aacute;lvaro Herrera)
+-->
+イベントトリガが入れ子の<command>ALTER TABLE</command>コマンドを処理するように修正しました。
+(Michael Paquier, &Aacute;lvaro Herrera)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Propagate parent process's transaction and statement start timestamps
       to parallel workers (Konstantin Knizhnik)
+-->
+親プロセスの、トランザクションと文の開始タイムスタンプがパラレルワーカに伝播するようにしました。
+(Konstantin Knizhnik)
      </para>
 
      <para>
+<!--
       This prevents misbehavior of functions such
       as <function>transaction_timestamp()</function> when executed in a
       worker.
+-->
+ワーカで実行されるときに<function>transaction_timestamp()</function>のような関数の誤動作を防ぎます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix transfer of expanded datums to parallel workers so that alignment
       is preserved, preventing crashes on alignment-picky platforms
       (Tom Lane, Amit Kapila)
+-->
+アライメントが維持されるように拡張されたデータムのワーカへの転送を修正し、アライメントに厳しいプラットフォームでのクラッシュを防止しました。
+(Tom Lane, Amit Kapila)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix WAL file recycling logic to work correctly on standby servers
       (Michael Paquier)
+-->
+スタンバイサーバで正しく働くようにWALファイル再利用のロジックを修正しました。
+(Michael Paquier)
      </para>
 
      <para>
+<!--
       Depending on the setting of <varname>archive_mode</varname>, a standby
       might fail to remove some WAL files that could be removed.
+-->
+<varname>archive_mode</varname>設定によっては、スタンバイが一部の削除してよいWALファイルの削除に失敗するかもしれませんでした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix handling of commit-timestamp tracking during recovery
       (Masahiko Sawasa, Michael Paquier)
+-->
+リカバリ中のコミットタイムスタンプ追跡の処理を修正しました。
+(Masahiko Sawasa, Michael Paquier)
      </para>
 
      <para>
+<!--
       If commit timestamp tracking has been turned on or off, recovery might
       fail due to trying to fetch the commit timestamp for a transaction
       that did not record it.
+-->
+コミットタイムスタンプ追跡が有効または無効に変更されると、それを記録していないトランザクションに対してコミットタイムスタンプを取得しようと試みるため、リカバリに失敗するかもしれませんでした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Randomize the <function>random()</function> seed in bootstrap and
       standalone backends, and in <application>initdb</application>
       (Noah Misch)
+-->
+
+ブートストラップとスタンドアローンバックエンドで、また、<application>initdb</application>で、<function>random()</function>のシードをランダム化するようにしました。
+(Noah Misch)
      </para>
 
      <para>
+<!--
       The main practical effect of this change is that it avoids a scenario
       where <application>initdb</application> might mistakenly conclude that
       POSIX shared memory is not available, due to name collisions caused by
       always using the same random seed.
+-->
+この変更の主たる実用的効果は、<application>initdb</application>が同じランダムシードを常に使うことによる名前の衝突でPOSIX共有メモリが使用できないと誤判断するシナリオを回避することです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Allow DSM allocation to be interrupted (Chris Travers)
+-->
+DSM割り当てを割り込み可能にしました。
+(Chris Travers)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid failure in a parallel worker when loading an extension that
       tries to access system caches within its init function (Thomas Munro)
+-->
+初期化関数内のシステムキャッシュへのアクセスを試みる拡張をロードするときのパラレルワーカでのエラーを回避しました。
+(Thomas Munro)
      </para>
 
      <para>
+<!--
       We don't consider that to be good extension coding practice, but it
       mostly worked before parallel query, so continue to support it for
       now.
+-->
+これは良い拡張のコーディング習慣とは考えていませんが、パラレル問い合わせ以前はたいてい動作したため、今のところサポートを継続します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Properly handle turning <varname>full_page_writes</varname> on
       dynamically (Kyotaro Horiguchi)
+-->
+動的な<varname>full_page_writes</varname>の変更を適切に処理するようにしました。
+(Kyotaro Horiguchi)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible crash due to double <function>free()</function> during
       SP-GiST rescan (Andrew Gierth)
+-->
+SP-GiSTの再スキャンのときに重複<function>free()</function>によるクラッシュの可能性があり、修正しました。
+(Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid possible buffer overrun when replaying GIN page recompression
       from WAL (Alexander Korotkov, Sivasubramanian Ramasubramanian)
+-->
+GINページ再圧縮をWALからリプレイするときにバッファオーバーランの可能性があり、回避しました。
+(Alexander Korotkov, Sivasubramanian Ramasubramanian)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix missed fsync of a replication slot's directory (Konstantin
       Knizhnik, Michael Paquier)
+-->
+レプリケーションスロットのディレクトリのfsyncが行われていなかったのを修正しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix unexpected timeouts when
       using <varname>wal_sender_timeout</varname> on a slow server
       (Noah Misch)
+-->
+遅いサーバで<varname>wal_sender_timeout</varname>を使ったときの予期せぬタイムアウトを修正しました。
+(Noah Misch)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that hot standby processes use the correct WAL consistency
       point (Alexander Kukushkin, Michael Paquier)
+-->
+ホットスタンバイプロセスが確実に正しいWALの一貫性のある地点を用いるようにしました。
+(Alexander Kukushkin, Michael Paquier)
      </para>
 
      <para>
+<!--
       This prevents possible misbehavior just after a standby server has
       reached a consistent database state during WAL replay.
+-->
+これによりスタンバイサーバがWALリプレイ中に一貫性のあるデータベース状態に到達した直後に起こりうる誤動作を防ぎます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure background workers are stopped properly when the postmaster
       receives a fast-shutdown request before completing database startup
       (Alexander Kukushkin)
+-->
+データベース起動が完了する前にポストマスタがfastシャットダウン要求を受けたときにバックエンドワーカが適切に停止されることを保証しました。
+(Alexander Kukushkin)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Update the free space map during WAL replay of page all-visible/frozen
       flag changes (&Aacute;lvaro Herrera)
+-->
+ページの全て可視、全て凍結済みのフラグを更新するWALリプレイ中にフリースペースマップを更新するようにしました。
+(&Aacute;lvaro Herrera)
      </para>
 
      <para>
+<!--
       Previously we were not careful about this, reasoning that the FSM is
       not critical data anyway.  However, if it's sufficiently out of date,
       that can result in significant performance degradation after a standby
       has been promoted to primary.  The FSM will eventually be healed by
       updates, but we'd like it to be good sooner, so work harder at
       maintaining it during WAL replay.
+-->
+何にせよFSMは重要なデータではないという理由で、これまでこのことに注意が払われていませんでした。
+しかしながら、FSMが古くなりすぎると、スタンバイがプライマリに昇格した後に著しい性能低下になる可能性があります。
+FSMはやがては更新で回復しますが、より早く良くしたいと考えて、WALリプレイ中により積極的に保全を行うようにしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid premature release of parallel-query resources when query end or
       tuple count limit is reached (Amit Kapila)
+-->
+問い合わせが終了したり、タプル総数の上限に達したときの、並列問い合わせリソースの早すぎる解放を回避しました。
+(Amit Kapila)
      </para>
 
      <para>
+<!--
       It's only okay to shut down the executor at this point if the caller
       cannot demand backwards scan afterwards.
+-->
+後で呼び出し元が逆向きスキャンを要求できない場合、その時点でエグゼキュータをシャットダウンするしかありません。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Don't run atexit callbacks when servicing <literal>SIGQUIT</literal>
       (Heikki Linnakangas)
+-->
+<literal>SIGQUIT</literal>を処理するときにatexitコールバックを実行しないようにしました。
+(Heikki Linnakangas)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Don't record foreign-server user mappings as members of extensions
       (Tom Lane)
+-->
+外部サーバのユーザマッピングを拡張のメンバーとして記録しないようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       If <command>CREATE USER MAPPING</command> is executed in an extension
       script, an extension dependency was created for the user mapping,
       which is unexpected.  Roles can't be extension members, so user
       mappings shouldn't be either.
+-->
+拡張のスクリプトで<command>CREATE USER MAPPING</command>が実行された場合、ユーザマッピングに対して拡張の依存性が作られますが、これは予期せぬものです。
+ロールは拡張のメンバーになれませんので、ユーザマッピングもなれないべきです。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Make syslogger more robust against failures in opening CSV log files
       (Tom Lane)
+-->
+CSVログファイルを開くときの失敗に対してsysloggerをより頑健にしました。
+(Tom Lane)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>psql</application>, as well as documentation
       examples, to call <function>PQconsumeInput()</function> before
       each <function>PQnotifies()</function> call (Tom Lane)
+-->
+各<function>PQnotifies()</function>呼び出しの前に<function>PQconsumeInput()</function>を呼ぶように<application>psql</application>および文書のサンプルを修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This fixes cases in which <application>psql</application> would not
       report receipt of a <literal>NOTIFY</literal> message until after the
       next command.
+-->
+これは、<application>psql</application>が次コマンド後まで<literal>NOTIFY</literal>メッセージ受領を報告しない場合について修正します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix possible inconsistency in <application>pg_dump</application>'s
       sorting of dissimilar object names (Jacob Champion)
+-->
+<application>pg_dump</application>の異なるオブジェクト名のソートでおこりうる一貫性の欠如を修正しました。
+(Jacob Champion)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Ensure that <application>pg_restore</application> will schema-qualify
       the table name when
       emitting <literal>DISABLE</literal>/<literal>ENABLE TRIGGER</literal>
       commands (Tom Lane)
+-->
+<application>pg_restore</application>が<literal>DISABLE</literal>/<literal>ENABLE TRIGGER</literal>コマンドを出力するときにテーブル名を確実にスキーマ修飾するようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This avoids failures due to the new policy of running restores with
       restrictive search path.
+-->
+これにより制限的なサーチパスを用いるリストア実行の新たな方針のための失敗を回避します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_upgrade</application> to handle event triggers in
       extensions correctly (Haribabu Kommi)
+-->
+<application>pg_upgrade</application>を拡張でイベントトリガを適切に処理するように修正しました。
+(Haribabu Kommi)
      </para>
 
      <para>
+<!--
       <application>pg_upgrade</application> failed to preserve an event
       trigger's extension-membership status.
+-->
+<application>pg_upgrade</application>はイベントトリガの拡張への所属状態を維持しませんでした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>pg_upgrade</application>'s cluster state check to
       work correctly on a standby server (Bruce Momjian)
+-->
+<application>pg_upgrade</application>のクラスタ状態検査をスタンバイサーバで正しく動作するように修正しました。
+(Bruce Momjian)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Enforce type <type>cube</type>'s dimension limit in
       all <filename>contrib/cube</filename> functions (Andrey Borodin)
+-->
+全ての<filename>contrib/cube</filename>の関数で、<type>cube</type>型の次元制限に従わせるようにしました。
+(Andrey Borodin)
      </para>
 
      <para>
+<!--
       Previously, some cube-related functions could construct values that
       would be rejected by <function>cube_in()</function>, leading to
       dump/reload failures.
+-->
+これまでは、一部のcube関連の関数は<function>cube_in()</function>で拒否される値を生成する可能性があり、ダンプ/リロードの失敗をもたらしました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       In <filename>contrib/postgres_fdw</filename>, don't try to ship a
       variable-free <literal>ORDER BY</literal> clause to the remote server
       (Andrew Gierth)
+-->
+<filename>contrib/postgres_fdw</filename>で変数無しの<literal>ORDER BY</literal>句をリモートサーバに移出しようとしなくしました。
+(Andrew Gierth)
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <filename>contrib/unaccent</filename>'s
       <function>unaccent()</function> function to use
       the <literal>unaccent</literal> text search dictionary that is in the
       same schema as the function (Tom Lane)
+-->
+<filename>contrib/unaccent</filename>の<function>unaccent()</function>関数を関数と同じスキーマの<literal>unaccent</literal>テキスト検索辞書を使うように修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Previously it tried to look up the dictionary using the search path,
       which could fail if the search path has a restrictive value.
+-->
+これまではサーチパスを使って辞書を探そうとしていましたが、サーチパスが制限的な値であると失敗する可能性がありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix build problems on macOS 10.14 (Mojave) (Tom Lane)
+-->
+macOS 10.14 でのビルド問題を修正しました。
+(Mojave) (Tom Lane)
      </para>
 
      <para>
+<!--
       Adjust <application>configure</application> to add
       an <option>-isysroot</option> switch to <varname>CPPFLAGS</varname>;
       without this, PL/Perl and PL/Tcl fail to configure or build on macOS
@@ -519,54 +804,83 @@
       or build time by setting the <varname>PG_SYSROOT</varname> variable in
       the arguments of <application>configure</application>
       or <application>make</application>.
+-->
+<varname>CPPFLAGS</varname>に<option>-isysroot</option>スイッチを加えるように<application>configure</application>を調整しました。
+これが無いとPL/PerlとPL/TclがmacOS 10.14でconfigureやビルドで失敗します。
+このsysroot指定はconfigure時またはビルド時に<application>configure</application>または<application>make</application>の引数で<varname>PG_SYSROOT</varname>変数を設定することで上書きできます。
      </para>
 
      <para>
+<!--
       It is now recommended that Perl-related extensions
       write <literal>$(perl_includespec)</literal> rather
       than <literal>-I$(perl_archlibexp)/CORE</literal> in their compiler
       flags.  The latter continues to work on most platforms, but not recent
       macOS.
+-->
+これからはPerl関連の拡張はコンパイラフラグの<literal>-I$(perl_archlibexp)/CORE</literal>ではなく<literal>$(perl_includespec)</literal>を書くことが推奨されます。
      </para>
 
      <para>
+<!--
       Also, it should no longer be necessary to
-      specify <option>--with-tclconfig</option> manually to get PL/Tcl to
+      specify <option>&#045;-with-tclconfig</option> manually to get PL/Tcl to
       build on recent macOS releases.
+-->
+また、最近のmacOSリリースではPL/Tclをビルドさせるのに、もはや<option>--with-tclconfig</option>を手動で指定する必要がありません。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix MSVC build and regression-test scripts to work on recent Perl
       versions (Andrew Dunstan)
+-->
+最近のPerlバージョンで動作するようにMSVCでのビルドとリグレッションテストスクリプトを修正しました。
+(Andrew Dunstan)
      </para>
 
      <para>
+<!--
       Perl no longer includes the current directory in its search path
       by default; work around that.
+-->
+Perlはもはやカレントディレクトリをデフォルトではサーチパスに含めず、このことに対応しました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       On Windows, allow the regression tests to be run by an Administrator
       account (Andrew Dunstan)
+-->
+Windowsで、リグレッションテストをAdministratorアカウントで実行できるようにしました。
+(Andrew Dunstan)
      </para>
 
      <para>
+<!--
       To do this safely, <application>pg_regress</application> now gives up
       any such privileges at startup.
+-->
+安全に行えるように、<application>pg_regress</application>は起動時に管理者の権限を手放すようになりました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Allow btree comparison functions to return <literal>INT_MIN</literal>
       (Tom Lane)
+-->
+Btreeの比較関数で<literal>INT_MIN</literal>を返せるようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Up to now, we've forbidden datatype-specific comparison functions from
       returning <literal>INT_MIN</literal>, which allows callers to invert
       the sort order just by negating the comparison result.  However, this
@@ -578,103 +892,159 @@
       Hence, we've removed this restriction.  Callers must now use
       the <literal>INVERT_COMPARE_RESULT()</literal> macro if they wish to
       invert the sort order.
+-->
+これまでは比較結果を逆転するだけで呼び出し元がソート順を逆にできるように、特定データ型の比較関数が<literal>INT_MIN</literal>を返すのを禁止していました。
+しかしながら、これは<function>memcmp()</function>、<function>strcmp()</function>等の結果を直接返す比較関数については、POSIXがそのような制限をこれら関数に設けていないため、全く安全ではありませんでした。
+少なくとも<function>memcmp()</function>の最近の一部バージョンは<literal>INT_MIN</literal>を返すことがあり、不適切なソート順をもたらしました。
+それゆえ、これら制限を取り除きました。
+これからは呼び出し元は、ソート順を反転させたい場合には<literal>INVERT_COMPARE_RESULT()</literal>マクロを使わなければなりません。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix recursion hazard in shared-invalidation message processing
       (Tom Lane)
+-->
+共有の無効化メッセージの生成で再帰障害を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       This error could, for example, result in failure to access a system
       catalog or index that had just been processed by <command>VACUUM
       FULL</command>.
+-->
+この誤りは、例えば、<command>VACUUM FULL</command>で処理された直後のシステムカタログやシステムインデックスへのアクセス失敗をもたらします。
      </para>
 
      <para>
+<!--
       This change adds a new result code
       for <function>LockAcquire</function>, which might possibly affect
       external callers of that function, though only very unusual usage
       patterns would have an issue with it.  The API
       of <function>LockAcquireExtended</function> is also changed.
+-->
+この変更では、とても稀な使用パターンでのみ出るものですが<function>LockAcquire</function>の新たな結果コードを追加しており、この関数の外部呼び出し元に影響があるかもしれません。
+<function>LockAcquireExtended</function>のAPIも変更されました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Save and restore SPI's global variables
       during <function>SPI_connect()</function>
       and <function>SPI_finish()</function> (Chapman Flack, Tom Lane)
+-->
+<function>SPI_connect()</function>と<function>SPI_finish()</function>のときにSPIのグローバル変数を退避し、復旧するようにしました。
+(Chapman Flack, Tom Lane)
      </para>
 
      <para>
+<!--
       This prevents possible interference when one SPI-using function calls
       another.
+-->
+これは、あるSPI使用関数が他を呼び出すときに起こりうる干渉を防止します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Avoid using potentially-under-aligned page buffers (Tom Lane)
+-->
+潜在的にアライメント調整されたページバッファの使用を回避しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       Invent new union types <type>PGAlignedBlock</type>
       and <type>PGAlignedXLogBlock</type>, and use these in place of plain
       char arrays, ensuring that the compiler can't place the buffer at a
       misaligned start address.  This fixes potential core dumps on
       alignment-picky platforms, and may improve performance even on
       platforms that allow misalignment.
+-->
+新たなunion型の<type>PGAlignedBlock</type>と<type>PGAlignedXLogBlock</type>を導入し、単なる文字配列に替えてこれらを使用して、コンパイラがバッファをアライメントを外れた開始アドレスに置くことがないようにしました。
+これはアライメントに厳しいプラットフォームでの潜在的なコアダンプを修正し、また、アライメント外れを許すプラットフォームであっても性能を改善すると考えられます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Make <filename>src/port/snprintf.c</filename> follow the C99
       standard's definition of <function>snprintf()</function>'s result
       value (Tom Lane)
+-->
+<filename>src/port/snprintf.c</filename>がC99標準の<function>snprintf()</function>の戻り値の定義に従うようにしました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       On platforms where this code is used (mostly Windows), its pre-C99
       behavior could lead to failure to detect buffer overrun, if the
       calling code assumed C99 semantics.
+-->
+このコードが使われるプラットフォーム（大部分はWindows）では、C99のセマンティクスを想定したコードを呼び出した場合に、このC99より前の振る舞いがバッファオーバラン検知の失敗をひき起こすおそれがありました。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       When building on i386 with the <application>clang</application>
       compiler, require <option>-msse2</option> to be used (Andres Freund)
+-->
+<application>clang</application>コンパイラでi386でビルドするときに、<option>-msse2</option>使用を必須としました。
+(Andres Freund)
      </para>
 
      <para>
+<!--
       This avoids problems with missed floating point overflow checks.
+-->
+これは浮動小数点オーバーフロー検査の問題を防ぎます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Fix <application>configure</application>'s detection of the result
       type of <function>strerror_r()</function> (Tom Lane)
+-->
+<application>configure</application>の<function>strerror_r()</function>の戻り型の検出を修正しました。
+(Tom Lane)
      </para>
 
      <para>
+<!--
       The previous coding got the wrong answer when building
       with <application>icc</application> on Linux (and perhaps in other
       cases), leading to <application>libpq</application> not returning
       useful error messages for system-reported errors.
+-->
+これまでのコーディングはLinux上の<application>icc</application>（と、おそらくは他のケースで）でビルドするときに誤った答を得ていて、<application>libpq</application>がシステムから報告されるエラーについて役立つエラーメッセージを返しませんでした。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Update time zone data files to <application>tzdata</application>
       release 2018g for DST law changes in Chile, Fiji, Morocco, and Russia
       (Volgograd), plus historical corrections for China, Hawaii, Japan,
       Macau, and North Korea.
+-->
+タイムゾーンデータファイルを<application>tzdata</application> release 2018gに更新しました。チリ、フィジー、モロッコ、ロシア（ヴォルゴグラード）の夏時間法の変更、中国、ハワイ、日本、マカオ、北朝鮮の歴史的修正が含まれます。
      </para>
     </listitem>
 


### PR DESCRIPTION
9.3.25、9.4.20、9.5.15.、9.6.11 リリース ノートの翻訳です。
大部分は 10.6 リリースノート（pr1360）と同じです。