### PR TITLE
update libpq for 12

### DIFF
--- a/doc/src/sgml/libpq.sgml
+++ b/doc/src/sgml/libpq.sgml
@@ -1960,7 +1960,7 @@ Unixドメインソケット経由でなされた接続の場合、このパラ�
 -->
 <acronym>GSSAPI</acronym>認証情報が(すなわち認証情報キャッシュに)存在すれば、まず<acronym>GSSAPI</acronym>暗号化接続を試行します。
 その試行に失敗した場合、もしくは認証情報がない場合には非<acronym>GSSAPI</acronym>暗号化接続を試行します。
-これが<productname>PostgreSQL</productname>を<acronym>GSSAPI</acronym>サポートを有効にしてコンパイルした場合のデフォルトです
+これが<productname>PostgreSQL</productname>を<acronym>GSSAPI</acronym>サポートを有効にしてコンパイルした場合のデフォルトです。
            </para>
           </listitem>
          </varlistentry>
@@ -9104,7 +9104,7 @@ void *PQresultAlloc(PGresult *res, size_t nBytes);
       Retrieves the number of bytes allocated for
       a <structname>PGresult</structname> object.
 -->
-<structname>PGresult</structname>オブジェクトのために割り当てられたバイト数と取り出します。
+<structname>PGresult</structname>オブジェクトのために割り当てられたバイト数を取り出します。
 <synopsis>
 size_t PQresultMemorySize(const PGresult *res);
 </synopsis>

--- a/doc/src/sgml/libpq.sgml
+++ b/doc/src/sgml/libpq.sgml
@@ -1810,12 +1810,19 @@ Unixドメインソケット経由でなされた接続の場合、またはキ�
       <term><literal>tcp_user_timeout</literal></term>
       <listitem>
        <para>
+<!--
         Controls the number of milliseconds that transmitted data may
         remain unacknowledged before a connection is forcibly closed.
         A value of zero uses the system default. This parameter is
         ignored for connections made via a Unix-domain socket.
         It is only supported on systems where <symbol>TCP_USER_TIMEOUT</symbol>
         is available; on other systems, it has no effect.
+-->
+接続が強制的に閉じられるまで、送信されたデータに対して応答がない状況をどれだけ認めるかをミリ秒単位で制御します。
+値0はシステムのデフォルトを使用します。
+Unixドメインソケット経由でなされた接続の場合、このパラメータは無視されます。
+<symbol>TCP_USER_TIMEOUT</symbol>が利用可能なシステムでのみサポートされます。
+他のシステムでは効果がありません。
        </para>
       </listitem>
      </varlistentry>
@@ -1914,24 +1921,35 @@ Unixドメインソケット経由でなされた接続の場合、またはキ�
       <term><literal>gssencmode</literal></term>
       <listitem>
        <para>
+<!--
         This option determines whether or with what priority a secure
         <acronym>GSS</acronym> TCP/IP connection will be negotiated with the
         server. There are three modes:
+-->
+このオプションは、<acronym>GSS</acronym>による安全なTCP/IP接続をサーバと調停するか、するのならどの優先度で調停するかを決定します。
+3つのモードがあります。
 
         <variablelist>
          <varlistentry>
           <term><literal>disable</literal></term>
           <listitem>
            <para>
+<!--
             only try a non-<acronym>GSSAPI</acronym>-encrypted connection
+-->
+非<acronym>GSSAPI</acronym>暗号化接続のみ試行
            </para>
           </listitem>
          </varlistentry>
 
          <varlistentry>
+<!--
           <term><literal>prefer</literal> (default)</term>
+-->
+          <term><literal>prefer</literal> (デフォルト)</term>
           <listitem>
            <para>
+<!--
             if there are <acronym>GSSAPI</acronym> credentials present (i.e.,
             in a credentials cache), first try
             a <acronym>GSSAPI</acronym>-encrypted connection; if that fails or
@@ -1939,6 +1957,10 @@ Unixドメインソケット経由でなされた接続の場合、またはキ�
             non-<acronym>GSSAPI</acronym>-encrypted connection.  This is the
             default when <productname>PostgreSQL</productname> has been
             compiled with <acronym>GSSAPI</acronym> support.
+-->
+<acronym>GSSAPI</acronym>認証情報が(すなわち認証情報キャッシュに)存在すれば、まず<acronym>GSSAPI</acronym>暗号化接続を試行します。
+その試行に失敗した場合、もしくは認証情報がない場合には非<acronym>GSSAPI</acronym>暗号化接続を試行します。
+これが<productname>PostgreSQL</productname>を<acronym>GSSAPI</acronym>サポートを有効にしてコンパイルした場合のデフォルトです
            </para>
           </listitem>
          </varlistentry>
