### PR TITLE
pgstattuple 内 pgstatindex に関する説明の微修正

### DIFF
--- a/doc/src/sgml/pgstattuple.sgml
+++ b/doc/src/sgml/pgstattuple.sgml
@@ -396,7 +396,7 @@ leaf_fragmentation | 0
      page-by-page, and should not be expected to represent an
      instantaneous snapshot of the whole index.
 -->
-<function>pgstattuple</function>では、結果はページ毎に累積されます。
+<function>pgstattuple</function>同様、結果はページ毎に累積されます。
 この瞬間のインデックス全体のスナップショットが存在すると想定してはいけません。
     </para>
     </listitem>


### PR DESCRIPTION
pgstatindex についての説明のところで、「pgstattuple では」となって
いることに違和感

英語では "As with" とあるので「〜同様」となるべきかと思います。