### PR TITLE
update ref/vacuumdb.sgml for 13.1

### DIFF
--- a/doc/src/sgml/ref/vacuumdb.sgml
+++ b/doc/src/sgml/ref/vacuumdb.sgml
@@ -209,7 +209,7 @@ PostgreSQL documentation
         commands simultaneously.  This option may reduce the processing time
         but it also increases the load on the database server.
 -->
-<replaceable class="parameter">njobs</replaceable>個のコマンドを同時に実行することで、vacuumまたはanalyzeコマンドを並列で実行します。このオプションは処理時間を短縮するかもしれませんが同時にデータベースサーバの負荷も増加します。
+<replaceable class="parameter">njobs</replaceable>個のコマンドを同時に実行することで、vacuumまたはanalyzeコマンドを並列で実行します。このオプションは処理時間を短縮することもありますがデータベースサーバの負荷も増加します。
        </para>
        <para>
 <!--
@@ -325,7 +325,7 @@ PostgreSQL documentation
          This option is only available for servers running
          <productname>PostgreSQL</productname> 13 and later.
 -->
-このオプションは<productname>PostgreSQL</productname>13以降が稼働しているサーバのみで利用可能です。
+このオプションは<productname>PostgreSQL</productname> 13以降が動作しているサーバでのみ利用可能です。
         </para>
        </note>
       </listitem>
@@ -607,9 +607,9 @@ PostgreSQL documentation
         other than the database name itself will be re-used when connecting
         to other databases.
 -->
-どのデータベースをバキュームしなければならないかを見つけ出すために接続するデータベースの名前を指定します。
-データベース名が指定されておらず、<option>-a</option>（または<option>--all</option>）も指定されなければ<literal>postgres</literal>データベースが使用され、もし存在しなければ<literal>template1</literal>が使用されます。
-これは<link linkend="libpq-connstring">接続文字列</link>に出来ます。その場合、接続文字列パラメータは競合するコマンドラインオプションを上書きします。また、データベース名以外の接続文字列は他のデータベースに接続する時に再利用されます。
+<option>-a</option>（または<option>--all</option>）が指定されている時、どのデータベースをバキュームしなければならないかを見つけ出すために接続するデータベースの名前を指定します。
+データベース名が指定されていなければ<literal>postgres</literal>データベースが使用され、もし存在しなければ<literal>template1</literal>が使用されます。
+これは<link linkend="libpq-connstring">接続文字列</link>に出来ます。その場合、接続文字列パラメータは競合するコマンドラインオプションを上書きします。また、データベース名以外の接続文字列パラメータは他のデータベースに接続する時に再利用されます。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/ref/vacuumdb.sgml
+++ b/doc/src/sgml/ref/vacuumdb.sgml
@@ -129,8 +129,8 @@ PostgreSQL documentation
         connection string parameters will override any conflicting command
         line options.
 -->
-不要領域のクリーンアップ、または、解析を行うデータベース名を指定します。
-データベース名が指定されておらず、<option>-a</option>（または<option>--all</option>）も指定されていない場合、データベース名は環境変数<envar>PGDATABASE</envar>から読み取られます。
+<option>-a</option>（または<option>--all</option>）も指定されていない場合、不要領域のクリーンアップ、または、解析を行うデータベース名を指定します。
+データベース名が指定されていない場合は、データベース名は環境変数<envar>PGDATABASE</envar>から読み取られます。
 この変数も設定されていない場合は、接続時に指定したユーザ名が使用されます。
 <replaceable>dbname</replaceable>は<link linkend="libpq-connstring">接続文字列</link>に出来ます。その場合、接続文字列パラメータは競合するコマンドラインオプションを上書きします。
        </para>
@@ -609,7 +609,9 @@ PostgreSQL documentation
 -->
 <option>-a</option>（または<option>--all</option>）が指定されている時、どのデータベースをバキュームしなければならないかを見つけ出すために接続するデータベースの名前を指定します。
 データベース名が指定されていなければ<literal>postgres</literal>データベースが使用され、もし存在しなければ<literal>template1</literal>が使用されます。