@@ -1947,7 +1969,10 @@ Unixドメインソケット経由でなされた接続の場合、またはキ�
           <term><literal>require</literal></term>
           <listitem>
            <para>
+<!--
             only try a <acronym>GSSAPI</acronym>-encrypted connection
+-->
+<acronym>GSSAPI</acronym>暗号化接続のみ試行
            </para>
           </listitem>
          </varlistentry>
@@ -1955,6 +1980,7 @@ Unixドメインソケット経由でなされた接続の場合、またはキ�
        </para>
 
        <para>
+<!--
         <literal>gssencmode</literal> is ignored for Unix domain socket
         communication.  If <productname>PostgreSQL</productname> is compiled
         without GSSAPI support, using the <literal>require</literal> option
@@ -1963,6 +1989,9 @@ Unixドメインソケット経由でなされた接続の場合、またはキ�
         a <acronym>GSSAPI</acronym>-encrypted
         connection.<indexterm><primary>GSSAPI</primary><secondary sortas="libpq">with
         libpq</secondary></indexterm>
+-->
+<literal>gssencmode</literal>はUnixドメインソケット通信では無視されます。
+<productname>PostgreSQL</productname>がGSSAPIなしでコンパイルされた場合、<literal>require</literal>オプションを使うとエラーになります。一方、<literal>prefer</literal>は受け付けられますが、<application>libpq</application>は実際には<acronym>GSSAPI</acronym>暗号化接続を試行しません。<indexterm><primary>GSSAPI</primary><secondary sortas="libpq">libpqでの</secondary></indexterm>
        </para>
       </listitem>
      </varlistentry>
@@ -2560,21 +2589,29 @@ char *PQhost(const PGconn *conn);
 
      <listitem>
       <para>
+<!--
        Returns the server IP address of the active connection.
        This can be the address that a host name resolved to,
        or an IP address provided through the <literal>hostaddr</literal>
        parameter.
+-->
+実際に接続したサーバIPアドレスを返します。
+これはホスト名を解決したアドレス、あるいは<literal>hostaddr</literal>パラメータ経由で与えられたIPアドレスになります。
 <synopsis>
 char *PQhostaddr(const PGconn *conn);
 </synopsis>
       </para>
 
       <para>
+<!--
        <function>PQhostaddr</function> returns <symbol>NULL</symbol> if the
        <parameter>conn</parameter> argument is <symbol>NULL</symbol>.
        Otherwise, if there is an error producing the host information
        (perhaps if the connection has not been fully established or
        there was an error), it returns an empty string.
+-->
+<parameter>conn</parameter>引数が<symbol>NULL</symbol>ならば、<function>PQhostaddr</function>は<symbol>NULL</symbol>を返します。
+そうでない場合、もしホスト情報の生成がエラーとなったら（おそらくコネクションまだ完全には確立されていないか、なんらかのエラーがある場合です）、空文字が返ります。
       </para>
      </listitem>
     </varlistentry>
@@ -8263,7 +8300,7 @@ int PQendcopy(PGconn *conn);
        retrieve details if the return value is nonzero.)
 -->
 この関数はサーバがコピーを完了するのを待ちます。
-この関数は、<function>PQputline</function>を使ったサーバへの文字列送信が完了した時点、あるいは<function>PGgetline</function>を使ったサーバからの文字列受信が完了した時点のいずれでも呼び出さなければなりません。
+この関数は、<function>PQputline</function>を使ったサーバへの文字列送信が完了した時点、あるいは<function>PQgetline</function>を使ったサーバからの文字列受信が完了した時点のいずれでも呼び出さなければなりません。
 これを発行しないと、サーバはクライアントとの<quote>同期がずれた</quote>状態になってしまいます。
 この関数から戻った時点で、サーバは次のSQLコマンドを受ける準備が整います。
 正常に終了した場合、返り値は0です。 さもなくば、非ゼロです。
@@ -8436,20 +8473,22 @@ PGVerbosity PQsetErrorVerbosity(PGconn *conn, PGVerbosity verbosity);
 <function>PQsetErrorVerbosity</function>は冗長度モードを設定し、接続における以前の状態を返します。
 <firstterm>TERSE</firstterm>モードでは、返されるメッセージには深刻度、主テキスト、位置のみが含まれます。
 これは通常単一行に収まります。
