### PR TITLE
btree.sgmlのPostgreSQL 11.3対応です。

### DIFF
--- a/doc/src/sgml/btree.sgml
+++ b/doc/src/sgml/btree.sgml
@@ -29,8 +29,7 @@
   index entry cannot exceed approximately one-third of a page (after TOAST
   compression, if applicable).
 -->
-<productname>PostgreSQL</productname>は、標準的な<acronym>btree</acronym>（multi-way binary tree）インデックスデータ構造を実装しています。
-（訳注：実は「btree」が「multi-way binary tree」の略語であるというのは正しくなく、<productname>PostgreSQL</productname> 11.2以降では、「multi-way balanced tree」と修正されています。）
+<productname>PostgreSQL</productname>は、標準的な<acronym>btree</acronym>（multi-way balanced tree）インデックスデータ構造を実装しています。
 明確に定義された線形順にソート可能なデータ型は、すべてbtreeインデックスで索引付できます。
 唯一の制限は、一つのインデックスエントリが（適用可能であれば、TOAST圧縮後）ページの約1/3を超えられないことです。
  </para>


### PR DESCRIPTION
btreeの意味の間違いが11.3で修正されたところ以外は変わっていません。