### PR TITLE
ハイフンの置き換えで見逃されていた差分を再チェック

### DIFF
--- a/doc/src/sgml/isn.sgml
+++ b/doc/src/sgml/isn.sgml
@@ -459,7 +459,7 @@
 
 <programlisting>
 <!--
-&#045;&#045;&#045;Using the types directly:
+&#045;&#045;Using the types directly:
 -->
 ---型を直接使う
 SELECT isbn('978-0-393-04002-9');

--- a/doc/src/sgml/plpgsql.sgml
+++ b/doc/src/sgml/plpgsql.sgml
@@ -3387,7 +3387,7 @@ LOOP
     EXIT WHEN count &gt; 100;
     CONTINUE WHEN count &lt; 50;
 <!--
-    &#045;&#045; some computations for count IN [50 .. 100] 
+    &#045;&#045; some computations for count IN [50 .. 100]
 -->
     -- 50から100を数える、何らかの演算
 END LOOP;
@@ -3984,9 +3984,9 @@ BEGIN
             RETURN;
         EXCEPTION WHEN unique_violation THEN
 <!--
-        &#045;&#045; Do nothing, and loop to try the UPDATE again.
+            &#045;&#045; Do nothing, and loop to try the UPDATE again.
 -->
-        -- 何もしないで、更新を再試行します
+            -- 何もしないで、更新を再試行します
         END;
     END LOOP;
 END;
@@ -6003,7 +6003,7 @@ CREATE OR REPLACE FUNCTION process_emp_audit() RETURNS TRIGGER AS $emp_audit$
         --
 <!--
         &#045;&#045; Create a row in emp_audit to reflect the operation performed on emp,
-        &#045;&#045; make use of the special variable TG_OP to work out the operation.
+        &#045;&#045; making use of the special variable TG_OP to work out the operation.
 -->
         -- empで行った操作を反映する行をemp_auditに作成
         -- 操作の種類を決定するために、特殊な変数TG_OPを活用
@@ -6231,7 +6231,7 @@ AS $maint_sales_summary_bytime$
 
 <!--
             &#045;&#045; forbid updates that change the time_key -
-            &#045;&#045; (probably not too onerous, as DELETE + INSERT is how most 
+            &#045;&#045; (probably not too onerous, as DELETE + INSERT is how most
             &#045;&#045; changes will be made).
 -->
             -- time_keyを変更する更新を禁止します
@@ -8032,9 +8032,9 @@ BEGIN
 
     IF a_running_job_count &gt; 0 THEN
 <!--
-        COMMIT; &#045;&#045; free lock <co id="co.plpgsql-porting-commit"/>
+        COMMIT; &#045;&#045; free lock
 -->
-        COMMIT; -- ロックを解放<co id="co.plpgsql-porting-commit"/>
+        COMMIT; -- ロックを解放
         raise_application_error(-20000,
                  'Unable to create a new job: a job is currently running.');
     END IF;
@@ -8073,6 +8073,10 @@ BEGIN
     SELECT count(*) INTO a_running_job_count FROM cs_jobs WHERE end_stamp IS NULL;
 
     IF a_running_job_count &gt; 0 THEN
+<!--
+        COMMIT; &#045;&#045; free lock
+-->
+        COMMIT; -- ロックを解放
         RAISE EXCEPTION 'Unable to create a new job: a job is currently running'; -- <co id="co.plpgsql-porting-raise"/>
     END IF;
 

--- a/doc/src/sgml/ref/create_table.sgml
+++ b/doc/src/sgml/ref/create_table.sgml
@@ -727,7 +727,7 @@ Bツリー演算子クラスがない場合はエラーが報告されます。
       modulus-16 partitions covering the same portion of the key space (one with
       a remainder equal to the remainder of the detached partition, and the
       other with a remainder equal to that value plus 8), and repopulate them
-      with data.  You can then repeat this -&#045;perhaps at a later time &#045;- for
+      with data.  You can then repeat this &#045;&#045; perhaps at a later time &#045;&#045; for
       each modulus-8 partition until none remain.  While this may still involve
       a large amount of data movement at each step, it is still better than
       having to create a whole new table and move all the data at once.

--- a/doc/src/sgml/ref/initdb.sgml
+++ b/doc/src/sgml/ref/initdb.sgml
@@ -110,7 +110,7 @@ PostgreSQL documentation
 <!--
     For security reasons the new cluster created by <command>initdb</command>
     will only be accessible by the cluster owner by default.  The
-    <option>&#45;-allow-group-access</option> option allows any user in the same
+    <option>&#045;-allow-group-access</option> option allows any user in the same
     group as the cluster owner to read files in the cluster.  This is useful
     for performing backups as a non-privileged user.
 -->