-デフォルトモードでは、上に加え、詳細、ヒント、文脈フィールドが含まれるメッセージが生成されます。
-（これは複数行に跨るかもしれません。）
+<firstterm>DEFAULT</firstterm>モードでは、上に加え、詳細、ヒント、文脈フィールドが含まれるメッセージが生成されます（これは複数行に跨るかもしれません。）
 <firstterm>VERBOSE</firstterm>モードでは、すべての利用可能なフィールドが含まれます。
-冗長度の変更は、既に存在する<structname>PGresult</structname>オブジェクト内から取り出せるメッセージには影響を与えません。
-その後に作成されたオブジェクトにのみ影響を与えます。
-（ただし、以前のエラーを異なる冗長さで表示したい場合は<function>PQresultVerboseErrorMessage</function>を参照してください。）
+<firstterm>SQLSTATE</firstterm>モードでは、エラーの深刻度と、利用可能であれば<symbol>SQLSTATE</symbol>エラーコードだけが含まれます(利用できなければ、出力は<firstterm>TERSE</firstterm>モードのようになります)。
      </para>
 
      <para>
+<!--
       Changing the verbosity setting does not affect the messages available
       from already-existing <structname>PGresult</structname> objects, only
       subsequently-created ones.
       (But see <function>PQresultVerboseErrorMessage</function> if you
       want to print a previous error with a different verbosity.)
+-->
+冗長度の変更は、既に存在する<structname>PGresult</structname>オブジェクト内から取り出せるメッセージには影響を与えません。
+その後に作成されたオブジェクトにのみ影響を与えます。
+（ただし、以前のエラーを異なる冗長さで表示したい場合は<function>PQresultVerboseErrorMessage</function>を参照してください。）
      </para>
     </listitem>
    </varlistentry>
