### PR TITLE
idx_scanの日本語訳

### DIFF
--- a/doc/src/sgml/monitoring.sgml
+++ b/doc/src/sgml/monitoring.sgml
@@ -4472,7 +4472,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
      <entry>Number of index scans initiated on this index</entry>
 -->
      <entry>
-インデックスに対して初期化されたインデックススキャンの個数です。
+インデックスに対して開始されたインデックススキャンの実行回数です。
      </entry>
     </row>
     <row>


### PR DESCRIPTION
"Number of index scans initiated on this index"
の日本語訳 "初期化されたインデックススキャンの個数です。"を修正しました。