### PR TITLE
REL_11_5との差分チェックによりみつかった問題修正

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -11906,15 +11906,6 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
         <entry><literal>pclose(path '[(0,0),(1,1),(2,0)]')</literal></entry>
        </row>
        <row>
-        <entry><literal><function>point(<type>lseg</type>, <type>lseg</type>)</function></literal></entry>
-        <entry><type>point</type></entry>
-<!--
-        <entry>intersection</entry>
--->
-        <entry>交点</entry>
-        <entry><literal>point(lseg '((-1,0),(1,0))',lseg '((-2,-2),(2,2))')</literal></entry>
-       </row>
-       <row>
         <entry><literal><function>popen(<type>path</type>)</function></literal></entry>
         <entry><type>path</type></entry>
 <!--

--- a/doc/src/sgml/func2.sgml
+++ b/doc/src/sgml/func2.sgml
@@ -4129,15 +4129,6 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
         <entry><literal>pclose(path '[(0,0),(1,1),(2,0)]')</literal></entry>
        </row>
        <row>
-        <entry><literal><function>point(<type>lseg</type>, <type>lseg</type>)</function></literal></entry>
-        <entry><type>point</type></entry>
-<!--
-        <entry>intersection</entry>
--->
-        <entry>交点</entry>
-        <entry><literal>point(lseg '((-1,0),(1,0))',lseg '((-2,-2),(2,2))')</literal></entry>
-       </row>
-       <row>
         <entry><literal><function>popen(<type>path</type>)</function></literal></entry>
         <entry><type>path</type></entry>
 <!--

--- a/doc/src/sgml/lobj.sgml
+++ b/doc/src/sgml/lobj.sgml
@@ -339,7 +339,6 @@ Oid lo_import(PGconn *conn, const char *filename);
 Oid lo_import_with_oid(PGconn *conn, const char *filename, Oid lobjId);
 </synopsis>
 <!--
-     <indexterm><primary>lo_import_with_oid</></>
      also imports a new large object.  The OID to be assigned can be
      specified by <replaceable class="parameter">lobjId</replaceable>;
      if so, failure occurs if that OID is already in use for some large

--- a/doc/src/sgml/release-11.sgml
+++ b/doc/src/sgml/release-11.sgml
@@ -5799,7 +5799,7 @@ macOS 10.14 でのビルド問題を修正しました。
       10.14.  The specific sysroot used can be overridden at configure time
       or build time by setting the <varname>PG_SYSROOT</varname> variable in
       the arguments of <application>configure</application>
-       or <application>make</application>.
+      or <application>make</application>.
 -->
 <varname>CPPFLAGS</varname>に<option>-isysroot</option>スイッチを加えるように<application>configure</application>を調整しました。
 これが無いとPL/PerlとPL/TclがmacOS 10.14でconfigureやビルドで失敗します。

--- a/doc/src/sgml/spi.sgml
+++ b/doc/src/sgml/spi.sgml
@@ -6241,10 +6241,10 @@ void SPI_rollback(void)
  </refsynopsisdiv>
 
  <refsect1>
-  <title>Description</title>
 <!--
-  <title>説明</title>
+  <title>Description</title>
 -->
+  <title>説明</title>
 
   <para>
 <!--


### PR DESCRIPTION
func.sgml: 元々コメント化されていてversion 11で削除されたが、マージ時に
コメント化の方を消してしまっていたのを修正
lobj.sgml: 不要行の削除
release-11.sgml: 原文のインデントが変更されていたのを戻した
spi.sgml: ここだけ間違って日本語訳の方をコメントアウトしていたのを修正