### PR TITLE
pg_class.relfrozenxid に関して、以前からの訳文について修正です。

### DIFF
--- a/doc/src/sgml/catalogs.sgml
+++ b/doc/src/sgml/catalogs.sgml
@@ -2877,7 +2877,7 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
        ID wraparound or to allow <literal>pg_xact</literal> to be shrunk.  Zero
        (<symbol>InvalidTransactionId</symbol>) if the relation is not a table.
 -->
-この値より以前のトランザクションIDはすべて、このテーブルで永続的な（<quote>凍結された</quote>）トランザクションIDに置き換えられます。
+この値より以前のトランザクションIDはすべて、このテーブルで永続的な（<quote>凍結された</quote>）トランザクションIDに置き換えられています。
 これは、このテーブルに対して、トランザクションID周回を防ぎ、かつ、<literal>pg_xact</literal>を縮小させることを目的としたバキュームを行うかどうかを追跡するために使用されます。
 リレーションがテーブルではない場合は0（<symbol>InvalidTransactionId</symbol>）です。
       </entry>


### PR DESCRIPTION
これから凍結されるのではなく、既に凍結されているという点が重要なので、
原文の現在完了時制を尊重しました。