@@ -8493,9 +8532,16 @@ PGContextVisibility PQsetErrorContextVisibility(PGconn *conn, PGContextVisibilit
       (However, if the verbosity setting is <firstterm>TERSE</firstterm>
       or <firstterm>SQLSTATE</firstterm>, <literal>CONTEXT</literal> fields
       are omitted regardless of the context display mode.)
+-->
+<function>PQsetErrorContextVisibility</function>はコンテキストの表示モードを設定し、その接続での以前の設定を返します。
+このモードはメッセージに<literal>CONTEXT</literal>フィールドが含まれるかどうかを制御します。
+<firstterm>NEVER</firstterm>モードでは、決して<literal>CONTEXT</literal>を含みませんが、<firstterm>ALWAYS</firstterm>では<literal>CONTEXT</literal>が利用可能であれば常に含まれます。
+<firstterm>ERRORS</firstterm>モード（デフォルト）では、<literal>CONTEXT</literal>はエラーメッセージには含まれますが、注意や警告では含まれません。
+（しかしながら、冗長設定が<firstterm>TERSE</firstterm>や<firstterm>SQLSTATE</firstterm>の場合は、コンテキストの表示モードに関わらず<literal>CONTEXT</literal>フィールドは省略されます。）
      </para>
 
      <para>
+<!--
       Changing this mode does not
       affect the messages available from
       already-existing <structname>PGresult</structname> objects, only
@@ -8503,10 +8549,6 @@ PGContextVisibility PQsetErrorContextVisibility(PGconn *conn, PGContextVisibilit
       (But see <function>PQresultVerboseErrorMessage</function> if you
       want to print a previous error with a different display mode.)
 -->
-<function>PQsetErrorContextVisibility</function>はコンテキストの表示モードを設定し、その接続での以前の設定を返します。
-このモードはメッセージに<literal>CONTEXT</literal>フィールドが含まれるかどうかを制御します（冗長設定が<firstterm>TERSE</firstterm>の場合は<literal>CONTEXT</literal>が決して表示されないので除きます）。
-<firstterm>NEVER</firstterm>モードでは、決して<literal>CONTEXT</literal>を含みませんが、<firstterm>ALWAYS</firstterm>では<literal>CONTEXT</literal>が利用可能であれば常に含まれます。
-<firstterm>ERRORS</firstterm>モード（デフォルト）では、<literal>CONTEXT</literal>はエラーメッセージには含まれますが、注意や警告では含まれません。
 このモードを変更しても、既存の<structname>PGresult</structname>から取得可能なメッセージには影響を与えず、その後で作成されるものにのみ影響します。
 （ただし、以前のエラーについて異なる表示モードで表示したい場合は、<function>PQresultVerboseErrorMessage</function>を参照してください。）
      </para>
@@ -9058,18 +9100,25 @@ void *PQresultAlloc(PGresult *res, size_t nBytes);
 
     <listitem>
      <para>
+<!--
       Retrieves the number of bytes allocated for
       a <structname>PGresult</structname> object.
+-->
+<structname>PGresult</structname>オブジェクトのために割り当てられたバイト数と取り出します。
 <synopsis>
 size_t PQresultMemorySize(const PGresult *res);
 </synopsis>
      </para>
 
      <para>
+<!--
       This value is the sum of all <function>malloc</function> requests
       associated with the <structname>PGresult</structname> object, that is,
       all the space that will be freed by <function>PQclear</function>.
       This information can be useful for managing memory consumption.
+-->
+この値は<structname>PGresult</structname>オブジェクトに関連する<function>malloc</function>要求すべての和、すなわち<function>PQclear</function>で解放される空間全体です。
+この情報はメモリ消費を管理するのに有用でしょう。
      </para>
     </listitem>
    </varlistentry>
@@ -9881,11 +9930,15 @@ int PQresultSetInstanceData(PGresult *res, PGEventProc proc, void *data);
       </para>
 
       <para>
+<!--
        Beware that any storage represented by <parameter>data</parameter>
        will not be accounted for by <function>PQresultMemorySize</function>,
        unless it is allocated using <function>PQresultAlloc</function>.
        (Doing so is recommendable because it eliminates the need to free
        such storage explicitly when the result is destroyed.)
+-->
+<parameter>data</parameter>で示された領域は、<function>PQresultAlloc</function>を使って割り当てたのでない限り、<function>PQresultMemorySize</function>では考慮されないことに注意してください。
+(結果を破棄する時に、領域を明示的に解放する必要がなくなりますので、<function>PQresultAlloc</function>を使って割り当てるのがお勧めです。)
       </para>
      </listitem>
     </varlistentry>
@@ -10293,16 +10346,6 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
     <listitem>
      <para>
       <indexterm>
-       <primary><envar>PGGSSENCMODE</envar></primary>
-      </indexterm>
-      <envar>PGGSSENCMODE</envar> behaves the same as the <xref
-      linkend="libpq-connect-gssencmode"/> connection parameter.
-     </para>
-    </listitem>
-
-    <listitem>
-     <para>
-      <indexterm>
        <primary><envar>PGOPTIONS</envar></primary>
       </indexterm>
 <!--
@@ -10440,8 +10483,11 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
       <indexterm>
        <primary><envar>PGGSSENCMODE</envar></primary>
       </indexterm>
+<!--
       <envar>PGGSSENCMODE</envar> behaves the same as the <xref
       linkend="libpq-connect-gssencmode"/> connection parameter.
+-->
+<envar>PGGSSENCMODE</envar>は<xref linkend="libpq-connect-gssencmode"/>接続パラメータと同様に動作します。
      </para>
     </listitem>
 
@@ -11232,7 +11278,7 @@ SSLは以下の３種類の攻撃に対する保護を提供することがで�
    verify against. This is analogous to using an <literal>https</literal>
    <acronym>URL</acronym> for encrypted web browsing.
 -->
-信頼できるとされる接続では、SSLの使用を接続確立前に<emphasis>クライアントとサーバの双方において</emphasis>設定されなければなりません。
+SSLで信頼できるとされる接続では、SSLの使用を接続確立前に<emphasis>クライアントとサーバの双方において</emphasis>設定されなければなりません。
 サーバのみに構成されると、クライアントはサーバが高度なセキュリティを必要とすることが判る以前に、（例えばパスワードのような）機密事項を扱う情報を結局送ることになります。
 libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-full</literal>または<literal>verify-ca</literal>に設定し、そして対象を検証するためルート証明書をシステムに提供することで、安全な接続を確実に行うことができます。
 これは暗号化されたweb閲覧に対する<literal>https</literal> <acronym>URL</acronym>の使用とよく似ています。


### PR DESCRIPTION
libpq.sgmlの12対応です。

PGGSSENCMODEの原文を削除してしまっているように見えますが、その直後の差分に全く同じものがありますので、マージ時の手違いだと思います。
あと、訳していて
  if there are GSSAPI credentials present (i.e. in a credentials cache),
という部分が、i.e.ではなくe.g.と書きたかったのではないかという気がするのです（「認証情報が(たとえば認証情報キャッシュに)存在」の方が流れとしてきれいなような、、、）が、そこまで自信がないので、本家への報告とかはしていません。