### PR TITLE
fix 'authors'

### DIFF
--- a/doc/src/sgml/bloom.sgml
+++ b/doc/src/sgml/bloom.sgml
@@ -366,7 +366,7 @@ DEFAULT FOR TYPE text USING bloom AS
 <!--
   <title>Authors</title>
 -->
-  <title>著者</title>
+  <title>作者</title>
 
   <para>
    Teodor Sigaev <email>teodor@postgrespro.ru</email>,


### PR DESCRIPTION
Authorsの訳がbloomだけ「著者」になっていましたので、周りに合わせました。