### PR TITLE
isn.sgmlの13.1対応です。

### DIFF
--- a/doc/src/sgml/isn.sgml
+++ b/doc/src/sgml/isn.sgml
@@ -428,7 +428,7 @@ weakモードの現在の状態を返します。
    into a table. Invalid means the check digit is wrong, not that there are
    missing numbers.
 -->
-<firstterm>Weak</firstterm>モードは無効なデータをテーブルに挿入できるようにするために使用されます。
+<firstterm>weak</firstterm>モードは無効なデータをテーブルに挿入できるようにするために使用されます。
 無効とは間違ったチェックディジットを意味するものであり、番号自体は存在します。
   </para>
 

--- a/doc/src/sgml/isn.sgml
+++ b/doc/src/sgml/isn.sgml
@@ -31,9 +31,12 @@
  </para>
 
  <para>
+<!--
   This module is considered <quote>trusted</quote>, that is, it can be
   installed by non-superusers who have <literal>CREATE</literal> privilege
   on the current database.
+-->
+このモジュールは<quote>trusted</quote>と見なされます。つまり、現在のデータベースに対して<literal>CREATE</literal>権限を持つ非スーパーユーザがインストールできます。
  </para>
 
  <sect2>
@@ -346,10 +349,16 @@
      <thead>
       <row>
        <entry role="func_table_entry"><para role="func_signature">
+<!--
         Function
+-->
+関数
        </para>
        <para>
+<!--
         Description
+-->
+説明
        </para></entry>
       </row>
      </thead>
@@ -362,7 +371,10 @@
         <returnvalue>boolean</returnvalue>
        </para>
        <para>
+<!--
         Sets the weak input mode, and returns new setting.
+-->
+weak入力モードを設定し、新しい設定を返します。
        </para></entry>
       </row>
 
@@ -372,7 +384,10 @@
         <returnvalue>boolean</returnvalue>
        </para>
        <para>
+<!--
         Returns the current status of the weak mode.
+-->
+weakモードの現在の状態を返します。
        </para></entry>
       </row>
 
@@ -383,7 +398,10 @@
         <returnvalue>isn</returnvalue>
        </para>
        <para>
+<!--
         Validates an invalid number (clears the invalid flag).
+-->
+無効な番号を検証します（無効フラグを消去します）。
        </para></entry>
       </row>
 
@@ -394,7 +412,10 @@
         <returnvalue>boolean</returnvalue>
        </para>
        <para>
+<!--
         Checks for the presence of the invalid flag.
+-->
+無効フラグの有無を検査します。
        </para></entry>
       </row>
      </tbody>
@@ -407,8 +428,8 @@
    into a table. Invalid means the check digit is wrong, not that there are
    missing numbers.
 -->
-<firstterm>弱めの</firstterm>モードは無効なデータをテーブルに挿入できるようにするために使用されます。
-無効とは間違った検査桁を意味するものであり、番号自体は存在します。
+<firstterm>Weak</firstterm>モードは無効なデータをテーブルに挿入できるようにするために使用されます。
+無効とは間違ったチェックディジットを意味するものであり、番号自体は存在します。
   </para>
 
   <para>
@@ -424,8 +445,8 @@
    information and validate it more easily; so for example you'd want to
    select all the invalid numbers in the table.
 -->
-この弱めのモードを使いたいと考えるのは何故でしょうか。
-大規模なISBN番号群があり、その内の多くが何らかの理由で間違った検査桁を持つことはあり得ます。
+このweakモードを使いたいと考えるのは何故でしょうか。
+大規模なISBN番号群があり、その内の多くが何らかの理由で間違ったチェックディジットを持つことはあり得ます。
 （印刷された一覧をスキャンしてOCRした結果番号を間違えた場合、手作業で番号を取り出した場合などがあり得ます。）
 とにかく、こうした混乱は整理したいことですが、データベース内に番号をすべて取り込んで、より簡単に情報を検査し有効にすることができるように、外部ツールを使用してデータベース内の無効な番号の位置を特定したいと思うかも知れません。
 例えば、テーブル内の無効な番号をすべて選択したいと思うかも知れません。
@@ -440,7 +461,7 @@
    the <function>is_valid</function> function and cleared with the
    <function>make_valid</function> function.
 -->
-弱めのモードを使用して無効な番号をテーブルに挿入する時、番号は修正された検査桁付きで挿入されますが、最後にイクスクラメーション印（<literal>!</literal>）付きで、例えば<literal>0-11-000322-5!</literal>と表示されます。
+weakモードを使用して無効な番号をテーブルに挿入する時、番号は修正されたチェックディジット付きで挿入されますが、最後にイクスクラメーション印（<literal>!</literal>）付きで、例えば<literal>0-11-000322-5!</literal>と表示されます。
 この無効印は<function>is_valid</function>関数を使って検査することができ、また、 <function>make_valid</function>関数で消去することができます。
   </para>
 
@@ -450,7 +471,7 @@
    weak mode, by appending the <literal>!</literal> character at the end of the
    number.
 -->
-また、番号の最後に<literal>!</literal>文字を付与することで、弱めのモードでなくとも無効な番号を強制的に挿入することもできます。
+また、番号の最後に<literal>!</literal>文字を付与することで、weakモードでなくとも無効な番号を強制的に挿入することもできます。
   </para>
 
   <para>
@@ -459,8 +480,8 @@
    <literal>?</literal> in place of the check digit, and the correct check digit
    will be inserted automatically.
 -->
-この他の入力における特殊な機能として、検査桁として<literal>?</literal>を書くことができます。
-これにより正確な検査桁が自動的に挿入されます。
+この他の入力における特殊な機能として、チェックディジットとして<literal>?</literal>を書くことができます。
+これにより正確なチェックディジットが自動的に挿入されます。
   </para>
  </sect2>
 
@@ -503,7 +524,7 @@ INSERT INTO test VALUES('9780393040029');
 <!--
 &#045;&#045;Automatically calculate check digits (observe the '?'):
 -->
---検査桁を自動的に計算する('?'を見よ)
+--チェックディジットを自動的に計算する('?'を見よ)
 INSERT INTO test VALUES('220500896?');
 INSERT INTO test VALUES('978055215372?');
 
@@ -513,7 +534,7 @@ SELECT ismn('979047213542?');
 <!--
 &#045;&#045;Using the weak mode:
 -->
---弱めのモードを利用する
+--weakモードを利用する
 SELECT isn_weak(true);
 INSERT INTO test VALUES('978-0-11-000533-4');
 INSERT INTO test VALUES('9780141219307');


### PR DESCRIPTION
更新された部分以外に以下の変更をしました。
「弱め」→「weak」
「検査桁」→「チェックディジット」

weakは「isn_weak」のために使用していて「弱め」と表現する例が他に無さそうなので、
そのままweakに変更しました。

「チェックディジット」は既に広く使われている様なので変更しました。