### PR TITLE
fix typos in libpq

### DIFF
--- a/doc/src/sgml/libpq.sgml
+++ b/doc/src/sgml/libpq.sgml
@@ -2336,7 +2336,7 @@ GSSAPIの認証時に使われるKerberosサービス名です。
 -->
 GSSAPI認証で使用されるGSSライブラリです。
 Windows上のみで使用されます。
-libpqが認証にデフォルトのSSPIではなく、強制的にGSSAPIライブラリを使用するようにするには<literal>gssapi</literal>を設定してください。
+認証にデフォルトのSSPIではなく、GSSAPIライブラリを使うようibpqに強制するには<literal>gssapi</literal>を設定してください。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/libpq.sgml
+++ b/doc/src/sgml/libpq.sgml
@@ -2336,7 +2336,7 @@ GSSAPIの認証時に使われるKerberosサービス名です。
 -->
 GSSAPI認証で使用されるGSSライブラリです。
 Windows上のみで使用されます。
-認証にデフォルトのSSPIではなく、GSSAPIライブラリを使うようibpqに強制するには<literal>gssapi</literal>を設定してください。
+認証にデフォルトのSSPIではなく、GSSAPIライブラリを使うようlibpqに強制するには<literal>gssapi</literal>を設定してください。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/libpq.sgml
+++ b/doc/src/sgml/libpq.sgml
@@ -91,7 +91,7 @@
 -->
 <productname>PostgreSQL</productname>のバックエンドサーバとの接続を作成するには、以下の関数を使用します。
 アプリケーションプログラムはバックエンドとの接続を一度に複数個開くことができます。
-（1つの理由として、複数のデータベースへのアクセスが挙げられます。）
+（そのようにする1つの理由として、複数のデータベースへのアクセスが挙げられます。）
 個々の接続は、<function>PQconnectdb</function>、<function>PQconnectdbParams</function>または<function>PQsetdbLogin</function>関数を呼び出すことで得られる<structname>PGconn</structname><indexterm><primary>PGconn</primary></indexterm>オブジェクトによって表されます。
 なお、これらの関数は、<structname>PGconn</structname>オブジェクトに割り当てるほんのわずかなメモリの余裕さえもない場合を除き、NULLではなく常にオブジェクトのポインタを返します。
 また、この接続オブジェクトを通じて問い合わせを送る前に、<function>PQstatus</function>関数を呼び出して、データベースとの接続に成功したか戻り値を検査しなければなりません。
@@ -147,7 +147,7 @@ Unix上で、libpq接続を開いたプロセスのフォークは、親と子�
      <function>WSAStartup()</function> so resources will not be freed when the last database
      connection is closed.
 -->
-Windowsでは、単一のデータベース接続が反復して開始と終了を繰り返す場合、性能を向上させる方法があります。
+Windowsでは、単一のデータベース接続が開始と終了を繰り返す場合、性能を向上させる方法があります。
 内部的には、接続開始と終了に対して、libpqはそれぞれ<function>WSAStartup()</function>と<function>WSACleanup()</function>を呼び出します。
 <function>WSAStartup()</function>は<function>WSACleanup()</function>で値が減少させられた内部Windowsライブラリ参照カウントを増加させます。
 参照カウントがたった１の場合、<function>WSACleanup()</function>呼び出しはすべてのリソースを解放し、すべてのDLLはアンロードされます。
