### PR TITLE
para内のコメント-翻訳の形式を修正

### DIFF
--- a/doc/src/sgml/backup.sgml
+++ b/doc/src/sgml/backup.sgml
@@ -93,7 +93,6 @@ pg_dump <replaceable class="parameter">dbname</replaceable> &gt; <replaceable cl
    you do have access using options such as
    <option>-n <replaceable>schema</replaceable></option>
    or <option>-t <replaceable>table</replaceable></option>.)
-  </para>
 -->
 <application>pg_dump</application>は、<productname>PostgreSQL</productname>の通常のクライアントアプリケーションです（その中でも特に優れた機能を発揮するものですが）。
 ということは、データベースに接続可能なあらゆるリモートホストからこのバックアップ手順を実行できます。

--- a/doc/src/sgml/bki.sgml
+++ b/doc/src/sgml/bki.sgml
@@ -458,7 +458,6 @@ NULL値は<literal>_null_</literal>で表します。
 <!--
          <filename>reformat_dat_file.pl</filename> preserves blank lines
          and comment lines as-is.
-        </para>
 -->
 <filename>reformat_dat_file.pl</filename>は空白行とコメント行をそのまま維持します。
         </para>

--- a/doc/src/sgml/charset.sgml
+++ b/doc/src/sgml/charset.sgml
@@ -2426,8 +2426,8 @@ $ <userinput>psql -l</userinput>
     </para>
 
     <important>
-<!--
      <para>
+<!--
       On most modern operating systems, <productname>PostgreSQL</productname>
       can determine which character set is implied by the <envar>LC_CTYPE</envar>
       setting, and it will enforce that only the matching database encoding is
@@ -2435,9 +2435,7 @@ $ <userinput>psql -l</userinput>
       the encoding expected by the locale you have selected.  A mistake in
       this area is likely to lead to strange behavior of locale-dependent
       operations such as sorting.
-     </para>
 -->
-     <para>
 最近のオペレーティングシステムでは、<productname>PostgreSQL</productname>は、<envar>LC_CTYPE</envar>の設定によりどの文字セットが指定されているか決定できます。
 そして、一致するデータベース符号化方式のみを強制的に使用します。
 古いオペレーティングシステムでは、自分で選択したロケールが想定している符号化方式を確実に使用することは各自の責任になります。

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -4945,7 +4945,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When <varname>archive_mode</varname> is enabled, completed WAL segments
         are sent to archive storage by setting
         <xref linkend="guc-archive-command"/>. In addition to <literal>off</literal>,
@@ -4956,26 +4956,25 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
         mode. In <literal>always</literal> mode, all files restored from the archive
         or streamed with streaming replication will be archived (again). See
         <xref linkend="continuous-archiving-in-standby"/> for details.
-       </para>
-       <para>
-        <varname>archive_mode</varname> and <varname>archive_command</varname> are
-        separate variables so that <varname>archive_command</varname> can be
-        changed without leaving archiving mode.
-        This parameter can only be set at server start.
-        <varname>archive_mode</varname> cannot be enabled when
-        <varname>wal_level</varname> is set to <literal>minimal</literal>.
-       -->
-       <varname>archive_mode</varname>が有効な場合、<xref linkend="guc-archive-command"/>を設定することにより、完了したWALセグメントはアーカイブ格納領域に送信されます。
+-->
+<varname>archive_mode</varname>が有効な場合、<xref linkend="guc-archive-command"/>を設定することにより、完了したWALセグメントはアーカイブ格納領域に送信されます。
 無効にするための<literal>off</literal>に加え、2つのモードがあります。<literal>on</literal>と<literal>always</literal>です。
 通常の運用ではこの2つのモードには違いはありませんが、<literal>always</literal>に設定すると、アーカイブリカバリおよびスタンバイモードでWALアーカイバが有効になります。
 <literal>always</literal>モードでは、アーカイブからリストアされたファイルや、ストリーミングレプリケーションでストリームされたファイルもすべて(再び)アーカイブされます。
 詳細は<xref linkend="continuous-archiving-in-standby"/>を参照してください。
        </para>
        <para>
+<!--
+        <varname>archive_mode</varname> and <varname>archive_command</varname> are
+        separate variables so that <varname>archive_command</varname> can be
+        changed without leaving archiving mode.
+        This parameter can only be set at server start.
+        <varname>archive_mode</varname> cannot be enabled when
+        <varname>wal_level</varname> is set to <literal>minimal</literal>.
+-->
 アーカイブモードを抜けることなく<varname>archive_command</varname>を変更できるように、<varname>archive_mode</varname>と<varname>archive_command</varname>は分離されました。
 このパラメータはサーバ起動時のみ設定可能です。
-<varname>wal_level</varname> が
-<literal>minimal</literal>に設定されている場合、<varname>archive_mode</varname>は有効になりません。
+<varname>wal_level</varname>が<literal>minimal</literal>に設定されている場合、<varname>archive_mode</varname>は有効になりません。
        </para>
       </listitem>
      </varlistentry>
@@ -6016,8 +6015,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         <structname>pg_stat_replication</structname></link> view).
         Specifying more than one synchronous standby can allow for very high
         availability and protection against data loss.
-       </para>
-       -->
+-->
 <xref linkend="synchronous-replication"/>で説明されているように、<firstterm>同期レプリケーション</firstterm>をサポート可能なスタンバイサーバのリストを指定します。
 活動中の同期スタンバイサーバは1つまたはそれ以上です。
 コミットを待機しているトランザクションは、このスタンバイサーバがそのデータの受信を確認してから処理の継続が許可されます。


### PR DESCRIPTION
para内でコメント化と翻訳の形式が一部違っているために未翻訳のチェック
を掛けると引っかかってしまうので、形式を修正しました。

para内で
```
＜para＞
＜！ーー原文のコメント化ーー＞
翻訳
＜／para＞
```
の形式になっていると、抽出と未翻訳のチェックが簡単になります。