### PR TITLE
update hstore and ltree for 12.4

### DIFF
--- a/doc/src/sgml/hstore.sgml
+++ b/doc/src/sgml/hstore.sgml
@@ -904,10 +904,14 @@ PL/Python向けの拡張は<literal>hstore_plpythonu</literal>、<literal>hstore
 
   <caution>
    <para>
+<!--
     It is strongly recommended that the transform extensions be installed in
     the same schema as <filename>hstore</filename>.  Otherwise there are
     installation-time security hazards if a transform extension's schema
     contains objects defined by a hostile user.
+-->
+変換の拡張は<filename>hstore</filename>と同じスキーマにインストールすることを強く勧めます。
+さもないと、変換の拡張のスキーマが悪意のあるユーザにより定義されたオブジェクトを含んでいた場合に、インストール時のセキュリティ問題になります。
    </para>
   </caution>
  </sect2>

--- a/doc/src/sgml/ltree.sgml
+++ b/doc/src/sgml/ltree.sgml
@@ -998,10 +998,14 @@ PL/Python言語向けに<type>ltree</type>型の変換を実装した追加の�
 
   <caution>
    <para>
+<!--
     It is strongly recommended that the transform extensions be installed in
     the same schema as <filename>ltree</filename>.  Otherwise there are
     installation-time security hazards if a transform extension's schema
     contains objects defined by a hostile user.
+-->
+変換の拡張は<filename>ltree</filename>と同じスキーマにインストールすることを強く勧めます。
+さもないと、変換の拡張のスキーマが悪意のあるユーザにより定義されたオブジェクトを含んでいた場合に、インストール時のセキュリティ問題になります。
    </para>
   </caution>
  </sect2>


### PR DESCRIPTION
以下のファイルの12.4対応です。

- hstore.sgml
- ltree.sgml

追加されたのがほぼ同じ文章でしたので、一緒にやりました。