### PR TITLE
round関数の説明の日本語訳を修正します。

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -1393,7 +1393,7 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
 <!--
        <entry>round to nearest integer</entry>
 -->
-       <entry>四捨五入</entry>
+       <entry>最も近い整数への丸め</entry>
        <entry><literal>round(42.4)</literal></entry>
        <entry><literal>42</literal></entry>
       </row>
@@ -1404,7 +1404,7 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
 <!--
        <entry>round to <parameter>s</parameter> decimal places</entry>
 -->
-       <entry>四捨五入して小数点第<parameter>s</parameter>位までにする</entry>
+       <entry>小数点第<parameter>s</parameter>位までの丸め</entry>
        <entry><literal>round(42.4382, 2)</literal></entry>
        <entry><literal>42.44</literal></entry>
       </row>


### PR DESCRIPTION
以前は、round関数の説明として「四捨五入」と記載されていました。
しかし、double precision型の少数を引数にround関数を実行すると、
四捨五入の動きにはなりません。例えば、round(0.5::double precision)の
結果は0です。このため、「四捨五入」との記述は正確ではないようです。

この修正では、英語での記述「round to nearest integer」の日本語訳である
「最も近い整数への丸め」を訳として採用します。下記のWikipediaの
記事によると、四捨五入も偶数への丸め(引数の型がdouble precisionの場合の
round関数の動き)も、広義の最近接丸めとのことで、
「最も近い整数への丸め」との訳は間違いではないようです。

https://ja.wikipedia.org/wiki/端数処理