### PR TITLE
monitoring.sgml内の表27.1 動的統計情報ビューの改善です

### DIFF
--- a/doc/src/sgml/monitoring.sgml
+++ b/doc/src/sgml/monitoring.sgml
@@ -463,7 +463,7 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
        the current activity of that process, such as state and current query.
        See <xref linkend="pg-stat-activity-view"/> for details.
 -->
-サーバ当たり１行の形式で、状態や現在の問い合わせ等のプロセスの現在の活動状況に関連した情報を表示します。
+サーバプロセスあたり１行の形式で、状態や現在の問い合わせ等のプロセスの現在の活動状況に関連した情報を表示します。
 詳細については<xref linkend="pg-stat-activity-view"/>を参照してください。
       </entry>
      </row>


### PR DESCRIPTION
pg_stat_activityの説明を改善してみました。

原文 (https://www.postgresql.org/docs/12/monitoring-stats.html)
　One row per server process, 
修正前
　サーバ当たり１行の形式で、
修正後
　サーバプロセスあたり１行の形式で、