@@ -1006,7 +1006,7 @@ PGPing PQpingParams(const char * const *keywords,
 <!--
        The function returns one of the following values:
 -->
-このサーバは以下の値のいずれかを返します。
+この関数は以下の値のいずれかを返します。
 
        <variablelist>
         <varlistentry id="libpq-pqpingparams-pqping-ok">
@@ -1450,7 +1450,7 @@ Unixドメインソケットを持たないマシンにおけるデフォルト�
 -->
 <literal>host</literal>の代わりに<literal>hostaddr</literal>を使用することで、アプリケーションがホスト名の検索を行なわずに済みます。
 特に時間的制約があるアプリケーションでは重要になるでしょう。
-しかし、GSSAP、SSPI認証方式では、ホスト名が必要になります。
+しかし、GSSAPI、SSPI認証方式では、ホスト名が必要になります。
 <literal>verify-full</literal>SSL証明書検証を行う場合も同様です。
 以下の規則が使用されます。
         <itemizedlist>
@@ -1851,8 +1851,8 @@ Unixドメインソケット経由でなされた接続の場合、このパラ�
        also be used by third-party applications.  For a description of the
        replication protocol, consult <xref linkend="protocol-replication"/>.
 -->
-このオプションは接続が通常プロトコルの代わりにレプリケーションプロトコルで使われるかどうかを決めます。
-これは<application>pg_basebackup</application>などのツールが内部的に使うPostgreSQLのレプリケーション接続ですが、サードパーティアプリケーションからも使われることがあります。
+このオプションは接続が通常プロトコルの代わりにレプリケーションプロトコルを使うかどうかを決めます。
+これはPostgreSQLのレプリケーション接続や<application>pg_basebackup</application>などのツールが内部的に使うものですが、サードパーティアプリケーションからも使われることがあります。
 レプリケーションプロトコルについての説明は<xref linkend="protocol-replication"/>を参照してください。
       </para>
 
@@ -1885,7 +1885,7 @@ Unixドメインソケット経由でなされた接続の場合、このパラ�
            The connection goes into logical replication mode, connecting to
            the database specified in the <literal>dbname</literal> parameter.
 -->
-接続はロジカルレプリケーションモードになり、<literal>dbname</literal>パラメータで指定されたデータベースに接続します。
+接続は論理レプリケーションモードになり、<literal>dbname</literal>パラメータで指定されたデータベースに接続します。
           </para>
          </listitem>
         </varlistentry>
@@ -2336,7 +2336,7 @@ GSSAPIの認証時に使われるKerberosサービス名です。
 -->
 GSSAPI認証で使用されるGSSライブラリです。
 Windows上のみで使用されます。
-libpqの認証がデフォルトのSSPIではなく、強制的にGSSAPIライブラリを使用させるには<literal>gssapi</literal>を設定してください。
+libpqが認証にデフォルトのSSPIではなく、強制的にGSSAPIライブラリを使用するようにするには<literal>gssapi</literal>を設定してください。
        </para>
       </listitem>
      </varlistentry>
@@ -2506,7 +2506,7 @@ char *PQpass(const PGconn *conn);
        the connection is established.  The status of the connection can be
        checked using the function <function>PQstatus</function>.
 -->
-<function>PQpass</function>は、接続パラメーターで指定されたパスワードを返します。
+<function>PQpass</function>は、接続パラメータで指定されたパスワードを返します。
 もし接続パラメータにパスワードがなくて、<link linkend="libpq-pgpass">パスワードファイル</link>からパスワードを取得できる場合には、そのパスワードを返します。
 この場合、接続パラメータに複数のホストが指定されていると、接続が確立するまでは、<function>PQpass</function>の結果を当てにすることはできません。
 接続の状態は、関数<function>PQstatus</function>で確認できます。
@@ -2562,7 +2562,7 @@ char *PQhost(const PGconn *conn);
        error), it returns an empty string.
 -->
 <parameter>conn</parameter>引数が<symbol>NULL</symbol>ならば、<function>PQhost</function>は<symbol>NULL</symbol>を返します。
-そうでない場合、もしホスト情報の生成中エラーとなったら（おそらくコネクションまだ完全には確立されていないか、なんらかのエラーがある場合です）、空文字が返ります。
+そうでない場合、もしホスト情報の生成中エラーとなったら（おそらくコネクションがまだ完全には確立されていないか、なんらかのエラーがある場合です）、空文字が返ります。
       </para>
 
       <para>
@@ -2572,7 +2572,7 @@ char *PQhost(const PGconn *conn);
        the connection is established.  The status of the connection can be
        checked using the function <function>PQstatus</function>.
 -->
