### PR TITLE
update installation for 11.3

### DIFF
--- a/doc/src/sgml/installation.sgml
+++ b/doc/src/sgml/installation.sgml
@@ -2087,9 +2087,14 @@ Flexプログラム。
        <term><envar>PERL</envar></term>
        <listitem>
         <para>
+<!--
          Perl interpreter program.  This will be used to determine the
          dependencies for building PL/Perl.  The default is
          <command>perl</command>.
+-->
+Perlインタプリタプログラム。
+これは、PL/Perl構築に関する依存性を決定するために使用されます。
+デフォルトは<command>perl</command>です。
         </para>
        </listitem>
       </varlistentry>
@@ -2098,6 +2103,7 @@ Flexプログラム。
        <term><envar>PYTHON</envar></term>
        <listitem>
         <para>
+<!--
          Python interpreter program.  This will be used to
          determine the dependencies for building PL/Python.  Also,
          whether Python 2 or 3 is specified here (or otherwise
@@ -2106,6 +2112,12 @@ Flexプログラム。
          <xref linkend="plpython-python23"/>
          for more information.  If this is not set, the following are probed
          in this order: <literal>python python3 python2</literal>.
+-->
+Pythonインタプリタプログラム。
+これは、PL/Python構築に関する依存性を決定するために使用されます。
+またここでPython 2または3を指定するかどうかで(あるいは暗黙的に選択されます)、どちらのPL/Python言語が利用可能になるかも決まります。
+<xref linkend="plpython-python23"/>を参照してください。
+設定されていなければ、<literal>python python3 python2</literal>の順で調べられます。
         </para>
        </listitem>
       </varlistentry>
@@ -2114,10 +2126,12 @@ Flexプログラム。
        <term><envar>TCLSH</envar></term>
        <listitem>
         <para>
+<!--
          Tcl interpreter program.  This will be used to
          determine the dependencies for building PL/Tcl, and it will
          be substituted into Tcl scripts.
-Tclインタプリタのフルパス名。
+-->
+Tclインタプリタプログラム。
 これは、PL/Tcl構築に関する依存性を決定するために使用され、Tclスクリプト内を置き換えます。
         </para>
        </listitem>
@@ -2789,8 +2803,8 @@ Linux (最近のディストリビューションすべて), Windows (Win2000 SP
    <email>pgsql-hackers@lists.postgresql.org</email> is the appropriate place
    to discuss that.
 -->
-最近のビルドファームの結果でサポートしているものとされているプラットフォームでインストールに問題があった場合は、<email>pgsql-bugs@postgresql.org</email>に報告してください。
-新しいプラットフォームへの<productname>PostgreSQL</productname>の移植に興味があるのならば、<email>pgsql-hackers@postgresql.org</email>がその議論に適しています。
+最近のビルドファームの結果でサポートしているものとされているプラットフォームでインストールに問題があった場合は、<email>pgsql-bugs@lists.postgresql.org</email>に報告してください。
+新しいプラットフォームへの<productname>PostgreSQL</productname>の移植に興味があるのならば、<email>pgsql-hackers@lists.postgresql.org</email>がその議論に適しています。
   </para>
  </sect1>
 
@@ -2915,6 +2929,9 @@ GCCまたは在来のIBMコンパイラ<command>xlc</command>が使用できま�
 -->
 もし、<literal>/usr/local</literal>にインストール済のreadlineやライブラリがある場合は、次の<command>configure</command>フラグを加えて下さい。
     <literal>--with-includes=/usr/local/include
+<!--
+    &#045;-with-libraries=/usr/local/lib</literal>.
+-->
     --with-libraries=/usr/local/lib</literal>
    </para>
 


### PR DESCRIPTION
 installation.sgmlの11.3対応です。

コンフリクト解消のときに日本語訳が消されてしまっているものがあるようですが、その部分の復旧も含んでいます。