### PR TITLE
pg_statsのmost_common_elem_freqs列の説明を修正

### DIFF
--- a/doc/src/sgml/catalogs.sgml
+++ b/doc/src/sgml/catalogs.sgml
@@ -15625,7 +15625,7 @@ SQL経由で作成された準備済み文では、これはクライアント�
 最も一般的な要素値の出現頻度のリストで、与えられた値の少なくとも1つのインスタンスを含む行の断片です。
 2つもしくは3つの追加の値が1つの要素ごとの出現頻度に続きます。
 最小で最大の要素ごとの出現頻度があります。さらにオプションとしてNULL要素の出現頻度もあります。
-(<structfield>most_common_elems</structfield>の場合はNULLになります。)
+（<structfield>most_common_elems</structfield>がNULLの時はNULLです。）
       </entry>
      </row>
 


### PR DESCRIPTION
most_common_elem_freqs列の訳が分かりづらかったため他の列の説明文に合わせて修正しました。