--- a/doc/src/sgml/ref/pg_dump.sgml
+++ b/doc/src/sgml/ref/pg_dump.sgml
@@ -197,7 +197,7 @@ PostgreSQL documentation
        <para>
 <!--
         Include large objects in the dump.  This is the default behavior
-       except when <option>&#045;&#045;schema</option>, <option>&#045;&#045;table</option>, or
+        except when <option>&#045;&#045;schema</option>, <option>&#045;&#045;table</option>, or
         <option>&#045;&#045;schema-only</option> is specified.  The <option>-b</option>
         switch is therefore only useful to add large objects to dumps
         where a specific schema or table has been requested.  Note that

--- a/doc/src/sgml/ref/pg_recvlogical.sgml
+++ b/doc/src/sgml/ref/pg_recvlogical.sgml
@@ -89,7 +89,7 @@ PostgreSQL documentation
 <!--
         Create a new logical replication slot with the name specified by
         <option>&#045;-slot</option>, using the output plugin specified by
-        <option>&#045;-plugin</option>, for the database given specified
+        <option>&#045;-plugin</option>, for the database specified
         by <option>&#045;-dbname</option>.
 -->
 新しい論理レプリケーションスロットを<option>--slot</option>で指定した名前で、<option>--plugin</option>の出力プラグインを使い、<option>--dbname</option>で指定したデータベースに対して作成します。
@@ -103,7 +103,7 @@ PostgreSQL documentation
        <para>
 <!--
         Drop the replication slot with the name specified
-        in <option>&#045;-slot</option>, then exit.
+        by <option>&#045;-slot</option>, then exit.
 -->
 <option>--slot</option>で指定された名前のレプリケーションスロットを削除して、終了します。
        </para>

--- a/doc/src/sgml/ref/pgbench.sgml
+++ b/doc/src/sgml/ref/pgbench.sgml
@@ -800,7 +800,7 @@ pgbench <optional> <replaceable>options</replaceable> </optional> <replaceable>d
 
        <para>
 <!--
-        If <option>#045;&#045;latency-limit</option> is used together with <option>#045;&#045;rate</option>,
+        If <option>&#045;&#045;latency-limit</option> is used together with <option>&#045;&#045;rate</option>,
         a transaction can lag behind so much that it is already over the
         latency limit when the previous transaction ends, because the latency
         is calculated from the scheduled start time. Such transactions are

--- a/doc/src/sgml/regress.sgml
+++ b/doc/src/sgml/regress.sgml
@@ -360,7 +360,7 @@ ECPGインタフェースライブラリのリグレッションテスト。
    Some of these auxiliary test suites use the TAP infrastructure explained
    in <xref linkend="regress-tap"/>.
    The TAP-based tests are run only when PostgreSQL was configured with the
-   option <option>&#45;-enable-tap-tests</option>.  This is recommended for
+   option <option>&#045;-enable-tap-tests</option>.  This is recommended for
    development, but can be omitted if there is no suitable Perl installation.
 -->
 オプション<option>--enable-tap-tests</option>を指定してPostgreSQLを構築した場合にのみ、TAPベースのテストが行なわれます。

--- a/doc/src/sgml/spi.sgml
+++ b/doc/src/sgml/spi.sgml
@@ -6635,7 +6635,7 @@ INSERT 0 2
  1
  2
 <!--
- 2                  &#045;&#045;&#045;&#045; 2 rows * 1 (x in first row)
+ 2                  &#045;&#045; 2 rows * 1 (x in first row)
  6                  &#045;&#045; 3 rows (2 + 1 just inserted) * 2 (x in second row)
 (4 rows)               ^^^^^^
                        rows visible to execq() in different invocations

--- a/doc/src/sgml/uuid-ossp.sgml
+++ b/doc/src/sgml/uuid-ossp.sgml
@@ -248,7 +248,7 @@ X.500区分名（DN）をUIDに選定した定数です。
    (though on modern Linux it is considered part
    of <literal>util-linux-ng</literal>).  When invoking <filename>configure</filename>,
    specify <option>&#045;&#045;with-uuid=bsd</option> to use the BSD functions,
-   or <option>&#045;with-uuid=e2fs</option> to
+   or <option>&#045;&#045;with-uuid=e2fs</option> to
    use <literal>e2fsprogs</literal>' <filename>libuuid</filename>, or
    <option>&#045;&#045;with-uuid=ossp</option> to use the OSSP UUID library.
    More than one of these libraries might be available on a particular


### PR DESCRIPTION
2つのハイフン(--)がコメント化されるときに&#045;に置き換えられるため、
差分チェック時に除外されている。
そのため、原文の変更による差分が見逃されれていたので、 &#045;を-に再置換えして
差分が無くなるように修正した。