### PR TITLE
update xindex for 13.1

### DIFF
--- a/doc/src/sgml/xindex.sgml
+++ b/doc/src/sgml/xindex.sgml
@@ -4,7 +4,7 @@
 <!--
  <title>Interfacing Extensions to Indexes</title>
 -->
-<title>インデックス拡張機能へのインタフェース</title>
+ <title>インデックス拡張機能へのインタフェース</title>
 
  <indexterm zone="xindex">
 <!--
@@ -652,10 +652,14 @@ BRINインデックスは、いずれも固定のストラテジ群を持たな�
   </para>
 
   <para>
+<!--
    Additionally, some opclasses allow users to specify parameters which
    control their behavior.  Each builtin index access method has an optional
    <function>options</function> support function, which defines a set of
    opclass-specific parameters.
+-->
+さらに、演算子クラスの中には、ユーザがその振る舞いを制御するパラメータを指定できるものもあります。
+各組み込みインデックスアクセスメソッドには省略可能な<function>options</function>サポート関数があり、演算子クラスに固有のパラメータの集合を定義しています。
   </para>
 
   <para>
@@ -667,7 +671,7 @@ BRINインデックスは、いずれも固定のストラテジ群を持たな�
    The requirements for these support functions are explained further in
    <xref linkend="btree-support-funcs"/>.
 -->
-<xref linkend="xindex-btree-support-table"/>に示すように、B-treeは比較サポート関数を必須とし、演算子クラスの作者が望めば二つの追加サポート関数を与えることができます。
+<xref linkend="xindex-btree-support-table"/>に示すように、B-treeは比較サポート関数を必須とし、演算子クラスの作者が望めば4つの追加サポート関数を与えることができます。
 これらのサポート関数の要件は<xref linkend="btree-support-funcs"/>でさらに詳しく解説されています。
   </para>
 
@@ -723,15 +727,21 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
       </row>
       <row>
        <entry>
+<!--
         Determine if it is safe for indexes that use the operator
         class to apply the btree deduplication optimization (optional)
+-->
+演算子クラスを使うインデックスがB-tree重複排除最適化を安全に適用できるかどうかを決定します(省略可能)。
        </entry>
        <entry>4</entry>
       </row>
       <row>
        <entry>
+<!--
         Defines a set of options that are specific to this operator class
         (optional)
+-->
+この演算子クラスに固有のオプションの集合を定義します(省略可能)。
        </entry>
        <entry>5</entry>
       </row>
@@ -745,7 +755,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
    be supplied at the operator class author's option, as shown in <xref
    linkend="xindex-hash-support-table"/>.
 -->
-<xref linkend="xindex-hash-support-table"/>に示すようにハッシュインデックスでは一つのサポート関数が必須で、演算子クラス作者が望むなら、もう一つのサポート関数を与えることができます。
+<xref linkend="xindex-hash-support-table"/>に示すようにハッシュインデックスでは一つのサポート関数が必須で、演算子クラス作者が望むなら、さらに2つのサポート関数を与えることができます。
   </para>
 
    <table tocentry="1" id="xindex-hash-support-table">
@@ -789,8 +799,11 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
       </row>
       <row>
        <entry>
+<!--
         Defines a set of options that are specific to this operator class
         (optional)
+-->
+この演算子クラスに固有のオプションの集合を定義します(省略可能)。
        </entry>
        <entry>3</entry>
       </row>
@@ -804,7 +817,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
    as shown in <xref linkend="xindex-gist-support-table"/>.
    (For more information see <xref linkend="gist"/>.)
 -->
-<xref linkend="xindex-gist-support-table"/>に示すように、GiSTインデックスには9つのサポート関数があり、また、そのうち２つは省略可能です。
+<xref linkend="xindex-gist-support-table"/>に示すように、GiSTインデックスには10のサポート関数があり、また、そのうち3つは省略可能です。
 (詳細については<xref linkend="gist"/>を参照してください。)
   </para>
 
@@ -831,70 +844,63 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
      </thead>
      <tbody>
       <row>
-<!--
        <entry><function>consistent</function></entry>
+<!--
        <entry>determine whether key satisfies the
         query qualifier</entry>
 -->
-       <entry><function>consistent</function></entry>
        <entry>キーが問い合わせ条件を満たすかどうかを決定します。</entry>
        <entry>1</entry>
       </row>
       <row>
-<!--
        <entry><function>union</function></entry>
+<!--
        <entry>compute union of a set of keys</entry>
 -->
-       <entry><function>union</function></entry>
        <entry>キー集合の和集合を計算します。</entry>
        <entry>2</entry>
       </row>
       <row>
-<!--
        <entry><function>compress</function></entry>
+<!--
        <entry>compute a compressed representation of a key or value
         to be indexed</entry>
 -->
