### PR TITLE
pgtrgm.sgmlの11.4対応です。

### DIFF
--- a/doc/src/sgml/pgtrgm.sgml
+++ b/doc/src/sgml/pgtrgm.sgml
@@ -250,6 +250,7 @@
 -->
 一方で、<function>strict_word_similarity(text, text)</function>は二番目の文字列の単語の範囲を選択します。
 上記の例で<function>strict_word_similarity(text, text)</function>は単語<literal>'words'</literal>の範囲を選択して、そのトライグラム集合は<literal>{"  w"," wo","wor","ord","rds","ds "}</literal>になるでしょう。
+
 <programlisting>
 # SELECT strict_word_similarity('word', 'two words'), similarity('word', 'words');
  strict_word_similarity | similarity
@@ -448,15 +449,22 @@
      <varname>pg_trgm.word_similarity_threshold</varname> (<type>real</type>)
      <indexterm>
       <primary>
+<!--
        <varname>pg_trgm.word_similarity_threshold</varname> configuration parameter
+-->
+       <varname>pg_trgm.word_similarity_threshold</varname>設定パラメータ
       </primary>
      </indexterm>
     </term>
     <listitem>
      <para>
+<!--
       Sets the current word similarity threshold that is used by the
       <literal>&lt;%</literal> and <literal>%&gt;</literal> operators.  The threshold
       must be between 0 and 1 (default is 0.6).
+-->
+<literal>&lt;%</literal>と<literal>%&gt;</literal><literal>%</literal>演算子が使用する現在の語類似度閾値を設定します。
+閾値は0から1の間でなければなりません。（デフォルトは0.6です）
      </para>
     </listitem>
    </varlistentry>
@@ -468,7 +476,7 @@
 <!--
        <varname>pg_trgm.strict_word_similarity_threshold</varname> configuration parameter
 -->
-        <varname>pg_trgm.word_similarity_threshold</varname>設定パラメータ
+       <varname>pg_trgm.strict_word_similarity_threshold</varname>設定パラメータ
       </primary>
      </indexterm>
     </term>
@@ -479,8 +487,8 @@
       <literal>&lt;&lt;%</literal> and <literal>%&gt;&gt;</literal> operators.  The threshold
       must be between 0 and 1 (default is 0.5).
 -->
-<literal>&lt;%</literal>と<literal>%&gt;</literal><literal>%</literal>演算子が使用する現在の語類似度閾値を設定します。
-閾値は0から1の間でなければなりません。（デフォルトは0.6です）
+<literal>&lt;%</literal>と<literal>%&gt;</literal><literal>%</literal>演算子が使用する現在の厳密な語類似度閾値を設定します。
+閾値は0から1の間でなければなりません。（デフォルトは0.5です）
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
似ている文が追加されたため、マージのときにズレてマージされていたのを修正しています。
実際に追加したのは「厳密な」と「デフォルト値」を修正したものを追加しただけです。