### PR TITLE
変更漏れがあった日本語側のURLを修正

### DIFF
--- a/doc/src/sgml/acronyms.sgml
+++ b/doc/src/sgml/acronyms.sgml
@@ -479,7 +479,7 @@
       <ulink url="https://www.iso.org/home.html">International Organization for
       Standardization</ulink>
 -->
-      <ulink url="https://www.iso.org/iso/home.htm">International Organization for
+      <ulink url="https://www.iso.org/home.htm">International Organization for
       Standardization（国際標準化機構）</ulink>
      </para>
     </listitem>

--- a/doc/src/sgml/advanced.sgml
+++ b/doc/src/sgml/advanced.sgml
@@ -1014,7 +1014,7 @@ SELECT name, elevation
     <ulink url="https://www.postgresql.org">web site</ulink>
     for links to more resources.
 -->
-もっと多くの入門資料がお望みであれば、PostgreSQLの<ulink url="https://www.postgresql.org/">Webサイト</ulink>により多くのリソースがリンクされています。
+もっと多くの入門資料がお望みであれば、PostgreSQLの<ulink url="https://www.postgresql.org">Webサイト</ulink>により多くのリソースがリンクされています。
    </para>
   </sect1>
  </chapter>

--- a/doc/src/sgml/charset.sgml
+++ b/doc/src/sgml/charset.sgml
@@ -1302,8 +1302,8 @@ SQL環境における照合順序オブジェクトにはどのような名前�
     definition.  The examples using the <literal>k*</literal> subtags require
     at least ICU version 54.
 -->
-詳細は、<ulink url="http://unicode.org/reports/tr35/tr35-collation.html">Unicode Technical Standard #35</ulink>と、<ulink url="https://tools.ietf.org/html/bcp47">BCP 47</ulink>をご覧ください。
-可能な照合順序型(<literal>co</literal>下位タグ)のリストは、<ulink url="http://www.unicode.org/repos/cldr/trunk/common/bcp47/collation.xml">CLDR repository</ulink>で参照できます。
+詳細は、<ulink url="https://www.unicode.org/reports/tr35/tr35-collation.html">Unicode Technical Standard #35</ulink>と、<ulink url="https://tools.ietf.org/html/bcp47">BCP 47</ulink>をご覧ください。
+可能な照合順序型(<literal>co</literal>下位タグ)のリストは、<ulink url="https://github.com/unicode-org/cldr/blob/master/common/bcp47/collation.xml">CLDR repository</ulink>で参照できます。
 <ulink url="https://ssl.icu-project.org/icu-bin/locexp">ICU Locale Explorer</ulink>で、特定のロケール定義の詳細を確認できます。
 <literal>k*</literal>下位タグを使う例では、は少なくともICUのバージョン54が必要です。
    </para>
@@ -1395,7 +1395,7 @@ CREATE COLLATION french FROM "fr-x-icu";
 一般的な状況では、大文字小文字を区別しない比較、アクセントを区別しない比較および異なるUnicode正規化形式による文字列の比較が含まれます。
 このような区別しない比較を実際に実装するかは照合順序のプロパイダ次第です。
 deterministicフラグはバイト単位の比較を用いて分解されるかどうかのみを決定します。
-用語の詳細については、<ulink url="https://unicode.org/reports/tr10">Unicode Technical Standard 10</ulink>を参照してください。
+用語の詳細については、<ulink url="https://www.unicode.org/reports/tr10">Unicode Technical Standard 10</ulink>を参照してください。
     </para>
 
     <para>

--- a/doc/src/sgml/docguide.sgml
+++ b/doc/src/sgml/docguide.sgml
@@ -414,7 +414,7 @@ checking for fop... fop
     url="https://www.postgresql.org/docs/current/">postgresql.org</ulink> instead of the
     default simple style use:
 -->
-デフォルトの簡単なスタイルではなく<ulink url="https://postgresql.org/docs/current">postgresql.org</ulink>で使われているスタイルシートのHTMLの文書を作成するには、次のようにします。
+デフォルトの簡単なスタイルではなく<ulink url="https://www.postgresql.org/docs/current/">postgresql.org</ulink>で使われているスタイルシートのHTMLの文書を作成するには、次のようにします。
 <screen>
 <prompt>doc/src/sgml$ </prompt><userinput>make STYLE=website html</userinput>
 </screen>

--- a/doc/src/sgml/info.sgml
+++ b/doc/src/sgml/info.sgml
@@ -46,7 +46,7 @@
       information to make your work or play with
       <productname>PostgreSQL</productname> more productive.
 -->
-<productname>PostgreSQL</productname>の<ulink url="https://www.postgresql.org/">Webサイト</ulink>には、最新のリリースに関する詳細についてや、<productname>PostgreSQL</productname>の利用・操作をする上で生産性をより高める情報があります。
+<productname>PostgreSQL</productname>の<ulink url="https://www.postgresql.org">Webサイト</ulink>には、最新のリリースに関する詳細についてや、<productname>PostgreSQL</productname>の利用・操作をする上で生産性をより高める情報があります。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/plperl.sgml
+++ b/doc/src/sgml/plperl.sgml
@@ -20,7 +20,7 @@
    <productname>PostgreSQL</productname> functions in the
    <ulink url="https://www.perl.org">Perl programming language</ulink>.
 -->
-PL/Perlは<ulink url="https://www.perl.org/">Perlプログラミング言語</ulink>を使用して<productname>PostgreSQL</productname>関数を作成することができる、ロード可能な手続き言語です。
+PL/Perlは<ulink url="https://www.perl.org">Perlプログラミング言語</ulink>を使用して<productname>PostgreSQL</productname>関数を作成することができる、ロード可能な手続き言語です。
   </para>
 
   <para>

--- a/doc/src/sgml/textsearch.sgml
+++ b/doc/src/sgml/textsearch.sgml
@@ -3904,7 +3904,7 @@ SELECT plainto_tsquery('supernova star');
     Wiki</ulink>.
 -->
 <productname>PostgreSQL</productname>の標準配布には、<application>Ispell</application>の設定ファイルは含まれていません。
-多くの言語用の辞書が<ulink url="https://ficus-www.cs.ucla.edu/geoff/ispell.html">Ispell</ulink>で入手できます。
+多くの言語用の辞書が<ulink url="https://www.cs.hmc.edu/~geoff/ispell.html">Ispell</ulink>で入手できます。
 また、より新しい辞書のフォーマットもサポートされています &mdash; <ulink url="https://en.wikipedia.org/wiki/MySpell">MySpell</ulink>(OO &lt; 2.0.1)と<ulink url="https://sourceforge.net/projects/hunspell/">Hunspell</ulink>(OO &gt;= 2.0.2)。
 多数の辞書のリストが <ulink url="https://wiki.openoffice.org/wiki/Dictionaries">OpenOffice Wiki</ulink>で入手できます。
    </para>


### PR DESCRIPTION
現在変換とチェックをするツールを作成中の関係で、日本語訳中の英語表記が原文に含まれているかをチェックしてます。
そのためURLが完全に一致するように修正しました。