### PR TITLE
fix translation of "single user"

### DIFF
--- a/doc/src/sgml/parallel.sgml
+++ b/doc/src/sgml/parallel.sgml
@@ -195,7 +195,7 @@ EXPLAIN SELECT * FROM pgbench_accounts WHERE filler LIKE '%x%';
     the entire database system is running in single process in this situation,
     no background workers will be available.
 -->
-加えて、システムはシングルユーザーモードで動いていてはいけません。
+加えて、システムはシングルユーザモードで動いていてはいけません。
 この場合はデータベースシステム全体が一つのプロセスで動いているので、バックグラウンドワーカーが使えません。
   </para>
 


### PR DESCRIPTION
「シングルユーザ」の訳が、一ヶ所だけ「シングルユーザー」となっていたのに気づいたので。