### PR TITLE
Update datatype.sgml

### DIFF
--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -2022,7 +2022,7 @@ SELECT b, char_length(b) FROM test2;
     tools don't understand it.)
 -->
 <type>bytea</type>型は入出力用に2つの書式をサポートします。
-<productname>PostgreSQL</productname>の歴史的な<quote>エスケープ</quote>書式と<quote>hex</quote>です。
+<quote>hex</quote>書式と<productname>PostgreSQL</productname>の歴史的な<quote>エスケープ</quote>書式です。
 入力ではこれらの両方とも常に受け入れられます。
 出力書式は<xref linkend="guc-bytea-output"/>設定パラメータに依存し、デフォルトではhexです。
 （hex書式は<productname>PostgreSQL</productname> 9.0から導入されたものであることに注意してください。
@@ -2254,9 +2254,9 @@ SELECT '\xDEADBEEF';
     that function.
 -->
 <xref linkend="datatype-binary-sqlesc"/>で示したように、シングルクォートが二重に必要な理由は、SQLコマンド中のあらゆる文字列に当てはまるためです。
-一般的な文字列パーサは最も外側のシングルクォートを消費し、一つの文字データのシングルクォートのペアを減らします。
-<type>bytea</type>を入力する関数で単純なデータ文字を扱うために単に一つのシングルクォートを入力するケースが見られます。
-しかし、<type>bytea</type>を入力する関数はバックスラッシュを特別なものとして扱うため、この関数で実装された<xref linkend="datatype-binary-sqlesc"/>では異なる動作が見られます。
+一般的な文字列パーサは最も外側のシングルクォートを消費し、シングルクォートのペアを一つの文字データに減らします。
+<type>bytea</type>を入力する関数が見るのは単に一つのシングルクォートであり、一個の単純なデータ文字として扱います。
+しかし、<type>bytea</type>を入力する関数はバックスラッシュを特別なものとして扱い、<xref linkend="datatype-binary-sqlesc"/>に示されているその他の動作はこの関数で実装されています。
    </para>
 
    <para>
@@ -2266,7 +2266,7 @@ SELECT '\xDEADBEEF';
     reduce pairs of backslashes to one data character;
     see <xref linkend="sql-syntax-strings"/>.
 -->
-一般的な文字列パーサは一つの文字データのバックスラッシュのペアを減らすため、文脈によってはバックスラッシュは上記に見られるように、重ねる必要があります。
+一般的な文字列パーサはバックスラッシュのペアを一つの文字データに減らすため、文脈によってはバックスラッシュは上記に見られるように、重ねる必要があります。
 <xref linkend="sql-syntax-strings"/>も参照ください。
    </para>
 
@@ -2280,9 +2280,9 @@ SELECT '\xDEADBEEF';
     Most <quote>printable</quote> octets are output by their standard
     representation in the client character set, e.g.:
 -->
-<type>Bytea</type>オクテットはデフォルトでは<literal>hex</literal>フォーマットで出力されます。
+<type>Bytea</type>オクテットはデフォルトでは<literal>hex</literal>書式で出力されます。
 <xref linkend="guc-bytea-output"/>を<literal>escape</literal>に変えると、<quote>表示できない</quote>オクテットは先頭にバックスラッシュがついた3桁のオクテットの値に変換されます。
-ほとんどの<quote>表示可能な</quote>オクテットはクライアントキャラクタセットの標準的な表示で出力されます。例:
+ほとんどの<quote>表示可能な</quote>オクテットはクライアント文字セットの標準的な表示で出力されます。例:
 
 <programlisting>
 SET bytea_output = 'escape';
@@ -2385,7 +2385,7 @@ SELECT 'abc \153\154\155 \052\251\124'::bytea;
     have to escape line feeds and carriage returns if your interface
     automatically translates these.
 -->
-使用する<productname>PostgreSQL</productname>のフロントエンドによっては、<type>bytea</type>文字列をエスケープまたはアンエスケープする際に、追加的な作業が必要になることがあります。
+使用する<productname>PostgreSQL</productname>のフロントエンドによっては、<type>bytea</type>文字列をエスケープまたはアンエスケープする追加的な作業が必要になることがあります。
 例えば、使用するインタフェースが改行文字や復帰文字を自動的に翻訳してしまう場合、これらの文字もエスケープしなければならないかもしれません。
    </para>
   </sect2>


### PR DESCRIPTION
誤訳、翻訳の改善など
> PostgreSQLの歴史的な「エスケープ」書式と「hex」です。
→「hex」書式とPostgreSQLの歴史的な「エスケープ」書式です。
# 出現順序を原文に合わせて、「hex」に書式を付ける

> Byteaオクテットはデフォルトではhexフォーマットで出力されます。
→Byteaオクテットはデフォルトではhex書式で出力されます。
# 訳語の統一

> ほとんどの「表示可能な」オクテットはクライアントキャラクタセットの標準的な表示で出力されます。
→ほとんどの「表示可能な」オクテットはクライアント文字セットの標準的な表示で出力されます。
# 表8.8の表記と合わせる