### PR TITLE
翻訳の改善、誤訳の修正

### DIFF
--- a/doc/src/sgml/wal.sgml
+++ b/doc/src/sgml/wal.sgml
@@ -347,7 +347,7 @@ CRCの値はそれぞれのWALレコードを書き込み、クラッシュ回�
    and it is assumed you will operate using RAM that uses industry standard
    Error Correcting Codes (ECC) or better protection.
 -->
-<productname>PostgreSQL</productname>は修復可能なメモリーエラーに対して保護を行いません。工業規格の誤り検出訂正（Error Correcting Codes -ECC-）またはバッテリー保護付きのRAM使用が想定されています。
+<productname>PostgreSQL</productname>は修復可能なメモリーエラーに対して保護を行いません。業界標準の誤り検出訂正（Error Correcting Codes -ECC-）またはそれ以上の保護付きのRAM使用が想定されています。
   </para>
  </sect1>
 


### PR DESCRIPTION
辞書を引くと、industry standard → 業界標準、industrial standard → 工業規格となっているようです。