### PR TITLE
func.sgmlのPostgreSQL 12.0対応です。

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -1642,7 +1642,7 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
 -->
 <function>random()</function>関数は単純な線形合同法を使用しています。
 高速ですが、暗号用途には適していません。より安全な代替物として<xref linkend="pgcrypto"/>モジュールを参照してください。
-<function>setseed()</function>が呼び出されると、<function>setseed()</function>を同じ引数で実行することによって現在のセッション内での以後の<function>random()</function>の呼び出し結果は再現可能となります。
+<function>setseed()</function>が呼び出されると、現在のセッション内での以後の<function>random()</function>の呼び出し結果は<function>setseed()</function>を同じ引数で実行することによって再現可能となります。
   </para>
 
   <para>
@@ -5609,7 +5609,7 @@ substring(<replaceable>string</replaceable>, <replaceable>pattern</replaceable>,
 -->
 <literal>SIMILAR TO</literal>と同様、指定したパターンがデータ文字列全体に一致する必要があります。一致しない場合、関数は失敗し、NULLを返します。
 マッチするデータのうちの対象とする部分文字列に対応するパターンの部分を示すために、エスケープ文字の後に二重引用符（<literal>"</literal>）を繋げたものを2つパターンに含める必要があります。<!-- " font-lock sanity -->
-これらの印で括られたパターンの一部に一致するテキストが返されます。
+マッチが成功すると、これらの印で括られたパターンの一部に一致するテキストが返されます。
    </para>
 
    <para>
@@ -9026,6 +9026,7 @@ POSIXはバックスラッシュ以降の空白文字を無視しません。
 <literal>FX</literal>オプションが無い場合、マイナス符号は曖昧で、区切り文字として解釈されるかも知れません。
 この曖昧さは次のようにして解消されます。
 テンプレート文字列中の<literal>TZH</literal>の前の区切り文字の数が入力文字列中のマイナス符号の前の区切り文字の数よりも少なければ、そのマイナス符号は<literal>TZH</literal>の一部として解釈されます。
+そうでない場合、マイナス記号が値の区切り記号と見なされます。
 たとえば、<literal>to_timestamp('2000 -10', 'YYYY TZH')</literal>では<literal>-10</literal>が<literal>TZH</literal>にマッチしますが、<literal>to_timestamp('2000 -10', 'YYYY&nbsp;&nbsp;TZH')</literal>では<literal>10</literal>が<literal>TZH</literal>にマッチします。
       </para>
      </listitem>
@@ -9064,7 +9065,7 @@ POSIXはバックスラッシュ以降の空白文字を無視しません。
           skip <literal>y</literal>, <literal>m</literal>, and
           <literal>d</literal>.
 -->
-<productname>PostgreSQL</productname> 12より前では、記号文字（訳注：原文は"non-letter or non-digit）を使って入力文字列中の任意のテキストをスキップすることが可能でした。
+<productname>PostgreSQL</productname> 12より前では、記号文字（訳注：原文は"non-letter or non-digit"）を使って入力文字列中の任意のテキストをスキップすることが可能でした。
 たとえば、<literal>to_timestamp('2000y6m1d', 'yyyy-MM-DD')</literal>は動作しました。
 現在は、この目的のために非記号文字（訳注：原文は"letter characters"）だけを使うことができます。
 たとえば、<literal>to_timestamp('2000y6m1d', 'yyyytMMtDDt')</literal>と<literal>to_timestamp('2000y6m1d', 'yyyy"y"MM"m"DD"d"')</literal>は、<literal>y</literal>、<literal>m</literal>、<literal>d</literal>をスキップします。
@@ -11391,7 +11392,7 @@ date_trunc(<replaceable>field</replaceable>, <replaceable>source</replaceable> [
 <!--
     Examples (assuming the local time zone is <literal>America/New_York</literal>):
 -->
-例：
+例（現地タイムゾーンは<literal>America/New_York</literal>と仮定します）：
 <screen>
 SELECT date_trunc('hour', TIMESTAMP '2001-02-16 20:38:40');
 <lineannotation>Result: </lineannotation><computeroutput>2001-02-16 20:00:00</computeroutput>
@@ -14199,9 +14200,8 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
    type <type>xml</type> are documented there, not in this section.
 -->
 この節で説明される関数および擬似関数式は、<type>xml</type>型の値に対して機能します。
-<type>xml</type>型についての情報は<xref linkend="datatype-xml"/>を点検してください。
-<type>xml</type>型のやりとりを変換する<function>xmlparse</function>および<function>xmlserialize</function>擬似関数式はここでは繰り返しません。
-これらの多くの関数を使用するには、インストレーションの際<command>configure --with-libxml</command>付きでビルドされていることが必要です。
+<type>xml</type>型についての情報は<xref linkend="datatype-xml"/>を参照してください。
+<type>xml</type>型のやりとりを変換する<function>xmlparse</function>および<function>xmlserialize</function>擬似関数式はこの節ではなく、そこに記載されています。
   </para>
 
   <para>
@@ -14210,7 +14210,7 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
    requires <productname>PostgreSQL</productname> to have been built
    with <command>configure &#045;&#045;with-libxml</command>.
 -->
-これらの関数の大半は<productname>PostgreSQL</productname>が<command>configure &#045;&#045;with-libxml</command>でビルドされていることを必要としています。
+これらの関数の大半は<productname>PostgreSQL</productname>が<command>configure --with-libxml</command>でビルドされていることを必要としています。
   </para>
 
   <sect2 id="functions-producing-xml">
@@ -14778,8 +14778,10 @@ SELECT xmlagg(x) FROM (SELECT * FROM test ORDER BY y DESC) AS tab;
      passed as the context item must be an XML document, not a content
      fragment or any non-XML value.
 -->
-関数<function>xmlexists</function>は第一引数のXPath式が何かしらのノードであれば真を返し、そうでなければ偽を返します。
-(もしいずれの引数もNULLであった場合はNULLを返します。)
+関数<function>xmlexists</function>は渡されたXML値をコンテキスト項目としてXPath 1.0式（第一引数）を評価します。
+この関数は評価が空のノード集合を生成する場合には偽を返し、それ以外の値を返すならば真を返します。
+もしどれかの引数がNULLであった場合はNULLを返します。
+コンテキスト項目として渡される非NULLの値は、内容の断片や非XML値ではなく、XML文書でなければなりません。
     </para>
 
     <para>
@@ -14942,8 +14944,9 @@ SELECT xml_is_well_formed_document('<pg:foo xmlns:pg="http://postgresql.org/stuf
      If the XPath expression returns a scalar value rather than a node-set,
      a single-element array is returned.
 -->
-関数<function>xpath</function>は、XML値<replaceable>xml</replaceable>に対し、XPath式<replaceable>xpath</replaceable>(ひとつの<type>text</type>値)を評価します。そして、XPath式で作成されたノードセットに対応するXML値の配列を返します。
-もし、XPath式がノードセットではなくスカラー値を返す場合、単一要素の配列が返されます。
+関数<function>xpath</function>は、XML値<replaceable>xml</replaceable>に対し、XPath 1.0式<replaceable>xpath</replaceable>(ひとつの<type>text</type>値)を評価します。
+そして、XPath式で作成されたノード集合に対応するXML値の配列を返します。
+もし、XPath式がノード集合ではなくスカラー値を返す場合、単一要素の配列が返されます。
     </para>
 
     <para>
@@ -15026,7 +15029,8 @@ SELECT xpath('//mydefns:b/text()', '<a xmlns="http://example.com"><b>test</b></a
      This function is equivalent to the <literal>XMLEXISTS</literal> predicate,
      except that it also offers support for a namespace mapping argument.
 -->
-関数<function>xpath_exists</function>は、<function>xpath</function>関数の特別な形式です。この関数は、XPathを満足する個別のXML値を返す代わりに、問い合わせがそれを満足するかどうかを論理値で返します。
+関数<function>xpath_exists</function>は、<function>xpath</function>関数の特別な形式です。
+この関数は、XPath 1.0を満足する個別のXML値を返す代わりに、問い合わせがそれを満足するかどうか（具体的には空のノード集合以外の値を返すかどうか）を論理値で返します。
 この関数は、名前空間にマッピングされた引数をもサポートする点を除き、標準の<literal>XMLEXISTS</literal>述語と同じです。
     </para>
 
@@ -15103,8 +15107,9 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
      is null, nor if the <replaceable>row_expression</replaceable> produces
      an empty node-set or any value other than a node-set.
 -->
-必須の<replaceable>row_expression</replaceable>引数はXPath式で、指定のXML文書に対して評価され、XMLノードの順序付きシーケンスが取得されます。
-このシーケンスが<function>xmltable</function>により出力行に変換されます。
+必須の<replaceable>row_expression</replaceable>引数はXPath 1.0式で、<replaceable>document_expression</replaceable>をそのコンテキスト項目とし渡し、XMLノード集合を得るために評価されます。
+このノードは<function>xmltable</function>が出力行に変換します。
+<replaceable>document_expression</replaceable>がNULLであるか、<replaceable>row_expression</replaceable>が空のノード集合あるいはノード集合以外の値を生成するなら行は出力されません。
     </para>
 
     <para>
@@ -15121,9 +15126,10 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
      expressions, as discussed in
      <xref linkend="functions-xml-limits-xpath1"/>.
 -->
-<replaceable>document_expression</replaceable>は演算の対象となるXML文書を提供します。
-<literal>BY REF</literal>句はPostgreSQLでは何の効果もありませんが、SQL準拠および他の実装との互換性のために受け入れられます。
-引数は整形されたXMLドキュメントでなければならず、フラグメントやフォレストは受け付けられません。
+<replaceable>document_expression</replaceable>は<replaceable>row_expression</replaceable>のためのコンテキスト項目を提供します。
+それは整形式XMLの文書でなければならず、フラグメントやフォレストは受け付けられません。
+<xref linkend="functions-xml-limits-postgresql"/>で議論されているように、<literal>BY REF</literal>句と<literal>BY VALUE</literal>句は受け付けられますが、無視されます。
+SQL標準では<function>xmltable</function>関数はXML問い合わせ言語の式を評価しますが、<xref linkend="functions-xml-limits-xpath1"/>で議論されているように<productname>PostgreSQL</productname>ではXPath 1.0式だけを受け付けます。
     </para>
 
     <para>
@@ -15149,7 +15155,7 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
      the <replaceable>row_expression</replaceable>'s result node-set.
      At most one column may be marked <literal>FOR ORDINALITY</literal>.
 -->
-<literal>FOR ORDINALITY</literal>と印がつけられた列には、元の入力XMLドキュメントの中に現れた出力行の順序に対応する行番号が入ります。
+<literal>FOR ORDINALITY</literal>と印がつけられた列には、<replaceable>row_expression</replaceable>の結果ノード集合から取得されたノードの順序に対応する1から始まる行番号が入ります。
 <literal>FOR ORDINALITY</literal>の印が付けられるのは最大でも1列です。
     </para>
 
@@ -15175,8 +15181,8 @@ XPath 1.0はノード集合内のノードの順序を指定しません。で�
      no <replaceable>column_expression</replaceable> is given, then the
      column name is used as an implicit path.
 -->
-列の<literal>column_expression</literal>はXPath式で、<replaceable>row_expression</replaceable>の結果に対応する各行について評価されて、列の値を得ます。
-<literal>column_expression</literal>が与えられなかった場合は、暗示的なパスとして列名が使用されます。
+列の<literal>column_expression</literal>はXPath 1.0式で、<replaceable>row_expression</replaceable>の結果における現在のノードをそのコンテキスト項目として<replaceable>row_expression</replaceable>の結果に対応する各行について評価されて、列の値を得ます。
+<literal>column_expression</literal>が与えられなかった場合は、暗黙的なパスとして列名が使用されます。
     </para>
 
     <para>
@@ -15251,8 +15257,8 @@ XPath 1.0の<function>string</function>関数で定義されているように�
 -->
 ある要素と、その子孫に含まれるすべてのテキストノードをドキュメントの順に結合したものがXML要素の文字列値です。
 テキストノードの子孫を持たない要素の文字列値は空文字列です。（ <literal>NULL</literal>ではありません。）
-<literal>xsi:nil</literal>属性は無視されます。
-非テキスト要素の間にある空白のみからなる<literal>text()</literal>2つのノードは保存され、<literal>text()</literal>の先頭の空白は平坦化されません。
+すべての<literal>xsi:nil</literal>属性は無視されます。
+非テキスト要素の間にある空白のみからなる<literal>text()</literal>2つのノードは保存され、<literal>text()</literal>の先頭の空白は平坦化されないことに注意してください。
 XPath 1.0 <function>string</function>関数が、他のXMLノード型と非XML値の文字列値を定義するルールのために参照されるかも知れません。
     </para>
 
@@ -15272,9 +15278,8 @@ XPath 1.0 <function>string</function>関数が、他のXMLノード型と非XML�
      a <replaceable>default_expression</replaceable> is specified; then the
      value resulting from evaluating that expression is used.
 -->
-パス式が行とマッチせず、<replaceable>default_expression</replaceable>が指定されている場合は、その式を評価した結果の値が使用されます。
-その列に<literal>DEFAULT</literal>句が指定されていない場合は、そのフィールドは<literal>NULL</literal>に設定されます。
-<replaceable>default_expression</replaceable>は列リスト内でそれより前に現れる出力列の値を参照して、ある列のデフォルト値を他の列の値に基づくものにすることができます。
+パス式がある行に対して空のノード集合（典型的にはマッチしなかった場合）を返した時は、<replaceable>default_expression</replaceable>が指定されている場合を除き、列には<literal>NULL</literal>が設定されます。
+そしてその式を評価した結果から生じる値が使用されます。
     </para>
 
     <para>
@@ -15300,11 +15305,9 @@ XPath 1.0 <function>string</function>関数が、他のXMLノード型と非XML�
      <function>nextval</function> in
      <replaceable>default_expression</replaceable>.
 -->
-PostgreSQLの通常の関数とは異なり、<replaceable>column_expression</replaceable>と<replaceable>default_expression</replaceable>は関数を呼び出す前には単純な値に評価されません。
-<replaceable>column_expression</replaceable>は通常は一つの入力行に対してちょうど一度だけ評価され、<replaceable>default_expression</replaceable>はフィールドにデフォルト値が必要になる度に評価されます。
+<function>xmltable</function>が呼び出されて直ちに評価されるのと異なり、<replaceable>default_expression</replaceable>はその列に対してデフォルトが必要になるたびに評価されます。
 式が安定（stable）または不変（immutable）とみなされる場合、評価は繰り返し行われないかもしれません。
-実際上、<function>xmltable</function>は関数呼び出しとしてよりも、副問合せのように動作します。
-これは<replaceable>default_expression</replaceable>の中で<function>nextval</function>のような揮発性（volatile）の関数を有効に使用できること、また<replaceable>column_expression</replaceable>はXML文書の他の部分に依存するかもしれないということを意味します。
+これは<replaceable>default_expression</replaceable>の中で<function>nextval</function>のような揮発性関数を使用できることを意味します。
     </para>
 
     <para>
@@ -15837,7 +15840,7 @@ SQL/JSON標準を更に学ぶためには、<xref linkend="sqltr-19075-6"/>を�
 -->
         <entry>演算子</entry>
         <entry>右オペランド型</entry>
-        <entry>Return type</entry>
+        <entry>戻り値型</entry>
         <entry>説明</entry>
         <entry>例</entry>
         <entry>例の結果</entry>

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -15107,7 +15107,7 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
      is null, nor if the <replaceable>row_expression</replaceable> produces
      an empty node-set or any value other than a node-set.
 -->
-必須の<replaceable>row_expression</replaceable>引数はXPath 1.0式で、<replaceable>document_expression</replaceable>をそのコンテキスト項目とし渡し、XMLノード集合を得るために評価されます。
+必須の<replaceable>row_expression</replaceable>引数は評価されるXPath 1.0式で、XMLノード集合を得るために<replaceable>document_expression</replaceable>をそのコンテキスト項目として渡します。
 このノードは<function>xmltable</function>が出力行に変換します。
 <replaceable>document_expression</replaceable>がNULLであるか、<replaceable>row_expression</replaceable>が空のノード集合あるいはノード集合以外の値を生成するなら行は出力されません。
     </para>
@@ -16101,7 +16101,7 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
 <!--
         <entry>Does JSON path return any item for the specified JSON value?</entry>
 -->
-        <entry>指定したJSON値に対応する要素を返すか？</entry>
+        <entry>JSONパスが指定したJSON値に対応する要素を返すか？</entry>
         <entry><literal>'{"a":[1,2,3,4,5]}'::jsonb @? '$.a[*] ? (@ > 2)'</literal></entry>
        </row>
        <row>

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -1291,10 +1291,17 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
         <indexterm>
          <primary>log10</primary>
         </indexterm>
+<!--
         <literal><function>log10(<type>dp</type> or <type>numeric</type>)</function></literal>
+-->
+        <literal><function>log10(<type>dp</type>あるいは<type>numeric</type>)</function></literal>
        </entry>
+<!--
        <entry>(same as input)</entry>
        <entry>base 10 logarithm</entry>
+-->
+       <entry>（入力型と同一）</entry>
+       <entry>10を底とした対数（常用対数）</entry>
        <entry><literal>log10(100.0)</literal></entry>
        <entry><literal>2</literal></entry>
       </row>
@@ -1633,8 +1640,9 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
    repeatable by re-issuing <function>setseed()</function> with the same
    argument.
 -->
-<literal><function>random()</function></literal>が返す値の特徴はシステムの実装に依存します。
-暗号への利用は適していません。代わりに<xref linkend="pgcrypto"/>モジュールを参照してください。
+<function>random()</function>関数は単純な線形合同法を使用しています。
+高速ですが、暗号用途には適していません。より安全な代替物として<xref linkend="pgcrypto"/>モジュールを参照してください。
+<function>setseed()</function>が呼び出されると、<function>setseed()</function>を同じ引数で実行することによって現在のセッション内での以後の<function>random()</function>の呼び出し結果は再現可能となります。
   </para>
 
   <para>
@@ -1646,7 +1654,7 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
    two variants, one that measures angles in radians and one that
    measures angles in degrees.
 -->
-最後に、使用可能な三角関数を<xref linkend="functions-math-trig-table"/>に示します。
+使用可能な三角関数を<xref linkend="functions-math-trig-table"/>に示します。
 全ての三角関数は<type>double precision</type>データ型の引数と戻り値を取ります。
 それぞれの三角関数には、角度の単位をラジアンにするものと度にするものの2種類があります。
   </para>
@@ -1846,22 +1854,35 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
   </note>
 
   <para>
+<!--
    <xref linkend="functions-math-hyp-table"/> shows the
    available hyperbolic functions.  All these functions
    take arguments and return values of type <type>double
    precision</type>.
+-->
+利用可能な双曲線関数を<xref linkend="functions-math-hyp-table"/>に示します。
+これら全ての関数は<type>double precision</type>データ型の引数と戻り値を取ります。
   </para>
 
   <table id="functions-math-hyp-table">
+<!--
     <title>Hyperbolic Functions</title>
+-->
+    <title>双曲線関数</title>
 
     <tgroup cols="4">
      <thead>
       <row>
+<!--
        <entry>Function</entry>
        <entry>Description</entry>
        <entry>Example</entry>
        <entry>Result</entry>
+-->
+       <entry>関数</entry>
+       <entry>説明</entry>
+       <entry>例</entry>
+       <entry>結果</entry>
       </row>
      </thead>
      <tbody>
@@ -1872,7 +1893,10 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
         </indexterm>
         <literal><function>sinh(<replaceable>x</replaceable>)</function></literal>
        </entry>
+<!--
        <entry>hyperbolic sine</entry>
+-->
+       <entry>双曲線正弦</entry>
        <entry><literal>sinh(0)</literal></entry>
        <entry><literal>0</literal></entry>
       </row>
@@ -1883,7 +1907,10 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
         </indexterm>
         <literal><function>cosh(<replaceable>x</replaceable>)</function></literal>
        </entry>
+<!--
        <entry>hyperbolic cosine</entry>
+-->
+       <entry>双曲線余弦</entry>
        <entry><literal>cosh(0)</literal></entry>
        <entry><literal>1</literal></entry>
       </row>
@@ -1894,7 +1921,10 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
         </indexterm>
         <literal><function>tanh(<replaceable>x</replaceable>)</function></literal>
        </entry>
+<!--
        <entry>hyperbolic tangent</entry>
+-->
+       <entry>双曲線正接</entry>
        <entry><literal>tanh(0)</literal></entry>
        <entry><literal>0</literal></entry>
       </row>
@@ -1905,7 +1935,10 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
         </indexterm>
         <literal><function>asinh(<replaceable>x</replaceable>)</function></literal>
        </entry>
+<!--
        <entry>inverse hyperbolic sine</entry>
+-->
+       <entry>逆双曲線正弦</entry>
        <entry><literal>asinh(0)</literal></entry>
        <entry><literal>0</literal></entry>
       </row>
@@ -1916,7 +1949,10 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
         </indexterm>
         <literal><function>acosh(<replaceable>x</replaceable>)</function></literal>
        </entry>
+<!--
        <entry>inverse hyperbolic cosine</entry>
+-->
+       <entry>逆双曲線余弦</entry>
        <entry><literal>acosh(1)</literal></entry>
        <entry><literal>0</literal></entry>
       </row>
@@ -1927,7 +1963,10 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
         </indexterm>
         <literal><function>atanh(<replaceable>x</replaceable>)</function></literal>
        </entry>
+<!--
        <entry>inverse hyperbolic tangent</entry>
+-->
+       <entry>双曲線正接</entry>
        <entry><literal>atanh(0)</literal></entry>
        <entry><literal>0</literal></entry>
       </row>
@@ -5210,9 +5249,13 @@ cast(-44 as bit(12))           <lineannotation>111111010100</lineannotation>
    </caution>
 
    <para>
+<!--
     The pattern matching operators of all three kinds do not support
     nondeterministic collations.  If required, apply a different collation to
     the expression to work around this limitation.
+-->
+この3種類のパターンマッチング演算子はどれも非決定的照合順序をサポートしていません。
+必要なら、この制限事項に対応するために別の照合順序を式に適用してください。
    </para>
 
   <sect2 id="functions-like">
@@ -5540,13 +5583,20 @@ SQLの正規表現は、<function>LIKE</function>表記と一般的な正規表�
     provides extraction of a substring that matches an SQL
     regular expression pattern.  The function can be written according
     to SQL99 syntax:
+-->
+3つのパラメータを持つ<function>substring</function>関数を使用して、SQL正規表現パターンに一致する部分文字列を取り出すことができます。
+SQL99の構文にしたがって、この関数は次のように書くことができます。
 <synopsis>
 substring(<replaceable>string</replaceable> from <replaceable>pattern</replaceable> for <replaceable>escape-character</replaceable>)
 </synopsis>
+<!--
     or as a plain three-argument function:
+-->
+あるいは単なる3引数関数として次のように書くこともできます。
 <synopsis>
 substring(<replaceable>string</replaceable>, <replaceable>pattern</replaceable>, <replaceable>escape-character</replaceable>)
 </synopsis>
+<!--
     As with <literal>SIMILAR TO</literal>, the
     specified pattern must match the entire data string, or else the
     function fails and returns null.  To indicate the part of the
@@ -5557,12 +5607,13 @@ substring(<replaceable>string</replaceable>, <replaceable>pattern</replaceable>,
     The text matching the portion of the pattern
     between these separators is returned when the match is successful.
 -->
-3つのパラメータを持つ<function>substring</function>関数、<function>substring(<parameter>string</parameter> from <replaceable>pattern</replaceable> for <replaceable>escape-character</replaceable>)</function>を使用して、SQL正規表現パターンに一致する部分文字列を取り出すことができます。
-<literal>SIMILAR TO</literal>と同様、指定したパターンがデータ文字列全体に一致する必要があります。一致しない場合、関数は終了し、NULLを返します。一致した場合に返されるべきパターンの一部を示すために、エスケープ文字の後に二重引用符（<literal>"</literal>）を繋げたものを2つパターンに含める必要があります。<!-- " font-lock sanity -->
+<literal>SIMILAR TO</literal>と同様、指定したパターンがデータ文字列全体に一致する必要があります。一致しない場合、関数は失敗し、NULLを返します。
+マッチするデータのうちの対象とする部分文字列に対応するパターンの部分を示すために、エスケープ文字の後に二重引用符（<literal>"</literal>）を繋げたものを2つパターンに含める必要があります。<!-- " font-lock sanity -->
 これらの印で括られたパターンの一部に一致するテキストが返されます。
    </para>
 
    <para>
+<!--
     The escape-double-quote separators actually
     divide <function>substring</function>'s pattern into three independent
     regular expressions; for example, a vertical bar (<literal>|</literal>)
@@ -5572,13 +5623,22 @@ substring(<replaceable>string</replaceable>, <replaceable>pattern</replaceable>,
     about how much of the data string matches which pattern.  (In POSIX
     parlance, the first and third regular expressions are forced to be
     non-greedy.)
+-->
+エスケープ文字と二重引用符による区切りは実際には<function>substring</function>のパターン引数を3つの独立した正規表現に分割します。
+たとえば3つのセクションのどこかに置いた垂直線（<literal>|</literal>）はそのセクションにしか影響を及ぼしません。
+また、どのパターンにデータ文字列がマッチするかについて曖昧さがある場合は、最初と3番目の正規表現は、可能な最大のテキストではなく、最小のテキストにマッチするものとして定義されます。
+（POSIX用語では、最初と3番目の正規表現は非貪欲（non-greedy）に強制されます。）
    </para>
 
    <para>
+<!--
     As an extension to the SQL standard, <productname>PostgreSQL</productname>
     allows there to be just one escape-double-quote separator, in which case
     the third regular expression is taken as empty; or no separators, in which
     case the first and third regular expressions are taken as empty.
+-->
+SQL標準への拡張として、<productname>PostgreSQL</productname>は、二重引用符による区切りが一個だけ存在することを許容し、その場合は3番目の正規表現が空として扱われます。
+あるいは、二重引用符による区切りがないことも許容し、その場合は最初と3番目の正規表現は空として扱われます。
    </para>
 
    <para>
@@ -6714,10 +6774,14 @@ REはバックスラッシュ<literal>\</literal>を終端とすることはで�
     the 7-bit ASCII set.
 -->
 ブラケット式内では、<literal>[:</literal>と<literal>:]</literal>の間にある文字クラスの名称は、そのクラスに属する全ての文字のリストを意味します。
-標準文字クラス名は、<literal>alnum</literal>、<literal>alpha</literal>、<literal>blank</literal>、<literal>cntrl</literal>、<literal>digit</literal>、<literal>graph</literal>、<literal>lower</literal>、<literal>print</literal>、<literal>punct</literal>、<literal>space</literal>、<literal>upper</literal>、<literal>xdigit</literal>です。
-これらは<citerefentry><refentrytitle>ctype</refentrytitle><manvolnum>3</manvolnum></citerefentry>で定義された文字クラスを意味します。
-ロケールは別のものを提供可能です。
-文字クラスは範囲の終端では使用することができません。
+文字クラスは範囲の終端位置としては使用できません。
+<acronym>POSIX</acronym>標準は以下の文字クラス名を定義しています。
+<literal>alnum</literal>（文字と数字）、<literal>alpha</literal>（文字）、<literal>blank</literal>（空白とタブ）、<literal>cntrl</literal>（制御文字）、<literal>digit</literal>（数字）、<literal>graph</literal>（空白以外の印字可能文字）、<literal>lower</literal>（小文字）、<literal>print</literal>（空白を含む印字可能文字）、<literal>punct</literal>（句読点）、<literal>space</literal>（空白）、<literal>upper</literal>（大文字）、<literal>xdigit</literal>（16進数）です。
+これらの標準文字クラスの振る舞いは7-bit ASCII集合の範囲であれば一般にどのプラットフォームでも同じです。
+与えられた非ASCII文字がこれらの文字クラスに属すると考えられるかどうかは、正規表現関数または演算子（<xref linkend="collation"/>参照）で使用される<firstterm>照合順</firstterm>、あるいはデフォルトとしてはデータベースの<envar>LC_CTYPE</envar>ロケール（<xref linkend="locale"/>)の設定によります。
+非ASCII文字の分類は、たとえ似たような名前のロケールであってもプラットフォームによって異なることがありえます。
+（ただし<literal>C</literal>ロケールでは、すべての非ASCII文字はこれらのクラスのどれにも所属しないものとされます。）
+これらの標準クラスに加え、<productname>PostgreSQL</productname>では7-bit ASCII集合を正確に含む<literal>ascii</literal>文字クラスが定義されています。
    </para>
 
    <para>
@@ -6738,7 +6802,7 @@ REはバックスラッシュ<literal>\</literal>を終端とすることはで�
 -->
 ブラケット式には2つの特殊な場合があります。<literal>[[:&lt;:]]</literal>と<literal>[[:&gt;:]]</literal>というブラケット式は、先頭と終端の単語がそれぞれ空文字であることにマッチする制約です。
 単語は、単語文字が前後に付かない単語文字の並びとして定義されます。
-単語文字とは（<citerefentry><refentrytitle>ctype</refentrytitle><manvolnum>3</manvolnum></citerefentry>で定義されている）1つの<literal>alnum</literal>文字またはアンダースコアです。
+単語文字とは（上述の<acronym>POSIX</acronym>文字クラスで定義されているように）1つの<literal>alnum</literal>文字またはアンダースコアです。
 これは、<acronym>POSIX</acronym> 1003.2との互換性はありますが、そこでは定義されていない式です。ですので、他システムへ移植予定のソフトウェアでの使用には注意が必要です。
 通常後述の制約エスケープの方がよく使われます。これはもはや標準ではありませんが、入力しやすいものです。
    </para>
@@ -7937,17 +8001,24 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
 <!-- end re_syntax.n man page -->
 
    <sect3 id="posix-vs-xquery">
+<!--
    <title>Differences From XQuery (<literal>LIKE_REGEX</literal>)</title>
+-->
+   <title>XQueryとの違い(<literal>LIKE_REGEX</literal>)</title>
 
    <indexterm zone="posix-vs-xquery">
     <primary><literal>LIKE_REGEX</literal></primary>
    </indexterm>
 
    <indexterm zone="posix-vs-xquery">
+<!--
     <primary>XQuery regular expressions</primary>
+-->
+    <primary>XQuery正規表現</primary>
    </indexterm>
 
     <para>
+<!--
      Since SQL:2008, the SQL standard includes
      a <literal>LIKE_REGEX</literal> operator that performs pattern
      matching according to the XQuery regular expression
@@ -7955,36 +8026,54 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
      implement this operator, but you can get very similar behavior using
      the <function>regexp_match()</function> function, since XQuery
      regular expressions are quite close to the ARE syntax described above.
+-->
+SQL:2008以降、SQL標準にはXQuery正規表現標準によるパターンマッチングを行う<literal>LIKE_REGEX</literal>演算子が含まれています。
+<productname>PostgreSQL</productname>は今の所この演算子を実装していませんが、<function>regexp_match()</function>を使ってよく似た振る舞いを得ることができます。
+XQueryの正規表現は上で述べたARE構文に非常に近いからです。
     </para>
 
     <para>
+<!--
      Notable differences between the existing POSIX-based
      regular-expression feature and XQuery regular expressions include:
+-->
+既存のPOSIXベースの正規表現機能とXQueryの正規表現の主な違いには以下のものが含まれます。
 
      <itemizedlist>
       <listitem>
        <para>
+<!--
         XQuery character class subtraction is not supported.  An example of
         this feature is using the following to match only English
         consonants: <literal>[a-z-[aeiou]]</literal>.
+-->
+XQueryの文字クラス減算はサポートされていません。
+この機能の例としては、<literal>[a-z-[aeiou]]</literal>のようにして英語の子音のみにマッチさせるというのがあります。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         XQuery character class shorthands <literal>\c</literal>,
         <literal>\C</literal>, <literal>\i</literal>,
         and <literal>\I</literal> are not supported.
+-->
+XQueryの文字クラス短縮形<literal>\c</literal>、<literal>\C</literal>、<literal>\i</literal>、<literal>\I</literal>はサポートされていません。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         XQuery character class elements
         using <literal>\p{UnicodeProperty}</literal> or the
         inverse <literal>\P{UnicodeProperty}</literal> are not supported.
+-->
+<literal>\p{UnicodeProperty}</literal>あるいはその逆である<literal>\P{UnicodeProperty}</literal>を使ったXQueryの文字クラス要素はサポートされていません。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         POSIX interprets character classes such as <literal>\w</literal>
         (see <xref linkend="posix-class-shorthand-escapes-table"/>)
         according to the prevailing locale (which you can control by
@@ -7992,60 +8081,87 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
         function).  XQuery specifies these classes by reference to Unicode
         character properties, so equivalent behavior is obtained only with
         a locale that follows the Unicode rules.
+-->
+POSIXは有効なロケール（演算子あるいは関数の<literal>COLLATE</literal>節で制御できます）にしたがい、<literal>\w</literal>（<xref linkend="posix-class-shorthand-escapes-table"/>参照）のような文字クラスを解釈します。
+XQueryはこれらのクラスをUnicodeの文字属性を参照してこれらのクラスを決定します。
+ですからUnicodeルールに従うロケールを使用してのみ同等の振る舞いを得ることができます。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         The SQL standard (not XQuery itself) attempts to cater for more
         variants of <quote>newline</quote> than POSIX does.  The
         newline-sensitive matching options described above consider only
         ASCII NL (<literal>\n</literal>) to be a newline, but SQL would have
-        us treat CR (<literal>\r</literal>), CRLF (<literal>\r\n</literal>)
+        us treat CR (<literal>\r</literal>)、CRLF (<literal>\r\n</literal>)
         (a Windows-style newline), and some Unicode-only characters like
         LINE SEPARATOR (U+2028) as newlines as well.
         Notably, <literal>.</literal> and <literal>\s</literal> should
         count <literal>\r\n</literal> as one character not two according to
         SQL.
+-->
+SQL標準（XQuery自身ではなく）はPOSIXが提供するより多様な<quote>newline</quote>の亜種を提供しようとしています。
+上で述べた改行に敏感なマッチオプションはASCII NL（<literal>\n</literal>）だけを改行として考慮します。
+しかしSQLはCR （<literal>\r</literal>）、CRLF （<literal>\r\n</literal>）(Windowsスタイルの改行）、LINE SEPARATOR (U+2028)のようなUnicodeのみの文字も改行として扱うことを求めています。
+とりわけ、SQLにおいては、<literal>.</literal>と<literal>\s</literal>は<literal>\r\n</literal>を2文字ではなく、1文字として数える必要があります。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         Of the character-entry escapes described in
         <xref linkend="posix-character-entry-escapes-table"/>,
         XQuery supports only <literal>\n</literal>, <literal>\r</literal>,
         and <literal>\t</literal>.
+-->
+<xref linkend="posix-character-entry-escapes-table"/>で示す文字エントリエスケープのうち、XQueryは<literal>\n</literal>、<literal>\r</literal>、<literal>\t</literal>だけをサポートしています。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         XQuery does not support
         the <literal>[:<replaceable>name</replaceable>:]</literal> syntax
         for character classes within bracket expressions.
+-->
+XQueryはブラケット式内の文字クラスとして<literal>[:<replaceable>name</replaceable>:]</literal>構文をサポートしていません。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         XQuery does not have lookahead or lookbehind constraints,
         nor any of the constraint escapes described in
         <xref linkend="posix-constraint-escapes-table"/>.
+-->
+XQueryには先行検索制約および後方検索制約がありませんし、<xref linkend="posix-constraint-escapes-table"/>に記述された制約エスケープもありません。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         The metasyntax forms described in <xref linkend="posix-metasyntax"/>
         do not exist in XQuery.
+-->
+<xref linkend="posix-metasyntax"/>に記述されたメタ構文形式はXQueryには存在しません。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         The regular expression flag letters defined by XQuery are
         related to but not the same as the option letters for POSIX
         (<xref linkend="posix-embedded-options-table"/>).  While the
         <literal>i</literal> and <literal>q</literal> options behave the
         same, others do not:
+-->
+XQueryで定義された正規表現フラグ文字はPOSIX（<xref linkend="posix-embedded-options-table"/>）のオプション文字に関連していますが、同じではありません。
+<literal>i</literal>と<literal>q</literal>オプションは同じように振る舞いますが、その他は違います。
         <itemizedlist>
          <listitem>
           <para>
+<!--
            XQuery's <literal>s</literal> (allow dot to match newline)
            and <literal>m</literal> (allow <literal>^</literal>
            and <literal>$</literal> to match at newlines) flags provide
@@ -8056,16 +8172,24 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
            POSIX's <literal>s</literal> and <literal>m</literal> flags.
            Note in particular that dot-matches-newline is the default
            behavior in POSIX but not XQuery.
+-->
+XQueryの<literal>s</literal>（ピリオドが改行にマッチすることを許容する）と<literal>m</literal>（<literal>^</literal>と<literal>$</literal>が改行位置でマッチすることを許容する）フラグは、POSIXの<literal>n</literal>、<literal>p</literal>、<literal>w</literal>フラグと同じ挙動を提供しますが、POSIXの<literal>s</literal>と<literal>m</literal>フラグの挙動とは一致<emphasis>しません</emphasis>。
+ピリオドが改行にマッチするのはPOSIXではデフォルトの挙動ですが、XQueryではそうでないことに留意してください。
           </para>
          </listitem>
          <listitem>
           <para>
+<!--
            XQuery's <literal>x</literal> (ignore whitespace in pattern) flag
            is noticeably different from POSIX's expanded-mode flag.
            POSIX's <literal>x</literal> flag also
            allows <literal>#</literal> to begin a comment in the pattern,
            and POSIX will not ignore a whitespace character after a
            backslash.
+-->
+XQueryの<literal>x</literal>（パターン中の空白を無視する）フラグはPOSIXの拡張モードフラグとは著しく異なります。
+POSIXの<literal>x</literal>フラグは<literal>#</literal>でパターン中のコメントを始めることもできます。
+POSIXはバックスラッシュ以降の空白文字を無視しません。
           </para>
          </listitem>
         </itemizedlist>
@@ -8843,15 +8967,16 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
        <literal>FX</literal> must be specified as the first item in
        the template.
 -->
-<literal>FX</literal>オプションが使用されていない場合、<function>to_timestamp</function>と<function>to_date</function>は入力文字列内の複数の空白スペースを無視します。
-例えば、<literal>to_timestamp('2000&nbsp;&nbsp;&nbsp;&nbsp;JUN', 'YYYY MON')</literal>は動作しますが、<literal>to_timestamp('2000&nbsp;&nbsp;&nbsp;&nbsp;JUN','FXYYYY MON')</literal>はエラーを返します。
-後者の<function>to_timestamp</function>はスペースが1つだけあることを期待するからです。
+<literal>FX</literal>オプションが使用されていない場合、<function>to_timestamp</function>と<function>to_date</function>は入力文字列内のはじまり、そして最初と日付と時間の値の周辺の複数の空白スペースを無視します。
+例えば、<literal>to_timestamp('2000&nbsp;&nbsp;&nbsp;&nbsp;JUN', 'YYYY MON')</literal>と<literal>to_timestamp('2000 - JUN', 'YYYY-MON')</literal>は動作しますが、<literal>to_timestamp('2000&nbsp;&nbsp;&nbsp;&nbsp;JUN','FXYYYY MON')</literal>はエラーを返します。
+後者の<function>to_timestamp</function>は単一のスペースだけがあることを期待するからです。
 <literal>FX</literal>はテンプレートの第1項目として指定される必要があります。
       </para>
      </listitem>
 
      <listitem>
       <para>
+<!--
        A separator (a space or non-letter/non-digit character) in the template string of
        <function>to_timestamp</function> and <function>to_date</function>
        matches any single separator in the input string or is skipped,
@@ -8861,8 +8986,12 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
        <literal>to_timestamp('2000//JUN', 'YYYY/MON')</literal>
        returns an error because the number of separators in the input string
        exceeds the number of separators in the template.
+-->
+<function>to_timestamp</function>と<function>to_date</function>のテンプレート文字列中の区切り文字（空白あるいは記号文字(訳注：原文は"non-letter/non-digit character"））は入力文字中のすべての単一の区切り文字とマッチし、<literal>FX</literal>オプションが使用されている場合はスキップします。
+たとえば、<literal>to_timestamp('2000JUN', 'YYYY///MON')</literal>と<literal>to_timestamp('2000/JUN', 'YYYY MON')</literal>は動作しますが、<literal>to_timestamp('2000//JUN', 'YYYY/MON')</literal>は入力文字列中の区切り文字の数がテンプレート中の区切り文字の数を上回っているため、エラーを返します。
       </para>
       <para>
+<!--
        If <literal>FX</literal> is specified, a separator in the template string
        matches exactly one character in the input string.  But note that the
        input string character is not required to be the same as the separator from the template string.
@@ -8870,11 +8999,16 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
        works, but <literal>to_timestamp('2000/JUN', 'FXYYYY&nbsp;&nbsp;MON')</literal>
        returns an error because the second space in the template string consumes
        the letter <literal>J</literal> from the input string.
+-->
+<literal>FX</literal>が指定されていると、テンプレート文字列中の区切り文字は正確に入力文字列中の一文字とマッチします。
+しかし、入力文字列の文字はテンプレート文字列中の区切り文字と一致する必要はないことに注意してください。
+たとえば、<literal>to_timestamp('2000/JUN', 'FXYYYY MON')</literal>は動作しますが、<literal>to_timestamp('2000/JUN', 'FXYYYY&nbsp;&nbsp;MON')</literal>はテンプレート文字列中の二番目の空白が入力文字列中の文字<literal>J</literal>を消費するため、エラーを返します。
       </para>
      </listitem>
 
      <listitem>
       <para>
+<!--
        A <literal>TZH</literal> template pattern can match a signed number.
        Without the <literal>FX</literal> option, minus signs may be ambiguous,
        and could be interpreted as a separator.
@@ -8887,6 +9021,12 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
        <literal>-10</literal> to <literal>TZH</literal>, but
        <literal>to_timestamp('2000 -10', 'YYYY&nbsp;&nbsp;TZH')</literal>
        matches <literal>10</literal> to <literal>TZH</literal>.
+-->
+<literal>TZH</literal>テンプレートパターンは符号付きの数字とマッチします。
+<literal>FX</literal>オプションが無い場合、マイナス符号は曖昧で、区切り文字として解釈されるかも知れません。
+この曖昧さは次のようにして解消されます。
+テンプレート文字列中の<literal>TZH</literal>の前の区切り文字の数が入力文字列中のマイナス符号の前の区切り文字の数よりも少なければ、そのマイナス符号は<literal>TZH</literal>の一部として解釈されます。
+たとえば、<literal>to_timestamp('2000 -10', 'YYYY TZH')</literal>では<literal>-10</literal>が<literal>TZH</literal>にマッチしますが、<literal>to_timestamp('2000 -10', 'YYYY&nbsp;&nbsp;TZH')</literal>では<literal>10</literal>が<literal>TZH</literal>にマッチします。
       </para>
      </listitem>
 
@@ -8913,6 +9053,7 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
       </para>
       <tip>
         <para>
+<!--
           Prior to <productname>PostgreSQL</productname> 12, it was possible to
           skip arbitrary text in the input string using non-letter or non-digit
           characters. For example,
@@ -8922,6 +9063,11 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
           <literal>to_timestamp('2000y6m1d', 'yyyy"y"MM"m"DD"d"')</literal>
           skip <literal>y</literal>, <literal>m</literal>, and
           <literal>d</literal>.
+-->
+<productname>PostgreSQL</productname> 12より前では、記号文字（訳注：原文は"non-letter or non-digit）を使って入力文字列中の任意のテキストをスキップすることが可能でした。
+たとえば、<literal>to_timestamp('2000y6m1d', 'yyyy-MM-DD')</literal>は動作しました。
+現在は、この目的のために非記号文字（訳注：原文は"letter characters"）だけを使うことができます。
+たとえば、<literal>to_timestamp('2000y6m1d', 'yyyytMMtDDt')</literal>と<literal>to_timestamp('2000y6m1d', 'yyyy"y"MM"m"DD"d"')</literal>は、<literal>y</literal>、<literal>m</literal>、<literal>d</literal>をスキップします。
         </para>
       </tip>
      </listitem>
@@ -10030,7 +10176,7 @@ ISO 8601週番号年の文脈では、<quote>月</quote>、あるいは<quote>�
 <!--
         <entry>Truncate to specified precision; see <xref linkend="functions-datetime-trunc"/>
 -->
-        <entry>指定された精度で切り捨て。<xref linkend="functions-datetime-trunc"/>も参照。
+        <entry>指定された精度で切り捨て。<xref linkend="functions-datetime-trunc"/>参照。
         </entry>
         <entry><literal>date_trunc('hour', timestamp '2001-02-16 20:38:40')</literal></entry>
         <entry><literal>2001-02-16 20:00:00</literal></entry>
@@ -10039,7 +10185,10 @@ ISO 8601週番号年の文脈では、<quote>月</quote>、あるいは<quote>�
        <row>
         <entry><literal><function>date_trunc(<type>text</type>, <type>timestamp with time zone</type>, <type>text</type>)</function></literal></entry>
         <entry><type>timestamp with time zone</type></entry>
+<!--
         <entry>Truncate to specified precision in the specified time zone; see <xref linkend="functions-datetime-trunc"/>
+-->
+        <entry>指定された時間帯において指定された精度で切り捨て。<xref linkend="functions-datetime-trunc"/>参照
         </entry>
         <entry><literal>date_trunc('day', timestamptz '2001-02-16 20:38:40+00', 'Australia/Sydney')</literal></entry>
         <entry><literal>2001-02-16 13:00:00+00</literal></entry>
@@ -10051,7 +10200,7 @@ ISO 8601週番号年の文脈では、<quote>月</quote>、あるいは<quote>�
 <!--
         <entry>Truncate to specified precision; see <xref linkend="functions-datetime-trunc"/>
 -->
-        <entry>指定された精度で切り捨て。<xref linkend="functions-datetime-trunc"/>も参照。
+        <entry>指定された精度で切り捨て。<xref linkend="functions-datetime-trunc"/>参照。
         </entry>
         <entry><literal>date_trunc('hour', interval '2 days 3 hours 40 minutes')</literal></entry>
         <entry><literal>2 days 03:00:00</literal></entry>
@@ -11184,10 +11333,10 @@ date_trunc(<replaceable>field</replaceable>, <replaceable>source</replaceable> [
     and it has all fields that are less significant than the
     selected one set to zero (or one, for day and month).
 -->
-<replaceable>source</replaceable>は、データ型<type>timestamp</type>もしくは<type>interval</type>の評価式です
+<replaceable>source</replaceable>は、データ型<type>timestamp</type>、<type>timestamp with time zone</type>もしくは<type>interval</type>の評価式です
 （<type>date</type>型と<type>time</type>型の値はそれぞれ自動的に<type>timestamp</type>もしくは<type>interval</type>にキャストされます。）
 <replaceable>field</replaceable>は、入力値の値をどの精度で切り捨てるかを選択します。
-戻り値は<type>timestamp</type>もしくは<type>interval</type>型で、指定した精度より下のすべてのフィールドがゼロに設定（日と月については1に設定）されます。
+同様に戻り値は<type>timestamp</type>、<type>timestamp with time zone</type>もしくは<type>interval</type>型で、指定した精度より下のすべてのフィールドがゼロに設定（日と月については1に設定）されます。
    </para>
 
    <para>
@@ -11213,6 +11362,7 @@ date_trunc(<replaceable>field</replaceable>, <replaceable>source</replaceable> [
    </para>
 
    <para>
+<!--
     When the input value is of type <type>timestamp with time zone</type>,
     the truncation is performed with respect to a particular time zone;
     for example, truncation to <literal>day</literal> produces a value that
@@ -11221,12 +11371,20 @@ date_trunc(<replaceable>field</replaceable>, <replaceable>source</replaceable> [
     optional <replaceable>time_zone</replaceable> argument can be provided
     to specify a different time zone.  The time zone name can be specified
     in any of the ways described in <xref linkend="datatype-timezones"/>.
+-->
+入力値が<type>timestamp with time zone</type>型の値なら、特定の時間帯を考慮して切り捨てが行われます。たとえば、<literal>日</literal>を切り捨てると値はその時間帯での真夜中になります。
+デフォルトでは切り捨ては現在の<xref linkend="guc-timezone"/>の設定に従いますが、別の時間帯を指定することができるようにオプションの<replaceable>time_zone</replaceable>引数が提供されています。
+時間帯名は<xref linkend="datatype-timezones"/>に記述されている方法で指定できます。
    </para>
 
    <para>
+<!--
     A time zone cannot be specified when processing <type>timestamp without
     time zone</type> or <type>interval</type> inputs.  These are always
     taken at face value.
+-->
+<type>timestamp without time zone</type>あるいは<type>interval</type>の入力を処理している間は時間帯は指定できません。
+これらは額面通りの値で扱われます。
    </para>
 
    <para>
@@ -14047,9 +14205,12 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
   </para>
 
   <para>
+<!--
    Use of most of these functions
    requires <productname>PostgreSQL</productname> to have been built
    with <command>configure &#045;&#045;with-libxml</command>.
+-->
+これらの関数の大半は<productname>PostgreSQL</productname>が<command>configure &#045;&#045;with-libxml</command>でビルドされていることを必要としています。
   </para>
 
   <sect2 id="functions-producing-xml">
@@ -14647,9 +14808,8 @@ SELECT xmlexists('//town[text() = ''Toronto'']' PASSING BY VALUE '<towns><town>T
      expression, as discussed in
      <xref linkend="functions-xml-limits-xpath1"/>.
 -->
-<literal>BY REF</literal>句は、PostgreSQLには何の影響も与えませんが、他の実装とのSQL互換性や順応性のため、付与することができます。
-SQL標準では1つ目の<literal>BY REF</literal>を必要としており、2つ目はオプショナルです。
-加えてSQL標準では<function>xmlexists</function>はXQuery式を第一引数として取る構成としていますが、PostgreSQLでは現在XQueryのサブセットにあたるXPathのみサポートしていることに注意してください。
+<productname>PostgreSQL</productname>は<literal>BY REF</literal>句と<literal>BY VALUE</literal>句を受け付けますが、<xref linkend="functions-xml-limits-postgresql"/>で議論されているように無視します。
+SQL標準では<function>xmlexists</function>関数はXML問い合わせ言語における式を評価しますが、<xref linkend="functions-xml-limits-xpath1"/>で議論されているように、<productname>PostgreSQL</productname>はXPath 1.0の式だけを受け付けます。
     </para>
    </sect3>
 
@@ -14995,10 +15155,14 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
 
     <note>
      <para>
+<!--
       XPath 1.0 does not specify an order for nodes in a node-set, so code
       that relies on a particular order of the results will be
       implementation-dependent.  Details can be found in
       <xref linkend="xml-xpath-1-specifics"/>.
+-->
+XPath 1.0はノード集合内のノードの順序を指定しません。ですから、結果が特定の順序になっていることに依存するコードは実装依存となります。
+詳細は<xref linkend="xml-xpath-1-specifics"/>をご覧ください。
      </para>
     </note>
 
@@ -15026,18 +15190,21 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
      column's type category is numeric, otherwise <literal>true</literal> or
      <literal>false</literal>.)
 -->
-列のXPath式が複数の要素を戻した場合、エラーが発生します。
-式が空のタグとマッチした場合、結果は空文字列となります（<literal>NULL</literal>ではありません）。
-<literal>xsi:nil</literal>の属性はすべて無視されます。
+列のXPath式が非XML値（XPath 1.0における文字列、真偽値、倍精度浮動小数点数に限られます）を返し、その列が<type>xml</type>以外のPostgreSQL型なら、あたかも値の文字列表現をPostgreSQL型にアサインしたように列に値がセットされます。
+（値が真偽値の場合、出力列型が数値カテゴリに属するならその文字列表現は<literal>1</literal>または<literal>0</literal>になり、それ外なら<literal>true</literal>または<literal>false</literal>になります。）
     </para>
 
     <para>
+<!--
      If a column's XPath expression returns a non-empty set of XML nodes
      and the column's PostgreSQL type is <type>xml</type>, the column will
      be assigned the expression result exactly, if it is of document or
      content form.
+-->
+列のXPath表現が空ではないXMLノードの集合を返し、列のPostgreSQL型が<type>xml</type>である場合には、式が文書あるいはフォームの内容なら、列には正確に式の結果がアサインされます。
      <footnote>
       <para>
+<!--
        A result containing more than one element node at the top level, or
        non-whitespace text outside of an element, is an example of content form.
        An XPath result can be of neither form, for example if it returns an
@@ -15045,11 +15212,17 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
        will be put into content form with each such disallowed node replaced by
        its string value, as defined for the XPath 1.0
        <function>string</function> function.
+-->
+トップレベルにおいて複数の要素ノードを含むか、あるいは要素の外側の非空白テキストであるような結果は、コンテントフォームの例です。
+XPathの結果はそのどちらでもないフォームであることがあり得ます。
+たとえば、それを含む要素から選択された属性ノードを返す場合です。
+XPath 1.0の<function>string</function>関数で定義されているように、そうした結果は、許可されないノードを文字列値で置き換えたコンテントフォームに設定されます。
       </para>
      </footnote>
     </para>
 
     <para>
+<!--
      A non-XML result assigned to an <type>xml</type> output column produces
      content, a single text node with the string value of the result.
      An XML result assigned to a column of any other type may not have more than
@@ -15057,6 +15230,10 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
      will be set as if by assigning the node's string
      value (as defined for the XPath 1.0 <function>string</function> function)
      to the PostgreSQL type.
+-->
+<type>xml</type>出力列にアサインされた非XMLの結果は、結果の値が文字列値となる単一のテキストノードであるコンテントを生成します。
+それ以外の型の列にアサインされたXMLの結果は複数のノードを持たないかも知れませんし、エラーを生じするかも知れません。
+正確に一つのノードだけが存在するなら、列にはあたかもノードの文字列値（XPath 1.0 <function>string</function>関数の定義されているように） がPostgreSQL型にアサインされたように設定されます。
     </para>
 
     <para>
@@ -15072,15 +15249,19 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
      The XPath 1.0 <function>string</function> function may be consulted for the
      rules defining the string value of other XML node types and non-XML values.
 -->
-<replaceable>column_expression</replaceable>にマッチしたXMLのテキスト本体が列の値として使用されます。
-要素内の複数の<literal>text()</literal>ノードは順番に結合されます。
-子要素、処理命令、コメントはすべて無視されますが、子要素のテキストコンテンツは結果に結合されます。
-2つの非テキスト要素間にある空白文字のみの<literal>text()</literal>ノードは保存されること、また<literal>text()</literal>ノードの先頭にある空白文字は削られないことに注意してください。
+ある要素と、その子孫に含まれるすべてのテキストノードをドキュメントの順に結合したものがXML要素の文字列値です。
+テキストノードの子孫を持たない要素の文字列値は空文字列です。（ <literal>NULL</literal>ではありません。）
+<literal>xsi:nil</literal>属性は無視されます。
+非テキスト要素の間にある空白のみからなる<literal>text()</literal>2つのノードは保存され、<literal>text()</literal>の先頭の空白は平坦化されません。
+XPath 1.0 <function>string</function>関数が、他のXMLノード型と非XML値の文字列値を定義するルールのために参照されるかも知れません。
     </para>
 
     <para>
+<!--
      The conversion rules presented here are not exactly those of the SQL
      standard, as discussed in <xref linkend="functions-xml-limits-casts"/>.
+-->
+ここで示した変換ルールは、<xref linkend="functions-xml-limits-casts"/>で議論されているように、正確にSQL標準に従っているわけではありません。
     </para>
 
     <para>
@@ -15587,31 +15768,47 @@ table2-mapping
   </indexterm>
 
   <para>
+<!--
    This section describes:
+-->
+この節では次のことを説明します。
 
    <itemizedlist>
     <listitem>
      <para>
+<!--
       functions and operators for processing and creating JSON data
+-->
+JSONデータを処理、生成する関数と演算子
      </para>
     </listitem>
     <listitem>
      <para>
+<!--
       the SQL/JSON path language
+-->
+SQL/JSONパス関数言語
      </para>
     </listitem>
    </itemizedlist>
   </para>
 
   <para>
+<!--
    To learn more about the SQL/JSON standard, see
    <xref linkend="sqltr-19075-6"/>. For details on JSON types
    supported in <productname>PostgreSQL</productname>,
    see <xref linkend="datatype-json"/>.
+-->
+SQL/JSON標準を更に学ぶためには、<xref linkend="sqltr-19075-6"/>をご覧ください。
+<productname>PostgreSQL</productname>でサポートされているJSON型の詳細に関しては、<xref linkend="datatype-json"/>をご覧ください。
   </para>
 
   <sect2 id="functions-json-processing">
+<!--
    <title>Processing and Creating JSON Data</title>
+-->
+   <title>JSONデータの処理と生成</title>
 
   <para>
 <!--
@@ -15619,7 +15816,7 @@ table2-mapping
    are available for use with JSON data types (see <xref
    linkend="datatype-json"/>).
 -->
-<xref linkend="functions-json-op-table"/>に2つのJSONデータ型(<xref linkend="datatype-json"/>を参照)で使用可能な演算子を示します。
+<xref linkend="functions-json-op-table"/>にJSONデータ型(<xref linkend="datatype-json"/>を参照)で使用可能な演算子を示します。
   </para>
 
   <table id="functions-json-op-table">
@@ -15898,15 +16095,23 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
        <row>
         <entry><literal>@?</literal></entry>
         <entry><type>jsonpath</type></entry>
+<!--
         <entry>Does JSON path return any item for the specified JSON value?</entry>
+-->
+        <entry>JSONパスが指定したJSON値のすべての要素を返すか？</entry>
         <entry><literal>'{"a":[1,2,3,4,5]}'::jsonb @? '$.a[*] ? (@ > 2)'</literal></entry>
        </row>
        <row>
         <entry><literal>@@</literal></entry>
         <entry><type>jsonpath</type></entry>
+<!--
         <entry>Returns the result of JSON path predicate check for the specified JSON value.
         Only the first item of the result is taken into account.  If the
         result is not Boolean, then <literal>null</literal> is returned.</entry>
+-->
+        <entry>指定したJSON値のJSONパス述語チェックの結果を返す。
+        結果の最初の項目だけが考慮されます。
+        結果がBooleanでないなら、<literal>null</literal>が返ります。</entry>
         <entry><literal>'{"a":[1,2,3,4,5]}'::jsonb @@ '$.a[*] > 2'</literal></entry>
        </row>
       </tbody>
@@ -15929,11 +16134,16 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
 
   <note>
    <para>
+<!--
     The <literal>@?</literal> and <literal>@@</literal> operators suppress
     the following errors: lacking object field or array element, unexpected
     JSON item type, and numeric errors.
     This behavior might be helpful while searching over JSON document
     collections of varying structure.
+-->
+<literal>@?</literal>および<literal>@@</literal>演算子は以下のエラーを抑止します。
+オブジェクトフィールドあるいは配列要素の欠如、期待しないJSON要素型、数値エラー。
+この振る舞いは、異なる構造のJSON文書集合を検索する際に役に立つかも知れません。
    </para>
   </note>
 
@@ -16680,8 +16890,11 @@ pathについての演算子について言うと、<replaceable>new_value</repl
         </entry>
         <entry><type>boolean</type></entry>
         <entry>
+<!--
           Checks whether JSON path returns any item for the specified JSON
           value.
+-->
+指定したJSON値に対してJSONパスがすべての項目を返すかどうかをチェックする。
         </entry>
         <entry>
          <para><literal>
@@ -16700,10 +16913,16 @@ pathについての演算子について言うと、<replaceable>new_value</repl
         </entry>
         <entry><type>boolean</type></entry>
         <entry>
+<!--
           Returns the result of JSON path predicate check for the specified JSON value.
           Only the first item of the result is taken into account.  If the
           result is not Boolean, then <literal>null</literal> is returned.
+-->
+        指定したJSON値のJSONパス述語チェックの結果を返す。
+        結果の最初の項目だけが考慮されます。
+        結果がBooleanでないなら、<literal>null</literal>が返ります。
         </entry>
+        <entry><literal>'{"a":[1,2,3,4,5]}'::jsonb @@ '$.a[*] > 2'</literal></entry>
         <entry>
          <para><literal>
            jsonb_path_match('{"a":[1,2,3,4,5]}', 'exists($.a[*] ? (@ >= $min &amp;&amp; @ &lt;= $max))', '{"min":2,"max":4}')
@@ -16721,8 +16940,11 @@ pathについての演算子について言うと、<replaceable>new_value</repl
         </entry>
         <entry><type>setof jsonb</type></entry>
         <entry>
+<!--
           Gets all JSON items returned by JSON path for the specified JSON
           value.
+-->
+指定したJSON値に対してJSONパスが返すすべてのJSON項目を得る。
         </entry>
         <entry>
          <para><literal>
@@ -16749,8 +16971,11 @@ pathについての演算子について言うと、<replaceable>new_value</repl
         </entry>
         <entry><type>jsonb</type></entry>
         <entry>
+<!--
           Gets all JSON items returned by JSON path for the specified JSON
           value and wraps result into an array.
+-->
+指定したJSON値に対してJSONパスが返すすべてのJSON項目を得て配列に格納する。
         </entry>
         <entry>
          <para><literal>
@@ -16769,8 +16994,12 @@ pathについての演算子について言うと、<replaceable>new_value</repl
         </entry>
         <entry><type>jsonb</type></entry>
         <entry>
+<!--
           Gets the first JSON item returned by JSON path for the specified JSON
           value.  Returns <literal>NULL</literal> on no results.
+-->
+指定したJSON値に対するJSONパスが返す最初のJSON項目を得る。
+結果がなければ<literal>NULL</literal>を返す。
         </entry>
         <entry>
          <para><literal>
@@ -16794,7 +17023,7 @@ pathについての演算子について言うと、<replaceable>new_value</repl
       done; but for <type>json</type> input, this may result in throwing an error,
       as noted in <xref linkend="datatype-json"/>.
 -->
-これらの多くの関数や演算子は、JSON文字列のUnicodeのエスケープを適切な一文字に変換します。
+これらの関数や演算子の多くは、JSON文字列のUnicodeのエスケープを適切な一文字に変換します。
 これは入力が<type>jsonb</type>型であれば、変換は既に行なわれていますので、重要な問題ではありません。しかし、<type>json</type>の入力に対しては、<xref linkend="datatype-json"/>で言及したようにこれはエラーを発生させる結果になるかもしれません。
     </para>
   </note>
@@ -16958,21 +17187,30 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
 
   <note>
    <para>
+<!--
     The <literal>jsonb_path_exists</literal>, <literal>jsonb_path_match</literal>,
     <literal>jsonb_path_query</literal>, <literal>jsonb_path_query_array</literal>, and
     <literal>jsonb_path_query_first</literal>
     functions have optional <literal>vars</literal> and <literal>silent</literal>
     arguments.
+-->
+<literal>jsonb_path_exists</literal>、<literal>jsonb_path_match</literal>、<literal>jsonb_path_query</literal>, <literal>jsonb_path_query_array</literal>、<literal>jsonb_path_query_first</literal>関数はオプションの<literal>vars</literal>と<literal>silent</literal>引数を持ちます。
    </para>
    <para>
+<!--
     If the <parameter>vars</parameter> argument is specified, it provides an
     object containing named variables to be substituted into a
     <literal>jsonpath</literal> expression.
+-->
+<parameter>vars</parameter>引数が指定されると、<literal>jsonpath</literal>式に変換できる名前付きの変数を含むオブジェクトを関数は返します。
    </para>
    <para>
+<!--
     If the <parameter>silent</parameter> argument is specified and has the
     <literal>true</literal> value, these functions suppress the same errors
     as the <literal>@?</literal> and <literal>@@</literal> operators.
+-->
+<parameter>silent</parameter>引数が指定され、それが値<literal>true</literal>なら、これらの関数は<literal>@?</literal>と<literal>@@</literal>演算子と同じエラーを抑止します。
    </para>
   </note>
 
@@ -16991,21 +17229,32 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
  </sect2>
 
  <sect2 id="functions-sqljson-path">
+<!--
   <title>The SQL/JSON Path Language</title>
+-->
+  <title>SQL/JSONパス言語</title>
 
   <indexterm zone="functions-sqljson-path">
+<!--
    <primary>SQL/JSON path language</primary>
+-->
+   <primary>SQL/JSONパス言語</primary>
   </indexterm>
 
   <para>
+<!--
    SQL/JSON path expressions specify the items to be retrieved
    from the JSON data, similar to XPath expressions used
    for SQL access to XML. In <productname>PostgreSQL</productname>,
    path expressions are implemented as the <type>jsonpath</type>
    data type and can use any elements described in
    <xref linkend="datatype-jsonpath"/>.
+-->
+SQL/JSONパス式は、XMLへのSQLアクセスで使用されるXPath同様、JSONデータから取り出す項目を指定します。
+<productname>PostgreSQL</productname>ではパス式は<type>jsonpath</type>データ型として実装されており、<xref linkend="datatype-jsonpath"/>で説明されているすべての要素を使うことができます。
   </para>
 
+<!--
   <para>JSON query functions and operators
    pass the provided path expression to the <firstterm>path engine</firstterm>
    for evaluation. If the expression matches the queried JSON data,
@@ -17014,9 +17263,16 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
    and can also include arithmetic expressions and functions.
    Query functions treat the provided expression as a
    text string, so it must be enclosed in single quotes.
+-->
+  <para>
+JSON問い合わせ関数と演算子は与えられたパス式を<firstterm>path engine</firstterm>に渡して評価します。
+式が問い合わせ対象のJSONデータにマッチすれば、関連するSQL/JSON項目が返却されます。
+パス式はSQL/JSONパス言語で書かれ、算術式と関数を含むことができます。
+問い合わせ関数は与えられた式をテキスト文字列として扱うので、単一引用符で括らなければなりません。
   </para>
 
   <para>
+<!--
    A path expression consists of a sequence of elements allowed
    by the <type>jsonpath</type> data type.
    The path expression is evaluated from left to right, but
@@ -17025,9 +17281,14 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
    (<firstterm>SQL/JSON sequence</firstterm>) is produced,
    and the evaluation result is returned to the JSON query function
    that completes the specified computation.
+-->
+パス式は<type>jsonpath</type>データ型で認められた一連の要素からなります。
+パス式は左から右へと評価されますが、括弧を使って演算の順序を変更することができます。
+評価が成功すれば、一連のSQL/JSON項目（<firstterm>SQL/JSON sequence</firstterm>）が生成され、評価結果が指定した計算を完了したJSON問い合わせ関数に戻されます。
   </para>
 
   <para>
+<!--
    To refer to the JSON data to be queried (the
    <firstterm>context item</firstterm>), use the <literal>$</literal> sign
    in the path expression. It can be followed by one or more
@@ -17035,11 +17296,19 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
    which go down the JSON structure level by level to retrieve the
    content of context item. Each operator that follows deals with the
    result of the previous evaluation step.
+-->
+問い合わせ対象（<firstterm>context item</firstterm>）のJSONデータを参照するには、パス式内で<literal>$</literal>記号を使います。
+複数の<link linkend="type-jsonpath-accessors">アクセス演算子</link>をその後に記述することもできます。
+それによってJSON構造をレベル順に訪れて文脈の項目の内容を取り出します。
+後続の個々の演算子はその前の評価段階の結果を処理します。
   </para>
 
   <para>
+<!--
    For example, suppose you have some JSON data from a GPS tracker that you
    would like to parse, such as:
+-->
+たとえば、次のようなパースしたいGPSトラッカーからのJSONデータがあるとします。
 <programlisting>
 {
   "track": {
@@ -17061,52 +17330,75 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
   </para>
 
   <para>
+<!--
    To retrieve the available track segments, you need to use the
    <literal>.<replaceable>key</replaceable></literal> accessor
    operator for all the preceding JSON objects:
+-->
+存在するトラックセグメントを取り出すには、<literal>.<replaceable>key</replaceable></literal>アクセッサ演算子をすべての先行するJSONオブジェクトに使用する必要があります。
 <programlisting>
 '$.track.segments'
 </programlisting>
   </para>
 
   <para>
+<!--
    If the item to retrieve is an element of an array, you have
    to unnest this array using the <literal>[*]</literal> operator. For example,
    the following path will return location coordinates for all
    the available track segments:
+-->
+取得したい項目が配列要素なら、<literal>[*]</literal>演算子を使って非配列化（unnest）する必要があります。
+たとえば次のパスはすべての存在するトラックセグメントの位置座標を返します。
 <programlisting>
 '$.track.segments[*].location'
 </programlisting>
   </para>
 
   <para>
+<!--
    To return the coordinates of the first segment only, you can
    specify the corresponding subscript in the <literal>[]</literal>
    accessor operator. Note that the SQL/JSON arrays are 0-relative:
+-->
+最初のセグメントの座標だけを返すには、<literal>[]</literal>アクセッサ演算子の中で対応する添え字を指定することができます。
+SQL/JSON配列は0スタートであることに注意してください。
 <programlisting>
 '$.track.segments[0].location'
 </programlisting>
   </para>
 
   <para>
+<!--
    The result of each path evaluation step can be processed
    by one or more <type>jsonpath</type> operators and methods
    listed in <xref linkend="functions-sqljson-path-operators"/>.
    Each method name must be preceded by a dot. For example,
    you can get an array size:
+-->
+各段階でのパス評価結果は<xref linkend="functions-sqljson-path-operators"/>に列挙されている一つ以上の<type>jsonpath</type>演算子とメソッドで処理することができます。
+各々のメソッド名の前にピリオドを付けなければなりません。
+たとえば配列の大きさを得ることができます。
 <programlisting>
 '$.track.segments.size()'
 </programlisting>
+<!--
    For more examples of using <type>jsonpath</type> operators
    and methods within path expressions, see
    <xref linkend="functions-sqljson-path-operators"/>.
+-->
+パス式内の<type>jsonpath</type>演算子とメソッドについては<xref linkend="functions-sqljson-path-operators"/>を参照してください。
   </para>
 
   <para>
+<!--
    When defining the path, you can also use one or more
    <firstterm>filter expressions</firstterm> that work similar to the
    <literal>WHERE</literal> clause in SQL. A filter expression begins with
    a question mark and provides a condition in parentheses:
+-->
+パスを定義する際にはSQLの<literal>WHERE</literal>節のように働く一つ以上の<firstterm>filter expressions</firstterm>が利用できます。
+フィルター式はクェスチョンマークで始まり、カッコ内に条件を記述します。
 
 <programlisting>
 ? (<replaceable>condition</replaceable>)
@@ -17114,6 +17406,7 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
   </para>
 
   <para>
+<!--
    Filter expressions must be specified right after the path evaluation step
    to which they are applied. The result of this step is filtered to include
    only those items that satisfy the provided condition. SQL/JSON defines
@@ -17123,84 +17416,128 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
    for with the <literal>is unknown</literal> predicate. Further path
    evaluation steps use only those items for which filter expressions
    return <literal>true</literal>.
+-->
+フィルター式はそれを適用するパス評価段階の直後に指定しなければなりません。
+この段階の結果は、指定した条件を満たす項目だけが含まれるようにフィルターされます。
+SQL/JSONは3値論理を定義しており、条件は<literal>true</literal>、<literal>false</literal>、<literal>unknown</literal>のどれかです。
+<literal>unknown</literal>は値はSQLの<literal>NULL</literal>と同じ役割を果たし、<literal>is unknown</literal>述語で評価できます。
+その後の評価段階では<literal>true</literal>を返すフィルター式に対応する項目だけが使われます。
   </para>
 
   <para>
+<!--
    Functions and operators that can be used in filter expressions are listed
    in <xref linkend="functions-sqljson-filter-ex-table"/>. The path
    evaluation result to be filtered is denoted by the <literal>@</literal>
    variable. To refer to a JSON element stored at a lower nesting level,
    add one or more accessor operators after <literal>@</literal>.
+-->
+フィルター式内で利用できる関数と演算子は<xref linkend="functions-sqljson-filter-ex-table"/>にリストされています。
+フィルターする必要のあるパス評価結果は<literal>@</literal>変数で示します。
+下位の入れ子レベルに格納されているJSON要素を参照するには、一つ以上のアクセッサ演算子を<literal>@</literal>の後に追加してください。
   </para>
 
   <para>
+<!--
    Suppose you would like to retrieve all heart rate values higher
    than 130. You can achieve this using the following expression:
+-->
+130より高い心拍数を取り出したいとします。次の式を使ってそれを得ることができます。
 <programlisting>
 '$.track.segments[*].HR ? (@ &gt; 130)'
 </programlisting>
   </para>
 
   <para>
+<!--
    To get the start time of segments with such values instead, you have to
    filter out irrelevant segments before returning the start time, so the
    filter expression is applied to the previous step, and the path used
    in the condition is different:
+-->
+代わりにそうした値を持つセグメントの開始時刻を得たい場合は、開始時刻を返す前に無関係のセグメントを取り除く必要があります。
+そうすることにより前の段階にフィルター式が適用されるので、その条件で適用されるパスは異なります。
 <programlisting>
 '$.track.segments[*] ? (@.HR &gt; 130)."start time"'
 </programlisting>
   </para>
 
   <para>
+<!--
    You can use several filter expressions on the same nesting level, if
    required. For example, the following expression selects all segments
    that contain locations with relevant coordinates and high heart rate values:
+-->
+必要なら同じ入れ子レベルに対して複数のフィルター式を使用することができます。
+たとえば次の式は指定した座標と高い心拍数値を持つ位置を持つすべてのセグメントを選択します。
 <programlisting>
 '$.track.segments[*] ? (@.location[1] &lt; 13.4) ? (@.HR &gt; 130)."start time"'
 </programlisting>
   </para>
 
   <para>
+<!--
    Using filter expressions at different nesting levels is also allowed.
    The following example first filters all segments by location, and then
    returns high heart rate values for these segments, if available:
+-->
+異なる入れ子レベルに対してフィルター式を適用することもできます。
+次の例では、まず位置ですべてのセグメントをフィルターし、もしあれば高い心拍数値を返します。
 <programlisting>
 '$.track.segments[*] ? (@.location[1] &lt; 13.4).HR ? (@ &gt; 130)'
 </programlisting>
   </para>
 
   <para>
+<!--
    You can also nest filter expressions within each other:
+-->
+フィルター式をお互いに入れ子にすることもできます。
 <programlisting>
 '$.track ? (exists(@.segments[*] ? (@.HR &gt; 130))).segments.size()'
 </programlisting>
+<!--
    This expression returns the size of the track if it contains any
    segments with high heart rate values, or an empty sequence otherwise.
+-->
+この式は高い心拍数値を含むトラックがあればそのすべてのサイズを返します。もしなければ空のシーケンスが返ります。
   </para>
 
   <para>
+<!--
    <productname>PostgreSQL</productname>'s implementation of SQL/JSON path
    language has the following deviations from the SQL/JSON standard:
+-->
+<productname>PostgreSQL</productname>のSQL/JSONパス言語の実装はSQL/JSON標準と次の点が異なります。
   </para>
 
   <itemizedlist>
    <listitem>
     <para>
+<!--
      <literal>.datetime()</literal> item method is not implemented yet
      mainly because immutable <type>jsonpath</type> functions and operators
      cannot reference session timezone, which is used in some datetime
      operations.  Datetime support will be added to <type>jsonpath</type>
      in future versions of <productname>PostgreSQL</productname>.
+-->
+<literal>.datetime()</literal>項目メソッドは、主に不揮発性<type>jsonpath</type>関数と演算子が日付日時演算子で使用されているセッション時間帯を参照できないという理由でまだ実装されていません。
+将来の<productname>PostgreSQL</productname>バージョンでは<type>jsonpath</type>のサポートが追加される予定です。
     </para>
    </listitem>
 
    <listitem>
     <para>
+<!--
      A path expression can be a Boolean predicate, although the SQL/JSON
      standard allows predicates only in filters.  This is necessary for
      implementation of the <literal>@@</literal> operator. For example,
      the following <type>jsonpath</type> expression is valid in
      <productname>PostgreSQL</productname>:
+-->
+SQL/JSON標準ではフィルター内でのみ述語が使えますが、パス式はBoolean述語でも構いません。
+これは<literal>@@</literal>演算子を実装するために必要です。
+たとえば、次の<type>jsonpath</type>式は<productname>PostgreSQL</productname>では有効です。
 <programlisting>
 '$.track.segments[*].HR &lt; 70'
 </programlisting>
@@ -17209,40 +17546,59 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
 
    <listitem>
     <para>
+<!--
      There are minor differences in the interpretation of regular
      expression patterns used in <literal>like_regex</literal> filters, as
      described in <xref linkend="jsonpath-regular-expressions"/>.
+-->
+<xref linkend="jsonpath-regular-expressions"/>で述べるように、<literal>like_regex</literal>フィルターで使用される正規表現パターンの解釈には些細な違いがあります。
     </para>
    </listitem>
   </itemizedlist>
 
    <sect3 id="strict-and-lax-modes">
+<!--
    <title>Strict and Lax Modes</title>
+-->
+   <title>厳密モードと非厳密モード</title>
     <para>
+<!--
      When you query JSON data, the path expression may not match the
      actual JSON data structure. An attempt to access a non-existent
      member of an object or element of an array results in a
      structural error. SQL/JSON path expressions have two modes
      of handling structural errors:
+-->
+JSONデータを問い合わせる際、パス式は実際のJSONデータ構造に一致しないかも知れません。
+存在しないオブジェクトのメンバーあるいは配列要素にアクセスしようとすると、構造上のエラーとなります。
+SQL/JSONパス式には構造上のエラーを扱うための2つのモードがあります。
     </para>
 
    <itemizedlist>
     <listitem>
      <para>
+<!--
       lax (default) &mdash; the path engine implicitly adapts
       the queried data to the specified path.
       Any remaining structural errors are suppressed and converted
       to empty SQL/JSON sequences.
+-->
+非厳密(lax)モード（デフォルト）&mdash; パスエンジンは指定したパスを問い合わせデータに暗黙的に適合させます。
+構造上のエラーは抑止され、空のSQL/JSONシーケンスへと変換されます。
      </para>
     </listitem>
     <listitem>
      <para>
+<!--
       strict &mdash; if a structural error occurs, an error is raised.
+-->
+厳密(strict)モード &mdash; 構造上のエラーがあるとエラーが発生します。
      </para>
     </listitem>
    </itemizedlist>
 
    <para>
+<!--
     The lax mode facilitates matching of a JSON document structure and path
     expression if the JSON data does not conform to the expected schema.
     If an operand does not match the requirements of a particular operation,
@@ -17252,40 +17608,60 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
     operands in the lax mode, so you can compare SQL/JSON arrays
     out-of-the-box. An array of size 1 is considered equal to its sole element.
     Automatic unwrapping is not performed only when:
+-->
+非厳密モードは、JSONデータが期待されるスキーマに沿わないときにJSON文書構造とパス式のマッチングを助けます。
+あるオペランドが操作の要件に合わないときにはそれをSQL/JSON配列にまとめたり、あるいは操作を行う前にそれをSQL/JSONシーケンスに展開することもできます。
+また非厳密モードにおいては、比較演算子は自動的にオペランドを展開し、SQL/JSON配列をそのまま比較することができます。
+大きさ1の配列はその単独要素と同じものとして扱われます。
+自動展開は以下の場合にのみ行われます。
     <itemizedlist>
      <listitem>
       <para>
+<!--
        The path expression contains <literal>type()</literal> or
        <literal>size()</literal> methods that return the type
        and the number of elements in the array, respectively.
+-->
+それぞれ配列の型、要素数を返す<literal>type()</literal>、<literal>size()</literal>をパス式が含む場合。
       </para>
      </listitem>
      <listitem>
       <para>
+<!--
        The queried JSON data contain nested arrays. In this case, only
        the outermost array is unwrapped, while all the inner arrays
        remain unchanged. Thus, implicit unwrapping can only go one
        level down within each path evaluation step.
+-->
+問い合わせ対象のJSONデータが入れ子の配列を含んでいる。この場合はもっとも外側の配列のみが展開され、内側の配列は変わりません。
+ですから、それぞれの評価段階において1レベルのみに暗黙的な展開が行われます。
       </para>
      </listitem>
     </itemizedlist>
    </para>
 
    <para>
+<!--
     For example, when querying the GPS data listed above, you can
     abstract from the fact that it stores an array of segments
     when using the lax mode:
+-->
+たとえば、上述のGPSデータに問い合わせする際、非厳密モードでは配列のセグメントを含んでいることを抽象化できます。
 <programlisting>
 'lax $.track.segments.location'
 </programlisting>
    </para>
 
    <para>
+<!--
     In the strict mode, the specified path must exactly match the structure of
     the queried JSON document to return an SQL/JSON item, so using this
     path expression will cause an error. To get the same result as in
     the lax mode, you have to explicitly unwrap the
     <literal>segments</literal> array:
+-->
+厳密モードでは、指定したパスはSQL/JSON項目を返す問い合わせ対象のJSON文書の構造に正確に一致していなければなりません。ですから、このパス式を使うとエラーになります。
+非厳密モードと同じ結果を得るためには、<literal>segments</literal>配列を明示的に展開する必要があります。
 <programlisting>
 'strict $.track.segments[*].location'
 </programlisting>
@@ -17294,24 +17670,35 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
    </sect3>
 
    <sect3 id="jsonpath-regular-expressions">
+<!--
     <title>Regular Expressions</title>
+-->
+    <title>正規表現</title>
 
     <indexterm zone="jsonpath-regular-expressions">
      <primary><literal>LIKE_REGEX</literal></primary>
+<!--
      <secondary>in SQL/JSON</secondary>
+-->
+     <secondary>SQL/JSONにおける</secondary>
     </indexterm>
 
     <para>
+<!--
      SQL/JSON path expressions allow matching text to a regular expression
      with the <literal>like_regex</literal> filter.  For example, the
      following SQL/JSON path query would case-insensitively match all
      strings in an array that start with an English vowel:
+-->
+SQL/JSONパス式では<literal>like_regex</literal>フィルターを使ってテキストを正規表現にマッチさせることができます。
+たとえば、次のSQL/JSONパス式問い合わせは、英語の母音で始まる配列内のすべての文字列に大文字小文字を無視してマッチするでしょう。
 <programlisting>
 '$[*] ? (@ like_regex "^[aeiou]" flag "i")'
 </programlisting>
     </para>
 
     <para>
+<!--
      The optional <literal>flag</literal> string may include one or more of
      the characters
      <literal>i</literal> for case-insensitive match,
@@ -17320,9 +17707,13 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
      <literal>s</literal> to allow <literal>.</literal> to match a newline,
      and <literal>q</literal> to quote the whole pattern (reducing the
      behavior to a simple substring match).
+-->
+オプションの<literal>flag</literal>文字列は一つ以上の文字を含むことができます。
+<literal>i</literal>は大文字小文字を無視したマッチ、<literal>m</literal>は<literal>^</literal>と<literal>$</literal>で改行にマッチ、<literal>s</literal>は<literal>.</literal>が改行にマッチ、<literal>q</literal>はパターン全体を参照します。（振る舞いを単純な部分文字列マッチとします）
     </para>
 
     <para>
+<!--
      The SQL/JSON standard borrows its definition for regular expressions
      from the <literal>LIKE_REGEX</literal> operator, which in turn uses the
      XQuery standard.  PostgreSQL does not currently support the
@@ -17335,14 +17726,25 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
      Note, however, that the flag-letter incompatibilities described there
      do not apply to SQL/JSON, as it translates the XQuery flag letters to
      match what the POSIX engine expects.
+-->
+SQL/JSON標準は正規表現の定義を、XQuery標準を使用する<literal>LIKE_REGEX</literal>演算子から借りています。
+PostgreSQLは今の所<literal>LIKE_REGEX</literal>演算子をサポートしていません。
+ですから、<literal>like_regex</literal>フィルターは<xref linkend="functions-posix-regexp"/>で説明されているPOSIX正規表現で実装されています。
+このことにより、<xref linkend="posix-vs-xquery"/>で列挙されているSQL/JSON標準の振る舞いとの小さな違いが生じます。
+しかし、ここで述べているフラグ文字の非互換性はSQL/JSONには適用されないことに注意してください。SQL/JSONは、XQueryのフラグ文字をPOSIXエンジンが期待するのと一致するように解釈するからです。
     </para>
 
     <para>
+<!--
      Keep in mind that the pattern argument of <literal>like_regex</literal>
      is a JSON path string literal, written according to the rules given in
      <xref linkend="datatype-jsonpath"/>.  This means in particular that any
      backslashes you want to use in the regular expression must be doubled.
      For example, to match strings that contain only digits:
+-->
+<literal>like_regex</literal>のパターン引数は<xref linkend="datatype-jsonpath"/>で説明されているルールにしたがって書かれたJSONパス文字列リテラルであることに注意してください。
+これは、正規表現で使用するすべてのバックスラッシュを二重に書かなければならないことを意味します。
+たとえば、数字のみを含む文字列にマッチさせるには以下のようにします。
 <programlisting>
 '$ ? (@ like_regex "^\\d+$")'
 </programlisting>
@@ -17351,115 +17753,176 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
    </sect3>
 
    <sect3 id="functions-sqljson-path-operators">
+<!--
    <title>SQL/JSON Path Operators and Methods</title>
+-->
+   <title>SQL/JSONパス演算子とメソッド</title>
 
    <para>
+<!--
     <xref linkend="functions-sqljson-op-table"/> shows the operators and
     methods available in <type>jsonpath</type>.  <xref
     linkend="functions-sqljson-filter-ex-table"/> shows the available filter
     expression elements.
+-->
+<xref linkend="functions-sqljson-op-table"/>に<type>jsonpath</type>で利用可能な演算子とメソッドを示します。
+<xref linkend="functions-sqljson-filter-ex-table"/>には利用可能なフィルター式要素が示されています。
    </para>
 
    <table id="functions-sqljson-op-table">
+<!--
     <title><type>jsonpath</type> Operators and Methods</title>
+-->
+    <title><type>jsonpath</type>演算子とメソッド</title>
      <tgroup cols="5">
       <thead>
        <row>
+<!--
         <entry>Operator/Method</entry>
         <entry>Description</entry>
         <entry>Example JSON</entry>
         <entry>Example Query</entry>
         <entry>Result</entry>
+-->
+        <entry>演算子/メソッド</entry>
+        <entry>説明</entry>
+        <entry>JSONの例</entry>
+        <entry>問い合わせ例</entry>
+        <entry>結果</entry>
        </row>
       </thead>
       <tbody>
        <row>
+<!--
         <entry><literal>+</literal> (unary)</entry>
         <entry>Plus operator that iterates over the SQL/JSON sequence</entry>
+-->
+        <entry><literal>+</literal>（単項）</entry>
+        <entry>SQL/JSONシーケンスに繰り返し適用される加算演算子</entry>
         <entry><literal>{"x": [2.85, -14.7, -9.4]}</literal></entry>
         <entry><literal>+ $.x.floor()</literal></entry>
         <entry><literal>2, -15, -10</literal></entry>
        </row>
        <row>
+<!--
         <entry><literal>-</literal> (unary)</entry>
         <entry>Minus operator that iterates over the SQL/JSON sequence</entry>
+-->
+        <entry><literal>-</literal>（単項）</entry>
+        <entry>SQL/JSONシーケンスに繰り返し適用される減算演算子</entry>
         <entry><literal>{"x": [2.85, -14.7, -9.4]}</literal></entry>
         <entry><literal>- $.x.floor()</literal></entry>
         <entry><literal>-2, 15, 10</literal></entry>
        </row>
        <row>
+<!--
         <entry><literal>+</literal> (binary)</entry>
         <entry>Addition</entry>
+-->
+        <entry><literal>+</literal>（二項）</entry>
+        <entry>加算</entry>
         <entry><literal>[2]</literal></entry>
         <entry><literal>2 + $[0]</literal></entry>
         <entry><literal>4</literal></entry>
        </row>
        <row>
+<!--
         <entry><literal>-</literal> (binary)</entry>
         <entry>Subtraction</entry>
+-->
+        <entry><literal>-</literal>（二項）</entry>
+        <entry>減算</entry>
         <entry><literal>[2]</literal></entry>
         <entry><literal>4 - $[0]</literal></entry>
         <entry><literal>2</literal></entry>
        </row>
        <row>
         <entry><literal>*</literal></entry>
+<!--
         <entry>Multiplication</entry>
+-->
+        <entry>積算</entry>
         <entry><literal>[4]</literal></entry>
         <entry><literal>2 * $[0]</literal></entry>
         <entry><literal>8</literal></entry>
        </row>
        <row>
+
         <entry><literal>/</literal></entry>
+<!--
         <entry>Division</entry>
+-->
+        <entry>除算</entry>
         <entry><literal>[8]</literal></entry>
         <entry><literal>$[0] / 2</literal></entry>
         <entry><literal>4</literal></entry>
        </row>
        <row>
         <entry><literal>%</literal></entry>
+<!--
         <entry>Modulus</entry>
+-->
+        <entry>剰余</entry>
         <entry><literal>[32]</literal></entry>
         <entry><literal>$[0] % 10</literal></entry>
         <entry><literal>2</literal></entry>
        </row>
        <row>
         <entry><literal>type()</literal></entry>
+<!--
         <entry>Type of the SQL/JSON item</entry>
+-->
+        <entry>SQL/JSON項目の型</entry>
         <entry><literal>[1, "2", {}]</literal></entry>
         <entry><literal>$[*].type()</literal></entry>
         <entry><literal>"number", "string", "object"</literal></entry>
        </row>
        <row>
         <entry><literal>size()</literal></entry>
+<!--
         <entry>Size of the SQL/JSON item</entry>
+-->
+        <entry>SQL/JSON項目の大きさ</entry>
         <entry><literal>{"m": [11, 15]}</literal></entry>
         <entry><literal>$.m.size()</literal></entry>
         <entry><literal>2</literal></entry>
        </row>
        <row>
         <entry><literal>double()</literal></entry>
+<!--
         <entry>Approximate floating-point number converted from an SQL/JSON number or a string</entry>
+-->
+        <entry>SQL/JSONの数字あるいは文字列から変換されたおおよその浮動小数点数</entry>
         <entry><literal>{"len": "1.9"}</literal></entry>
         <entry><literal>$.len.double() * 2</literal></entry>
         <entry><literal>3.8</literal></entry>
        </row>
        <row>
         <entry><literal>ceiling()</literal></entry>
+<!--
         <entry>Nearest integer greater than or equal to the SQL/JSON number</entry>
+-->
+        <entry>SQL/JSON数字以上でもっとも近い整数</entry>
         <entry><literal>{"h": 1.3}</literal></entry>
         <entry><literal>$.h.ceiling()</literal></entry>
         <entry><literal>2</literal></entry>
        </row>
        <row>
         <entry><literal>floor()</literal></entry>
+<!--
         <entry>Nearest integer less than or equal to the SQL/JSON number</entry>
+-->
+        <entry>SQL/JSON数字以下でもっとも近い整数</entry>
         <entry><literal>{"h": 1.3}</literal></entry>
         <entry><literal>$.h.floor()</literal></entry>
         <entry><literal>1</literal></entry>
        </row>
        <row>
         <entry><literal>abs()</literal></entry>
+<!--
         <entry>Absolute value of the SQL/JSON number</entry>
+-->
+        <entry>SQL/JSON数字の絶対値</entry>
         <entry><literal>{"z": -0.3}</literal></entry>
         <entry><literal>$.z.abs()</literal></entry>
         <entry><literal>0.3</literal></entry>
@@ -17467,11 +17930,16 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
        <row>
         <entry><literal>keyvalue()</literal></entry>
         <entry>
+<!--
           Sequence of object's key-value pairs represented as array of items
           containing three fields (<literal>"key"</literal>,
           <literal>"value"</literal>, and <literal>"id"</literal>).
           <literal>"id"</literal> is a unique identifier of the object
           key-value pair belongs to.
+-->
+3つのフィールド（<literal>"key"</literal>、<literal>"value"</literal>、<literal>"id"</literal>）を含む項目の配列で表現されたオブジェクトの
+キーバリューペアのシーケンス。
+<literal>"id"</literal>はキーバリューペアが所属するオブジェクトのユニーク識別子です。
         </entry>
         <entry><literal>{"x": "20", "y": 32}</literal></entry>
         <entry><literal>$.keyvalue()</literal></entry>
@@ -17482,70 +17950,104 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
     </table>
 
     <table id="functions-sqljson-filter-ex-table">
+<!--
      <title><type>jsonpath</type> Filter Expression Elements</title>
+-->
+     <title><type>jsonpath</type>フィルター式要素</title>
      <tgroup cols="5">
       <thead>
        <row>
+<!--
         <entry>Value/Predicate</entry>
         <entry>Description</entry>
         <entry>Example JSON</entry>
         <entry>Example Query</entry>
         <entry>Result</entry>
+-->
+        <entry>値/述語</entry>
+        <entry>説明</entry>
+        <entry>JSONの例</entry>
+        <entry>問い合わせ例</entry>
+        <entry>結果</entry>
        </row>
       </thead>
       <tbody>
        <row>
         <entry><literal>==</literal></entry>
+<!--
         <entry>Equality operator</entry>
+-->
+        <entry>等値演算子</entry>
         <entry><literal>[1, 2, 1, 3]</literal></entry>
         <entry><literal>$[*] ? (@ == 1)</literal></entry>
         <entry><literal>1, 1</literal></entry>
        </row>
        <row>
         <entry><literal>!=</literal></entry>
+<!--
         <entry>Non-equality operator</entry>
+-->
+        <entry>非等値演算子</entry>
         <entry><literal>[1, 2, 1, 3]</literal></entry>
         <entry><literal>$[*] ? (@ != 1)</literal></entry>
         <entry><literal>2, 3</literal></entry>
        </row>
        <row>
         <entry><literal>&lt;&gt;</literal></entry>
+<!--
         <entry>Non-equality operator (same as <literal>!=</literal>)</entry>
+-->
+        <entry>非等値演算子（<literal>!=</literal>と同じ）</entry>
         <entry><literal>[1, 2, 1, 3]</literal></entry>
         <entry><literal>$[*] ? (@ &lt;&gt; 1)</literal></entry>
         <entry><literal>2, 3</literal></entry>
        </row>
        <row>
         <entry><literal>&lt;</literal></entry>
+<!--
         <entry>Less-than operator</entry>
+-->
+        <entry>未満演算子</entry>
         <entry><literal>[1, 2, 3]</literal></entry>
         <entry><literal>$[*] ? (@ &lt; 2)</literal></entry>
         <entry><literal>1</literal></entry>
        </row>
        <row>
         <entry><literal>&lt;=</literal></entry>
+<!--
         <entry>Less-than-or-equal-to operator</entry>
+-->
+        <entry>以下演算子</entry>
         <entry><literal>[1, 2, 3]</literal></entry>
         <entry><literal>$[*] ? (@ &lt;= 2)</literal></entry>
         <entry><literal>1, 2</literal></entry>
        </row>
        <row>
         <entry><literal>&gt;</literal></entry>
+<!--
         <entry>Greater-than operator</entry>
+-->
+        <entry>より大きい演算子</entry>
         <entry><literal>[1, 2, 3]</literal></entry>
         <entry><literal>$[*] ? (@ &gt; 2)</literal></entry>
         <entry><literal>3</literal></entry>
        </row>
        <row>
         <entry><literal>&gt;=</literal></entry>
+<!--
         <entry>Greater-than-or-equal-to operator</entry>
+-->
+        <entry>以上演算子</entry>
         <entry><literal>[1, 2, 3]</literal></entry>
         <entry><literal>$[*] ? (@ &gt;= 2)</literal></entry>
         <entry><literal>2, 3</literal></entry>
        </row>
        <row>
         <entry><literal>true</literal></entry>
+<!--
         <entry>Value used to perform comparison with JSON <literal>true</literal> literal</entry>
+-->
+        <entry>JSONの<literal>true</literal>リテラルとの比較に用いられる値</entry>
         <entry><literal>[{"name": "John", "parent": false},
                            {"name": "Chris", "parent": true}]</literal></entry>
         <entry><literal>$[*] ? (@.parent == true)</literal></entry>
@@ -17553,7 +18055,10 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
        </row>
        <row>
         <entry><literal>false</literal></entry>
+<!--
         <entry>Value used to perform comparison with JSON <literal>false</literal> literal</entry>
+-->
+        <entry>JSONの<literal>true</literal>リテラルとの比較に用いられる値</entry>
         <entry><literal>[{"name": "John", "parent": false},
                            {"name": "Chris", "parent": true}]</literal></entry>
         <entry><literal>$[*] ? (@.parent == false)</literal></entry>
@@ -17561,7 +18066,10 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
        </row>
        <row>
         <entry><literal>null</literal></entry>
+<!--
         <entry>Value used to perform comparison with JSON <literal>null</literal> value</entry>
+-->
+        <entry>JSONの<literal>true</literal>リテラルとの比較に用いられる値</entry>
         <entry><literal>[{"name": "Mary", "job": null},
                          {"name": "Michael", "job": "driver"}]</literal></entry>
         <entry><literal>$[*] ? (@.job == null) .name</literal></entry>
@@ -17569,21 +18077,31 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
        </row>
        <row>
         <entry><literal>&amp;&amp;</literal></entry>
+<!--
         <entry>Boolean AND</entry>
+-->
+        <entry>論理AND</entry>
         <entry><literal>[1, 3, 7]</literal></entry>
         <entry><literal>$[*] ? (@ &gt; 1 &amp;&amp; @ &lt; 5)</literal></entry>
         <entry><literal>3</literal></entry>
        </row>
        <row>
         <entry><literal>||</literal></entry>
+<!--
         <entry>Boolean OR</entry>
+-->
+        <entry>論理OR</entry>
         <entry><literal>[1, 3, 7]</literal></entry>
         <entry><literal>$[*] ? (@ &lt; 1 || @ &gt; 5)</literal></entry>
         <entry><literal>7</literal></entry>
        </row>
        <row>
         <entry><literal>!</literal></entry>
+
+<!--
         <entry>Boolean NOT</entry>
+-->
+        <entry>論理NOT</entry>
         <entry><literal>[1, 3, 7]</literal></entry>
         <entry><literal>$[*] ? (!(@ &lt; 5))</literal></entry>
         <entry><literal>7</literal></entry>
@@ -17591,10 +18109,14 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
        <row>
         <entry><literal>like_regex</literal></entry>
         <entry>
+<!--
           Tests whether the first operand matches the regular expression
           given by the second operand, optionally with modifications
           described by a string of <literal>flag</literal> characters (see
           <xref linkend="jsonpath-regular-expressions"/>)
+-->
+最初のオペランドが2番目のオペランドで与えられる正規表現にマッチするかどうかテストする。
+オプションで<literal>flag</literal>文字列で記述される変更を伴う。（<xref linkend="jsonpath-regular-expressions"/>参照）
         </entry>
         <entry><literal>["abc", "abd", "aBdC", "abdacb", "babc"]</literal></entry>
         <entry><literal>$[*] ? (@ like_regex "^ab.*c" flag "i")</literal></entry>
@@ -17602,21 +18124,30 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
        </row>
        <row>
         <entry><literal>starts with</literal></entry>
+<!--
         <entry>Tests whether the second operand is an initial substring of the first operand</entry>
+-->
+        <entry>2番目の文字列が1番目のオペランドの最初の部分文字列かどうかをテストする</entry>
         <entry><literal>["John Smith", "Mary Stone", "Bob Johnson"]</literal></entry>
         <entry><literal>$[*] ? (@ starts with "John")</literal></entry>
         <entry><literal>"John Smith"</literal></entry>
        </row>
        <row>
         <entry><literal>exists</literal></entry>
+<!--
         <entry>Tests whether a path expression matches at least one SQL/JSON item</entry>
+-->
+        <entry>パス式が少なくとも一つのSQL/JSON項目とマッチするかどうかをテストする</entry>
         <entry><literal>{"x": [1, 2], "y": [2, 4]}</literal></entry>
         <entry><literal>strict $.* ? (exists (@ ? (@[*] > 2)))</literal></entry>
         <entry><literal>2, 4</literal></entry>
        </row>
        <row>
         <entry><literal>is unknown</literal></entry>
+<!--
         <entry>Tests whether a Boolean condition is <literal>unknown</literal></entry>
+-->
+        <entry>論理条件が<literal>unknown</literal>かどうかをテストする</entry>
         <entry><literal>[-1, 2, 7, "infinity"]</literal></entry>
         <entry><literal>$[*] ? ((@ > 0) is unknown)</literal></entry>
         <entry><literal>"infinity"</literal></entry>
@@ -18068,10 +18599,13 @@ SELECT setval('foo', 42, false);    <lineannotation>次の<function>nextval</fun
 
    <note>
     <para>
+<!--
      Although <token>COALESCE</token>, <token>GREATEST</token>, and
      <token>LEAST</token> are syntactically similar to functions, they are
      not ordinary functions, and thus cannot be used with explicit
      <token>VARIADIC</token> array arguments.
+-->
+<token>COALESCE</token>、<token>GREATEST</token>、<token>LEAST</token>は構文的には関数に似ていますが通常の関数ではなく、明示的な<token>VARIADIC</token>配列引数と一緒には使えません。
     </para>
    </note>
 
@@ -24361,10 +24895,14 @@ SELECT has_function_privilege('joeuser', 'myfunc(int, text)', 'execute');
    </para>
 
   <para>
+<!--
    <xref linkend="functions-aclitem-fn-table"/> shows the operators
    available for the <type>aclitem</type> type, which is the catalog
    representation of access privileges.  See <xref linkend="ddl-priv"/>
    for information about how to read access privilege values.
+-->
+アクセス権限のカタログ表現である<type>aclitem</type>型で利用可能な演算子を<xref linkend="functions-aclitem-fn-table"/>に示します。
+アクセス権限値を解釈する方法に関する情報は<xref linkend="ddl-priv"/>をご覧ください。
   </para>
 
    <indexterm>
@@ -24384,35 +24922,53 @@ SELECT has_function_privilege('joeuser', 'myfunc(int, text)', 'execute');
    </indexterm>
 
     <table id="functions-aclitem-op-table">
+<!--
      <title><type>aclitem</type> Operators</title>
+-->
+     <title><type>aclitem</type>演算子</title>
      <tgroup cols="4">
       <thead>
        <row>
+<!--
         <entry>Operator</entry>
         <entry>Description</entry>
         <entry>Example</entry>
         <entry>Result</entry>
+-->
+        <entry>演算子</entry>
+        <entry>説明</entry>
+        <entry>例</entry>
+        <entry>結果</entry>
        </row>
       </thead>
       <tbody>
 
        <row>
         <entry> <literal>=</literal> </entry>
+<!--
         <entry>equal</entry>
+-->
+        <entry>等しい</entry>
         <entry><literal>'calvin=r*w/hobbes'::aclitem = 'calvin=r*w*/hobbes'::aclitem</literal></entry>
         <entry><literal>f</literal></entry>
        </row>
 
        <row>
         <entry> <literal>@&gt;</literal> </entry>
+<!--
         <entry>contains element</entry>
+-->
+        <entry>要素を含む</entry>
         <entry><literal>'{calvin=r*w/hobbes,hobbes=r*w*/postgres}'::aclitem[] @&gt; 'calvin=r*w/hobbes'::aclitem</literal></entry>
         <entry><literal>t</literal></entry>
        </row>
 
        <row>
         <entry> <literal>~</literal> </entry>
+<!--
         <entry>contains element</entry>
+-->
+        <entry>要素を含む</entry>
         <entry><literal>'{calvin=r*w/hobbes,hobbes=r*w*/postgres}'::aclitem[] ~ 'calvin=r*w/hobbes'::aclitem</literal></entry>
         <entry><literal>t</literal></entry>
        </row>
@@ -24422,38 +24978,57 @@ SELECT has_function_privilege('joeuser', 'myfunc(int, text)', 'execute');
     </table>
 
    <para>
+<!--
     <xref linkend="functions-aclitem-fn-table"/> shows some additional
     functions to manage the <type>aclitem</type> type.
+-->
+<xref linkend="functions-aclitem-fn-table"/>に<type>aclitem</type>型を管理する追加の関数を示します。
    </para>
 
    <table id="functions-aclitem-fn-table">
+<!--
     <title><type>aclitem</type> Functions</title>
+-->
+    <title><type>aclitem</type>関数</title>
     <tgroup cols="3">
      <thead>
+<!--
       <row><entry>Name</entry> <entry>Return Type</entry> <entry>Description</entry></row>
+-->
+      <row><entry>名称</entry> <entry>戻り型</entry> <entry>説明</entry></row>
      </thead>
      <tbody>
       <row>
        <entry><literal><function>acldefault</function>(<parameter>type</parameter>,
         <parameter>ownerId</parameter>)</literal></entry>
        <entry><type>aclitem[]</type></entry>
+<!--
        <entry>get the default access privileges for an object belonging to <parameter>ownerId</parameter></entry>
+-->
+       <entry><parameter>ownerId</parameter>に所属するオブジェクトのデフォルトアクセス権限を得る</entry>
       </row>
       <row>
        <entry><literal><function>aclexplode</function>(<parameter>aclitem[]</parameter>)</literal></entry>
        <entry><type>setof record</type></entry>
+<!--
        <entry>get <type>aclitem</type> array as tuples</entry>
+-->
+       <entry><type>aclitem</type>配列をタプルとして得る</entry>
       </row>
       <row>
        <entry><literal><function>makeaclitem</function>(<parameter>grantee</parameter>, <parameter>grantor</parameter>, <parameter>privilege</parameter>, <parameter>grantable</parameter>)</literal></entry>
        <entry><type>aclitem</type></entry>
+<!--
        <entry>build an <type>aclitem</type> from input</entry>
+-->
+       <entry>入力から<type>aclitem</type>を構築する</entry>
       </row>
      </tbody>
     </tgroup>
    </table>
 
    <para>
+<!--
     <function>acldefault</function> returns the built-in default access
     privileges for an object of type <parameter>type</parameter> belonging to
     role <parameter>ownerId</parameter>.  These represent the access
@@ -24473,15 +25048,25 @@ SELECT has_function_privilege('joeuser', 'myfunc(int, text)', 'execute');
     'S' for <literal>FOREIGN SERVER</literal>,
     or
     'T' for <literal>TYPE</literal> or <literal>DOMAIN</literal>.
+-->
+<function>acldefault</function>は<parameter>ownerId</parameter>ロールに所属する<parameter>type</parameter>型のオブジェクトの組み込みデフォルトアクセス権限を返します。
+これらはオブジェクトのACLエントリがNULLの時に持つと見なされるアクセス権限を表現します。
+（デフォルトアクセス権限は<xref linkend="ddl-priv"/>で説明されています。）
+<parameter>type</parameter>パラメータは<type>CHAR</type>であり、'c'で<literal>COLUMN</literal>、'r'で<literal>TABLE</literal>およびテーブルに見えるオブジェクト、's'で<literal>SEQUENCE</literal>、'd'で<literal>DATABASE</literal>、'f'で<literal>FUNCTION</literal>あるいは<literal>PROCEDURE</literal>、'l'で<literal>LANGUAGE</literal>、'L'で<literal>LARGE OBJECT</literal>、'n'で<literal>SCHEMA</literal>、't'で<literal>TABLESPACE</literal>、'F'で<literal>FOREIGN DATA WRAPPER</literal>、'S'で<literal>FOREIGN SERVER</literal>、'T'で<literal>TYPE</literal>あるいは<literal>DOMAIN</literal>を表します。
    </para>
 
    <para>
+<!--
     <function>aclexplode</function> returns an <type>aclitem</type> array
     as a set of rows. Output columns are grantor <type>oid</type>,
     grantee <type>oid</type> (<literal>0</literal> for <literal>PUBLIC</literal>),
     granted privilege as <type>text</type> (<literal>SELECT</literal>, ...)
     and whether the privilege is grantable as <type>boolean</type>.
     <function>makeaclitem</function> performs the inverse operation.
+-->
+<function>aclexplode</function>は行の集合として<type>aclitem</type>配列を返します。
+出力列はアクセス権を与える側の<type>oid</type>、アクセス権を与えられる側の<type>oid</type>（<literal>0</literal>で<literal>PUBLIC</literal>を表します）、与えられた権限<type>text</type>（<literal>SELECT</literal>, ...）、権限が許可可能かどうかの<type>boolean</type>です。
+<function>makeaclitem</function>は逆の操作を実行します。
    </para>
 
   <para>
@@ -27562,6 +28147,7 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         </entry>
        <entry><type>boolean</type></entry>
        <entry>
+<!--
         Promotes a physical standby server.  With <parameter>wait</parameter>
         set to <literal>true</literal> (the default), the function waits until
         promotion is completed or <parameter>wait_seconds</parameter> seconds
@@ -27572,6 +28158,11 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         <literal>SIGUSR1</literal> to the postmaster to trigger the promotion.
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
+-->
+物理スタンバイサーバを昇格します。
+<parameter>wait</parameter>に<literal>true</literal>（デフォルト）を設定すると、この関数は昇格が完了するか、<parameter>wait_seconds</parameter>秒が経過するまで待ち、昇格に成功すれば<literal>true</literal>、さもなければ<literal>false</literal>を返します。
+        <parameter>wait</parameter>に<literal>false</literal>を設定すると、この関数は昇格を起こすためにpostmasterに<literal>SIGUSR1</literal>を送信した後直ちに<literal>true</literal>を返します。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
        </entry>
       </row>
       <row>
@@ -27874,6 +28465,7 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         (<parameter>slot_name</parameter> <type>name</type>, <parameter>lsn</parameter> <type>pg_lsn</type>)
        </entry>
        <entry>
+<!--
         Creates a new logical (decoding) replication slot named
         <parameter>slot_name</parameter> using the output plugin
         <parameter>plugin</parameter>. The optional third
@@ -27883,6 +28475,11 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         released upon any error. A call to this function has the same
         effect as the replication protocol command
         <literal>CREATE_REPLICATION_SLOT ... LOGICAL</literal>.
+-->
+出力プラグイン<parameter>plugin</parameter>を使って<parameter>slot_name</parameter>という名前の新しいロジカル（デコーディング）レプリケーションスロットを作ります。
+3番目のオプションパラメータ<parameter>temporary</parameter>をtrueに設定すると、このスロットを永続的にディスクに保存するべきではなく、現在のセッションでのみ使われることを意図します。
+また、一時スロットはエラーが起きると解放されます。
+この関数の呼び出しはレプリケーションプロトコルコマンドの<literal>CREATE_REPLICATION_SLOT ... LOGICAL</literal>と同じ効果があります。
        </entry>
       </row>
 
@@ -27897,12 +28494,18 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         (<parameter>slot_name</parameter> <type>name</type>, <parameter>lsn</parameter> <type>pg_lsn</type>)
        </entry>
        <entry>
+<!--
         Copies an existing physical replication slot named <parameter>src_slot_name</parameter>
         to a physical replication slot named <parameter>dst_slot_name</parameter>.
         The copied physical slot starts to reserve WAL from the same <acronym>LSN</acronym> as the
         source slot.
         <parameter>temporary</parameter> is optional. If <parameter>temporary</parameter>
         is omitted, the same value as the source slot is used.
+-->
+<parameter>src_slot_name</parameter>という名前の既存の物理レプリケーションスロットを<parameter>dst_slot_name</parameter>という名前の物理レプリケーションスロットにコピーします。
+コピーされた物理スロットはソーススロットと同じ<acronym>LSN</acronym>からWALの保存を開始します。
+<parameter>temporary</parameter>はオプションです。
+<parameter>temporary</parameter>を省略すると、ソーススロットと同じ値を使用します。
        </entry>
       </row>
 
@@ -27917,6 +28520,7 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         (<parameter>slot_name</parameter> <type>name</type>, <parameter>lsn</parameter> <type>pg_lsn</type>)
        </entry>
        <entry>
+<!--
         Copies an existing logical replication slot name <parameter>src_slot_name</parameter>
         to a logical replication slot named <parameter>dst_slot_name</parameter>
         while changing the output plugin and persistence. The copied logical slot starts
@@ -27924,6 +28528,11 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         <parameter>temporary</parameter> and <parameter>plugin</parameter> are optional.
         If <parameter>temporary</parameter> or <parameter>plugin</parameter> are omitted,
         the same values as the source logical slot are used.
+-->
+<parameter>src_slot_name</parameter>という名前の既存の物理レプリケーションスロットを<parameter>dst_slot_name</parameter>という名前の物理レプリケーションスロットに出力プラグインと永続性を変更しながらコピーします。
+コピーされたロジカルスロットはソースロジカルスロットと同じ<acronym>LSN</acronym>から開始します。
+<parameter>temporary</parameter>と<parameter>plugin</parameter>はどちらもオプションです。
+<parameter>temporary</parameter>あるいは<parameter>plugin</parameter>を省略すると、ソースロジカルスロットと同じ値が使用されます。
        </entry>
       </row>
 
@@ -28918,10 +29527,16 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
    </para>
 
    <table id="functions-info-partition">
+<!--
     <title>Partitioning Information Functions</title>
+-->
+    <title>パーティション情報関数</title>
     <tgroup cols="3">
      <thead>
+<!--
       <row><entry>Name</entry> <entry>Return Type</entry> <entry>Description</entry></row>
+-->
+      <row><entry>名前</entry> <entry>戻り型</entry> <entry>説明</entry></row>
      </thead>
 
      <tbody>
@@ -28932,6 +29547,7 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
        </entry>
        <entry><type>setof record</type></entry>
        <entry>
+<!--
         List information about tables or indexes in a partition tree for a
         given partitioned table or partitioned index, with one row for each
         partition.  Information provided includes the name of the partition,
@@ -28941,6 +29557,10 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
         or index in its role as the root of the partition tree,
         <literal>1</literal> for its partitions, <literal>2</literal> for
         their partitions, and so on.
+-->
+1行1パーティションで与えられたパーティション化テーブルあるいはパーティション化インデックスのパーティションツリー内のテーブルあるいはインデックスの情報を表示します。
+提供される情報にはパーティション名、その直接の親、パーティションが葉かどうかを示す真偽値、階層内のレベルを表す整数が含まれます。
+レベル値は与えられたテーブルあるいはインデックスがパーティションツリーの根としての役割を持つことを表す<literal>0</literal>で始まり、<literal>1</literal>ならその直下のパーティション、<literal>2</literal>ならそのまた下のパーティションなどとなります。
        </entry>
       </row>
       <row>
@@ -28950,8 +29570,11 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
        </entry>
        <entry><type>setof regclass</type></entry>
        <entry>
+<!--
         List the ancestor relations of the given partition,
         including the partition itself.
+-->
+パーティション自身を含む、与えられたパーティションの先祖リレーションを列挙します。
        </entry>
       </row>
       <row>
@@ -28961,8 +29584,11 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
        </entry>
        <entry><type>regclass</type></entry>
        <entry>
+<!--
         Return the top-most parent of a partition tree to which the given
         relation belongs.
+-->
+与えられたリレーションが所属するパーティションツリーの最上位の親を返します。
        </entry>
       </row>
      </tbody>
@@ -28970,10 +29596,13 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
    </table>
 
    <para>
+<!--
     To check the total size of the data contained in
     <structname>measurement</structname> table described in
     <xref linkend="ddl-partitioning-declarative-example"/>, one could use the
     following query:
+-->
+<xref linkend="ddl-partitioning-declarative-example"/>で説明されている<structname>measurement</structname>テーブルに含まれるデータの全体サイズを確認するには、次の問い合わせが利用できます。
    </para>
 
 <programlisting>
@@ -29218,10 +29847,14 @@ WALディレクトリ内のファイルの名前、サイズ、最終更新時�
        </entry>
        <entry><type>setof record</type></entry>
        <entry>
+<!--
         List the name, size, and last modification time of files in the WAL
         archive status directory. Access is granted to members of the
         <literal>pg_monitor</literal> role and may be granted to other
         non-superuser roles.
+-->
+WALアーカイブステータスディレクトリ内のファイルの名前、サイズ、最終更新時刻を一覧表示します。
+<literal>pg_monitor</literal>ロールのメンバーにはアクセス権が付与されており、他の非スーパーユーザのロールにもアクセス権を付与することができます。
        </entry>
       </row>
       <row>
@@ -29230,12 +29863,17 @@ WALディレクトリ内のファイルの名前、サイズ、最終更新時�
        </entry>
        <entry><type>setof record</type></entry>
        <entry>
+<!--
         List the name, size, and last modification time of files in the
         temporary directory for <parameter>tablespace</parameter>.  If
         <parameter>tablespace</parameter> is not provided, the
         <literal>pg_default</literal> tablespace is used.  Access is granted
         to members of the <literal>pg_monitor</literal> role and may be
         granted to other non-superuser roles.
+-->
+<parameter>tablespace</parameter>用の一時ディレクトリ内のファイルの名前、サイズ、最終更新時刻を一覧表示します。
+<parameter>tablespace</parameter>が与えられなかった場合は<literal>pg_default</literal>テーブル空間が使用されます。
+<literal>pg_monitor</literal>ロールのメンバーにはアクセス権が付与されており、他の非スーパーユーザのロールにもアクセス権を付与することができます。
        </entry>
       </row>
       <row>
@@ -29345,18 +29983,24 @@ WALディレクトリ内のファイルの名前、サイズ、最終更新時�
     <primary>pg_ls_archive_statusdir</primary>
    </indexterm>
    <para>
+<!--
     <function>pg_ls_archive_statusdir</function> returns the name, size, and
     last modified time (mtime) of each file in the WAL archive status
     directory <filename>pg_wal/archive_status</filename>. By default only
     superusers and members of the <literal>pg_monitor</literal> role can
     use this function. Access may be granted to others using
     <command>GRANT</command>.
+-->
+<function>pg_ls_archive_statusdir</function>はWALアーカイブディレクトリ内の各ファイルについて、名前、サイズ、最終更新時刻（mtime）を返します。
+デフォルトでは、スーパーユーザと<literal>pg_monitor</literal>ロールのメンバーだけがこの関数を使用できます。
+<command>GRANT</command>を使って他のロールにアクセス権を付与することができます。
    </para>
 
    <indexterm>
     <primary>pg_ls_tmpdir</primary>
    </indexterm>
    <para>
+<!--
     <function>pg_ls_tmpdir</function> returns the name, size, and last modified
     time (mtime) of each file in the temporary file directory for the specified
     <parameter>tablespace</parameter>.  If <parameter>tablespace</parameter> is
@@ -29364,6 +30008,11 @@ WALディレクトリ内のファイルの名前、サイズ、最終更新時�
     default only superusers and members of the <literal>pg_monitor</literal>
     role can use this function.  Access may be granted to others using
     <command>GRANT</command>.
+-->
+<function>pg_ls_tmpdir</function>は指定された<parameter>tablespace</parameter>用の一時ディレクトリ内のファイルの名前、サイズ、最終更新時刻を一覧表示します。
+<parameter>tablespace</parameter>が与えられなかった場合は<literal>pg_default</literal>テーブル空間が使用されます。
+デフォルトでは、スーパーユーザと<literal>pg_monitor</literal>ロールのメンバーだけがこの関数を使用できます。
+<command>GRANT</command>を使って他のロールにアクセス権を付与することができます。
    </para>
 
    <indexterm>
@@ -30354,20 +31003,33 @@ CREATE EVENT TRIGGER test_table_rewrite_oid
 <!-- split-func4-end -->
 
   <sect1 id="functions-statistics">
+<!--
    <title>Statistics Information Functions</title>
+-->
+   <title>統計情報関数</title>
 
    <indexterm zone="functions-statistics">
+<!--
     <primary>function</primary>
     <secondary>statistics</secondary>
+-->
+    <primary>関数</primary>
+    <secondary>統計</secondary>
    </indexterm>
 
    <para>
+<!--
     <productname>PostgreSQL</productname> provides a function to inspect complex
     statistics defined using the <command>CREATE STATISTICS</command> command.
+-->
+<productname>PostgreSQL</productname>は<command>CREATE STATISTICS</command>コマンドを使って定義した複雑な統計を調べる関数を提供しています。
    </para>
 
   <sect2 id="functions-statistics-mcv">
+<!--
    <title>Inspecting MCV Lists</title>
+-->
+   <title>MCVリストの調査</title>
 
    <indexterm>
      <primary>pg_mcv_list_items</primary>
@@ -30375,17 +31037,25 @@ CREATE EVENT TRIGGER test_table_rewrite_oid
    </indexterm>
 
    <para>
+<!--
     <function>pg_mcv_list_items</function> returns a list of all items
     stored in a multi-column <acronym>MCV</acronym> list, and returns the
     following columns:
+-->
+<function>pg_mcv_list_items</function>は複数列<acronym>MCV</acronym>リストに格納されたすべての項目を列挙し、次の列を返します。
 
     <informaltable>
      <tgroup cols="3">
       <thead>
        <row>
+<!--
         <entry>Name</entry>
         <entry>Type</entry>
         <entry>Description</entry>
+-->
+        <entry>名前</entry>
+        <entry>型</entry>
+        <entry>説明</entry>
        </row>
       </thead>
 
@@ -30393,27 +31063,42 @@ CREATE EVENT TRIGGER test_table_rewrite_oid
        <row>
         <entry><literal>index</literal></entry>
         <entry><type>int</type></entry>
+<!--
         <entry>index of the item in the <acronym>MCV</acronym> list</entry>
+-->
+        <entry><acronym>MCV</acronym>リスト内の項目のインデックス</entry>
        </row>
        <row>
         <entry><literal>values</literal></entry>
         <entry><type>text[]</type></entry>
+<!--
         <entry>values stored in the MCV item</entry>
+-->
+        <entry>MCV項目に格納された値</entry>
        </row>
        <row>
         <entry><literal>nulls</literal></entry>
         <entry><type>boolean[]</type></entry>
+<!--
         <entry>flags identifying <literal>NULL</literal> values</entry>
+-->
+        <entry><literal>NULL</literal>値を識別するフラグ</entry>
        </row>
        <row>
         <entry><literal>frequency</literal></entry>
         <entry><type>double precision</type></entry>
+<!--
         <entry>frequency of this <acronym>MCV</acronym> item</entry>
+-->
+        <entry>この<acronym>MCV</acronym>項目の頻度</entry>
        </row>
        <row>
         <entry><literal>base_frequency</literal></entry>
         <entry><type>double precision</type></entry>
+<!--
         <entry>base frequency of this <acronym>MCV</acronym> item</entry>
+-->
+        <entry>この<acronym>MCV</acronym>項目のベース頻度</entry>
        </row>
       </tbody>
      </tgroup>
@@ -30421,15 +31106,21 @@ CREATE EVENT TRIGGER test_table_rewrite_oid
    </para>
 
    <para>
+<!--
     The <function>pg_mcv_list_items</function> function can be used like this:
+-->
+<function>pg_mcv_list_items</function>関数は次のように使用することができます。
 
 <programlisting>
 SELECT m.* FROM pg_statistic_ext join pg_statistic_ext_data on (oid = stxoid),
                 pg_mcv_list_items(stxdmcv) m WHERE stxname = 'stts';
 </programlisting>
 
+<!--
      Values of the <type>pg_mcv_list</type> can be obtained only from the
      <literal>pg_statistic_ext_data.stxdmcv</literal> column.
+-->
+<type>pg_mcv_list</type>の値は<literal>pg_statistic_ext_data.stxdmcv</literal>列からのみ得られます。
    </para>
   </sect2>
 

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -28532,7 +28532,7 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         If <parameter>temporary</parameter> or <parameter>plugin</parameter> are omitted,
         the same values as the source logical slot are used.
 -->
-<parameter>src_slot_name</parameter>という名前の既存の物理レプリケーションスロットを<parameter>dst_slot_name</parameter>という名前の物理レプリケーションスロットに出力プラグインと永続性を変更しながらコピーします。
+<parameter>src_slot_name</parameter>という名前の既存の論理レプリケーションスロットを<parameter>dst_slot_name</parameter>という名前の論理レプリケーションスロットに出力プラグインと永続性を変更しながらコピーします。
 コピーされたロジカルスロットはソースロジカルスロットと同じ<acronym>LSN</acronym>から開始します。
 <parameter>temporary</parameter>と<parameter>plugin</parameter>はどちらもオプションです。
 <parameter>temporary</parameter>あるいは<parameter>plugin</parameter>を省略すると、ソースロジカルスロットと同じ値が使用されます。

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -15790,7 +15790,7 @@ JSONデータを処理、生成する関数と演算子
 <!--
       the SQL/JSON path language
 -->
-SQL/JSONパス関数言語
+SQL/JSONパス言語
      </para>
     </listitem>
    </itemizedlist>
@@ -16101,7 +16101,7 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
 <!--
         <entry>Does JSON path return any item for the specified JSON value?</entry>
 -->
-        <entry>JSONパスが指定したJSON値のすべての要素を返すか？</entry>
+        <entry>指定したJSON値に対応する要素を返すか？</entry>
         <entry><literal>'{"a":[1,2,3,4,5]}'::jsonb @? '$.a[*] ? (@ > 2)'</literal></entry>
        </row>
        <row>
@@ -16897,7 +16897,7 @@ pathについての演算子について言うと、<replaceable>new_value</repl
           Checks whether JSON path returns any item for the specified JSON
           value.
 -->
-指定したJSON値に対してJSONパスがすべての項目を返すかどうかをチェックする。
+JSONパスが指定したJSON値に対して項目を返すかどうかをチェックする。
         </entry>
         <entry>
          <para><literal>
@@ -17400,7 +17400,7 @@ SQL/JSON配列は0スタートであることに注意してください。
    <literal>WHERE</literal> clause in SQL. A filter expression begins with
    a question mark and provides a condition in parentheses:
 -->
-パスを定義する際にはSQLの<literal>WHERE</literal>節のように働く一つ以上の<firstterm>filter expressions</firstterm>が利用できます。
+パスを定義する際にはSQLの<literal>WHERE</literal>節のように働く一つ以上の<firstterm>フィルター式</firstterm>が利用できます。
 フィルター式はクェスチョンマークで始まり、カッコ内に条件を記述します。
 
 <programlisting>
@@ -17616,7 +17616,7 @@ SQL/JSONパス式には構造上のエラーを扱うための2つのモード�
 あるオペランドが操作の要件に合わないときにはそれをSQL/JSON配列にまとめたり、あるいは操作を行う前にそれをSQL/JSONシーケンスに展開することもできます。
 また非厳密モードにおいては、比較演算子は自動的にオペランドを展開し、SQL/JSON配列をそのまま比較することができます。
 大きさ1の配列はその単独要素と同じものとして扱われます。
-自動展開は以下の場合にのみ行われます。
+自動展開は以下の場合にのみ行われません。
     <itemizedlist>
      <listitem>
       <para>
@@ -17625,7 +17625,7 @@ SQL/JSONパス式には構造上のエラーを扱うための2つのモード�
        <literal>size()</literal> methods that return the type
        and the number of elements in the array, respectively.
 -->
-それぞれ配列の型、要素数を返す<literal>type()</literal>、<literal>size()</literal>をパス式が含む場合。
+それぞれ配列の型、要素数を返す<literal>type()</literal>、<literal>size()</literal>をパス式が含む。
       </para>
      </listitem>
      <listitem>
@@ -17636,7 +17636,8 @@ SQL/JSONパス式には構造上のエラーを扱うための2つのモード�
        remain unchanged. Thus, implicit unwrapping can only go one
        level down within each path evaluation step.
 -->
-問い合わせ対象のJSONデータが入れ子の配列を含んでいる。この場合はもっとも外側の配列のみが展開され、内側の配列は変わりません。
+問い合わせ対象のJSONデータが入れ子の配列を含む。
+この場合はもっとも外側の配列のみが展開され、内側の配列は変わりません。
 ですから、それぞれの評価段階において1レベルのみに暗黙的な展開が行われます。
       </para>
      </listitem>
@@ -17940,8 +17941,7 @@ PostgreSQLは今の所<literal>LIKE_REGEX</literal>演算子をサポートし�
           <literal>"id"</literal> is a unique identifier of the object
           key-value pair belongs to.
 -->
-3つのフィールド（<literal>"key"</literal>、<literal>"value"</literal>、<literal>"id"</literal>）を含む項目の配列で表現されたオブジェクトの
-キーバリューペアのシーケンス。
+3つのフィールド（<literal>"key"</literal>、<literal>"value"</literal>、<literal>"id"</literal>）を含む項目の配列で表現されたオブジェクトのキーバリューペアのシーケンス。
 <literal>"id"</literal>はキーバリューペアが所属するオブジェクトのユニーク識別子です。
         </entry>
         <entry><literal>{"x": "20", "y": 32}</literal></entry>
@@ -18072,7 +18072,7 @@ PostgreSQLは今の所<literal>LIKE_REGEX</literal>演算子をサポートし�
 <!--
         <entry>Value used to perform comparison with JSON <literal>null</literal> value</entry>
 -->
-        <entry>JSONの<literal>null</literal>リテラルとの比較に用いられる値</entry>
+        <entry>JSONの<literal>null</literal>値との比較に用いられる値</entry>
         <entry><literal>[{"name": "Mary", "job": null},
                          {"name": "Michael", "job": "driver"}]</literal></entry>
         <entry><literal>$[*] ? (@.job == null) .name</literal></entry>

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -1966,7 +1966,7 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
 <!--
        <entry>inverse hyperbolic tangent</entry>
 -->
-       <entry>双曲線正接</entry>
+       <entry>逆双曲線正接</entry>
        <entry><literal>atanh(0)</literal></entry>
        <entry><literal>0</literal></entry>
       </row>
@@ -8094,7 +8094,7 @@ XQueryはこれらのクラスをUnicodeの文字属性を参照してこれら�
         variants of <quote>newline</quote> than POSIX does.  The
         newline-sensitive matching options described above consider only
         ASCII NL (<literal>\n</literal>) to be a newline, but SQL would have
-        us treat CR (<literal>\r</literal>)、CRLF (<literal>\r\n</literal>)
+        us treat CR (<literal>\r</literal>), CRLF (<literal>\r\n</literal>)
         (a Windows-style newline), and some Unicode-only characters like
         LINE SEPARATOR (U+2028) as newlines as well.
         Notably, <literal>.</literal> and <literal>\s</literal> should
@@ -8967,7 +8967,7 @@ POSIXはバックスラッシュ以降の空白文字を無視しません。
        <literal>FX</literal> must be specified as the first item in
        the template.
 -->
-<literal>FX</literal>オプションが使用されていない場合、<function>to_timestamp</function>と<function>to_date</function>は入力文字列内のはじまり、そして最初と日付と時間の値の周辺の複数の空白スペースを無視します。
+<literal>FX</literal>オプションが使用されていない限り、<function>to_timestamp</function>と<function>to_date</function>は入力文字列内最初の連続した空白と、日付と時間の値の周辺の複数の空白を無視します。
 例えば、<literal>to_timestamp('2000&nbsp;&nbsp;&nbsp;&nbsp;JUN', 'YYYY MON')</literal>と<literal>to_timestamp('2000 - JUN', 'YYYY-MON')</literal>は動作しますが、<literal>to_timestamp('2000&nbsp;&nbsp;&nbsp;&nbsp;JUN','FXYYYY MON')</literal>はエラーを返します。
 後者の<function>to_timestamp</function>は単一のスペースだけがあることを期待するからです。
 <literal>FX</literal>はテンプレートの第1項目として指定される必要があります。
@@ -8987,7 +8987,7 @@ POSIXはバックスラッシュ以降の空白文字を無視しません。
        returns an error because the number of separators in the input string
        exceeds the number of separators in the template.
 -->
-<function>to_timestamp</function>と<function>to_date</function>のテンプレート文字列中の区切り文字（空白あるいは記号文字(訳注：原文は"non-letter/non-digit character"））は入力文字中のすべての単一の区切り文字とマッチし、<literal>FX</literal>オプションが使用されている場合はスキップします。
+<literal>FX</literal>オプションが使用されていない限り、<function>to_timestamp</function>と<function>to_date</function>のテンプレート文字列中の区切り文字（空白あるいは記号文字(訳注：原文は"non-letter/non-digit character"））は入力文字中のすべての単一の区切り文字とマッチするか、あるいはマッチしない場合はスキップします。
 たとえば、<literal>to_timestamp('2000JUN', 'YYYY///MON')</literal>と<literal>to_timestamp('2000/JUN', 'YYYY MON')</literal>は動作しますが、<literal>to_timestamp('2000//JUN', 'YYYY/MON')</literal>は入力文字列中の区切り文字の数がテンプレート中の区切り文字の数を上回っているため、エラーを返します。
       </para>
       <para>
@@ -11334,7 +11334,7 @@ date_trunc(<replaceable>field</replaceable>, <replaceable>source</replaceable> [
     and it has all fields that are less significant than the
     selected one set to zero (or one, for day and month).
 -->
-<replaceable>source</replaceable>は、データ型<type>timestamp</type>、<type>timestamp with time zone</type>もしくは<type>interval</type>の評価式です
+<replaceable>source</replaceable>は、データ型<type>timestamp</type>、<type>timestamp with time zone</type>もしくは<type>interval</type>の評価式です。
 （<type>date</type>型と<type>time</type>型の値はそれぞれ自動的に<type>timestamp</type>もしくは<type>interval</type>にキャストされます。）
 <replaceable>field</replaceable>は、入力値の値をどの精度で切り捨てるかを選択します。
 同様に戻り値は<type>timestamp</type>、<type>timestamp with time zone</type>もしくは<type>interval</type>型で、指定した精度より下のすべてのフィールドがゼロに設定（日と月については1に設定）されます。
@@ -17301,7 +17301,7 @@ JSON問い合わせ関数と演算子は与えられたパス式を<firstterm>pa
    result of the previous evaluation step.
 -->
 問い合わせ対象（<firstterm>context item</firstterm>）のJSONデータを参照するには、パス式内で<literal>$</literal>記号を使います。
-複数の<link linkend="type-jsonpath-accessors">アクセス演算子</link>をその後に記述することもできます。
+複数の<link linkend="type-jsonpath-accessors">アクセッサ演算子</link>をその後に記述することもできます。
 それによってJSON構造をレベル順に訪れて文脈の項目の内容を取り出します。
 後続の個々の演算子はその前の評価段階の結果を処理します。
   </para>
@@ -17524,7 +17524,7 @@ SQL/JSONは3値論理を定義しており、条件は<literal>true</literal>、
      operations.  Datetime support will be added to <type>jsonpath</type>
      in future versions of <productname>PostgreSQL</productname>.
 -->
-<literal>.datetime()</literal>項目メソッドは、主に不揮発性<type>jsonpath</type>関数と演算子が日付日時演算子で使用されているセッション時間帯を参照できないという理由でまだ実装されていません。
+<literal>.datetime()</literal>項目メソッドは、主に不揮発性<type>jsonpath</type>関数と演算子が日付時刻操作で使用されているセッション時間帯を参照できないという理由でまだ実装されていません。
 将来の<productname>PostgreSQL</productname>バージョンでは<type>jsonpath</type>のサポートが追加される予定です。
     </para>
    </listitem>
@@ -18061,7 +18061,7 @@ PostgreSQLは今の所<literal>LIKE_REGEX</literal>演算子をサポートし�
 <!--
         <entry>Value used to perform comparison with JSON <literal>false</literal> literal</entry>
 -->
-        <entry>JSONの<literal>true</literal>リテラルとの比較に用いられる値</entry>
+        <entry>JSONの<literal>false</literal>リテラルとの比較に用いられる値</entry>
         <entry><literal>[{"name": "John", "parent": false},
                            {"name": "Chris", "parent": true}]</literal></entry>
         <entry><literal>$[*] ? (@.parent == false)</literal></entry>
@@ -18072,7 +18072,7 @@ PostgreSQLは今の所<literal>LIKE_REGEX</literal>演算子をサポートし�
 <!--
         <entry>Value used to perform comparison with JSON <literal>null</literal> value</entry>
 -->
-        <entry>JSONの<literal>true</literal>リテラルとの比較に用いられる値</entry>
+        <entry>JSONの<literal>null</literal>リテラルとの比較に用いられる値</entry>
         <entry><literal>[{"name": "Mary", "job": null},
                          {"name": "Michael", "job": "driver"}]</literal></entry>
         <entry><literal>$[*] ? (@.job == null) .name</literal></entry>
@@ -28164,7 +28164,7 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
 -->
 物理スタンバイサーバを昇格します。
 <parameter>wait</parameter>に<literal>true</literal>（デフォルト）を設定すると、この関数は昇格が完了するか、<parameter>wait_seconds</parameter>秒が経過するまで待ち、昇格に成功すれば<literal>true</literal>、さもなければ<literal>false</literal>を返します。
-        <parameter>wait</parameter>に<literal>false</literal>を設定すると、この関数は昇格を起こすためにpostmasterに<literal>SIGUSR1</literal>を送信した後直ちに<literal>true</literal>を返します。
+<parameter>wait</parameter>に<literal>false</literal>を設定すると、この関数は昇格を起こすためにpostmasterに<literal>SIGUSR1</literal>を送信した後、直ちに<literal>true</literal>を返します。
 デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
        </entry>
       </row>

--- a/doc/src/sgml/func0.sgml
+++ b/doc/src/sgml/func0.sgml
@@ -68,20 +68,33 @@
 <!-- split-func0-end -->
 
   <sect1 id="functions-statistics">
+<!--
    <title>Statistics Information Functions</title>
+-->
+   <title>統計情報関数</title>
 
    <indexterm zone="functions-statistics">
+<!--
     <primary>function</primary>
     <secondary>statistics</secondary>
+-->
+    <primary>関数</primary>
+    <secondary>統計</secondary>
    </indexterm>
 
    <para>
+<!--
     <productname>PostgreSQL</productname> provides a function to inspect complex
     statistics defined using the <command>CREATE STATISTICS</command> command.
+-->
+<productname>PostgreSQL</productname>は<command>CREATE STATISTICS</command>コマンドを使って定義した複雑な統計を調べる関数を提供しています。
    </para>
 
   <sect2 id="functions-statistics-mcv">
+<!--
    <title>Inspecting MCV Lists</title>
+-->
+   <title>MCVリストの調査</title>
 
    <indexterm>
      <primary>pg_mcv_list_items</primary>
@@ -89,17 +102,25 @@
    </indexterm>
 
    <para>
+<!--
     <function>pg_mcv_list_items</function> returns a list of all items
     stored in a multi-column <acronym>MCV</acronym> list, and returns the
     following columns:
+-->
+<function>pg_mcv_list_items</function>は複数列<acronym>MCV</acronym>リストに格納されたすべての項目を列挙し、次の列を返します。
 
     <informaltable>
      <tgroup cols="3">
       <thead>
        <row>
+<!--
         <entry>Name</entry>
         <entry>Type</entry>
         <entry>Description</entry>
+-->
+        <entry>名前</entry>
+        <entry>型</entry>
+        <entry>説明</entry>
        </row>
       </thead>
 
@@ -107,27 +128,42 @@
        <row>
         <entry><literal>index</literal></entry>
         <entry><type>int</type></entry>
+<!--
         <entry>index of the item in the <acronym>MCV</acronym> list</entry>
+-->
+        <entry><acronym>MCV</acronym>リスト内の項目のインデックス</entry>
        </row>
        <row>
         <entry><literal>values</literal></entry>
         <entry><type>text[]</type></entry>
+<!--
         <entry>values stored in the MCV item</entry>
+-->
+        <entry>MCV項目に格納された値</entry>
        </row>
        <row>
         <entry><literal>nulls</literal></entry>
         <entry><type>boolean[]</type></entry>
+<!--
         <entry>flags identifying <literal>NULL</literal> values</entry>
+-->
+        <entry><literal>NULL</literal>値を識別するフラグ</entry>
        </row>
        <row>
         <entry><literal>frequency</literal></entry>
         <entry><type>double precision</type></entry>
+<!--
         <entry>frequency of this <acronym>MCV</acronym> item</entry>
+-->
+        <entry>この<acronym>MCV</acronym>項目の頻度</entry>
        </row>
        <row>
         <entry><literal>base_frequency</literal></entry>
         <entry><type>double precision</type></entry>
+<!--
         <entry>base frequency of this <acronym>MCV</acronym> item</entry>
+-->
+        <entry>この<acronym>MCV</acronym>項目のベース頻度</entry>
        </row>
       </tbody>
      </tgroup>
@@ -135,15 +171,21 @@
    </para>
 
    <para>
+<!--
     The <function>pg_mcv_list_items</function> function can be used like this:
+-->
+<function>pg_mcv_list_items</function>関数は次のように使用することができます。
 
 <programlisting>
 SELECT m.* FROM pg_statistic_ext join pg_statistic_ext_data on (oid = stxoid),
                 pg_mcv_list_items(stxdmcv) m WHERE stxname = 'stts';
 </programlisting>
 
+<!--
      Values of the <type>pg_mcv_list</type> can be obtained only from the
      <literal>pg_statistic_ext_data.stxdmcv</literal> column.
+-->
+<type>pg_mcv_list</type>の値は<literal>pg_statistic_ext_data.stxdmcv</literal>列からのみ得られます。
    </para>
   </sect2>
 

--- a/doc/src/sgml/func1.sgml
+++ b/doc/src/sgml/func1.sgml
@@ -1918,7 +1918,7 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
 <!--
        <entry>inverse hyperbolic tangent</entry>
 -->
-       <entry>双曲線正接</entry>
+       <entry>逆双曲線正接</entry>
        <entry><literal>atanh(0)</literal></entry>
        <entry><literal>0</literal></entry>
       </row>
@@ -8046,7 +8046,7 @@ XQueryはこれらのクラスをUnicodeの文字属性を参照してこれら�
         variants of <quote>newline</quote> than POSIX does.  The
         newline-sensitive matching options described above consider only
         ASCII NL (<literal>\n</literal>) to be a newline, but SQL would have
-        us treat CR (<literal>\r</literal>)、CRLF (<literal>\r\n</literal>)
+        us treat CR (<literal>\r</literal>), CRLF (<literal>\r\n</literal>)
         (a Windows-style newline), and some Unicode-only characters like
         LINE SEPARATOR (U+2028) as newlines as well.
         Notably, <literal>.</literal> and <literal>\s</literal> should

--- a/doc/src/sgml/func1.sgml
+++ b/doc/src/sgml/func1.sgml
@@ -1243,10 +1243,17 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
         <indexterm>
          <primary>log10</primary>
         </indexterm>
+<!--
         <literal><function>log10(<type>dp</type> or <type>numeric</type>)</function></literal>
+-->
+        <literal><function>log10(<type>dp</type>あるいは<type>numeric</type>)</function></literal>
        </entry>
+<!--
        <entry>(same as input)</entry>
        <entry>base 10 logarithm</entry>
+-->
+       <entry>（入力型と同一）</entry>
+       <entry>10を底とした対数（常用対数）</entry>
        <entry><literal>log10(100.0)</literal></entry>
        <entry><literal>2</literal></entry>
       </row>
@@ -1585,8 +1592,9 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
    repeatable by re-issuing <function>setseed()</function> with the same
    argument.
 -->
-<literal><function>random()</function></literal>が返す値の特徴はシステムの実装に依存します。
-暗号への利用は適していません。代わりに<xref linkend="pgcrypto"/>モジュールを参照してください。
+<function>random()</function>関数は単純な線形合同法を使用しています。
+高速ですが、暗号用途には適していません。より安全な代替物として<xref linkend="pgcrypto"/>モジュールを参照してください。
+<function>setseed()</function>が呼び出されると、<function>setseed()</function>を同じ引数で実行することによって現在のセッション内での以後の<function>random()</function>の呼び出し結果は再現可能となります。
   </para>
 
   <para>
@@ -1598,7 +1606,7 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
    two variants, one that measures angles in radians and one that
    measures angles in degrees.
 -->
-最後に、使用可能な三角関数を<xref linkend="functions-math-trig-table"/>に示します。
+使用可能な三角関数を<xref linkend="functions-math-trig-table"/>に示します。
 全ての三角関数は<type>double precision</type>データ型の引数と戻り値を取ります。
 それぞれの三角関数には、角度の単位をラジアンにするものと度にするものの2種類があります。
   </para>
@@ -1798,22 +1806,35 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
   </note>
 
   <para>
+<!--
    <xref linkend="functions-math-hyp-table"/> shows the
    available hyperbolic functions.  All these functions
    take arguments and return values of type <type>double
    precision</type>.
+-->
+利用可能な双曲線関数を<xref linkend="functions-math-hyp-table"/>に示します。
+これら全ての関数は<type>double precision</type>データ型の引数と戻り値を取ります。
   </para>
 
   <table id="functions-math-hyp-table">
+<!--
     <title>Hyperbolic Functions</title>
+-->
+    <title>双曲線関数</title>
 
     <tgroup cols="4">
      <thead>
       <row>
+<!--
        <entry>Function</entry>
        <entry>Description</entry>
        <entry>Example</entry>
        <entry>Result</entry>
+-->
+       <entry>関数</entry>
+       <entry>説明</entry>
+       <entry>例</entry>
+       <entry>結果</entry>
       </row>
      </thead>
      <tbody>
@@ -1824,7 +1845,10 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
         </indexterm>
         <literal><function>sinh(<replaceable>x</replaceable>)</function></literal>
        </entry>
+<!--
        <entry>hyperbolic sine</entry>
+-->
+       <entry>双曲線正弦</entry>
        <entry><literal>sinh(0)</literal></entry>
        <entry><literal>0</literal></entry>
       </row>
@@ -1835,7 +1859,10 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
         </indexterm>
         <literal><function>cosh(<replaceable>x</replaceable>)</function></literal>
        </entry>
+<!--
        <entry>hyperbolic cosine</entry>
+-->
+       <entry>双曲線余弦</entry>
        <entry><literal>cosh(0)</literal></entry>
        <entry><literal>1</literal></entry>
       </row>
@@ -1846,7 +1873,10 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
         </indexterm>
         <literal><function>tanh(<replaceable>x</replaceable>)</function></literal>
        </entry>
+<!--
        <entry>hyperbolic tangent</entry>
+-->
+       <entry>双曲線正接</entry>
        <entry><literal>tanh(0)</literal></entry>
        <entry><literal>0</literal></entry>
       </row>
@@ -1857,7 +1887,10 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
         </indexterm>
         <literal><function>asinh(<replaceable>x</replaceable>)</function></literal>
        </entry>
+<!--
        <entry>inverse hyperbolic sine</entry>
+-->
+       <entry>逆双曲線正弦</entry>
        <entry><literal>asinh(0)</literal></entry>
        <entry><literal>0</literal></entry>
       </row>
@@ -1868,7 +1901,10 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
         </indexterm>
         <literal><function>acosh(<replaceable>x</replaceable>)</function></literal>
        </entry>
+<!--
        <entry>inverse hyperbolic cosine</entry>
+-->
+       <entry>逆双曲線余弦</entry>
        <entry><literal>acosh(1)</literal></entry>
        <entry><literal>0</literal></entry>
       </row>
@@ -1879,7 +1915,10 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
         </indexterm>
         <literal><function>atanh(<replaceable>x</replaceable>)</function></literal>
        </entry>
+<!--
        <entry>inverse hyperbolic tangent</entry>
+-->
+       <entry>双曲線正接</entry>
        <entry><literal>atanh(0)</literal></entry>
        <entry><literal>0</literal></entry>
       </row>
@@ -5162,9 +5201,13 @@ cast(-44 as bit(12))           <lineannotation>111111010100</lineannotation>
    </caution>
 
    <para>
+<!--
     The pattern matching operators of all three kinds do not support
     nondeterministic collations.  If required, apply a different collation to
     the expression to work around this limitation.
+-->
+この3種類のパターンマッチング演算子はどれも非決定的照合順序をサポートしていません。
+必要なら、この制限事項に対応するために別の照合順序を式に適用してください。
    </para>
 
   <sect2 id="functions-like">
@@ -5492,13 +5535,20 @@ SQLの正規表現は、<function>LIKE</function>表記と一般的な正規表�
     provides extraction of a substring that matches an SQL
     regular expression pattern.  The function can be written according
     to SQL99 syntax:
+-->
+3つのパラメータを持つ<function>substring</function>関数を使用して、SQL正規表現パターンに一致する部分文字列を取り出すことができます。
+SQL99の構文にしたがって、この関数は次のように書くことができます。
 <synopsis>
 substring(<replaceable>string</replaceable> from <replaceable>pattern</replaceable> for <replaceable>escape-character</replaceable>)
 </synopsis>
+<!--
     or as a plain three-argument function:
+-->
+あるいは単なる3引数関数として次のように書くこともできます。
 <synopsis>
 substring(<replaceable>string</replaceable>, <replaceable>pattern</replaceable>, <replaceable>escape-character</replaceable>)
 </synopsis>
+<!--
     As with <literal>SIMILAR TO</literal>, the
     specified pattern must match the entire data string, or else the
     function fails and returns null.  To indicate the part of the
@@ -5509,12 +5559,13 @@ substring(<replaceable>string</replaceable>, <replaceable>pattern</replaceable>,
     The text matching the portion of the pattern
     between these separators is returned when the match is successful.
 -->
-3つのパラメータを持つ<function>substring</function>関数、<function>substring(<parameter>string</parameter> from <replaceable>pattern</replaceable> for <replaceable>escape-character</replaceable>)</function>を使用して、SQL正規表現パターンに一致する部分文字列を取り出すことができます。
-<literal>SIMILAR TO</literal>と同様、指定したパターンがデータ文字列全体に一致する必要があります。一致しない場合、関数は終了し、NULLを返します。一致した場合に返されるべきパターンの一部を示すために、エスケープ文字の後に二重引用符（<literal>"</literal>）を繋げたものを2つパターンに含める必要があります。<!-- " font-lock sanity -->
+<literal>SIMILAR TO</literal>と同様、指定したパターンがデータ文字列全体に一致する必要があります。一致しない場合、関数は失敗し、NULLを返します。
+マッチするデータのうちの対象とする部分文字列に対応するパターンの部分を示すために、エスケープ文字の後に二重引用符（<literal>"</literal>）を繋げたものを2つパターンに含める必要があります。<!-- " font-lock sanity -->
 これらの印で括られたパターンの一部に一致するテキストが返されます。
    </para>
 
    <para>
+<!--
     The escape-double-quote separators actually
     divide <function>substring</function>'s pattern into three independent
     regular expressions; for example, a vertical bar (<literal>|</literal>)
@@ -5524,13 +5575,22 @@ substring(<replaceable>string</replaceable>, <replaceable>pattern</replaceable>,
     about how much of the data string matches which pattern.  (In POSIX
     parlance, the first and third regular expressions are forced to be
     non-greedy.)
+-->
+エスケープ文字と二重引用符による区切りは実際には<function>substring</function>のパターン引数を3つの独立した正規表現に分割します。
+たとえば3つのセクションのどこかに置いた垂直線（<literal>|</literal>）はそのセクションにしか影響を及ぼしません。
+また、どのパターンにデータ文字列がマッチするかについて曖昧さがある場合は、最初と3番目の正規表現は、可能な最大のテキストではなく、最小のテキストにマッチするものとして定義されます。
+（POSIX用語では、最初と3番目の正規表現は非貪欲（non-greedy）に強制されます。）
    </para>
 
    <para>
+<!--
     As an extension to the SQL standard, <productname>PostgreSQL</productname>
     allows there to be just one escape-double-quote separator, in which case
     the third regular expression is taken as empty; or no separators, in which
     case the first and third regular expressions are taken as empty.
+-->
+SQL標準への拡張として、<productname>PostgreSQL</productname>は、二重引用符による区切りが一個だけ存在することを許容し、その場合は3番目の正規表現が空として扱われます。
+あるいは、二重引用符による区切りがないことも許容し、その場合は最初と3番目の正規表現は空として扱われます。
    </para>
 
    <para>
@@ -6666,10 +6726,14 @@ REはバックスラッシュ<literal>\</literal>を終端とすることはで�
     the 7-bit ASCII set.
 -->
 ブラケット式内では、<literal>[:</literal>と<literal>:]</literal>の間にある文字クラスの名称は、そのクラスに属する全ての文字のリストを意味します。
-標準文字クラス名は、<literal>alnum</literal>、<literal>alpha</literal>、<literal>blank</literal>、<literal>cntrl</literal>、<literal>digit</literal>、<literal>graph</literal>、<literal>lower</literal>、<literal>print</literal>、<literal>punct</literal>、<literal>space</literal>、<literal>upper</literal>、<literal>xdigit</literal>です。
-これらは<citerefentry><refentrytitle>ctype</refentrytitle><manvolnum>3</manvolnum></citerefentry>で定義された文字クラスを意味します。
-ロケールは別のものを提供可能です。
-文字クラスは範囲の終端では使用することができません。
+文字クラスは範囲の終端位置としては使用できません。
+<acronym>POSIX</acronym>標準は以下の文字クラス名を定義しています。
+<literal>alnum</literal>（文字と数字）、<literal>alpha</literal>（文字）、<literal>blank</literal>（空白とタブ）、<literal>cntrl</literal>（制御文字）、<literal>digit</literal>（数字）、<literal>graph</literal>（空白以外の印字可能文字）、<literal>lower</literal>（小文字）、<literal>print</literal>（空白を含む印字可能文字）、<literal>punct</literal>（句読点）、<literal>space</literal>（空白）、<literal>upper</literal>（大文字）、<literal>xdigit</literal>（16進数）です。
+これらの標準文字クラスの振る舞いは7-bit ASCII集合の範囲であれば一般にどのプラットフォームでも同じです。
+与えられた非ASCII文字がこれらの文字クラスに属すると考えられるかどうかは、正規表現関数または演算子（<xref linkend="collation"/>参照）で使用される<firstterm>照合順</firstterm>、あるいはデフォルトとしてはデータベースの<envar>LC_CTYPE</envar>ロケール（<xref linkend="locale"/>)の設定によります。
+非ASCII文字の分類は、たとえ似たような名前のロケールであってもプラットフォームによって異なることがありえます。
+（ただし<literal>C</literal>ロケールでは、すべての非ASCII文字はこれらのクラスのどれにも所属しないものとされます。）
+これらの標準クラスに加え、<productname>PostgreSQL</productname>では7-bit ASCII集合を正確に含む<literal>ascii</literal>文字クラスが定義されています。
    </para>
 
    <para>
@@ -6690,7 +6754,7 @@ REはバックスラッシュ<literal>\</literal>を終端とすることはで�
 -->
 ブラケット式には2つの特殊な場合があります。<literal>[[:&lt;:]]</literal>と<literal>[[:&gt;:]]</literal>というブラケット式は、先頭と終端の単語がそれぞれ空文字であることにマッチする制約です。
 単語は、単語文字が前後に付かない単語文字の並びとして定義されます。
-単語文字とは（<citerefentry><refentrytitle>ctype</refentrytitle><manvolnum>3</manvolnum></citerefentry>で定義されている）1つの<literal>alnum</literal>文字またはアンダースコアです。
+単語文字とは（上述の<acronym>POSIX</acronym>文字クラスで定義されているように）1つの<literal>alnum</literal>文字またはアンダースコアです。
 これは、<acronym>POSIX</acronym> 1003.2との互換性はありますが、そこでは定義されていない式です。ですので、他システムへ移植予定のソフトウェアでの使用には注意が必要です。
 通常後述の制約エスケープの方がよく使われます。これはもはや標準ではありませんが、入力しやすいものです。
    </para>
@@ -7889,17 +7953,24 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
 <!-- end re_syntax.n man page -->
 
    <sect3 id="posix-vs-xquery">
+<!--
    <title>Differences From XQuery (<literal>LIKE_REGEX</literal>)</title>
+-->
+   <title>XQueryとの違い(<literal>LIKE_REGEX</literal>)</title>
 
    <indexterm zone="posix-vs-xquery">
     <primary><literal>LIKE_REGEX</literal></primary>
    </indexterm>
 
    <indexterm zone="posix-vs-xquery">
+<!--
     <primary>XQuery regular expressions</primary>
+-->
+    <primary>XQuery正規表現</primary>
    </indexterm>
 
     <para>
+<!--
      Since SQL:2008, the SQL standard includes
      a <literal>LIKE_REGEX</literal> operator that performs pattern
      matching according to the XQuery regular expression
@@ -7907,36 +7978,54 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
      implement this operator, but you can get very similar behavior using
      the <function>regexp_match()</function> function, since XQuery
      regular expressions are quite close to the ARE syntax described above.
+-->
+SQL:2008以降、SQL標準にはXQuery正規表現標準によるパターンマッチングを行う<literal>LIKE_REGEX</literal>演算子が含まれています。
+<productname>PostgreSQL</productname>は今の所この演算子を実装していませんが、<function>regexp_match()</function>を使ってよく似た振る舞いを得ることができます。
+XQueryの正規表現は上で述べたARE構文に非常に近いからです。
     </para>
 
     <para>
+<!--
      Notable differences between the existing POSIX-based
      regular-expression feature and XQuery regular expressions include:
+-->
+既存のPOSIXベースの正規表現機能とXQueryの正規表現の主な違いには以下のものが含まれます。
 
      <itemizedlist>
       <listitem>
        <para>
+<!--
         XQuery character class subtraction is not supported.  An example of
         this feature is using the following to match only English
         consonants: <literal>[a-z-[aeiou]]</literal>.
+-->
+XQueryの文字クラス減算はサポートされていません。
+この機能の例としては、<literal>[a-z-[aeiou]]</literal>のようにして英語の子音のみにマッチさせるというのがあります。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         XQuery character class shorthands <literal>\c</literal>,
         <literal>\C</literal>, <literal>\i</literal>,
         and <literal>\I</literal> are not supported.
+-->
+XQueryの文字クラス短縮形<literal>\c</literal>、<literal>\C</literal>、<literal>\i</literal>、<literal>\I</literal>はサポートされていません。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         XQuery character class elements
         using <literal>\p{UnicodeProperty}</literal> or the
         inverse <literal>\P{UnicodeProperty}</literal> are not supported.
+-->
+<literal>\p{UnicodeProperty}</literal>あるいはその逆である<literal>\P{UnicodeProperty}</literal>を使ったXQueryの文字クラス要素はサポートされていません。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         POSIX interprets character classes such as <literal>\w</literal>
         (see <xref linkend="posix-class-shorthand-escapes-table"/>)
         according to the prevailing locale (which you can control by
@@ -7944,60 +8033,87 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
         function).  XQuery specifies these classes by reference to Unicode
         character properties, so equivalent behavior is obtained only with
         a locale that follows the Unicode rules.
+-->
+POSIXは有効なロケール（演算子あるいは関数の<literal>COLLATE</literal>節で制御できます）にしたがい、<literal>\w</literal>（<xref linkend="posix-class-shorthand-escapes-table"/>参照）のような文字クラスを解釈します。
+XQueryはこれらのクラスをUnicodeの文字属性を参照してこれらのクラスを決定します。
+ですからUnicodeルールに従うロケールを使用してのみ同等の振る舞いを得ることができます。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         The SQL standard (not XQuery itself) attempts to cater for more
         variants of <quote>newline</quote> than POSIX does.  The
         newline-sensitive matching options described above consider only
         ASCII NL (<literal>\n</literal>) to be a newline, but SQL would have
-        us treat CR (<literal>\r</literal>), CRLF (<literal>\r\n</literal>)
+        us treat CR (<literal>\r</literal>)、CRLF (<literal>\r\n</literal>)
         (a Windows-style newline), and some Unicode-only characters like
         LINE SEPARATOR (U+2028) as newlines as well.
         Notably, <literal>.</literal> and <literal>\s</literal> should
         count <literal>\r\n</literal> as one character not two according to
         SQL.
+-->
+SQL標準（XQuery自身ではなく）はPOSIXが提供するより多様な<quote>newline</quote>の亜種を提供しようとしています。
+上で述べた改行に敏感なマッチオプションはASCII NL（<literal>\n</literal>）だけを改行として考慮します。
+しかしSQLはCR （<literal>\r</literal>）、CRLF （<literal>\r\n</literal>）(Windowsスタイルの改行）、LINE SEPARATOR (U+2028)のようなUnicodeのみの文字も改行として扱うことを求めています。
+とりわけ、SQLにおいては、<literal>.</literal>と<literal>\s</literal>は<literal>\r\n</literal>を2文字ではなく、1文字として数える必要があります。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         Of the character-entry escapes described in
         <xref linkend="posix-character-entry-escapes-table"/>,
         XQuery supports only <literal>\n</literal>, <literal>\r</literal>,
         and <literal>\t</literal>.
+-->
+<xref linkend="posix-character-entry-escapes-table"/>で示す文字エントリエスケープのうち、XQueryは<literal>\n</literal>、<literal>\r</literal>、<literal>\t</literal>だけをサポートしています。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         XQuery does not support
         the <literal>[:<replaceable>name</replaceable>:]</literal> syntax
         for character classes within bracket expressions.
+-->
+XQueryはブラケット式内の文字クラスとして<literal>[:<replaceable>name</replaceable>:]</literal>構文をサポートしていません。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         XQuery does not have lookahead or lookbehind constraints,
         nor any of the constraint escapes described in
         <xref linkend="posix-constraint-escapes-table"/>.
+-->
+XQueryには先行検索制約および後方検索制約がありませんし、<xref linkend="posix-constraint-escapes-table"/>に記述された制約エスケープもありません。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         The metasyntax forms described in <xref linkend="posix-metasyntax"/>
         do not exist in XQuery.
+-->
+<xref linkend="posix-metasyntax"/>に記述されたメタ構文形式はXQueryには存在しません。
        </para>
       </listitem>
       <listitem>
        <para>
+<!--
         The regular expression flag letters defined by XQuery are
         related to but not the same as the option letters for POSIX
         (<xref linkend="posix-embedded-options-table"/>).  While the
         <literal>i</literal> and <literal>q</literal> options behave the
         same, others do not:
+-->
+XQueryで定義された正規表現フラグ文字はPOSIX（<xref linkend="posix-embedded-options-table"/>）のオプション文字に関連していますが、同じではありません。
+<literal>i</literal>と<literal>q</literal>オプションは同じように振る舞いますが、その他は違います。
         <itemizedlist>
          <listitem>
           <para>
+<!--
            XQuery's <literal>s</literal> (allow dot to match newline)
            and <literal>m</literal> (allow <literal>^</literal>
            and <literal>$</literal> to match at newlines) flags provide
@@ -8008,16 +8124,24 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
            POSIX's <literal>s</literal> and <literal>m</literal> flags.
            Note in particular that dot-matches-newline is the default
            behavior in POSIX but not XQuery.
+-->
+XQueryの<literal>s</literal>（ピリオドが改行にマッチすることを許容する）と<literal>m</literal>（<literal>^</literal>と<literal>$</literal>が改行位置でマッチすることを許容する）フラグは、POSIXの<literal>n</literal>、<literal>p</literal>、<literal>w</literal>フラグと同じ挙動を提供しますが、POSIXの<literal>s</literal>と<literal>m</literal>フラグの挙動とは一致<emphasis>しません</emphasis>。
+ピリオドが改行にマッチするのはPOSIXではデフォルトの挙動ですが、XQueryではそうでないことに留意してください。
           </para>
          </listitem>
          <listitem>
           <para>
+<!--
            XQuery's <literal>x</literal> (ignore whitespace in pattern) flag
            is noticeably different from POSIX's expanded-mode flag.
            POSIX's <literal>x</literal> flag also
            allows <literal>#</literal> to begin a comment in the pattern,
            and POSIX will not ignore a whitespace character after a
            backslash.
+-->
+XQueryの<literal>x</literal>（パターン中の空白を無視する）フラグはPOSIXの拡張モードフラグとは著しく異なります。
+POSIXの<literal>x</literal>フラグは<literal>#</literal>でパターン中のコメントを始めることもできます。
+POSIXはバックスラッシュ以降の空白文字を無視しません。
           </para>
          </listitem>
         </itemizedlist>

--- a/doc/src/sgml/func1.sgml
+++ b/doc/src/sgml/func1.sgml
@@ -1594,7 +1594,7 @@ NULL値が入力されると、<quote>不明</quote>という論理値として�
 -->
 <function>random()</function>関数は単純な線形合同法を使用しています。
 高速ですが、暗号用途には適していません。より安全な代替物として<xref linkend="pgcrypto"/>モジュールを参照してください。
-<function>setseed()</function>が呼び出されると、<function>setseed()</function>を同じ引数で実行することによって現在のセッション内での以後の<function>random()</function>の呼び出し結果は再現可能となります。
+<function>setseed()</function>が呼び出されると、現在のセッション内での以後の<function>random()</function>の呼び出し結果は<function>setseed()</function>を同じ引数で実行することによって再現可能となります。
   </para>
 
   <para>
@@ -5561,7 +5561,7 @@ substring(<replaceable>string</replaceable>, <replaceable>pattern</replaceable>,
 -->
 <literal>SIMILAR TO</literal>と同様、指定したパターンがデータ文字列全体に一致する必要があります。一致しない場合、関数は失敗し、NULLを返します。
 マッチするデータのうちの対象とする部分文字列に対応するパターンの部分を示すために、エスケープ文字の後に二重引用符（<literal>"</literal>）を繋げたものを2つパターンに含める必要があります。<!-- " font-lock sanity -->
-これらの印で括られたパターンの一部に一致するテキストが返されます。
+マッチが成功すると、これらの印で括られたパターンの一部に一致するテキストが返されます。
    </para>
 
    <para>

--- a/doc/src/sgml/func2.sgml
+++ b/doc/src/sgml/func2.sgml
@@ -770,7 +770,7 @@
        <literal>FX</literal> must be specified as the first item in
        the template.
 -->
-<literal>FX</literal>オプションが使用されていない場合、<function>to_timestamp</function>と<function>to_date</function>は入力文字列内のはじまり、そして最初と日付と時間の値の周辺の複数の空白スペースを無視します。
+<literal>FX</literal>オプションが使用されていない限り、<function>to_timestamp</function>と<function>to_date</function>は入力文字列内最初の連続した空白と、日付と時間の値の周辺の複数の空白を無視します。
 例えば、<literal>to_timestamp('2000&nbsp;&nbsp;&nbsp;&nbsp;JUN', 'YYYY MON')</literal>と<literal>to_timestamp('2000 - JUN', 'YYYY-MON')</literal>は動作しますが、<literal>to_timestamp('2000&nbsp;&nbsp;&nbsp;&nbsp;JUN','FXYYYY MON')</literal>はエラーを返します。
 後者の<function>to_timestamp</function>は単一のスペースだけがあることを期待するからです。
 <literal>FX</literal>はテンプレートの第1項目として指定される必要があります。
@@ -790,7 +790,7 @@
        returns an error because the number of separators in the input string
        exceeds the number of separators in the template.
 -->
-<function>to_timestamp</function>と<function>to_date</function>のテンプレート文字列中の区切り文字（空白あるいは記号文字(訳注：原文は"non-letter/non-digit character"））は入力文字中のすべての単一の区切り文字とマッチし、<literal>FX</literal>オプションが使用されている場合はスキップします。
+<literal>FX</literal>オプションが使用されていない限り、<function>to_timestamp</function>と<function>to_date</function>のテンプレート文字列中の区切り文字（空白あるいは記号文字(訳注：原文は"non-letter/non-digit character"））は入力文字中のすべての単一の区切り文字とマッチするか、あるいはマッチしない場合はスキップします。
 たとえば、<literal>to_timestamp('2000JUN', 'YYYY///MON')</literal>と<literal>to_timestamp('2000/JUN', 'YYYY MON')</literal>は動作しますが、<literal>to_timestamp('2000//JUN', 'YYYY/MON')</literal>は入力文字列中の区切り文字の数がテンプレート中の区切り文字の数を上回っているため、エラーを返します。
       </para>
       <para>
@@ -3137,7 +3137,7 @@ date_trunc(<replaceable>field</replaceable>, <replaceable>source</replaceable> [
     and it has all fields that are less significant than the
     selected one set to zero (or one, for day and month).
 -->
-<replaceable>source</replaceable>は、データ型<type>timestamp</type>、<type>timestamp with time zone</type>もしくは<type>interval</type>の評価式です
+<replaceable>source</replaceable>は、データ型<type>timestamp</type>、<type>timestamp with time zone</type>もしくは<type>interval</type>の評価式です。
 （<type>date</type>型と<type>time</type>型の値はそれぞれ自動的に<type>timestamp</type>もしくは<type>interval</type>にキャストされます。）
 <replaceable>field</replaceable>は、入力値の値をどの精度で切り捨てるかを選択します。
 同様に戻り値は<type>timestamp</type>、<type>timestamp with time zone</type>もしくは<type>interval</type>型で、指定した精度より下のすべてのフィールドがゼロに設定（日と月については1に設定）されます。

--- a/doc/src/sgml/func2.sgml
+++ b/doc/src/sgml/func2.sgml
@@ -829,6 +829,7 @@
 <literal>FX</literal>オプションが無い場合、マイナス符号は曖昧で、区切り文字として解釈されるかも知れません。
 この曖昧さは次のようにして解消されます。
 テンプレート文字列中の<literal>TZH</literal>の前の区切り文字の数が入力文字列中のマイナス符号の前の区切り文字の数よりも少なければ、そのマイナス符号は<literal>TZH</literal>の一部として解釈されます。
+そうでない場合、マイナス記号が値の区切り記号と見なされます。
 たとえば、<literal>to_timestamp('2000 -10', 'YYYY TZH')</literal>では<literal>-10</literal>が<literal>TZH</literal>にマッチしますが、<literal>to_timestamp('2000 -10', 'YYYY&nbsp;&nbsp;TZH')</literal>では<literal>10</literal>が<literal>TZH</literal>にマッチします。
       </para>
      </listitem>
@@ -867,7 +868,7 @@
           skip <literal>y</literal>, <literal>m</literal>, and
           <literal>d</literal>.
 -->
-<productname>PostgreSQL</productname> 12より前では、記号文字（訳注：原文は"non-letter or non-digit）を使って入力文字列中の任意のテキストをスキップすることが可能でした。
+<productname>PostgreSQL</productname> 12より前では、記号文字（訳注：原文は"non-letter or non-digit"）を使って入力文字列中の任意のテキストをスキップすることが可能でした。
 たとえば、<literal>to_timestamp('2000y6m1d', 'yyyy-MM-DD')</literal>は動作しました。
 現在は、この目的のために非記号文字（訳注：原文は"letter characters"）だけを使うことができます。
 たとえば、<literal>to_timestamp('2000y6m1d', 'yyyytMMtDDt')</literal>と<literal>to_timestamp('2000y6m1d', 'yyyy"y"MM"m"DD"d"')</literal>は、<literal>y</literal>、<literal>m</literal>、<literal>d</literal>をスキップします。
@@ -3194,7 +3195,7 @@ date_trunc(<replaceable>field</replaceable>, <replaceable>source</replaceable> [
 <!--
     Examples (assuming the local time zone is <literal>America/New_York</literal>):
 -->
-例：
+例（現地タイムゾーンは<literal>America/New_York</literal>と仮定します）：
 <screen>
 SELECT date_trunc('hour', TIMESTAMP '2001-02-16 20:38:40');
 <lineannotation>Result: </lineannotation><computeroutput>2001-02-16 20:00:00</computeroutput>
@@ -6002,9 +6003,8 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
    type <type>xml</type> are documented there, not in this section.
 -->
 この節で説明される関数および擬似関数式は、<type>xml</type>型の値に対して機能します。
-<type>xml</type>型についての情報は<xref linkend="datatype-xml"/>を点検してください。
-<type>xml</type>型のやりとりを変換する<function>xmlparse</function>および<function>xmlserialize</function>擬似関数式はここでは繰り返しません。
-これらの多くの関数を使用するには、インストレーションの際<command>configure --with-libxml</command>付きでビルドされていることが必要です。
+<type>xml</type>型についての情報は<xref linkend="datatype-xml"/>を参照してください。
+<type>xml</type>型のやりとりを変換する<function>xmlparse</function>および<function>xmlserialize</function>擬似関数式はこの節ではなく、そこに記載されています。
   </para>
 
   <para>
@@ -6013,7 +6013,7 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
    requires <productname>PostgreSQL</productname> to have been built
    with <command>configure &#045;&#045;with-libxml</command>.
 -->
-これらの関数の大半は<productname>PostgreSQL</productname>が<command>configure &#045;&#045;with-libxml</command>でビルドされていることを必要としています。
+これらの関数の大半は<productname>PostgreSQL</productname>が<command>configure --with-libxml</command>でビルドされていることを必要としています。
   </para>
 
   <sect2 id="functions-producing-xml">
@@ -6581,8 +6581,10 @@ SELECT xmlagg(x) FROM (SELECT * FROM test ORDER BY y DESC) AS tab;
      passed as the context item must be an XML document, not a content
      fragment or any non-XML value.
 -->
-関数<function>xmlexists</function>は第一引数のXPath式が何かしらのノードであれば真を返し、そうでなければ偽を返します。
-(もしいずれの引数もNULLであった場合はNULLを返します。)
+関数<function>xmlexists</function>は渡されたXML値をコンテキスト項目としてXPath 1.0式（第一引数）を評価します。
+この関数は評価が空のノード集合を生成する場合には偽を返し、それ以外の値を返すならば真を返します。
+もしどれかの引数がNULLであった場合はNULLを返します。
+コンテキスト項目として渡される非NULLの値は、内容の断片や非XML値ではなく、XML文書でなければなりません。
     </para>
 
     <para>
@@ -6745,8 +6747,9 @@ SELECT xml_is_well_formed_document('<pg:foo xmlns:pg="http://postgresql.org/stuf
      If the XPath expression returns a scalar value rather than a node-set,
      a single-element array is returned.
 -->
-関数<function>xpath</function>は、XML値<replaceable>xml</replaceable>に対し、XPath式<replaceable>xpath</replaceable>(ひとつの<type>text</type>値)を評価します。そして、XPath式で作成されたノードセットに対応するXML値の配列を返します。
-もし、XPath式がノードセットではなくスカラー値を返す場合、単一要素の配列が返されます。
+関数<function>xpath</function>は、XML値<replaceable>xml</replaceable>に対し、XPath 1.0式<replaceable>xpath</replaceable>(ひとつの<type>text</type>値)を評価します。
+そして、XPath式で作成されたノード集合に対応するXML値の配列を返します。
+もし、XPath式がノード集合ではなくスカラー値を返す場合、単一要素の配列が返されます。
     </para>
 
     <para>
@@ -6829,7 +6832,8 @@ SELECT xpath('//mydefns:b/text()', '<a xmlns="http://example.com"><b>test</b></a
      This function is equivalent to the <literal>XMLEXISTS</literal> predicate,
      except that it also offers support for a namespace mapping argument.
 -->
-関数<function>xpath_exists</function>は、<function>xpath</function>関数の特別な形式です。この関数は、XPathを満足する個別のXML値を返す代わりに、問い合わせがそれを満足するかどうかを論理値で返します。
+関数<function>xpath_exists</function>は、<function>xpath</function>関数の特別な形式です。
+この関数は、XPath 1.0を満足する個別のXML値を返す代わりに、問い合わせがそれを満足するかどうか（具体的には空のノード集合以外の値を返すかどうか）を論理値で返します。
 この関数は、名前空間にマッピングされた引数をもサポートする点を除き、標準の<literal>XMLEXISTS</literal>述語と同じです。
     </para>
 
@@ -6906,8 +6910,9 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
      is null, nor if the <replaceable>row_expression</replaceable> produces
      an empty node-set or any value other than a node-set.
 -->
-必須の<replaceable>row_expression</replaceable>引数はXPath式で、指定のXML文書に対して評価され、XMLノードの順序付きシーケンスが取得されます。
-このシーケンスが<function>xmltable</function>により出力行に変換されます。
+必須の<replaceable>row_expression</replaceable>引数はXPath 1.0式で、<replaceable>document_expression</replaceable>をそのコンテキスト項目とし渡し、XMLノード集合を得るために評価されます。
+このノードは<function>xmltable</function>が出力行に変換します。
+<replaceable>document_expression</replaceable>がNULLであるか、<replaceable>row_expression</replaceable>が空のノード集合あるいはノード集合以外の値を生成するなら行は出力されません。
     </para>
 
     <para>
@@ -6924,9 +6929,10 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
      expressions, as discussed in
      <xref linkend="functions-xml-limits-xpath1"/>.
 -->
-<replaceable>document_expression</replaceable>は演算の対象となるXML文書を提供します。
-<literal>BY REF</literal>句はPostgreSQLでは何の効果もありませんが、SQL準拠および他の実装との互換性のために受け入れられます。
-引数は整形されたXMLドキュメントでなければならず、フラグメントやフォレストは受け付けられません。
+<replaceable>document_expression</replaceable>は<replaceable>row_expression</replaceable>のためのコンテキスト項目を提供します。
+それは整形式XMLの文書でなければならず、フラグメントやフォレストは受け付けられません。
+<xref linkend="functions-xml-limits-postgresql"/>で議論されているように、<literal>BY REF</literal>句と<literal>BY VALUE</literal>句は受け付けられますが、無視されます。
+SQL標準では<function>xmltable</function>関数はXML問い合わせ言語の式を評価しますが、<xref linkend="functions-xml-limits-xpath1"/>で議論されているように<productname>PostgreSQL</productname>ではXPath 1.0式だけを受け付けます。
     </para>
 
     <para>
@@ -6952,7 +6958,7 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
      the <replaceable>row_expression</replaceable>'s result node-set.
      At most one column may be marked <literal>FOR ORDINALITY</literal>.
 -->
-<literal>FOR ORDINALITY</literal>と印がつけられた列には、元の入力XMLドキュメントの中に現れた出力行の順序に対応する行番号が入ります。
+<literal>FOR ORDINALITY</literal>と印がつけられた列には、<replaceable>row_expression</replaceable>の結果ノード集合から取得されたノードの順序に対応する1から始まる行番号が入ります。
 <literal>FOR ORDINALITY</literal>の印が付けられるのは最大でも1列です。
     </para>
 
@@ -6978,8 +6984,8 @@ XPath 1.0はノード集合内のノードの順序を指定しません。で�
      no <replaceable>column_expression</replaceable> is given, then the
      column name is used as an implicit path.
 -->
-列の<literal>column_expression</literal>はXPath式で、<replaceable>row_expression</replaceable>の結果に対応する各行について評価されて、列の値を得ます。
-<literal>column_expression</literal>が与えられなかった場合は、暗示的なパスとして列名が使用されます。
+列の<literal>column_expression</literal>はXPath 1.0式で、<replaceable>row_expression</replaceable>の結果における現在のノードをそのコンテキスト項目として<replaceable>row_expression</replaceable>の結果に対応する各行について評価されて、列の値を得ます。
+<literal>column_expression</literal>が与えられなかった場合は、暗黙的なパスとして列名が使用されます。
     </para>
 
     <para>
@@ -7054,8 +7060,8 @@ XPath 1.0の<function>string</function>関数で定義されているように�
 -->
 ある要素と、その子孫に含まれるすべてのテキストノードをドキュメントの順に結合したものがXML要素の文字列値です。
 テキストノードの子孫を持たない要素の文字列値は空文字列です。（ <literal>NULL</literal>ではありません。）
-<literal>xsi:nil</literal>属性は無視されます。
-非テキスト要素の間にある空白のみからなる<literal>text()</literal>2つのノードは保存され、<literal>text()</literal>の先頭の空白は平坦化されません。
+すべての<literal>xsi:nil</literal>属性は無視されます。
+非テキスト要素の間にある空白のみからなる<literal>text()</literal>2つのノードは保存され、<literal>text()</literal>の先頭の空白は平坦化されないことに注意してください。
 XPath 1.0 <function>string</function>関数が、他のXMLノード型と非XML値の文字列値を定義するルールのために参照されるかも知れません。
     </para>
 
@@ -7075,9 +7081,8 @@ XPath 1.0 <function>string</function>関数が、他のXMLノード型と非XML�
      a <replaceable>default_expression</replaceable> is specified; then the
      value resulting from evaluating that expression is used.
 -->
-パス式が行とマッチせず、<replaceable>default_expression</replaceable>が指定されている場合は、その式を評価した結果の値が使用されます。
-その列に<literal>DEFAULT</literal>句が指定されていない場合は、そのフィールドは<literal>NULL</literal>に設定されます。
-<replaceable>default_expression</replaceable>は列リスト内でそれより前に現れる出力列の値を参照して、ある列のデフォルト値を他の列の値に基づくものにすることができます。
+パス式がある行に対して空のノード集合（典型的にはマッチしなかった場合）を返した時は、<replaceable>default_expression</replaceable>が指定されている場合を除き、列には<literal>NULL</literal>が設定されます。
+そしてその式を評価した結果から生じる値が使用されます。
     </para>
 
     <para>
@@ -7103,11 +7108,9 @@ XPath 1.0 <function>string</function>関数が、他のXMLノード型と非XML�
      <function>nextval</function> in
      <replaceable>default_expression</replaceable>.
 -->
-PostgreSQLの通常の関数とは異なり、<replaceable>column_expression</replaceable>と<replaceable>default_expression</replaceable>は関数を呼び出す前には単純な値に評価されません。
-<replaceable>column_expression</replaceable>は通常は一つの入力行に対してちょうど一度だけ評価され、<replaceable>default_expression</replaceable>はフィールドにデフォルト値が必要になる度に評価されます。
+<function>xmltable</function>が呼び出されて直ちに評価されるのと異なり、<replaceable>default_expression</replaceable>はその列に対してデフォルトが必要になるたびに評価されます。
 式が安定（stable）または不変（immutable）とみなされる場合、評価は繰り返し行われないかもしれません。
-実際上、<function>xmltable</function>は関数呼び出しとしてよりも、副問合せのように動作します。
-これは<replaceable>default_expression</replaceable>の中で<function>nextval</function>のような揮発性（volatile）の関数を有効に使用できること、また<replaceable>column_expression</replaceable>はXML文書の他の部分に依存するかもしれないということを意味します。
+これは<replaceable>default_expression</replaceable>の中で<function>nextval</function>のような揮発性関数を使用できることを意味します。
     </para>
 
     <para>

--- a/doc/src/sgml/func2.sgml
+++ b/doc/src/sgml/func2.sgml
@@ -770,15 +770,16 @@
        <literal>FX</literal> must be specified as the first item in
        the template.
 -->
-<literal>FX</literal>オプションが使用されていない場合、<function>to_timestamp</function>と<function>to_date</function>は入力文字列内の複数の空白スペースを無視します。
-例えば、<literal>to_timestamp('2000&nbsp;&nbsp;&nbsp;&nbsp;JUN', 'YYYY MON')</literal>は動作しますが、<literal>to_timestamp('2000&nbsp;&nbsp;&nbsp;&nbsp;JUN','FXYYYY MON')</literal>はエラーを返します。
-後者の<function>to_timestamp</function>はスペースが1つだけあることを期待するからです。
+<literal>FX</literal>オプションが使用されていない場合、<function>to_timestamp</function>と<function>to_date</function>は入力文字列内のはじまり、そして最初と日付と時間の値の周辺の複数の空白スペースを無視します。
+例えば、<literal>to_timestamp('2000&nbsp;&nbsp;&nbsp;&nbsp;JUN', 'YYYY MON')</literal>と<literal>to_timestamp('2000 - JUN', 'YYYY-MON')</literal>は動作しますが、<literal>to_timestamp('2000&nbsp;&nbsp;&nbsp;&nbsp;JUN','FXYYYY MON')</literal>はエラーを返します。
+後者の<function>to_timestamp</function>は単一のスペースだけがあることを期待するからです。
 <literal>FX</literal>はテンプレートの第1項目として指定される必要があります。
       </para>
      </listitem>
 
      <listitem>
       <para>
+<!--
        A separator (a space or non-letter/non-digit character) in the template string of
        <function>to_timestamp</function> and <function>to_date</function>
        matches any single separator in the input string or is skipped,
@@ -788,8 +789,12 @@
        <literal>to_timestamp('2000//JUN', 'YYYY/MON')</literal>
        returns an error because the number of separators in the input string
        exceeds the number of separators in the template.
+-->
+<function>to_timestamp</function>と<function>to_date</function>のテンプレート文字列中の区切り文字（空白あるいは記号文字(訳注：原文は"non-letter/non-digit character"））は入力文字中のすべての単一の区切り文字とマッチし、<literal>FX</literal>オプションが使用されている場合はスキップします。
+たとえば、<literal>to_timestamp('2000JUN', 'YYYY///MON')</literal>と<literal>to_timestamp('2000/JUN', 'YYYY MON')</literal>は動作しますが、<literal>to_timestamp('2000//JUN', 'YYYY/MON')</literal>は入力文字列中の区切り文字の数がテンプレート中の区切り文字の数を上回っているため、エラーを返します。
       </para>
       <para>
+<!--
        If <literal>FX</literal> is specified, a separator in the template string
        matches exactly one character in the input string.  But note that the
        input string character is not required to be the same as the separator from the template string.
@@ -797,11 +802,16 @@
        works, but <literal>to_timestamp('2000/JUN', 'FXYYYY&nbsp;&nbsp;MON')</literal>
        returns an error because the second space in the template string consumes
        the letter <literal>J</literal> from the input string.
+-->
+<literal>FX</literal>が指定されていると、テンプレート文字列中の区切り文字は正確に入力文字列中の一文字とマッチします。
+しかし、入力文字列の文字はテンプレート文字列中の区切り文字と一致する必要はないことに注意してください。
+たとえば、<literal>to_timestamp('2000/JUN', 'FXYYYY MON')</literal>は動作しますが、<literal>to_timestamp('2000/JUN', 'FXYYYY&nbsp;&nbsp;MON')</literal>はテンプレート文字列中の二番目の空白が入力文字列中の文字<literal>J</literal>を消費するため、エラーを返します。
       </para>
      </listitem>
 
      <listitem>
       <para>
+<!--
        A <literal>TZH</literal> template pattern can match a signed number.
        Without the <literal>FX</literal> option, minus signs may be ambiguous,
        and could be interpreted as a separator.
@@ -814,6 +824,12 @@
        <literal>-10</literal> to <literal>TZH</literal>, but
        <literal>to_timestamp('2000 -10', 'YYYY&nbsp;&nbsp;TZH')</literal>
        matches <literal>10</literal> to <literal>TZH</literal>.
+-->
+<literal>TZH</literal>テンプレートパターンは符号付きの数字とマッチします。
+<literal>FX</literal>オプションが無い場合、マイナス符号は曖昧で、区切り文字として解釈されるかも知れません。
+この曖昧さは次のようにして解消されます。
+テンプレート文字列中の<literal>TZH</literal>の前の区切り文字の数が入力文字列中のマイナス符号の前の区切り文字の数よりも少なければ、そのマイナス符号は<literal>TZH</literal>の一部として解釈されます。
+たとえば、<literal>to_timestamp('2000 -10', 'YYYY TZH')</literal>では<literal>-10</literal>が<literal>TZH</literal>にマッチしますが、<literal>to_timestamp('2000 -10', 'YYYY&nbsp;&nbsp;TZH')</literal>では<literal>10</literal>が<literal>TZH</literal>にマッチします。
       </para>
      </listitem>
 
@@ -840,6 +856,7 @@
       </para>
       <tip>
         <para>
+<!--
           Prior to <productname>PostgreSQL</productname> 12, it was possible to
           skip arbitrary text in the input string using non-letter or non-digit
           characters. For example,
@@ -849,6 +866,11 @@
           <literal>to_timestamp('2000y6m1d', 'yyyy"y"MM"m"DD"d"')</literal>
           skip <literal>y</literal>, <literal>m</literal>, and
           <literal>d</literal>.
+-->
+<productname>PostgreSQL</productname> 12より前では、記号文字（訳注：原文は"non-letter or non-digit）を使って入力文字列中の任意のテキストをスキップすることが可能でした。
+たとえば、<literal>to_timestamp('2000y6m1d', 'yyyy-MM-DD')</literal>は動作しました。
+現在は、この目的のために非記号文字（訳注：原文は"letter characters"）だけを使うことができます。
+たとえば、<literal>to_timestamp('2000y6m1d', 'yyyytMMtDDt')</literal>と<literal>to_timestamp('2000y6m1d', 'yyyy"y"MM"m"DD"d"')</literal>は、<literal>y</literal>、<literal>m</literal>、<literal>d</literal>をスキップします。
         </para>
       </tip>
      </listitem>
@@ -1957,7 +1979,7 @@ ISO 8601週番号年の文脈では、<quote>月</quote>、あるいは<quote>�
 <!--
         <entry>Truncate to specified precision; see <xref linkend="functions-datetime-trunc"/>
 -->
-        <entry>指定された精度で切り捨て。<xref linkend="functions-datetime-trunc"/>も参照。
+        <entry>指定された精度で切り捨て。<xref linkend="functions-datetime-trunc"/>参照。
         </entry>
         <entry><literal>date_trunc('hour', timestamp '2001-02-16 20:38:40')</literal></entry>
         <entry><literal>2001-02-16 20:00:00</literal></entry>
@@ -1966,7 +1988,10 @@ ISO 8601週番号年の文脈では、<quote>月</quote>、あるいは<quote>�
        <row>
         <entry><literal><function>date_trunc(<type>text</type>, <type>timestamp with time zone</type>, <type>text</type>)</function></literal></entry>
         <entry><type>timestamp with time zone</type></entry>
+<!--
         <entry>Truncate to specified precision in the specified time zone; see <xref linkend="functions-datetime-trunc"/>
+-->
+        <entry>指定された時間帯において指定された精度で切り捨て。<xref linkend="functions-datetime-trunc"/>参照
         </entry>
         <entry><literal>date_trunc('day', timestamptz '2001-02-16 20:38:40+00', 'Australia/Sydney')</literal></entry>
         <entry><literal>2001-02-16 13:00:00+00</literal></entry>
@@ -1978,7 +2003,7 @@ ISO 8601週番号年の文脈では、<quote>月</quote>、あるいは<quote>�
 <!--
         <entry>Truncate to specified precision; see <xref linkend="functions-datetime-trunc"/>
 -->
-        <entry>指定された精度で切り捨て。<xref linkend="functions-datetime-trunc"/>も参照。
+        <entry>指定された精度で切り捨て。<xref linkend="functions-datetime-trunc"/>参照。
         </entry>
         <entry><literal>date_trunc('hour', interval '2 days 3 hours 40 minutes')</literal></entry>
         <entry><literal>2 days 03:00:00</literal></entry>
@@ -3111,10 +3136,10 @@ date_trunc(<replaceable>field</replaceable>, <replaceable>source</replaceable> [
     and it has all fields that are less significant than the
     selected one set to zero (or one, for day and month).
 -->
-<replaceable>source</replaceable>は、データ型<type>timestamp</type>もしくは<type>interval</type>の評価式です
+<replaceable>source</replaceable>は、データ型<type>timestamp</type>、<type>timestamp with time zone</type>もしくは<type>interval</type>の評価式です
 （<type>date</type>型と<type>time</type>型の値はそれぞれ自動的に<type>timestamp</type>もしくは<type>interval</type>にキャストされます。）
 <replaceable>field</replaceable>は、入力値の値をどの精度で切り捨てるかを選択します。
-戻り値は<type>timestamp</type>もしくは<type>interval</type>型で、指定した精度より下のすべてのフィールドがゼロに設定（日と月については1に設定）されます。
+同様に戻り値は<type>timestamp</type>、<type>timestamp with time zone</type>もしくは<type>interval</type>型で、指定した精度より下のすべてのフィールドがゼロに設定（日と月については1に設定）されます。
    </para>
 
    <para>
@@ -3140,6 +3165,7 @@ date_trunc(<replaceable>field</replaceable>, <replaceable>source</replaceable> [
    </para>
 
    <para>
+<!--
     When the input value is of type <type>timestamp with time zone</type>,
     the truncation is performed with respect to a particular time zone;
     for example, truncation to <literal>day</literal> produces a value that
@@ -3148,12 +3174,20 @@ date_trunc(<replaceable>field</replaceable>, <replaceable>source</replaceable> [
     optional <replaceable>time_zone</replaceable> argument can be provided
     to specify a different time zone.  The time zone name can be specified
     in any of the ways described in <xref linkend="datatype-timezones"/>.
+-->
+入力値が<type>timestamp with time zone</type>型の値なら、特定の時間帯を考慮して切り捨てが行われます。たとえば、<literal>日</literal>を切り捨てると値はその時間帯での真夜中になります。
+デフォルトでは切り捨ては現在の<xref linkend="guc-timezone"/>の設定に従いますが、別の時間帯を指定することができるようにオプションの<replaceable>time_zone</replaceable>引数が提供されています。
+時間帯名は<xref linkend="datatype-timezones"/>に記述されている方法で指定できます。
    </para>
 
    <para>
+<!--
     A time zone cannot be specified when processing <type>timestamp without
     time zone</type> or <type>interval</type> inputs.  These are always
     taken at face value.
+-->
+<type>timestamp without time zone</type>あるいは<type>interval</type>の入力を処理している間は時間帯は指定できません。
+これらは額面通りの値で扱われます。
    </para>
 
    <para>
@@ -5974,9 +6008,12 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
   </para>
 
   <para>
+<!--
    Use of most of these functions
    requires <productname>PostgreSQL</productname> to have been built
    with <command>configure &#045;&#045;with-libxml</command>.
+-->
+これらの関数の大半は<productname>PostgreSQL</productname>が<command>configure &#045;&#045;with-libxml</command>でビルドされていることを必要としています。
   </para>
 
   <sect2 id="functions-producing-xml">
@@ -6574,9 +6611,8 @@ SELECT xmlexists('//town[text() = ''Toronto'']' PASSING BY VALUE '<towns><town>T
      expression, as discussed in
      <xref linkend="functions-xml-limits-xpath1"/>.
 -->
-<literal>BY REF</literal>句は、PostgreSQLには何の影響も与えませんが、他の実装とのSQL互換性や順応性のため、付与することができます。
-SQL標準では1つ目の<literal>BY REF</literal>を必要としており、2つ目はオプショナルです。
-加えてSQL標準では<function>xmlexists</function>はXQuery式を第一引数として取る構成としていますが、PostgreSQLでは現在XQueryのサブセットにあたるXPathのみサポートしていることに注意してください。
+<productname>PostgreSQL</productname>は<literal>BY REF</literal>句と<literal>BY VALUE</literal>句を受け付けますが、<xref linkend="functions-xml-limits-postgresql"/>で議論されているように無視します。
+SQL標準では<function>xmlexists</function>関数はXML問い合わせ言語における式を評価しますが、<xref linkend="functions-xml-limits-xpath1"/>で議論されているように、<productname>PostgreSQL</productname>はXPath 1.0の式だけを受け付けます。
     </para>
    </sect3>
 
@@ -6922,10 +6958,14 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
 
     <note>
      <para>
+<!--
       XPath 1.0 does not specify an order for nodes in a node-set, so code
       that relies on a particular order of the results will be
       implementation-dependent.  Details can be found in
       <xref linkend="xml-xpath-1-specifics"/>.
+-->
+XPath 1.0はノード集合内のノードの順序を指定しません。ですから、結果が特定の順序になっていることに依存するコードは実装依存となります。
+詳細は<xref linkend="xml-xpath-1-specifics"/>をご覧ください。
      </para>
     </note>
 
@@ -6953,18 +6993,21 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
      column's type category is numeric, otherwise <literal>true</literal> or
      <literal>false</literal>.)
 -->
-列のXPath式が複数の要素を戻した場合、エラーが発生します。
-式が空のタグとマッチした場合、結果は空文字列となります（<literal>NULL</literal>ではありません）。
-<literal>xsi:nil</literal>の属性はすべて無視されます。
+列のXPath式が非XML値（XPath 1.0における文字列、真偽値、倍精度浮動小数点数に限られます）を返し、その列が<type>xml</type>以外のPostgreSQL型なら、あたかも値の文字列表現をPostgreSQL型にアサインしたように列に値がセットされます。
+（値が真偽値の場合、出力列型が数値カテゴリに属するならその文字列表現は<literal>1</literal>または<literal>0</literal>になり、それ外なら<literal>true</literal>または<literal>false</literal>になります。）
     </para>
 
     <para>
+<!--
      If a column's XPath expression returns a non-empty set of XML nodes
      and the column's PostgreSQL type is <type>xml</type>, the column will
      be assigned the expression result exactly, if it is of document or
      content form.
+-->
+列のXPath表現が空ではないXMLノードの集合を返し、列のPostgreSQL型が<type>xml</type>である場合には、式が文書あるいはフォームの内容なら、列には正確に式の結果がアサインされます。
      <footnote>
       <para>
+<!--
        A result containing more than one element node at the top level, or
        non-whitespace text outside of an element, is an example of content form.
        An XPath result can be of neither form, for example if it returns an
@@ -6972,11 +7015,17 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
        will be put into content form with each such disallowed node replaced by
        its string value, as defined for the XPath 1.0
        <function>string</function> function.
+-->
+トップレベルにおいて複数の要素ノードを含むか、あるいは要素の外側の非空白テキストであるような結果は、コンテントフォームの例です。
+XPathの結果はそのどちらでもないフォームであることがあり得ます。
+たとえば、それを含む要素から選択された属性ノードを返す場合です。
+XPath 1.0の<function>string</function>関数で定義されているように、そうした結果は、許可されないノードを文字列値で置き換えたコンテントフォームに設定されます。
       </para>
      </footnote>
     </para>
 
     <para>
+<!--
      A non-XML result assigned to an <type>xml</type> output column produces
      content, a single text node with the string value of the result.
      An XML result assigned to a column of any other type may not have more than
@@ -6984,6 +7033,10 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
      will be set as if by assigning the node's string
      value (as defined for the XPath 1.0 <function>string</function> function)
      to the PostgreSQL type.
+-->
+<type>xml</type>出力列にアサインされた非XMLの結果は、結果の値が文字列値となる単一のテキストノードであるコンテントを生成します。
+それ以外の型の列にアサインされたXMLの結果は複数のノードを持たないかも知れませんし、エラーを生じするかも知れません。
+正確に一つのノードだけが存在するなら、列にはあたかもノードの文字列値（XPath 1.0 <function>string</function>関数の定義されているように） がPostgreSQL型にアサインされたように設定されます。
     </para>
 
     <para>
@@ -6999,15 +7052,19 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
      The XPath 1.0 <function>string</function> function may be consulted for the
      rules defining the string value of other XML node types and non-XML values.
 -->
-<replaceable>column_expression</replaceable>にマッチしたXMLのテキスト本体が列の値として使用されます。
-要素内の複数の<literal>text()</literal>ノードは順番に結合されます。
-子要素、処理命令、コメントはすべて無視されますが、子要素のテキストコンテンツは結果に結合されます。
-2つの非テキスト要素間にある空白文字のみの<literal>text()</literal>ノードは保存されること、また<literal>text()</literal>ノードの先頭にある空白文字は削られないことに注意してください。
+ある要素と、その子孫に含まれるすべてのテキストノードをドキュメントの順に結合したものがXML要素の文字列値です。
+テキストノードの子孫を持たない要素の文字列値は空文字列です。（ <literal>NULL</literal>ではありません。）
+<literal>xsi:nil</literal>属性は無視されます。
+非テキスト要素の間にある空白のみからなる<literal>text()</literal>2つのノードは保存され、<literal>text()</literal>の先頭の空白は平坦化されません。
+XPath 1.0 <function>string</function>関数が、他のXMLノード型と非XML値の文字列値を定義するルールのために参照されるかも知れません。
     </para>
 
     <para>
+<!--
      The conversion rules presented here are not exactly those of the SQL
      standard, as discussed in <xref linkend="functions-xml-limits-casts"/>.
+-->
+ここで示した変換ルールは、<xref linkend="functions-xml-limits-casts"/>で議論されているように、正確にSQL標準に従っているわけではありません。
     </para>
 
     <para>

--- a/doc/src/sgml/func2.sgml
+++ b/doc/src/sgml/func2.sgml
@@ -6910,7 +6910,7 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
      is null, nor if the <replaceable>row_expression</replaceable> produces
      an empty node-set or any value other than a node-set.
 -->
-必須の<replaceable>row_expression</replaceable>引数はXPath 1.0式で、<replaceable>document_expression</replaceable>をそのコンテキスト項目とし渡し、XMLノード集合を得るために評価されます。
+必須の<replaceable>row_expression</replaceable>引数は評価されるXPath 1.0式で、XMLノード集合を得るために<replaceable>document_expression</replaceable>をそのコンテキスト項目として渡します。
 このノードは<function>xmltable</function>が出力行に変換します。
 <replaceable>document_expression</replaceable>がNULLであるか、<replaceable>row_expression</replaceable>が空のノード集合あるいはノード集合以外の値を生成するなら行は出力されません。
     </para>

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -42,7 +42,7 @@ JSONデータを処理、生成する関数と演算子
 <!--
       the SQL/JSON path language
 -->
-SQL/JSONパス関数言語
+SQL/JSONパス言語
      </para>
     </listitem>
    </itemizedlist>
@@ -353,7 +353,7 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
 <!--
         <entry>Does JSON path return any item for the specified JSON value?</entry>
 -->
-        <entry>JSONパスが指定したJSON値のすべての要素を返すか？</entry>
+        <entry>指定したJSON値に対応する要素を返すか？</entry>
         <entry><literal>'{"a":[1,2,3,4,5]}'::jsonb @? '$.a[*] ? (@ > 2)'</literal></entry>
        </row>
        <row>
@@ -1149,7 +1149,7 @@ pathについての演算子について言うと、<replaceable>new_value</repl
           Checks whether JSON path returns any item for the specified JSON
           value.
 -->
-指定したJSON値に対してJSONパスがすべての項目を返すかどうかをチェックする。
+JSONパスが指定したJSON値に対して項目を返すかどうかをチェックする。
         </entry>
         <entry>
          <para><literal>
@@ -1652,7 +1652,7 @@ SQL/JSON配列は0スタートであることに注意してください。
    <literal>WHERE</literal> clause in SQL. A filter expression begins with
    a question mark and provides a condition in parentheses:
 -->
-パスを定義する際にはSQLの<literal>WHERE</literal>節のように働く一つ以上の<firstterm>filter expressions</firstterm>が利用できます。
+パスを定義する際にはSQLの<literal>WHERE</literal>節のように働く一つ以上の<firstterm>フィルター式</firstterm>が利用できます。
 フィルター式はクェスチョンマークで始まり、カッコ内に条件を記述します。
 
 <programlisting>
@@ -1868,7 +1868,7 @@ SQL/JSONパス式には構造上のエラーを扱うための2つのモード�
 あるオペランドが操作の要件に合わないときにはそれをSQL/JSON配列にまとめたり、あるいは操作を行う前にそれをSQL/JSONシーケンスに展開することもできます。
 また非厳密モードにおいては、比較演算子は自動的にオペランドを展開し、SQL/JSON配列をそのまま比較することができます。
 大きさ1の配列はその単独要素と同じものとして扱われます。
-自動展開は以下の場合にのみ行われます。
+自動展開は以下の場合にのみ行われません。
     <itemizedlist>
      <listitem>
       <para>
@@ -1877,7 +1877,7 @@ SQL/JSONパス式には構造上のエラーを扱うための2つのモード�
        <literal>size()</literal> methods that return the type
        and the number of elements in the array, respectively.
 -->
-それぞれ配列の型、要素数を返す<literal>type()</literal>、<literal>size()</literal>をパス式が含む場合。
+それぞれ配列の型、要素数を返す<literal>type()</literal>、<literal>size()</literal>をパス式が含む。
       </para>
      </listitem>
      <listitem>
@@ -1888,7 +1888,8 @@ SQL/JSONパス式には構造上のエラーを扱うための2つのモード�
        remain unchanged. Thus, implicit unwrapping can only go one
        level down within each path evaluation step.
 -->
-問い合わせ対象のJSONデータが入れ子の配列を含んでいる。この場合はもっとも外側の配列のみが展開され、内側の配列は変わりません。
+問い合わせ対象のJSONデータが入れ子の配列を含む。
+この場合はもっとも外側の配列のみが展開され、内側の配列は変わりません。
 ですから、それぞれの評価段階において1レベルのみに暗黙的な展開が行われます。
       </para>
      </listitem>
@@ -2192,8 +2193,7 @@ PostgreSQLは今の所<literal>LIKE_REGEX</literal>演算子をサポートし�
           <literal>"id"</literal> is a unique identifier of the object
           key-value pair belongs to.
 -->
-3つのフィールド（<literal>"key"</literal>、<literal>"value"</literal>、<literal>"id"</literal>）を含む項目の配列で表現されたオブジェクトの
-キーバリューペアのシーケンス。
+3つのフィールド（<literal>"key"</literal>、<literal>"value"</literal>、<literal>"id"</literal>）を含む項目の配列で表現されたオブジェクトのキーバリューペアのシーケンス。
 <literal>"id"</literal>はキーバリューペアが所属するオブジェクトのユニーク識別子です。
         </entry>
         <entry><literal>{"x": "20", "y": 32}</literal></entry>
@@ -2324,7 +2324,7 @@ PostgreSQLは今の所<literal>LIKE_REGEX</literal>演算子をサポートし�
 <!--
         <entry>Value used to perform comparison with JSON <literal>null</literal> value</entry>
 -->
-        <entry>JSONの<literal>null</literal>リテラルとの比較に用いられる値</entry>
+        <entry>JSONの<literal>null</literal>値との比較に用いられる値</entry>
         <entry><literal>[{"name": "Mary", "job": null},
                          {"name": "Michael", "job": "driver"}]</literal></entry>
         <entry><literal>$[*] ? (@.job == null) .name</literal></entry>

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -1553,7 +1553,7 @@ JSON問い合わせ関数と演算子は与えられたパス式を<firstterm>pa
    result of the previous evaluation step.
 -->
 問い合わせ対象（<firstterm>context item</firstterm>）のJSONデータを参照するには、パス式内で<literal>$</literal>記号を使います。
-複数の<link linkend="type-jsonpath-accessors">アクセス演算子</link>をその後に記述することもできます。
+複数の<link linkend="type-jsonpath-accessors">アクセッサ演算子</link>をその後に記述することもできます。
 それによってJSON構造をレベル順に訪れて文脈の項目の内容を取り出します。
 後続の個々の演算子はその前の評価段階の結果を処理します。
   </para>
@@ -1776,7 +1776,7 @@ SQL/JSONは3値論理を定義しており、条件は<literal>true</literal>、
      operations.  Datetime support will be added to <type>jsonpath</type>
      in future versions of <productname>PostgreSQL</productname>.
 -->
-<literal>.datetime()</literal>項目メソッドは、主に不揮発性<type>jsonpath</type>関数と演算子が日付日時演算子で使用されているセッション時間帯を参照できないという理由でまだ実装されていません。
+<literal>.datetime()</literal>項目メソッドは、主に不揮発性<type>jsonpath</type>関数と演算子が日付時刻操作で使用されているセッション時間帯を参照できないという理由でまだ実装されていません。
 将来の<productname>PostgreSQL</productname>バージョンでは<type>jsonpath</type>のサポートが追加される予定です。
     </para>
    </listitem>
@@ -2313,7 +2313,7 @@ PostgreSQLは今の所<literal>LIKE_REGEX</literal>演算子をサポートし�
 <!--
         <entry>Value used to perform comparison with JSON <literal>false</literal> literal</entry>
 -->
-        <entry>JSONの<literal>true</literal>リテラルとの比較に用いられる値</entry>
+        <entry>JSONの<literal>false</literal>リテラルとの比較に用いられる値</entry>
         <entry><literal>[{"name": "John", "parent": false},
                            {"name": "Chris", "parent": true}]</literal></entry>
         <entry><literal>$[*] ? (@.parent == false)</literal></entry>
@@ -2324,7 +2324,7 @@ PostgreSQLは今の所<literal>LIKE_REGEX</literal>演算子をサポートし�
 <!--
         <entry>Value used to perform comparison with JSON <literal>null</literal> value</entry>
 -->
-        <entry>JSONの<literal>true</literal>リテラルとの比較に用いられる値</entry>
+        <entry>JSONの<literal>null</literal>リテラルとの比較に用いられる値</entry>
         <entry><literal>[{"name": "Mary", "job": null},
                          {"name": "Michael", "job": "driver"}]</literal></entry>
         <entry><literal>$[*] ? (@.job == null) .name</literal></entry>

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -92,7 +92,7 @@ SQL/JSON標準を更に学ぶためには、<xref linkend="sqltr-19075-6"/>を�
 -->
         <entry>演算子</entry>
         <entry>右オペランド型</entry>
-        <entry>Return type</entry>
+        <entry>戻り値型</entry>
         <entry>説明</entry>
         <entry>例</entry>
         <entry>例の結果</entry>

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -353,7 +353,7 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
 <!--
         <entry>Does JSON path return any item for the specified JSON value?</entry>
 -->
-        <entry>指定したJSON値に対応する要素を返すか？</entry>
+        <entry>JSONパスが指定したJSON値に対応する要素を返すか？</entry>
         <entry><literal>'{"a":[1,2,3,4,5]}'::jsonb @? '$.a[*] ? (@ > 2)'</literal></entry>
        </row>
        <row>

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -23,31 +23,47 @@
   </indexterm>
 
   <para>
+<!--
    This section describes:
+-->
+この節では次のことを説明します。
 
    <itemizedlist>
     <listitem>
      <para>
+<!--
       functions and operators for processing and creating JSON data
+-->
+JSONデータを処理、生成する関数と演算子
      </para>
     </listitem>
     <listitem>
      <para>
+<!--
       the SQL/JSON path language
+-->
+SQL/JSONパス関数言語
      </para>
     </listitem>
    </itemizedlist>
   </para>
 
   <para>
+<!--
    To learn more about the SQL/JSON standard, see
    <xref linkend="sqltr-19075-6"/>. For details on JSON types
    supported in <productname>PostgreSQL</productname>,
    see <xref linkend="datatype-json"/>.
+-->
+SQL/JSON標準を更に学ぶためには、<xref linkend="sqltr-19075-6"/>をご覧ください。
+<productname>PostgreSQL</productname>でサポートされているJSON型の詳細に関しては、<xref linkend="datatype-json"/>をご覧ください。
   </para>
 
   <sect2 id="functions-json-processing">
+<!--
    <title>Processing and Creating JSON Data</title>
+-->
+   <title>JSONデータの処理と生成</title>
 
   <para>
 <!--
@@ -55,7 +71,7 @@
    are available for use with JSON data types (see <xref
    linkend="datatype-json"/>).
 -->
-<xref linkend="functions-json-op-table"/>に2つのJSONデータ型(<xref linkend="datatype-json"/>を参照)で使用可能な演算子を示します。
+<xref linkend="functions-json-op-table"/>にJSONデータ型(<xref linkend="datatype-json"/>を参照)で使用可能な演算子を示します。
   </para>
 
   <table id="functions-json-op-table">
@@ -334,15 +350,23 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
        <row>
         <entry><literal>@?</literal></entry>
         <entry><type>jsonpath</type></entry>
+<!--
         <entry>Does JSON path return any item for the specified JSON value?</entry>
+-->
+        <entry>JSONパスが指定したJSON値のすべての要素を返すか？</entry>
         <entry><literal>'{"a":[1,2,3,4,5]}'::jsonb @? '$.a[*] ? (@ > 2)'</literal></entry>
        </row>
        <row>
         <entry><literal>@@</literal></entry>
         <entry><type>jsonpath</type></entry>
+<!--
         <entry>Returns the result of JSON path predicate check for the specified JSON value.
         Only the first item of the result is taken into account.  If the
         result is not Boolean, then <literal>null</literal> is returned.</entry>
+-->
+        <entry>指定したJSON値のJSONパス述語チェックの結果を返す。
+        結果の最初の項目だけが考慮されます。
+        結果がBooleanでないなら、<literal>null</literal>が返ります。</entry>
         <entry><literal>'{"a":[1,2,3,4,5]}'::jsonb @@ '$.a[*] > 2'</literal></entry>
        </row>
       </tbody>
@@ -365,11 +389,16 @@ JSON配列の添字を整数で受け取り、フィールド、要素、パス�
 
   <note>
    <para>
+<!--
     The <literal>@?</literal> and <literal>@@</literal> operators suppress
     the following errors: lacking object field or array element, unexpected
     JSON item type, and numeric errors.
     This behavior might be helpful while searching over JSON document
     collections of varying structure.
+-->
+<literal>@?</literal>および<literal>@@</literal>演算子は以下のエラーを抑止します。
+オブジェクトフィールドあるいは配列要素の欠如、期待しないJSON要素型、数値エラー。
+この振る舞いは、異なる構造のJSON文書集合を検索する際に役に立つかも知れません。
    </para>
   </note>
 
@@ -1116,8 +1145,11 @@ pathについての演算子について言うと、<replaceable>new_value</repl
         </entry>
         <entry><type>boolean</type></entry>
         <entry>
+<!--
           Checks whether JSON path returns any item for the specified JSON
           value.
+-->
+指定したJSON値に対してJSONパスがすべての項目を返すかどうかをチェックする。
         </entry>
         <entry>
          <para><literal>
@@ -1136,10 +1168,16 @@ pathについての演算子について言うと、<replaceable>new_value</repl
         </entry>
         <entry><type>boolean</type></entry>
         <entry>
+<!--
           Returns the result of JSON path predicate check for the specified JSON value.
           Only the first item of the result is taken into account.  If the
           result is not Boolean, then <literal>null</literal> is returned.
+-->
+        指定したJSON値のJSONパス述語チェックの結果を返す。
+        結果の最初の項目だけが考慮されます。
+        結果がBooleanでないなら、<literal>null</literal>が返ります。
         </entry>
+        <entry><literal>'{"a":[1,2,3,4,5]}'::jsonb @@ '$.a[*] > 2'</literal></entry>
         <entry>
          <para><literal>
            jsonb_path_match('{"a":[1,2,3,4,5]}', 'exists($.a[*] ? (@ >= $min &amp;&amp; @ &lt;= $max))', '{"min":2,"max":4}')
@@ -1157,8 +1195,11 @@ pathについての演算子について言うと、<replaceable>new_value</repl
         </entry>
         <entry><type>setof jsonb</type></entry>
         <entry>
+<!--
           Gets all JSON items returned by JSON path for the specified JSON
           value.
+-->
+指定したJSON値に対してJSONパスが返すすべてのJSON項目を得る。
         </entry>
         <entry>
          <para><literal>
@@ -1185,8 +1226,11 @@ pathについての演算子について言うと、<replaceable>new_value</repl
         </entry>
         <entry><type>jsonb</type></entry>
         <entry>
+<!--
           Gets all JSON items returned by JSON path for the specified JSON
           value and wraps result into an array.
+-->
+指定したJSON値に対してJSONパスが返すすべてのJSON項目を得て配列に格納する。
         </entry>
         <entry>
          <para><literal>
@@ -1205,8 +1249,12 @@ pathについての演算子について言うと、<replaceable>new_value</repl
         </entry>
         <entry><type>jsonb</type></entry>
         <entry>
+<!--
           Gets the first JSON item returned by JSON path for the specified JSON
           value.  Returns <literal>NULL</literal> on no results.
+-->
+指定したJSON値に対するJSONパスが返す最初のJSON項目を得る。
+結果がなければ<literal>NULL</literal>を返す。
         </entry>
         <entry>
          <para><literal>
@@ -1230,7 +1278,7 @@ pathについての演算子について言うと、<replaceable>new_value</repl
       done; but for <type>json</type> input, this may result in throwing an error,
       as noted in <xref linkend="datatype-json"/>.
 -->
-これらの多くの関数や演算子は、JSON文字列のUnicodeのエスケープを適切な一文字に変換します。
+これらの関数や演算子の多くは、JSON文字列のUnicodeのエスケープを適切な一文字に変換します。
 これは入力が<type>jsonb</type>型であれば、変換は既に行なわれていますので、重要な問題ではありません。しかし、<type>json</type>の入力に対しては、<xref linkend="datatype-json"/>で言及したようにこれはエラーを発生させる結果になるかもしれません。
     </para>
   </note>
@@ -1394,21 +1442,30 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
 
   <note>
    <para>
+<!--
     The <literal>jsonb_path_exists</literal>, <literal>jsonb_path_match</literal>,
     <literal>jsonb_path_query</literal>, <literal>jsonb_path_query_array</literal>, and
     <literal>jsonb_path_query_first</literal>
     functions have optional <literal>vars</literal> and <literal>silent</literal>
     arguments.
+-->
+<literal>jsonb_path_exists</literal>、<literal>jsonb_path_match</literal>、<literal>jsonb_path_query</literal>, <literal>jsonb_path_query_array</literal>、<literal>jsonb_path_query_first</literal>関数はオプションの<literal>vars</literal>と<literal>silent</literal>引数を持ちます。
    </para>
    <para>
+<!--
     If the <parameter>vars</parameter> argument is specified, it provides an
     object containing named variables to be substituted into a
     <literal>jsonpath</literal> expression.
+-->
+<parameter>vars</parameter>引数が指定されると、<literal>jsonpath</literal>式に変換できる名前付きの変数を含むオブジェクトを関数は返します。
    </para>
    <para>
+<!--
     If the <parameter>silent</parameter> argument is specified and has the
     <literal>true</literal> value, these functions suppress the same errors
     as the <literal>@?</literal> and <literal>@@</literal> operators.
+-->
+<parameter>silent</parameter>引数が指定され、それが値<literal>true</literal>なら、これらの関数は<literal>@?</literal>と<literal>@@</literal>演算子と同じエラーを抑止します。
    </para>
   </note>
 
@@ -1427,21 +1484,32 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
  </sect2>
 
  <sect2 id="functions-sqljson-path">
+<!--
   <title>The SQL/JSON Path Language</title>
+-->
+  <title>SQL/JSONパス言語</title>
 
   <indexterm zone="functions-sqljson-path">
+<!--
    <primary>SQL/JSON path language</primary>
+-->
+   <primary>SQL/JSONパス言語</primary>
   </indexterm>
 
   <para>
+<!--
    SQL/JSON path expressions specify the items to be retrieved
    from the JSON data, similar to XPath expressions used
    for SQL access to XML. In <productname>PostgreSQL</productname>,
    path expressions are implemented as the <type>jsonpath</type>
    data type and can use any elements described in
    <xref linkend="datatype-jsonpath"/>.
+-->
+SQL/JSONパス式は、XMLへのSQLアクセスで使用されるXPath同様、JSONデータから取り出す項目を指定します。
+<productname>PostgreSQL</productname>ではパス式は<type>jsonpath</type>データ型として実装されており、<xref linkend="datatype-jsonpath"/>で説明されているすべての要素を使うことができます。
   </para>
 
+<!--
   <para>JSON query functions and operators
    pass the provided path expression to the <firstterm>path engine</firstterm>
    for evaluation. If the expression matches the queried JSON data,
@@ -1450,9 +1518,16 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
    and can also include arithmetic expressions and functions.
    Query functions treat the provided expression as a
    text string, so it must be enclosed in single quotes.
+-->
+  <para>
+JSON問い合わせ関数と演算子は与えられたパス式を<firstterm>path engine</firstterm>に渡して評価します。
+式が問い合わせ対象のJSONデータにマッチすれば、関連するSQL/JSON項目が返却されます。
+パス式はSQL/JSONパス言語で書かれ、算術式と関数を含むことができます。
+問い合わせ関数は与えられた式をテキスト文字列として扱うので、単一引用符で括らなければなりません。
   </para>
 
   <para>
+<!--
    A path expression consists of a sequence of elements allowed
    by the <type>jsonpath</type> data type.
    The path expression is evaluated from left to right, but
@@ -1461,9 +1536,14 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
    (<firstterm>SQL/JSON sequence</firstterm>) is produced,
    and the evaluation result is returned to the JSON query function
    that completes the specified computation.
+-->
+パス式は<type>jsonpath</type>データ型で認められた一連の要素からなります。
+パス式は左から右へと評価されますが、括弧を使って演算の順序を変更することができます。
+評価が成功すれば、一連のSQL/JSON項目（<firstterm>SQL/JSON sequence</firstterm>）が生成され、評価結果が指定した計算を完了したJSON問い合わせ関数に戻されます。
   </para>
 
   <para>
+<!--
    To refer to the JSON data to be queried (the
    <firstterm>context item</firstterm>), use the <literal>$</literal> sign
    in the path expression. It can be followed by one or more
@@ -1471,11 +1551,19 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
    which go down the JSON structure level by level to retrieve the
    content of context item. Each operator that follows deals with the
    result of the previous evaluation step.
+-->
+問い合わせ対象（<firstterm>context item</firstterm>）のJSONデータを参照するには、パス式内で<literal>$</literal>記号を使います。
+複数の<link linkend="type-jsonpath-accessors">アクセス演算子</link>をその後に記述することもできます。
+それによってJSON構造をレベル順に訪れて文脈の項目の内容を取り出します。
+後続の個々の演算子はその前の評価段階の結果を処理します。
   </para>
 
   <para>
+<!--
    For example, suppose you have some JSON data from a GPS tracker that you
    would like to parse, such as:
+-->
+たとえば、次のようなパースしたいGPSトラッカーからのJSONデータがあるとします。
 <programlisting>
 {
   "track": {
@@ -1497,52 +1585,75 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
   </para>
 
   <para>
+<!--
    To retrieve the available track segments, you need to use the
    <literal>.<replaceable>key</replaceable></literal> accessor
    operator for all the preceding JSON objects:
+-->
+存在するトラックセグメントを取り出すには、<literal>.<replaceable>key</replaceable></literal>アクセッサ演算子をすべての先行するJSONオブジェクトに使用する必要があります。
 <programlisting>
 '$.track.segments'
 </programlisting>
   </para>
 
   <para>
+<!--
    If the item to retrieve is an element of an array, you have
    to unnest this array using the <literal>[*]</literal> operator. For example,
    the following path will return location coordinates for all
    the available track segments:
+-->
+取得したい項目が配列要素なら、<literal>[*]</literal>演算子を使って非配列化（unnest）する必要があります。
+たとえば次のパスはすべての存在するトラックセグメントの位置座標を返します。
 <programlisting>
 '$.track.segments[*].location'
 </programlisting>
   </para>
 
   <para>
+<!--
    To return the coordinates of the first segment only, you can
    specify the corresponding subscript in the <literal>[]</literal>
    accessor operator. Note that the SQL/JSON arrays are 0-relative:
+-->
+最初のセグメントの座標だけを返すには、<literal>[]</literal>アクセッサ演算子の中で対応する添え字を指定することができます。
+SQL/JSON配列は0スタートであることに注意してください。
 <programlisting>
 '$.track.segments[0].location'
 </programlisting>
   </para>
 
   <para>
+<!--
    The result of each path evaluation step can be processed
    by one or more <type>jsonpath</type> operators and methods
    listed in <xref linkend="functions-sqljson-path-operators"/>.
    Each method name must be preceded by a dot. For example,
    you can get an array size:
+-->
+各段階でのパス評価結果は<xref linkend="functions-sqljson-path-operators"/>に列挙されている一つ以上の<type>jsonpath</type>演算子とメソッドで処理することができます。
+各々のメソッド名の前にピリオドを付けなければなりません。
+たとえば配列の大きさを得ることができます。
 <programlisting>
 '$.track.segments.size()'
 </programlisting>
+<!--
    For more examples of using <type>jsonpath</type> operators
    and methods within path expressions, see
    <xref linkend="functions-sqljson-path-operators"/>.
+-->
+パス式内の<type>jsonpath</type>演算子とメソッドについては<xref linkend="functions-sqljson-path-operators"/>を参照してください。
   </para>
 
   <para>
+<!--
    When defining the path, you can also use one or more
    <firstterm>filter expressions</firstterm> that work similar to the
    <literal>WHERE</literal> clause in SQL. A filter expression begins with
    a question mark and provides a condition in parentheses:
+-->
+パスを定義する際にはSQLの<literal>WHERE</literal>節のように働く一つ以上の<firstterm>filter expressions</firstterm>が利用できます。
+フィルター式はクェスチョンマークで始まり、カッコ内に条件を記述します。
 
 <programlisting>
 ? (<replaceable>condition</replaceable>)
@@ -1550,6 +1661,7 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
   </para>
 
   <para>
+<!--
    Filter expressions must be specified right after the path evaluation step
    to which they are applied. The result of this step is filtered to include
    only those items that satisfy the provided condition. SQL/JSON defines
@@ -1559,84 +1671,128 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
    for with the <literal>is unknown</literal> predicate. Further path
    evaluation steps use only those items for which filter expressions
    return <literal>true</literal>.
+-->
+フィルター式はそれを適用するパス評価段階の直後に指定しなければなりません。
+この段階の結果は、指定した条件を満たす項目だけが含まれるようにフィルターされます。
+SQL/JSONは3値論理を定義しており、条件は<literal>true</literal>、<literal>false</literal>、<literal>unknown</literal>のどれかです。
+<literal>unknown</literal>は値はSQLの<literal>NULL</literal>と同じ役割を果たし、<literal>is unknown</literal>述語で評価できます。
+その後の評価段階では<literal>true</literal>を返すフィルター式に対応する項目だけが使われます。
   </para>
 
   <para>
+<!--
    Functions and operators that can be used in filter expressions are listed
    in <xref linkend="functions-sqljson-filter-ex-table"/>. The path
    evaluation result to be filtered is denoted by the <literal>@</literal>
    variable. To refer to a JSON element stored at a lower nesting level,
    add one or more accessor operators after <literal>@</literal>.
+-->
+フィルター式内で利用できる関数と演算子は<xref linkend="functions-sqljson-filter-ex-table"/>にリストされています。
+フィルターする必要のあるパス評価結果は<literal>@</literal>変数で示します。
+下位の入れ子レベルに格納されているJSON要素を参照するには、一つ以上のアクセッサ演算子を<literal>@</literal>の後に追加してください。
   </para>
 
   <para>
+<!--
    Suppose you would like to retrieve all heart rate values higher
    than 130. You can achieve this using the following expression:
+-->
+130より高い心拍数を取り出したいとします。次の式を使ってそれを得ることができます。
 <programlisting>
 '$.track.segments[*].HR ? (@ &gt; 130)'
 </programlisting>
   </para>
 
   <para>
+<!--
    To get the start time of segments with such values instead, you have to
    filter out irrelevant segments before returning the start time, so the
    filter expression is applied to the previous step, and the path used
    in the condition is different:
+-->
+代わりにそうした値を持つセグメントの開始時刻を得たい場合は、開始時刻を返す前に無関係のセグメントを取り除く必要があります。
+そうすることにより前の段階にフィルター式が適用されるので、その条件で適用されるパスは異なります。
 <programlisting>
 '$.track.segments[*] ? (@.HR &gt; 130)."start time"'
 </programlisting>
   </para>
 
   <para>
+<!--
    You can use several filter expressions on the same nesting level, if
    required. For example, the following expression selects all segments
    that contain locations with relevant coordinates and high heart rate values:
+-->
+必要なら同じ入れ子レベルに対して複数のフィルター式を使用することができます。
+たとえば次の式は指定した座標と高い心拍数値を持つ位置を持つすべてのセグメントを選択します。
 <programlisting>
 '$.track.segments[*] ? (@.location[1] &lt; 13.4) ? (@.HR &gt; 130)."start time"'
 </programlisting>
   </para>
 
   <para>
+<!--
    Using filter expressions at different nesting levels is also allowed.
    The following example first filters all segments by location, and then
    returns high heart rate values for these segments, if available:
+-->
+異なる入れ子レベルに対してフィルター式を適用することもできます。
+次の例では、まず位置ですべてのセグメントをフィルターし、もしあれば高い心拍数値を返します。
 <programlisting>
 '$.track.segments[*] ? (@.location[1] &lt; 13.4).HR ? (@ &gt; 130)'
 </programlisting>
   </para>
 
   <para>
+<!--
    You can also nest filter expressions within each other:
+-->
+フィルター式をお互いに入れ子にすることもできます。
 <programlisting>
 '$.track ? (exists(@.segments[*] ? (@.HR &gt; 130))).segments.size()'
 </programlisting>
+<!--
    This expression returns the size of the track if it contains any
    segments with high heart rate values, or an empty sequence otherwise.
+-->
+この式は高い心拍数値を含むトラックがあればそのすべてのサイズを返します。もしなければ空のシーケンスが返ります。
   </para>
 
   <para>
+<!--
    <productname>PostgreSQL</productname>'s implementation of SQL/JSON path
    language has the following deviations from the SQL/JSON standard:
+-->
+<productname>PostgreSQL</productname>のSQL/JSONパス言語の実装はSQL/JSON標準と次の点が異なります。
   </para>
 
   <itemizedlist>
    <listitem>
     <para>
+<!--
      <literal>.datetime()</literal> item method is not implemented yet
      mainly because immutable <type>jsonpath</type> functions and operators
      cannot reference session timezone, which is used in some datetime
      operations.  Datetime support will be added to <type>jsonpath</type>
      in future versions of <productname>PostgreSQL</productname>.
+-->
+<literal>.datetime()</literal>項目メソッドは、主に不揮発性<type>jsonpath</type>関数と演算子が日付日時演算子で使用されているセッション時間帯を参照できないという理由でまだ実装されていません。
+将来の<productname>PostgreSQL</productname>バージョンでは<type>jsonpath</type>のサポートが追加される予定です。
     </para>
    </listitem>
 
    <listitem>
     <para>
+<!--
      A path expression can be a Boolean predicate, although the SQL/JSON
      standard allows predicates only in filters.  This is necessary for
      implementation of the <literal>@@</literal> operator. For example,
      the following <type>jsonpath</type> expression is valid in
      <productname>PostgreSQL</productname>:
+-->
+SQL/JSON標準ではフィルター内でのみ述語が使えますが、パス式はBoolean述語でも構いません。
+これは<literal>@@</literal>演算子を実装するために必要です。
+たとえば、次の<type>jsonpath</type>式は<productname>PostgreSQL</productname>では有効です。
 <programlisting>
 '$.track.segments[*].HR &lt; 70'
 </programlisting>
@@ -1645,40 +1801,59 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
 
    <listitem>
     <para>
+<!--
      There are minor differences in the interpretation of regular
      expression patterns used in <literal>like_regex</literal> filters, as
      described in <xref linkend="jsonpath-regular-expressions"/>.
+-->
+<xref linkend="jsonpath-regular-expressions"/>で述べるように、<literal>like_regex</literal>フィルターで使用される正規表現パターンの解釈には些細な違いがあります。
     </para>
    </listitem>
   </itemizedlist>
 
    <sect3 id="strict-and-lax-modes">
+<!--
    <title>Strict and Lax Modes</title>
+-->
+   <title>厳密モードと非厳密モード</title>
     <para>
+<!--
      When you query JSON data, the path expression may not match the
      actual JSON data structure. An attempt to access a non-existent
      member of an object or element of an array results in a
      structural error. SQL/JSON path expressions have two modes
      of handling structural errors:
+-->
+JSONデータを問い合わせる際、パス式は実際のJSONデータ構造に一致しないかも知れません。
+存在しないオブジェクトのメンバーあるいは配列要素にアクセスしようとすると、構造上のエラーとなります。
+SQL/JSONパス式には構造上のエラーを扱うための2つのモードがあります。
     </para>
 
    <itemizedlist>
     <listitem>
      <para>
+<!--
       lax (default) &mdash; the path engine implicitly adapts
       the queried data to the specified path.
       Any remaining structural errors are suppressed and converted
       to empty SQL/JSON sequences.
+-->
+非厳密(lax)モード（デフォルト）&mdash; パスエンジンは指定したパスを問い合わせデータに暗黙的に適合させます。
+構造上のエラーは抑止され、空のSQL/JSONシーケンスへと変換されます。
      </para>
     </listitem>
     <listitem>
      <para>
+<!--
       strict &mdash; if a structural error occurs, an error is raised.
+-->
+厳密(strict)モード &mdash; 構造上のエラーがあるとエラーが発生します。
      </para>
     </listitem>
    </itemizedlist>
 
    <para>
+<!--
     The lax mode facilitates matching of a JSON document structure and path
     expression if the JSON data does not conform to the expected schema.
     If an operand does not match the requirements of a particular operation,
@@ -1688,40 +1863,60 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
     operands in the lax mode, so you can compare SQL/JSON arrays
     out-of-the-box. An array of size 1 is considered equal to its sole element.
     Automatic unwrapping is not performed only when:
+-->
+非厳密モードは、JSONデータが期待されるスキーマに沿わないときにJSON文書構造とパス式のマッチングを助けます。
+あるオペランドが操作の要件に合わないときにはそれをSQL/JSON配列にまとめたり、あるいは操作を行う前にそれをSQL/JSONシーケンスに展開することもできます。
+また非厳密モードにおいては、比較演算子は自動的にオペランドを展開し、SQL/JSON配列をそのまま比較することができます。
+大きさ1の配列はその単独要素と同じものとして扱われます。
+自動展開は以下の場合にのみ行われます。
     <itemizedlist>
      <listitem>
       <para>
+<!--
        The path expression contains <literal>type()</literal> or
        <literal>size()</literal> methods that return the type
        and the number of elements in the array, respectively.
+-->
+それぞれ配列の型、要素数を返す<literal>type()</literal>、<literal>size()</literal>をパス式が含む場合。
       </para>
      </listitem>
      <listitem>
       <para>
+<!--
        The queried JSON data contain nested arrays. In this case, only
        the outermost array is unwrapped, while all the inner arrays
        remain unchanged. Thus, implicit unwrapping can only go one
        level down within each path evaluation step.
+-->
+問い合わせ対象のJSONデータが入れ子の配列を含んでいる。この場合はもっとも外側の配列のみが展開され、内側の配列は変わりません。
+ですから、それぞれの評価段階において1レベルのみに暗黙的な展開が行われます。
       </para>
      </listitem>
     </itemizedlist>
    </para>
 
    <para>
+<!--
     For example, when querying the GPS data listed above, you can
     abstract from the fact that it stores an array of segments
     when using the lax mode:
+-->
+たとえば、上述のGPSデータに問い合わせする際、非厳密モードでは配列のセグメントを含んでいることを抽象化できます。
 <programlisting>
 'lax $.track.segments.location'
 </programlisting>
    </para>
 
    <para>
+<!--
     In the strict mode, the specified path must exactly match the structure of
     the queried JSON document to return an SQL/JSON item, so using this
     path expression will cause an error. To get the same result as in
     the lax mode, you have to explicitly unwrap the
     <literal>segments</literal> array:
+-->
+厳密モードでは、指定したパスはSQL/JSON項目を返す問い合わせ対象のJSON文書の構造に正確に一致していなければなりません。ですから、このパス式を使うとエラーになります。
+非厳密モードと同じ結果を得るためには、<literal>segments</literal>配列を明示的に展開する必要があります。
 <programlisting>
 'strict $.track.segments[*].location'
 </programlisting>
@@ -1730,24 +1925,35 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
    </sect3>
 
    <sect3 id="jsonpath-regular-expressions">
+<!--
     <title>Regular Expressions</title>
+-->
+    <title>正規表現</title>
 
     <indexterm zone="jsonpath-regular-expressions">
      <primary><literal>LIKE_REGEX</literal></primary>
+<!--
      <secondary>in SQL/JSON</secondary>
+-->
+     <secondary>SQL/JSONにおける</secondary>
     </indexterm>
 
     <para>
+<!--
      SQL/JSON path expressions allow matching text to a regular expression
      with the <literal>like_regex</literal> filter.  For example, the
      following SQL/JSON path query would case-insensitively match all
      strings in an array that start with an English vowel:
+-->
+SQL/JSONパス式では<literal>like_regex</literal>フィルターを使ってテキストを正規表現にマッチさせることができます。
+たとえば、次のSQL/JSONパス式問い合わせは、英語の母音で始まる配列内のすべての文字列に大文字小文字を無視してマッチするでしょう。
 <programlisting>
 '$[*] ? (@ like_regex "^[aeiou]" flag "i")'
 </programlisting>
     </para>
 
     <para>
+<!--
      The optional <literal>flag</literal> string may include one or more of
      the characters
      <literal>i</literal> for case-insensitive match,
@@ -1756,9 +1962,13 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
      <literal>s</literal> to allow <literal>.</literal> to match a newline,
      and <literal>q</literal> to quote the whole pattern (reducing the
      behavior to a simple substring match).
+-->
+オプションの<literal>flag</literal>文字列は一つ以上の文字を含むことができます。
+<literal>i</literal>は大文字小文字を無視したマッチ、<literal>m</literal>は<literal>^</literal>と<literal>$</literal>で改行にマッチ、<literal>s</literal>は<literal>.</literal>が改行にマッチ、<literal>q</literal>はパターン全体を参照します。（振る舞いを単純な部分文字列マッチとします）
     </para>
 
     <para>
+<!--
      The SQL/JSON standard borrows its definition for regular expressions
      from the <literal>LIKE_REGEX</literal> operator, which in turn uses the
      XQuery standard.  PostgreSQL does not currently support the
@@ -1771,14 +1981,25 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
      Note, however, that the flag-letter incompatibilities described there
      do not apply to SQL/JSON, as it translates the XQuery flag letters to
      match what the POSIX engine expects.
+-->
+SQL/JSON標準は正規表現の定義を、XQuery標準を使用する<literal>LIKE_REGEX</literal>演算子から借りています。
+PostgreSQLは今の所<literal>LIKE_REGEX</literal>演算子をサポートしていません。
+ですから、<literal>like_regex</literal>フィルターは<xref linkend="functions-posix-regexp"/>で説明されているPOSIX正規表現で実装されています。
+このことにより、<xref linkend="posix-vs-xquery"/>で列挙されているSQL/JSON標準の振る舞いとの小さな違いが生じます。
+しかし、ここで述べているフラグ文字の非互換性はSQL/JSONには適用されないことに注意してください。SQL/JSONは、XQueryのフラグ文字をPOSIXエンジンが期待するのと一致するように解釈するからです。
     </para>
 
     <para>
+<!--
      Keep in mind that the pattern argument of <literal>like_regex</literal>
      is a JSON path string literal, written according to the rules given in
      <xref linkend="datatype-jsonpath"/>.  This means in particular that any
      backslashes you want to use in the regular expression must be doubled.
      For example, to match strings that contain only digits:
+-->
+<literal>like_regex</literal>のパターン引数は<xref linkend="datatype-jsonpath"/>で説明されているルールにしたがって書かれたJSONパス文字列リテラルであることに注意してください。
+これは、正規表現で使用するすべてのバックスラッシュを二重に書かなければならないことを意味します。
+たとえば、数字のみを含む文字列にマッチさせるには以下のようにします。
 <programlisting>
 '$ ? (@ like_regex "^\\d+$")'
 </programlisting>
@@ -1787,115 +2008,176 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
    </sect3>
 
    <sect3 id="functions-sqljson-path-operators">
+<!--
    <title>SQL/JSON Path Operators and Methods</title>
+-->
+   <title>SQL/JSONパス演算子とメソッド</title>
 
    <para>
+<!--
     <xref linkend="functions-sqljson-op-table"/> shows the operators and
     methods available in <type>jsonpath</type>.  <xref
     linkend="functions-sqljson-filter-ex-table"/> shows the available filter
     expression elements.
+-->
+<xref linkend="functions-sqljson-op-table"/>に<type>jsonpath</type>で利用可能な演算子とメソッドを示します。
+<xref linkend="functions-sqljson-filter-ex-table"/>には利用可能なフィルター式要素が示されています。
    </para>
 
    <table id="functions-sqljson-op-table">
+<!--
     <title><type>jsonpath</type> Operators and Methods</title>
+-->
+    <title><type>jsonpath</type>演算子とメソッド</title>
      <tgroup cols="5">
       <thead>
        <row>
+<!--
         <entry>Operator/Method</entry>
         <entry>Description</entry>
         <entry>Example JSON</entry>
         <entry>Example Query</entry>
         <entry>Result</entry>
+-->
+        <entry>演算子/メソッド</entry>
+        <entry>説明</entry>
+        <entry>JSONの例</entry>
+        <entry>問い合わせ例</entry>
+        <entry>結果</entry>
        </row>
       </thead>
       <tbody>
        <row>
+<!--
         <entry><literal>+</literal> (unary)</entry>
         <entry>Plus operator that iterates over the SQL/JSON sequence</entry>
+-->
+        <entry><literal>+</literal>（単項）</entry>
+        <entry>SQL/JSONシーケンスに繰り返し適用される加算演算子</entry>
         <entry><literal>{"x": [2.85, -14.7, -9.4]}</literal></entry>
         <entry><literal>+ $.x.floor()</literal></entry>
         <entry><literal>2, -15, -10</literal></entry>
        </row>
        <row>
+<!--
         <entry><literal>-</literal> (unary)</entry>
         <entry>Minus operator that iterates over the SQL/JSON sequence</entry>
+-->
+        <entry><literal>-</literal>（単項）</entry>
+        <entry>SQL/JSONシーケンスに繰り返し適用される減算演算子</entry>
         <entry><literal>{"x": [2.85, -14.7, -9.4]}</literal></entry>
         <entry><literal>- $.x.floor()</literal></entry>
         <entry><literal>-2, 15, 10</literal></entry>
        </row>
        <row>
+<!--
         <entry><literal>+</literal> (binary)</entry>
         <entry>Addition</entry>
+-->
+        <entry><literal>+</literal>（二項）</entry>
+        <entry>加算</entry>
         <entry><literal>[2]</literal></entry>
         <entry><literal>2 + $[0]</literal></entry>
         <entry><literal>4</literal></entry>
        </row>
        <row>
+<!--
         <entry><literal>-</literal> (binary)</entry>
         <entry>Subtraction</entry>
+-->
+        <entry><literal>-</literal>（二項）</entry>
+        <entry>減算</entry>
         <entry><literal>[2]</literal></entry>
         <entry><literal>4 - $[0]</literal></entry>
         <entry><literal>2</literal></entry>
        </row>
        <row>
         <entry><literal>*</literal></entry>
+<!--
         <entry>Multiplication</entry>
+-->
+        <entry>積算</entry>
         <entry><literal>[4]</literal></entry>
         <entry><literal>2 * $[0]</literal></entry>
         <entry><literal>8</literal></entry>
        </row>
        <row>
+
         <entry><literal>/</literal></entry>
+<!--
         <entry>Division</entry>
+-->
+        <entry>除算</entry>
         <entry><literal>[8]</literal></entry>
         <entry><literal>$[0] / 2</literal></entry>
         <entry><literal>4</literal></entry>
        </row>
        <row>
         <entry><literal>%</literal></entry>
+<!--
         <entry>Modulus</entry>
+-->
+        <entry>剰余</entry>
         <entry><literal>[32]</literal></entry>
         <entry><literal>$[0] % 10</literal></entry>
         <entry><literal>2</literal></entry>
        </row>
        <row>
         <entry><literal>type()</literal></entry>
+<!--
         <entry>Type of the SQL/JSON item</entry>
+-->
+        <entry>SQL/JSON項目の型</entry>
         <entry><literal>[1, "2", {}]</literal></entry>
         <entry><literal>$[*].type()</literal></entry>
         <entry><literal>"number", "string", "object"</literal></entry>
        </row>
        <row>
         <entry><literal>size()</literal></entry>
+<!--
         <entry>Size of the SQL/JSON item</entry>
+-->
+        <entry>SQL/JSON項目の大きさ</entry>
         <entry><literal>{"m": [11, 15]}</literal></entry>
         <entry><literal>$.m.size()</literal></entry>
         <entry><literal>2</literal></entry>
        </row>
        <row>
         <entry><literal>double()</literal></entry>
+<!--
         <entry>Approximate floating-point number converted from an SQL/JSON number or a string</entry>
+-->
+        <entry>SQL/JSONの数字あるいは文字列から変換されたおおよその浮動小数点数</entry>
         <entry><literal>{"len": "1.9"}</literal></entry>
         <entry><literal>$.len.double() * 2</literal></entry>
         <entry><literal>3.8</literal></entry>
        </row>
        <row>
         <entry><literal>ceiling()</literal></entry>
+<!--
         <entry>Nearest integer greater than or equal to the SQL/JSON number</entry>
+-->
+        <entry>SQL/JSON数字以上でもっとも近い整数</entry>
         <entry><literal>{"h": 1.3}</literal></entry>
         <entry><literal>$.h.ceiling()</literal></entry>
         <entry><literal>2</literal></entry>
        </row>
        <row>
         <entry><literal>floor()</literal></entry>
+<!--
         <entry>Nearest integer less than or equal to the SQL/JSON number</entry>
+-->
+        <entry>SQL/JSON数字以下でもっとも近い整数</entry>
         <entry><literal>{"h": 1.3}</literal></entry>
         <entry><literal>$.h.floor()</literal></entry>
         <entry><literal>1</literal></entry>
        </row>
        <row>
         <entry><literal>abs()</literal></entry>
+<!--
         <entry>Absolute value of the SQL/JSON number</entry>
+-->
+        <entry>SQL/JSON数字の絶対値</entry>
         <entry><literal>{"z": -0.3}</literal></entry>
         <entry><literal>$.z.abs()</literal></entry>
         <entry><literal>0.3</literal></entry>
@@ -1903,11 +2185,16 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
        <row>
         <entry><literal>keyvalue()</literal></entry>
         <entry>
+<!--
           Sequence of object's key-value pairs represented as array of items
           containing three fields (<literal>"key"</literal>,
           <literal>"value"</literal>, and <literal>"id"</literal>).
           <literal>"id"</literal> is a unique identifier of the object
           key-value pair belongs to.
+-->
+3つのフィールド（<literal>"key"</literal>、<literal>"value"</literal>、<literal>"id"</literal>）を含む項目の配列で表現されたオブジェクトの
+キーバリューペアのシーケンス。
+<literal>"id"</literal>はキーバリューペアが所属するオブジェクトのユニーク識別子です。
         </entry>
         <entry><literal>{"x": "20", "y": 32}</literal></entry>
         <entry><literal>$.keyvalue()</literal></entry>
@@ -1918,70 +2205,104 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
     </table>
 
     <table id="functions-sqljson-filter-ex-table">
+<!--
      <title><type>jsonpath</type> Filter Expression Elements</title>
+-->
+     <title><type>jsonpath</type>フィルター式要素</title>
      <tgroup cols="5">
       <thead>
        <row>
+<!--
         <entry>Value/Predicate</entry>
         <entry>Description</entry>
         <entry>Example JSON</entry>
         <entry>Example Query</entry>
         <entry>Result</entry>
+-->
+        <entry>値/述語</entry>
+        <entry>説明</entry>
+        <entry>JSONの例</entry>
+        <entry>問い合わせ例</entry>
+        <entry>結果</entry>
        </row>
       </thead>
       <tbody>
        <row>
         <entry><literal>==</literal></entry>
+<!--
         <entry>Equality operator</entry>
+-->
+        <entry>等値演算子</entry>
         <entry><literal>[1, 2, 1, 3]</literal></entry>
         <entry><literal>$[*] ? (@ == 1)</literal></entry>
         <entry><literal>1, 1</literal></entry>
        </row>
        <row>
         <entry><literal>!=</literal></entry>
+<!--
         <entry>Non-equality operator</entry>
+-->
+        <entry>非等値演算子</entry>
         <entry><literal>[1, 2, 1, 3]</literal></entry>
         <entry><literal>$[*] ? (@ != 1)</literal></entry>
         <entry><literal>2, 3</literal></entry>
        </row>
        <row>
         <entry><literal>&lt;&gt;</literal></entry>
+<!--
         <entry>Non-equality operator (same as <literal>!=</literal>)</entry>
+-->
+        <entry>非等値演算子（<literal>!=</literal>と同じ）</entry>
         <entry><literal>[1, 2, 1, 3]</literal></entry>
         <entry><literal>$[*] ? (@ &lt;&gt; 1)</literal></entry>
         <entry><literal>2, 3</literal></entry>
        </row>
        <row>
         <entry><literal>&lt;</literal></entry>
+<!--
         <entry>Less-than operator</entry>
+-->
+        <entry>未満演算子</entry>
         <entry><literal>[1, 2, 3]</literal></entry>
         <entry><literal>$[*] ? (@ &lt; 2)</literal></entry>
         <entry><literal>1</literal></entry>
        </row>
        <row>
         <entry><literal>&lt;=</literal></entry>
+<!--
         <entry>Less-than-or-equal-to operator</entry>
+-->
+        <entry>以下演算子</entry>
         <entry><literal>[1, 2, 3]</literal></entry>
         <entry><literal>$[*] ? (@ &lt;= 2)</literal></entry>
         <entry><literal>1, 2</literal></entry>
        </row>
        <row>
         <entry><literal>&gt;</literal></entry>
+<!--
         <entry>Greater-than operator</entry>
+-->
+        <entry>より大きい演算子</entry>
         <entry><literal>[1, 2, 3]</literal></entry>
         <entry><literal>$[*] ? (@ &gt; 2)</literal></entry>
         <entry><literal>3</literal></entry>
        </row>
        <row>
         <entry><literal>&gt;=</literal></entry>
+<!--
         <entry>Greater-than-or-equal-to operator</entry>
+-->
+        <entry>以上演算子</entry>
         <entry><literal>[1, 2, 3]</literal></entry>
         <entry><literal>$[*] ? (@ &gt;= 2)</literal></entry>
         <entry><literal>2, 3</literal></entry>
        </row>
        <row>
         <entry><literal>true</literal></entry>
+<!--
         <entry>Value used to perform comparison with JSON <literal>true</literal> literal</entry>
+-->
+        <entry>JSONの<literal>true</literal>リテラルとの比較に用いられる値</entry>
         <entry><literal>[{"name": "John", "parent": false},
                            {"name": "Chris", "parent": true}]</literal></entry>
         <entry><literal>$[*] ? (@.parent == true)</literal></entry>
@@ -1989,7 +2310,10 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
        </row>
        <row>
         <entry><literal>false</literal></entry>
+<!--
         <entry>Value used to perform comparison with JSON <literal>false</literal> literal</entry>
+-->
+        <entry>JSONの<literal>true</literal>リテラルとの比較に用いられる値</entry>
         <entry><literal>[{"name": "John", "parent": false},
                            {"name": "Chris", "parent": true}]</literal></entry>
         <entry><literal>$[*] ? (@.parent == false)</literal></entry>
@@ -1997,7 +2321,10 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
        </row>
        <row>
         <entry><literal>null</literal></entry>
+<!--
         <entry>Value used to perform comparison with JSON <literal>null</literal> value</entry>
+-->
+        <entry>JSONの<literal>true</literal>リテラルとの比較に用いられる値</entry>
         <entry><literal>[{"name": "Mary", "job": null},
                          {"name": "Michael", "job": "driver"}]</literal></entry>
         <entry><literal>$[*] ? (@.job == null) .name</literal></entry>
@@ -2005,21 +2332,31 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
        </row>
        <row>
         <entry><literal>&amp;&amp;</literal></entry>
+<!--
         <entry>Boolean AND</entry>
+-->
+        <entry>論理AND</entry>
         <entry><literal>[1, 3, 7]</literal></entry>
         <entry><literal>$[*] ? (@ &gt; 1 &amp;&amp; @ &lt; 5)</literal></entry>
         <entry><literal>3</literal></entry>
        </row>
        <row>
         <entry><literal>||</literal></entry>
+<!--
         <entry>Boolean OR</entry>
+-->
+        <entry>論理OR</entry>
         <entry><literal>[1, 3, 7]</literal></entry>
         <entry><literal>$[*] ? (@ &lt; 1 || @ &gt; 5)</literal></entry>
         <entry><literal>7</literal></entry>
        </row>
        <row>
         <entry><literal>!</literal></entry>
+
+<!--
         <entry>Boolean NOT</entry>
+-->
+        <entry>論理NOT</entry>
         <entry><literal>[1, 3, 7]</literal></entry>
         <entry><literal>$[*] ? (!(@ &lt; 5))</literal></entry>
         <entry><literal>7</literal></entry>
@@ -2027,10 +2364,14 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
        <row>
         <entry><literal>like_regex</literal></entry>
         <entry>
+<!--
           Tests whether the first operand matches the regular expression
           given by the second operand, optionally with modifications
           described by a string of <literal>flag</literal> characters (see
           <xref linkend="jsonpath-regular-expressions"/>)
+-->
+最初のオペランドが2番目のオペランドで与えられる正規表現にマッチするかどうかテストする。
+オプションで<literal>flag</literal>文字列で記述される変更を伴う。（<xref linkend="jsonpath-regular-expressions"/>参照）
         </entry>
         <entry><literal>["abc", "abd", "aBdC", "abdacb", "babc"]</literal></entry>
         <entry><literal>$[*] ? (@ like_regex "^ab.*c" flag "i")</literal></entry>
@@ -2038,21 +2379,30 @@ JSON値を出力列のSQL型に変換する際に以下のルールが順番に�
        </row>
        <row>
         <entry><literal>starts with</literal></entry>
+<!--
         <entry>Tests whether the second operand is an initial substring of the first operand</entry>
+-->
+        <entry>2番目の文字列が1番目のオペランドの最初の部分文字列かどうかをテストする</entry>
         <entry><literal>["John Smith", "Mary Stone", "Bob Johnson"]</literal></entry>
         <entry><literal>$[*] ? (@ starts with "John")</literal></entry>
         <entry><literal>"John Smith"</literal></entry>
        </row>
        <row>
         <entry><literal>exists</literal></entry>
+<!--
         <entry>Tests whether a path expression matches at least one SQL/JSON item</entry>
+-->
+        <entry>パス式が少なくとも一つのSQL/JSON項目とマッチするかどうかをテストする</entry>
         <entry><literal>{"x": [1, 2], "y": [2, 4]}</literal></entry>
         <entry><literal>strict $.* ? (exists (@ ? (@[*] > 2)))</literal></entry>
         <entry><literal>2, 4</literal></entry>
        </row>
        <row>
         <entry><literal>is unknown</literal></entry>
+<!--
         <entry>Tests whether a Boolean condition is <literal>unknown</literal></entry>
+-->
+        <entry>論理条件が<literal>unknown</literal>かどうかをテストする</entry>
         <entry><literal>[-1, 2, 7, "infinity"]</literal></entry>
         <entry><literal>$[*] ? ((@ > 0) is unknown)</literal></entry>
         <entry><literal>"infinity"</literal></entry>
@@ -2504,10 +2854,13 @@ SELECT setval('foo', 42, false);    <lineannotation>次の<function>nextval</fun
 
    <note>
     <para>
+<!--
      Although <token>COALESCE</token>, <token>GREATEST</token>, and
      <token>LEAST</token> are syntactically similar to functions, they are
      not ordinary functions, and thus cannot be used with explicit
      <token>VARIADIC</token> array arguments.
+-->
+<token>COALESCE</token>、<token>GREATEST</token>、<token>LEAST</token>は構文的には関数に似ていますが通常の関数ではなく、明示的な<token>VARIADIC</token>配列引数と一緒には使えません。
     </para>
    </note>
 

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -5947,7 +5947,7 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
 -->
 物理スタンバイサーバを昇格します。
 <parameter>wait</parameter>に<literal>true</literal>（デフォルト）を設定すると、この関数は昇格が完了するか、<parameter>wait_seconds</parameter>秒が経過するまで待ち、昇格に成功すれば<literal>true</literal>、さもなければ<literal>false</literal>を返します。
-        <parameter>wait</parameter>に<literal>false</literal>を設定すると、この関数は昇格を起こすためにpostmasterに<literal>SIGUSR1</literal>を送信した後直ちに<literal>true</literal>を返します。
+<parameter>wait</parameter>に<literal>false</literal>を設定すると、この関数は昇格を起こすためにpostmasterに<literal>SIGUSR1</literal>を送信した後、直ちに<literal>true</literal>を返します。
 デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
        </entry>
       </row>

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -2681,10 +2681,14 @@ SELECT has_function_privilege('joeuser', 'myfunc(int, text)', 'execute');
    </para>
 
   <para>
+<!--
    <xref linkend="functions-aclitem-fn-table"/> shows the operators
    available for the <type>aclitem</type> type, which is the catalog
    representation of access privileges.  See <xref linkend="ddl-priv"/>
    for information about how to read access privilege values.
+-->
+アクセス権限のカタログ表現である<type>aclitem</type>型で利用可能な演算子を<xref linkend="functions-aclitem-fn-table"/>に示します。
+アクセス権限値を解釈する方法に関する情報は<xref linkend="ddl-priv"/>をご覧ください。
   </para>
 
    <indexterm>
@@ -2704,35 +2708,53 @@ SELECT has_function_privilege('joeuser', 'myfunc(int, text)', 'execute');
    </indexterm>
 
     <table id="functions-aclitem-op-table">
+<!--
      <title><type>aclitem</type> Operators</title>
+-->
+     <title><type>aclitem</type>演算子</title>
      <tgroup cols="4">
       <thead>
        <row>
+<!--
         <entry>Operator</entry>
         <entry>Description</entry>
         <entry>Example</entry>
         <entry>Result</entry>
+-->
+        <entry>演算子</entry>
+        <entry>説明</entry>
+        <entry>例</entry>
+        <entry>結果</entry>
        </row>
       </thead>
       <tbody>
 
        <row>
         <entry> <literal>=</literal> </entry>
+<!--
         <entry>equal</entry>
+-->
+        <entry>等しい</entry>
         <entry><literal>'calvin=r*w/hobbes'::aclitem = 'calvin=r*w*/hobbes'::aclitem</literal></entry>
         <entry><literal>f</literal></entry>
        </row>
 
        <row>
         <entry> <literal>@&gt;</literal> </entry>
+<!--
         <entry>contains element</entry>
+-->
+        <entry>要素を含む</entry>
         <entry><literal>'{calvin=r*w/hobbes,hobbes=r*w*/postgres}'::aclitem[] @&gt; 'calvin=r*w/hobbes'::aclitem</literal></entry>
         <entry><literal>t</literal></entry>
        </row>
 
        <row>
         <entry> <literal>~</literal> </entry>
+<!--
         <entry>contains element</entry>
+-->
+        <entry>要素を含む</entry>
         <entry><literal>'{calvin=r*w/hobbes,hobbes=r*w*/postgres}'::aclitem[] ~ 'calvin=r*w/hobbes'::aclitem</literal></entry>
         <entry><literal>t</literal></entry>
        </row>
@@ -2742,38 +2764,57 @@ SELECT has_function_privilege('joeuser', 'myfunc(int, text)', 'execute');
     </table>
 
    <para>
+<!--
     <xref linkend="functions-aclitem-fn-table"/> shows some additional
     functions to manage the <type>aclitem</type> type.
+-->
+<xref linkend="functions-aclitem-fn-table"/>に<type>aclitem</type>型を管理する追加の関数を示します。
    </para>
 
    <table id="functions-aclitem-fn-table">
+<!--
     <title><type>aclitem</type> Functions</title>
+-->
+    <title><type>aclitem</type>関数</title>
     <tgroup cols="3">
      <thead>
+<!--
       <row><entry>Name</entry> <entry>Return Type</entry> <entry>Description</entry></row>
+-->
+      <row><entry>名称</entry> <entry>戻り型</entry> <entry>説明</entry></row>
      </thead>
      <tbody>
       <row>
        <entry><literal><function>acldefault</function>(<parameter>type</parameter>,
         <parameter>ownerId</parameter>)</literal></entry>
        <entry><type>aclitem[]</type></entry>
+<!--
        <entry>get the default access privileges for an object belonging to <parameter>ownerId</parameter></entry>
+-->
+       <entry><parameter>ownerId</parameter>に所属するオブジェクトのデフォルトアクセス権限を得る</entry>
       </row>
       <row>
        <entry><literal><function>aclexplode</function>(<parameter>aclitem[]</parameter>)</literal></entry>
        <entry><type>setof record</type></entry>
+<!--
        <entry>get <type>aclitem</type> array as tuples</entry>
+-->
+       <entry><type>aclitem</type>配列をタプルとして得る</entry>
       </row>
       <row>
        <entry><literal><function>makeaclitem</function>(<parameter>grantee</parameter>, <parameter>grantor</parameter>, <parameter>privilege</parameter>, <parameter>grantable</parameter>)</literal></entry>
        <entry><type>aclitem</type></entry>
+<!--
        <entry>build an <type>aclitem</type> from input</entry>
+-->
+       <entry>入力から<type>aclitem</type>を構築する</entry>
       </row>
      </tbody>
     </tgroup>
    </table>
 
    <para>
+<!--
     <function>acldefault</function> returns the built-in default access
     privileges for an object of type <parameter>type</parameter> belonging to
     role <parameter>ownerId</parameter>.  These represent the access
@@ -2793,15 +2834,25 @@ SELECT has_function_privilege('joeuser', 'myfunc(int, text)', 'execute');
     'S' for <literal>FOREIGN SERVER</literal>,
     or
     'T' for <literal>TYPE</literal> or <literal>DOMAIN</literal>.
+-->
+<function>acldefault</function>は<parameter>ownerId</parameter>ロールに所属する<parameter>type</parameter>型のオブジェクトの組み込みデフォルトアクセス権限を返します。
+これらはオブジェクトのACLエントリがNULLの時に持つと見なされるアクセス権限を表現します。
+（デフォルトアクセス権限は<xref linkend="ddl-priv"/>で説明されています。）
+<parameter>type</parameter>パラメータは<type>CHAR</type>であり、'c'で<literal>COLUMN</literal>、'r'で<literal>TABLE</literal>およびテーブルに見えるオブジェクト、's'で<literal>SEQUENCE</literal>、'd'で<literal>DATABASE</literal>、'f'で<literal>FUNCTION</literal>あるいは<literal>PROCEDURE</literal>、'l'で<literal>LANGUAGE</literal>、'L'で<literal>LARGE OBJECT</literal>、'n'で<literal>SCHEMA</literal>、't'で<literal>TABLESPACE</literal>、'F'で<literal>FOREIGN DATA WRAPPER</literal>、'S'で<literal>FOREIGN SERVER</literal>、'T'で<literal>TYPE</literal>あるいは<literal>DOMAIN</literal>を表します。
    </para>
 
    <para>
+<!--
     <function>aclexplode</function> returns an <type>aclitem</type> array
     as a set of rows. Output columns are grantor <type>oid</type>,
     grantee <type>oid</type> (<literal>0</literal> for <literal>PUBLIC</literal>),
     granted privilege as <type>text</type> (<literal>SELECT</literal>, ...)
     and whether the privilege is grantable as <type>boolean</type>.
     <function>makeaclitem</function> performs the inverse operation.
+-->
+<function>aclexplode</function>は行の集合として<type>aclitem</type>配列を返します。
+出力列はアクセス権を与える側の<type>oid</type>、アクセス権を与えられる側の<type>oid</type>（<literal>0</literal>で<literal>PUBLIC</literal>を表します）、与えられた権限<type>text</type>（<literal>SELECT</literal>, ...）、権限が許可可能かどうかの<type>boolean</type>です。
+<function>makeaclitem</function>は逆の操作を実行します。
    </para>
 
   <para>
@@ -5882,6 +5933,7 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         </entry>
        <entry><type>boolean</type></entry>
        <entry>
+<!--
         Promotes a physical standby server.  With <parameter>wait</parameter>
         set to <literal>true</literal> (the default), the function waits until
         promotion is completed or <parameter>wait_seconds</parameter> seconds
@@ -5892,6 +5944,11 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         <literal>SIGUSR1</literal> to the postmaster to trigger the promotion.
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
+-->
+物理スタンバイサーバを昇格します。
+<parameter>wait</parameter>に<literal>true</literal>（デフォルト）を設定すると、この関数は昇格が完了するか、<parameter>wait_seconds</parameter>秒が経過するまで待ち、昇格に成功すれば<literal>true</literal>、さもなければ<literal>false</literal>を返します。
+        <parameter>wait</parameter>に<literal>false</literal>を設定すると、この関数は昇格を起こすためにpostmasterに<literal>SIGUSR1</literal>を送信した後直ちに<literal>true</literal>を返します。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
        </entry>
       </row>
       <row>
@@ -6194,6 +6251,7 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         (<parameter>slot_name</parameter> <type>name</type>, <parameter>lsn</parameter> <type>pg_lsn</type>)
        </entry>
        <entry>
+<!--
         Creates a new logical (decoding) replication slot named
         <parameter>slot_name</parameter> using the output plugin
         <parameter>plugin</parameter>. The optional third
@@ -6203,6 +6261,11 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         released upon any error. A call to this function has the same
         effect as the replication protocol command
         <literal>CREATE_REPLICATION_SLOT ... LOGICAL</literal>.
+-->
+出力プラグイン<parameter>plugin</parameter>を使って<parameter>slot_name</parameter>という名前の新しいロジカル（デコーディング）レプリケーションスロットを作ります。
+3番目のオプションパラメータ<parameter>temporary</parameter>をtrueに設定すると、このスロットを永続的にディスクに保存するべきではなく、現在のセッションでのみ使われることを意図します。
+また、一時スロットはエラーが起きると解放されます。
+この関数の呼び出しはレプリケーションプロトコルコマンドの<literal>CREATE_REPLICATION_SLOT ... LOGICAL</literal>と同じ効果があります。
        </entry>
       </row>
 
@@ -6217,12 +6280,18 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         (<parameter>slot_name</parameter> <type>name</type>, <parameter>lsn</parameter> <type>pg_lsn</type>)
        </entry>
        <entry>
+<!--
         Copies an existing physical replication slot named <parameter>src_slot_name</parameter>
         to a physical replication slot named <parameter>dst_slot_name</parameter>.
         The copied physical slot starts to reserve WAL from the same <acronym>LSN</acronym> as the
         source slot.
         <parameter>temporary</parameter> is optional. If <parameter>temporary</parameter>
         is omitted, the same value as the source slot is used.
+-->
+<parameter>src_slot_name</parameter>という名前の既存の物理レプリケーションスロットを<parameter>dst_slot_name</parameter>という名前の物理レプリケーションスロットにコピーします。
+コピーされた物理スロットはソーススロットと同じ<acronym>LSN</acronym>からWALの保存を開始します。
+<parameter>temporary</parameter>はオプションです。
+<parameter>temporary</parameter>を省略すると、ソーススロットと同じ値を使用します。
        </entry>
       </row>
 
@@ -6237,6 +6306,7 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         (<parameter>slot_name</parameter> <type>name</type>, <parameter>lsn</parameter> <type>pg_lsn</type>)
        </entry>
        <entry>
+<!--
         Copies an existing logical replication slot name <parameter>src_slot_name</parameter>
         to a logical replication slot named <parameter>dst_slot_name</parameter>
         while changing the output plugin and persistence. The copied logical slot starts
@@ -6244,6 +6314,11 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         <parameter>temporary</parameter> and <parameter>plugin</parameter> are optional.
         If <parameter>temporary</parameter> or <parameter>plugin</parameter> are omitted,
         the same values as the source logical slot are used.
+-->
+<parameter>src_slot_name</parameter>という名前の既存の物理レプリケーションスロットを<parameter>dst_slot_name</parameter>という名前の物理レプリケーションスロットに出力プラグインと永続性を変更しながらコピーします。
+コピーされたロジカルスロットはソースロジカルスロットと同じ<acronym>LSN</acronym>から開始します。
+<parameter>temporary</parameter>と<parameter>plugin</parameter>はどちらもオプションです。
+<parameter>temporary</parameter>あるいは<parameter>plugin</parameter>を省略すると、ソースロジカルスロットと同じ値が使用されます。
        </entry>
       </row>
 
@@ -7238,10 +7313,16 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
    </para>
 
    <table id="functions-info-partition">
+<!--
     <title>Partitioning Information Functions</title>
+-->
+    <title>パーティション情報関数</title>
     <tgroup cols="3">
      <thead>
+<!--
       <row><entry>Name</entry> <entry>Return Type</entry> <entry>Description</entry></row>
+-->
+      <row><entry>名前</entry> <entry>戻り型</entry> <entry>説明</entry></row>
      </thead>
 
      <tbody>
@@ -7252,6 +7333,7 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
        </entry>
        <entry><type>setof record</type></entry>
        <entry>
+<!--
         List information about tables or indexes in a partition tree for a
         given partitioned table or partitioned index, with one row for each
         partition.  Information provided includes the name of the partition,
@@ -7261,6 +7343,10 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
         or index in its role as the root of the partition tree,
         <literal>1</literal> for its partitions, <literal>2</literal> for
         their partitions, and so on.
+-->
+1行1パーティションで与えられたパーティション化テーブルあるいはパーティション化インデックスのパーティションツリー内のテーブルあるいはインデックスの情報を表示します。
+提供される情報にはパーティション名、その直接の親、パーティションが葉かどうかを示す真偽値、階層内のレベルを表す整数が含まれます。
+レベル値は与えられたテーブルあるいはインデックスがパーティションツリーの根としての役割を持つことを表す<literal>0</literal>で始まり、<literal>1</literal>ならその直下のパーティション、<literal>2</literal>ならそのまた下のパーティションなどとなります。
        </entry>
       </row>
       <row>
@@ -7270,8 +7356,11 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
        </entry>
        <entry><type>setof regclass</type></entry>
        <entry>
+<!--
         List the ancestor relations of the given partition,
         including the partition itself.
+-->
+パーティション自身を含む、与えられたパーティションの先祖リレーションを列挙します。
        </entry>
       </row>
       <row>
@@ -7281,8 +7370,11 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
        </entry>
        <entry><type>regclass</type></entry>
        <entry>
+<!--
         Return the top-most parent of a partition tree to which the given
         relation belongs.
+-->
+与えられたリレーションが所属するパーティションツリーの最上位の親を返します。
        </entry>
       </row>
      </tbody>
@@ -7290,10 +7382,13 @@ numeric値で表現されたサイズ（バイト数）を、サイズの単位�
    </table>
 
    <para>
+<!--
     To check the total size of the data contained in
     <structname>measurement</structname> table described in
     <xref linkend="ddl-partitioning-declarative-example"/>, one could use the
     following query:
+-->
+<xref linkend="ddl-partitioning-declarative-example"/>で説明されている<structname>measurement</structname>テーブルに含まれるデータの全体サイズを確認するには、次の問い合わせが利用できます。
    </para>
 
 <programlisting>
@@ -7538,10 +7633,14 @@ WALディレクトリ内のファイルの名前、サイズ、最終更新時�
        </entry>
        <entry><type>setof record</type></entry>
        <entry>
+<!--
         List the name, size, and last modification time of files in the WAL
         archive status directory. Access is granted to members of the
         <literal>pg_monitor</literal> role and may be granted to other
         non-superuser roles.
+-->
+WALアーカイブステータスディレクトリ内のファイルの名前、サイズ、最終更新時刻を一覧表示します。
+<literal>pg_monitor</literal>ロールのメンバーにはアクセス権が付与されており、他の非スーパーユーザのロールにもアクセス権を付与することができます。
        </entry>
       </row>
       <row>
@@ -7550,12 +7649,17 @@ WALディレクトリ内のファイルの名前、サイズ、最終更新時�
        </entry>
        <entry><type>setof record</type></entry>
        <entry>
+<!--
         List the name, size, and last modification time of files in the
         temporary directory for <parameter>tablespace</parameter>.  If
         <parameter>tablespace</parameter> is not provided, the
         <literal>pg_default</literal> tablespace is used.  Access is granted
         to members of the <literal>pg_monitor</literal> role and may be
         granted to other non-superuser roles.
+-->
+<parameter>tablespace</parameter>用の一時ディレクトリ内のファイルの名前、サイズ、最終更新時刻を一覧表示します。
+<parameter>tablespace</parameter>が与えられなかった場合は<literal>pg_default</literal>テーブル空間が使用されます。
+<literal>pg_monitor</literal>ロールのメンバーにはアクセス権が付与されており、他の非スーパーユーザのロールにもアクセス権を付与することができます。
        </entry>
       </row>
       <row>
@@ -7665,18 +7769,24 @@ WALディレクトリ内のファイルの名前、サイズ、最終更新時�
     <primary>pg_ls_archive_statusdir</primary>
    </indexterm>
    <para>
+<!--
     <function>pg_ls_archive_statusdir</function> returns the name, size, and
     last modified time (mtime) of each file in the WAL archive status
     directory <filename>pg_wal/archive_status</filename>. By default only
     superusers and members of the <literal>pg_monitor</literal> role can
     use this function. Access may be granted to others using
     <command>GRANT</command>.
+-->
+<function>pg_ls_archive_statusdir</function>はWALアーカイブディレクトリ内の各ファイルについて、名前、サイズ、最終更新時刻（mtime）を返します。
+デフォルトでは、スーパーユーザと<literal>pg_monitor</literal>ロールのメンバーだけがこの関数を使用できます。
+<command>GRANT</command>を使って他のロールにアクセス権を付与することができます。
    </para>
 
    <indexterm>
     <primary>pg_ls_tmpdir</primary>
    </indexterm>
    <para>
+<!--
     <function>pg_ls_tmpdir</function> returns the name, size, and last modified
     time (mtime) of each file in the temporary file directory for the specified
     <parameter>tablespace</parameter>.  If <parameter>tablespace</parameter> is
@@ -7684,6 +7794,11 @@ WALディレクトリ内のファイルの名前、サイズ、最終更新時�
     default only superusers and members of the <literal>pg_monitor</literal>
     role can use this function.  Access may be granted to others using
     <command>GRANT</command>.
+-->
+<function>pg_ls_tmpdir</function>は指定された<parameter>tablespace</parameter>用の一時ディレクトリ内のファイルの名前、サイズ、最終更新時刻を一覧表示します。
+<parameter>tablespace</parameter>が与えられなかった場合は<literal>pg_default</literal>テーブル空間が使用されます。
+デフォルトでは、スーパーユーザと<literal>pg_monitor</literal>ロールのメンバーだけがこの関数を使用できます。
+<command>GRANT</command>を使って他のロールにアクセス権を付与することができます。
    </para>
 
    <indexterm>

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -6315,7 +6315,7 @@ postgres=# SELECT * FROM pg_walfile_name_offset(pg_stop_backup());
         If <parameter>temporary</parameter> or <parameter>plugin</parameter> are omitted,
         the same values as the source logical slot are used.
 -->
-<parameter>src_slot_name</parameter>という名前の既存の物理レプリケーションスロットを<parameter>dst_slot_name</parameter>という名前の物理レプリケーションスロットに出力プラグインと永続性を変更しながらコピーします。
+<parameter>src_slot_name</parameter>という名前の既存の論理レプリケーションスロットを<parameter>dst_slot_name</parameter>という名前の論理レプリケーションスロットに出力プラグインと永続性を変更しながらコピーします。
 コピーされたロジカルスロットはソースロジカルスロットと同じ<acronym>LSN</acronym>から開始します。
 <parameter>temporary</parameter>と<parameter>plugin</parameter>はどちらもオプションです。
 <parameter>temporary</parameter>あるいは<parameter>plugin</parameter>を省略すると、ソースロジカルスロットと同じ値が使用されます。


### PR DESCRIPTION
例によってレビューはfunc[0-4].sgmlに行ってください。

「欲張り」→「貪欲」への置き換えはこのコミットではまだ行っていません。