-接続パラメーター中に複数のホストが指定されると、接続が確立するまでは<function>PQhost</function>の結果を当てにすることはできません。
+接続パラメータ中に複数のホストが指定されると、接続が確立するまでは<function>PQhost</function>の結果を当てにすることはできません。
 接続の状態は、<function>PQstatus</function>関数で確認できます。
       </para>
      </listitem>
@@ -2611,7 +2611,7 @@ char *PQhostaddr(const PGconn *conn);
        there was an error), it returns an empty string.
 -->
 <parameter>conn</parameter>引数が<symbol>NULL</symbol>ならば、<function>PQhostaddr</function>は<symbol>NULL</symbol>を返します。
-そうでない場合、もしホスト情報の生成がエラーとなったら（おそらくコネクションまだ完全には確立されていないか、なんらかのエラーがある場合です）、空文字が返ります。
+そうでない場合、もしホスト情報の生成がエラーとなったら（おそらくコネクションがまだ完全には確立されていないか、なんらかのエラーがある場合です）、空文字が返ります。
       </para>
      </listitem>
     </varlistentry>
@@ -2653,7 +2653,7 @@ char *PQport(const PGconn *conn);
        error), it returns an empty string.
 -->
 <parameter>conn</parameter>引数が<symbol>NULL</symbol>ならば、<function>PQport</function>は<symbol>NULL</symbol>を返します。
-そうでない場合、もしホスト情報の生成がエラーとなったら（おそらくコネクションまだ完全には確立されていないか、なんらかのエラーがある場合です）、空文字が返ります。
+そうでない場合、もしホスト情報の生成がエラーとなったら（おそらくコネクションがまだ完全には確立されていないか、なんらかのエラーがある場合です）、空文字が返ります。
       </para>
 
       <para>
@@ -2663,7 +2663,7 @@ char *PQport(const PGconn *conn);
        the connection is established.  The status of the connection can be
        checked using the function <function>PQstatus</function>.
 -->
-接続パラメーター中に複数のポートが指定されると、接続が確立するまでは<function>PQport</function>の結果を当てにすることはできません。
+接続パラメータ中に複数のポートが指定されると、接続が確立するまでは<function>PQport</function>の結果を当てにすることはできません。
 接続の状態は、<function>PQstatus</function>関数で確認できます。
       </para>
      </listitem>
@@ -10734,9 +10734,9 @@ Microsoft Windowsでは、このファイルの名前は<filename>%APPDATA%\post
 最初に現在の接続パラメータと一致した行のパスワードフィールドが使用されます。
 (従って、ワイルドカードを使用する場合は、始めの方により具体的な項目を入力してください。)
 項目内に<literal>:</literal>または<literal>\</literal>を含める必要があれば、<literal>\</literal>でこれらの文字をエスケープする必要があります。
-ホスト名フィールドは、<literal>host</literal>接続パラメータか、もし指定されていれば、<literal>hostaddr</literal>パラメーターと一致します。
+ホスト名フィールドは、<literal>host</literal>接続パラメータか、もし指定されていれば、<literal>hostaddr</literal>パラメータと一致します。
 どちらも指定されていなければ、ホスト名<literal>localhost</literal>が検索されます。
-接続がUnixドメインソケット接続で、<literal>host</literal>パラメーターが<application>libpq</application>のデフォルトソケットディレクトリパスに一致した場合も、ホスト名<literal>localhost</literal>が検索されます。
+接続がUnixドメインソケット接続で、<literal>host</literal>パラメータが<application>libpq</application>のデフォルトソケットディレクトリパスに一致した場合も、ホスト名<literal>localhost</literal>が検索されます。
 スタンバイサーバでは、<literal>replication</literal>という名称のデータベースは、マスタサーバとの間でなされるストリーミングレプリケーション用の接続に一致します。
 同一のクラスタ内のすべてのデータベースに対するパスワードは同じものですので、データベースフィールドの有用性は限定的なものです。
   </para>


### PR DESCRIPTION
libpq で気になる部分をいくつか見つけましたので、その修正案です。

パラメーター → パラメータ も同時にやっています。
（パラメーターと伸ばしているのはlibpqしかないようです。）