-       <entry><function>compress</function></entry>
        <entry>キーまたはインデックス付けされる値の圧縮表現を計算します。</entry>
        <entry>3</entry>
       </row>
       <row>
-<!--
        <entry><function>decompress</function></entry>
+<!--
        <entry>compute a decompressed representation of a
         compressed key</entry>
 -->
-       <entry><function>decompress</function></entry>
        <entry>圧縮されたキーを伸張した表現を計算します。</entry>
        <entry>4</entry>
       </row>
       <row>
-<!--
        <entry><function>penalty</function></entry>
+<!--
        <entry>compute penalty for inserting new key into subtree
        with given subtree's key</entry>
 -->
-       <entry><function>penalty</function></entry>
        <entry>指定された副ツリーキーを持つ副ツリーに新しいキーを挿入する時のペナルティを計算します。</entry>
        <entry>5</entry>
       </row>
       <row>
-<!--
        <entry><function>picksplit</function></entry>
+<!--
        <entry>determine which entries of a page are to be moved
        to the new page and compute the union keys for resulting pages</entry>
 -->
-       <entry><function>picksplit</function></entry>
        <entry>ページのどのエントリを新しいページに移動させるかを決定し、結果ページ用の統合キーを計算します。</entry>
        <entry>6</entry>
       </row>
       <row>
-<!--
        <entry><function>equal</function></entry>
+<!--
        <entry>compare two keys and return true if they are equal</entry>
 -->
-       <entry><function>equal</function></entry>
        <entry>2つのキーを比較し、等しければ真を返します。</entry>
        <entry>7</entry>
       </row>
@@ -922,8 +928,11 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
       <row>
        <entry><function>options</function></entry>
        <entry>
+<!--
         Defines a set of options that are specific to this operator class
         (optional)
+-->
+この演算子クラスに固有のオプションの集合を定義します(省略可能)。
        </entry>
        <entry>10</entry>
       </row>
@@ -937,7 +946,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
    shown in <xref linkend="xindex-spgist-support-table"/>.
    (For more information see <xref linkend="spgist"/>.)
 -->
-<xref linkend="xindex-spgist-support-table"/>に示すように、SP-GiSTインデックスでは５つのサポート関数が必要です。
+<xref linkend="xindex-spgist-support-table"/>に示すように、SP-GiSTインデックスでは6つのサポート関数があり、また、そのうち1つは省略可能です。
 (詳細については<xref linkend="spgist"/>を参照してください。)
   </para>
 
@@ -1008,8 +1017,11 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
       <row>
        <entry><function>options</function></entry>
        <entry>
+<!--
         Defines a set of options that are specific to this operator class
         (optional)
+-->
+この演算子クラスに固有のオプションの集合を定義します(省略可能)。
        </entry>
        <entry>6</entry>
       </row>
@@ -1023,7 +1035,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
    as shown in <xref linkend="xindex-gin-support-table"/>.
    (For more information see <xref linkend="gin"/>.)
 -->
-<xref linkend="xindex-gin-support-table"/>に示すように、GINインデックスには、6つのサポート関数があり、また、そのうち３つは省略可能です。
+<xref linkend="xindex-gin-support-table"/>に示すように、GINインデックスには、7つのサポート関数があり、また、そのうち4つは省略可能です。
 (詳細については<xref linkend="gin"/>を参照してください。)
   </para>
 
@@ -1118,8 +1130,11 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
       <row>
        <entry><function>options</function></entry>
        <entry>
+<!--
         Defines a set of options that are specific to this operator class
         (optional)
+-->
+この演算子クラスに固有のオプションの集合を定義します(省略可能)。
        </entry>
        <entry>7</entry>
       </row>
@@ -1134,7 +1149,8 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
    the basic functions require additional support functions to be provided.
    (For more information see <xref linkend="brin-extensibility"/>.)
 -->
-<xref linkend="xindex-brin-support-table"/>に示すようにBRINインデックスには、4つの基本サポート関数があります。この基本関数は追加のサポート関数の提供を要求するかもしれません。
+<xref linkend="xindex-brin-support-table"/>に示すようにBRINインデックスには、5つの基本サポート関数があり、また、そのうち1つは省略可能です。
+基本関数の版には追加のサポート関数の提供を要求するものもあります。
 (詳細については<xref linkend="brin-extensibility"/>を参照してください。)
   </para>
 
@@ -1200,8 +1216,11 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
       <row>
        <entry><function>options</function></entry>
        <entry>
+<!--
         Defines a set of options that are specific to this operator class
         (optional)
+-->
+この演算子クラスに固有のオプションの集合を定義します(省略可能)。
        </entry>
        <entry>5</entry>
       </row>


### PR DESCRIPTION
xindex.sgmlの13.1対応です。


13での目玉機能の1つだと思いますが、ここでは「B-tree重複排除最適化」と訳してしまいました。
決まった訳があれば指摘いただきたく。