-これは<link linkend="libpq-connstring">接続文字列</link>に出来ます。その場合、接続文字列パラメータは競合するコマンドラインオプションを上書きします。また、データベース名以外の接続文字列パラメータは他のデータベースに接続する時に再利用されます。
+これは<link linkend="libpq-connstring">接続文字列</link>に出来ます。
+その場合、接続文字列パラメータは競合するコマンドラインオプションを上書きします。
+また、データベース名以外の接続文字列パラメータは他のデータベースに接続する時に再利用されます。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/ref/vacuumdb.sgml
+++ b/doc/src/sgml/ref/vacuumdb.sgml
@@ -132,6 +132,7 @@ PostgreSQL documentation
 不要領域のクリーンアップ、または、解析を行うデータベース名を指定します。
 データベース名が指定されておらず、<option>-a</option>（または<option>--all</option>）も指定されていない場合、データベース名は環境変数<envar>PGDATABASE</envar>から読み取られます。
 この変数も設定されていない場合は、接続時に指定したユーザ名が使用されます。
+<replaceable>dbname</replaceable>は<link linkend="libpq-connstring">接続文字列</link>に出来ます。その場合、接続文字列パラメータは競合するコマンドラインオプションを上書きします。
        </para>
       </listitem>
      </varlistentry>
@@ -208,7 +209,7 @@ PostgreSQL documentation
         commands simultaneously.  This option may reduce the processing time
         but it also increases the load on the database server.
 -->
-<replaceable class="parameter">njobs</replaceable>個のコマンドを同時に実行することで、vacuumまたはanalyzeコマンドを並列で実行します。
+<replaceable class="parameter">njobs</replaceable>個のコマンドを同時に実行することで、vacuumまたはanalyzeコマンドを並列で実行します。このオプションは処理時間を短縮するかもしれませんが同時にデータベースサーバの負荷も増加します。
        </para>
        <para>
 <!--
@@ -311,14 +312,20 @@ PostgreSQL documentation
       <term><option>--parallel=<replaceable class="parameter">parallel_degree</replaceable></option></term>
       <listitem>
        <para>
+<!--
         Specify the parallel degree of <firstterm>parallel vacuum</firstterm>.
         This allows the vacuum to leverage multiple CPUs to process indexes.
         See <xref linkend="sql-vacuum"/>.
+-->
+<firstterm>並列バキューム</firstterm>の並列度を指定します。これによりバキュームが複数CPUを活用してインデックスを処理することが出来ます。<xref linkend="sql-vacuum"/>を参照してください。
        </para>
        <note>
         <para>
+<!--
          This option is only available for servers running
          <productname>PostgreSQL</productname> 13 and later.
+-->
+このオプションは<productname>PostgreSQL</productname>13以降が稼働しているサーバのみで利用可能です。
         </para>
        </note>
       </listitem>
@@ -601,7 +608,8 @@ PostgreSQL documentation
         to other databases.
 -->
 どのデータベースをバキュームしなければならないかを見つけ出すために接続するデータベースの名前を指定します。
-指定されなければ<literal>postgres</literal>データベースが使用され、もし存在しなければ<literal>template1</literal>が使用されます。
+データベース名が指定されておらず、<option>-a</option>（または<option>--all</option>）も指定されなければ<literal>postgres</literal>データベースが使用され、もし存在しなければ<literal>template1</literal>が使用されます。
+これは<link linkend="libpq-connstring">接続文字列</link>に出来ます。その場合、接続文字列パラメータは競合するコマンドラインオプションを上書きします。また、データベース名以外の接続文字列は他のデータベースに接続する時に再利用されます。
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
新規追加の並列バキュームの訳追加と、過去のバージョンで訳していない箇所も一応訳を追加しました(削除は簡単なので)。