### PR TITLE
テーブルの一つ余分な/row,rowを削除

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -8710,8 +8710,6 @@ POSIXはバックスラッシュ以降の空白文字を無視しません。
        </row>
        <row>
         <entry><literal>ID</literal></entry>
-       </row>
-       <row>
 <!--
         <entry>ISO 8601 day of the week, Monday (<literal>1</literal>) to Sunday (<literal>7</literal>)</entry>
 -->


### PR DESCRIPTION
このため次の行に表示されていました。
https://pgsql-jp.github.io/current/html/functions-formatting.html#FUNCTIONS-FORMATTING-DATETIME-TABLE