### PR TITLE
update explain and pg_checksums for 13.1

### DIFF
--- a/doc/src/sgml/ref/explain.sgml
+++ b/doc/src/sgml/ref/explain.sgml
@@ -262,7 +262,7 @@ ROLLBACK;
       <literal>FALSE</literal>.
 -->
 バッファの使用状況に関する情報を含めます。
-具体的には、共有ブロックのヒット数、読み取り数、ダーティブロック数、書き出し数、ローカルブロックのヒット数、ダーティブロック数、読み取り数、書き出し数、一時ブロックの読み取り数、書き出し数が含められます。
+具体的には、共有ブロックのヒット数、読み取り数、ダーティブロック数、書き出し数、ローカルブロックのヒット数、ダーティブロック数、読み取り数、書き出し数、一時ブロックの読み取り数、書き出し数、そして、<xref linkend="guc-track-io-timing"/>が有効にされていればデータファイルブロックの読み取り、書き出しに掛かった時間(ミリ秒単位)が含められます。
 <emphasis>ヒット</emphasis>とは、必要な時にキャッシュ内にそのブロックが見つかったため読み取りが避けられたことを意味します。
 共有ブロックには、通常のテーブルとインデックスからのデータが含まれます。
 ローカルブロックには、一時テーブルとそのインデックスからのデータが含まれます。
@@ -271,7 +271,6 @@ ROLLBACK;
 <emphasis>書き出し</emphasis>ブロック数は、問い合わせ処理の間にバックエンドにより、ダーティ状態だったブロックの内キャッシュから追い出されたブロックの数を示します。
 上位レベルのノードで表示されるブロック数には、その子ノードすべてで使用されるブロックが含まれます。
 テキスト形式では、非ゼロの値のみが出力されます。
-このパラメータは<literal>ANALYZE</literal>パラメータも有効である場合にのみ使用することができます。
 デフォルトは<literal>FALSE</literal>です。
      </para>
     </listitem>
@@ -281,11 +280,18 @@ ROLLBACK;
     <term><literal>WAL</literal></term>
     <listitem>
      <para>
+<!--
       Include information on WAL record generation. Specifically, include the
       number of records, number of full page images (fpi) and amount of WAL
       bytes generated.  In text format, only non-zero values are printed.  This
       parameter may only be used when <literal>ANALYZE</literal> is also
       enabled.  It defaults to <literal>FALSE</literal>.
+-->
+WALレコード生成に関する情報を含めます。
+具体的には、レコード数、ページ全体のイメージ(fpi)の数、生成されたWALのバイト量が含められます。
+テキスト形式では、非ゼロの値のみが出力されます。
+このパラメータは<literal>ANALYZE</literal>パラメータも有効である場合にのみ使用できます。
+デフォルトは<literal>FALSE</literal>です。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/ref/pg_checksums.sgml
+++ b/doc/src/sgml/ref/pg_checksums.sgml
@@ -67,7 +67,7 @@ PostgreSQL documentation
    Disabling checksums only updates the file <filename>pg_control</filename>.
 -->
 チェックサムを検査する場合、クラスタ内の全てのファイルがスキャンされます。
-チェックサムの有効化ではクラスタ内のすべてのファイルが書き換えられます。
+チェックサムの有効化ではクラスタ内のすべてのファイルがその場で書き換えられます。
 チェックサムの無効化ではファイル<filename>pg_control</filename>だけ更新されます。
   </para>
  </refsect1>


### PR DESCRIPTION
以下のファイルの13.1対応です。

- ref/explain.sgml
- ref/pg_checksums.sgml