### PR TITLE
fix translation of "cluster"

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -5359,7 +5359,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      これらの設定は組み込みの<firstterm>ストリーミングレプリケーション</firstterm>機能の動作を制御します（<xref linkend="streaming-replication"/>を参照ください）。
       サーバ群のサーバはマスターかスタンバイのいずれかです。マスターはデータを送出する一方、複数のスタンバイは複製されたデータを常に受け取ります。カスケードレプリケーション（<xref linkend="cascading-replication"/>を参照）が使用されている場合、スタンバイサーバ群は受け取り手でもあり、送り手でもあります。
       パラメータは主として送出サーバとスタンバイサーバ用ですが、いくつかのパラメータはマスターサーバのみに効力を発します。
-      必要とあればクラスターに渡って問題なく設定を変化させることができます。
+必要とあればクラスタに渡って問題なく設定を変化させることができます。
     </para>
 
     <sect2 id="runtime-config-replication-sender">

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -5356,9 +5356,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      parameters have meaning only on the master server.  Settings may vary
      across the cluster without problems if that is required.
 -->
-     これらの設定は組み込みの<firstterm>ストリーミングレプリケーション</firstterm>機能の動作を制御します（<xref linkend="streaming-replication"/>を参照ください）。
-      サーバ群のサーバはマスターかスタンバイのいずれかです。マスターはデータを送出する一方、複数のスタンバイは複製されたデータを常に受け取ります。カスケードレプリケーション（<xref linkend="cascading-replication"/>を参照）が使用されている場合、スタンバイサーバ群は受け取り手でもあり、送り手でもあります。
-      パラメータは主として送出サーバとスタンバイサーバ用ですが、いくつかのパラメータはマスターサーバのみに効力を発します。
+これらの設定は組み込みの<firstterm>ストリーミングレプリケーション</firstterm>機能の動作を制御します（<xref linkend="streaming-replication"/>を参照ください）。
+サーバ群のサーバはマスターかスタンバイのいずれかです。マスターはデータを送出する一方、複数のスタンバイは複製されたデータを常に受け取ります。カスケードレプリケーション（<xref linkend="cascading-replication"/>を参照）が使用されている場合、スタンバイサーバ群は受け取り手でもあり、送り手でもあります。
+パラメータは主として送出サーバとスタンバイサーバ用ですが、いくつかのパラメータはマスターサーバのみに効力を発します。
 必要とあればクラスタに渡って問題なく設定を変化させることができます。
     </para>
 

--- a/doc/src/sgml/config1.sgml
+++ b/doc/src/sgml/config1.sgml
@@ -1785,9 +1785,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      parameters have meaning only on the master server.  Settings may vary
      across the cluster without problems if that is required.
 -->
-     これらの設定は組み込みの<firstterm>ストリーミングレプリケーション</firstterm>機能の動作を制御します（<xref linkend="streaming-replication"/>を参照ください）。
-      サーバ群のサーバはマスターかスタンバイのいずれかです。マスターはデータを送出する一方、複数のスタンバイは複製されたデータを常に受け取ります。カスケードレプリケーション（<xref linkend="cascading-replication"/>を参照）が使用されている場合、スタンバイサーバ群は受け取り手でもあり、送り手でもあります。
-      パラメータは主として送出サーバとスタンバイサーバ用ですが、いくつかのパラメータはマスターサーバのみに効力を発します。
+これらの設定は組み込みの<firstterm>ストリーミングレプリケーション</firstterm>機能の動作を制御します（<xref linkend="streaming-replication"/>を参照ください）。
+サーバ群のサーバはマスターかスタンバイのいずれかです。マスターはデータを送出する一方、複数のスタンバイは複製されたデータを常に受け取ります。カスケードレプリケーション（<xref linkend="cascading-replication"/>を参照）が使用されている場合、スタンバイサーバ群は受け取り手でもあり、送り手でもあります。
+パラメータは主として送出サーバとスタンバイサーバ用ですが、いくつかのパラメータはマスターサーバのみに効力を発します。
 必要とあればクラスタに渡って問題なく設定を変化させることができます。
     </para>
 

--- a/doc/src/sgml/config1.sgml
+++ b/doc/src/sgml/config1.sgml
@@ -1788,7 +1788,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      これらの設定は組み込みの<firstterm>ストリーミングレプリケーション</firstterm>機能の動作を制御します（<xref linkend="streaming-replication"/>を参照ください）。
       サーバ群のサーバはマスターかスタンバイのいずれかです。マスターはデータを送出する一方、複数のスタンバイは複製されたデータを常に受け取ります。カスケードレプリケーション（<xref linkend="cascading-replication"/>を参照）が使用されている場合、スタンバイサーバ群は受け取り手でもあり、送り手でもあります。
       パラメータは主として送出サーバとスタンバイサーバ用ですが、いくつかのパラメータはマスターサーバのみに効力を発します。
-      必要とあればクラスターに渡って問題なく設定を変化させることができます。
+必要とあればクラスタに渡って問題なく設定を変化させることができます。
     </para>
 
     <sect2 id="runtime-config-replication-sender">


### PR DESCRIPTION
「クラスター」と伸ばしているのは、この一ヶ所だけです。