### PR TITLE
バキューム閾値・解析閾値の定義式の表示

### DIFF
--- a/doc/src/sgml/maintenance.sgml
+++ b/doc/src/sgml/maintenance.sgml
@@ -1178,11 +1178,11 @@ HINT:  Stop the postmaster and vacuum that database in single-user mode.
 さもなければ、直前の<command>VACUUM</command>の後に不要となったタプル数が<quote>バキューム閾値</quote>を超えると、テーブルはバキュームされます。
 このバキューム閾値は以下のように定義されます。
 <programlisting>
+バキューム閾値 = バキューム基礎閾値 + バキューム規模係数 * タプル数
+</programlisting>
 <!--
 vacuum threshold = vacuum base threshold + vacuum scale factor * number of tuples
 -->
-バキューム閾値 = バキューム基礎閾値 + バキューム規模係数 * タプル数
-</programlisting>
 <!--
     where the vacuum base threshold is
     <xref linkend="guc-autovacuum-vacuum-threshold"/>,
@@ -1215,11 +1215,11 @@ vacuum threshold = vacuum base threshold + vacuum scale factor * number of tuple
 解析でも似たような条件が使用されます。
 以下で定義される閾値が、前回の<command>ANALYZE</command>の後に挿入、更新、削除されたタプル数と比較されます。
 <programlisting>
+解析閾値 = 解析基礎閾値 + 解析規模係数 * タプル数
+</programlisting>
 <!--
 analyze threshold = analyze base threshold + analyze scale factor * number of tuples
 -->
-解析閾値 = 解析基礎閾値 + 解析規模係数 * タプル数
-</programlisting>
 <!--
     is compared to the total number of tuples inserted, updated, or deleted
     since the last <command>ANALYZE</command>.


### PR DESCRIPTION
バキューム閾値・解析閾値の定義式に空行があったため、空行を削除しました。
programlistingタグ内に、元の英語のコードがコメントアウトされており、それが改行と判定されていたことが原因であると考えられます。

よって英語のコードをprogramlistingタグ外に置いた所、空行が削除されました。
しかし、このコメントアウトの表記が正しいか自信が無いため皆様のご意見を頂戴したいです。