### PR TITLE
pg_stat_statementsの説明文の文言修正・統一

### DIFF
--- a/doc/src/sgml/pgstatstatements.sgml
+++ b/doc/src/sgml/pgstatstatements.sgml
@@ -220,7 +220,7 @@
 <!--
       <entry>Total number of shared blocks dirtied by the statement</entry>
 -->
-      <entry>文によりダーティ状態となった共有ブロックの総数</entry>
+      <entry>SQL文によってダーティ状態となった共有ブロックの総数</entry>
      </row>
 
      <row>
@@ -260,7 +260,7 @@
 <!--
       <entry>Total number of local blocks dirtied by the statement</entry>
 -->
-      <entry>SQL文によりダーティ状態となったローカルブロックの総数</entry>
+      <entry>SQL文によってダーティ状態となったローカルブロックの総数</entry>
      </row>
 
      <row>


### PR DESCRIPTION
翻訳のご対応ありがとうございます。
pg_stat_statementsのドキュメントを確認時に誤記と思われる記述を見つけましたので、ご報告いたします。