### PR TITLE
fix 'alone' word

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -26130,7 +26130,7 @@ SELECT currval(pg_get_serial_sequence('sometable', 'id'));
 <!--
       <entry>Does the access method support exclusion constraints?
 -->
-      <entry>アクセスメソッドは除外制約をサポートしているか
+      <entry>アクセスメソッドは排他制約をサポートしているか
       </entry>
      </row>
      <row>

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -3916,7 +3916,7 @@ SELECT currval(pg_get_serial_sequence('sometable', 'id'));
 <!--
       <entry>Does the access method support exclusion constraints?
 -->
-      <entry>アクセスメソッドは除外制約をサポートしているか
+      <entry>アクセスメソッドは排他制約をサポートしているか
       </entry>
      </row>
      <row>

--- a/doc/src/sgml/indices.sgml
+++ b/doc/src/sgml/indices.sgml
@@ -1583,7 +1583,7 @@ CREATE UNIQUE INDEX tests_success_constraint ON tests (subject, target)
 -->
 このパフォーマンス問題を解決するため、<productname>PostgreSQL</productname>は<firstterm>インデックスオンリースキャン</firstterm>をサポートします。
 これは、問い合わせに対してヒープアクセスをせずにインデックスのみで回答できるものです。
-基本的な考え方は、関連するヒープのエントリを参照せずに、各インデクスエントリから直接に値を返すというものです。
+基本的な考え方は、関連するヒープのエントリを参照せずに、各インデックスエントリから直接に値を返すというものです。
 この方法が使用できるためには2つの基本的な制限があります。
 
    <orderedlist>


### PR DESCRIPTION
除外制約→排他制約
インデクス→インデックス
です。どちらも前者は1つだけしかなくて、それ以外のところでは後者でした。