### PR TITLE
comment-out failure in runtime

### DIFF
--- a/doc/src/sgml/runtime.sgml
+++ b/doc/src/sgml/runtime.sgml
@@ -1328,6 +1328,7 @@ POSIXセマフォを使用している場合、System Vと同じ数のセマフ�
       </term>
       <listitem>
        <para>
+<!--
         The default IPC settings can be changed using
         the <command>sysctl</command> or
         <command>loader</command> interfaces.  The following


### PR DESCRIPTION
runtime.sgml で原文のコメント化に失敗しているところを見つけました。