### PR TITLE
fix "superuser"

### DIFF
--- a/doc/src/sgml/adminpack.sgml
+++ b/doc/src/sgml/adminpack.sgml
@@ -33,7 +33,7 @@
 -->
 <xref linkend="functions-adminpack-table"/>に示す関数はサーバをホスティングしているマシン上のファイルに対して書き込みアクセスを提供します。
 (<xref linkend="functions-admin-genfile-table"/>の関数も参照してください。そちらは読み取り専用アクセスを提供します。)
-ユーザーがスーパーユーザーか、関数に応じたpg_read_server_files、またはpg_write_server_filesロールのいずれかのロールを与えられていない限り、データベースクラスタディレクトリ内のファイルにのみアクセス可能です。
+ユーザがスーパーユーザか、関数に応じたpg_read_server_files、またはpg_write_server_filesロールのいずれかのロールを与えられていない限り、データベースクラスタディレクトリ内のファイルにのみアクセス可能です。
 ただし、相対パスと絶対パスのどちらも利用できます。
  </para>
 

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -14773,9 +14773,9 @@ WALディスクブロックの容量を報告します。
         system.  Only superusers can change this setting.
 -->
 システムテーブルの構造変更とその他の危険性の高いシステムテーブルに対するアクションを許可します。
-これは通常スーパユーザにさえ許可されません。
+これは通常スーパーユーザにさえ許可されません。
 この設定の無分別な使用は回復不能なデータ喪失やデータベースシステムの重大な破損を招きます。
-スーパユーザだけがこの設定を変更できます。
+スーパーユーザだけがこの設定を変更できます。
        </para>
       </listitem>
      </varlistentry>
@@ -14815,7 +14815,7 @@ WALディスクブロックの容量を報告します。
 <!--
         This parameter can only be set by superusers.
 -->
-スーパユーザだけがこのパラメータを設定できます。
+スーパーユーザだけがこのパラメータを設定できます。
        </para>
       </listitem>
      </varlistentry>
@@ -15454,7 +15454,7 @@ LLVMに要求された機能がある場合は、生成した関数を<productna
 生成された<productname>LLVM</productname> IRを<xref linkend="guc-data-directory"/>内のファイルシステムに出力します。
 これはJITコンパイルのインターナルについて作業するときだけ有用です。
 デフォルト設定は<literal>off</literal>です。
-このパラメータはスーパユーザだけが変更可能です。
+このパラメータはスーパーユーザだけが変更可能です。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/config3.sgml
+++ b/doc/src/sgml/config3.sgml
@@ -2777,9 +2777,9 @@ WALディスクブロックの容量を報告します。
         system.  Only superusers can change this setting.
 -->
 システムテーブルの構造変更とその他の危険性の高いシステムテーブルに対するアクションを許可します。
-これは通常スーパユーザにさえ許可されません。
+これは通常スーパーユーザにさえ許可されません。
 この設定の無分別な使用は回復不能なデータ喪失やデータベースシステムの重大な破損を招きます。
-スーパユーザだけがこの設定を変更できます。
+スーパーユーザだけがこの設定を変更できます。
        </para>
       </listitem>
      </varlistentry>
@@ -2819,7 +2819,7 @@ WALディスクブロックの容量を報告します。
 <!--
         This parameter can only be set by superusers.
 -->
-スーパユーザだけがこのパラメータを設定できます。
+スーパーユーザだけがこのパラメータを設定できます。
        </para>
       </listitem>
      </varlistentry>
@@ -3458,7 +3458,7 @@ LLVMに要求された機能がある場合は、生成した関数を<productna
 生成された<productname>LLVM</productname> IRを<xref linkend="guc-data-directory"/>内のファイルシステムに出力します。
 これはJITコンパイルのインターナルについて作業するときだけ有用です。
 デフォルト設定は<literal>off</literal>です。
-このパラメータはスーパユーザだけが変更可能です。
+このパラメータはスーパーユーザだけが変更可能です。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -4590,7 +4590,7 @@ REVOKE CREATE ON SCHEMA public FROM PUBLIC;
 スキーマは様々な方法でデータの編成に使用できます。
 <firstterm>セキュアなスキーマの使用パターン</firstterm>は信頼できないユーザが他のユーザの問い合わせの振る舞いを変えるのを防ぎます。
 データベースがセキュアなスキーマの使用パターンを使わない場合、セキュアにデータベースを問い合わせたいユーザはセッションの開始毎に防御的なアクションを取るようにします。
-とりわけユーザは<varname>search_path</varname>に空文字をセットするか、さもなければ非スーパユーザが書き込めるスキーマを<varname>search_path</varname>から削除します。
+とりわけユーザは<varname>search_path</varname>に空文字をセットするか、さもなければ非スーパーユーザが書き込めるスキーマを<varname>search_path</varname>から削除します。
 デフォルト構成で簡単にサポートできるお勧めの使用パターンがいくつかあります。
     <itemizedlist>
      <listitem>

--- a/doc/src/sgml/logical-replication.sgml
+++ b/doc/src/sgml/logical-replication.sgml
@@ -324,9 +324,9 @@ PostgreSQLは両方の仕組みを同時にサポートします。
    skipped, because non-superusers cannot read all subscription information
    from the <structname>pg_subscription</structname> catalog.
 -->
-現在のユーザがスーパーユーザーならば、サブスクリプションは<command>pg_dump</command>でダンプできます。
+現在のユーザがスーパーユーザならば、サブスクリプションは<command>pg_dump</command>でダンプできます。
 そうでない場合には、警告が出力され、サブスクリプションはスキップされます。
-非スーパーユーザーはすべてのサブスクリプション情報を、<structname>pg_subscription</structname>カタログから読み出せないからです。
+非スーパーユーザはすべてのサブスクリプション情報を、<structname>pg_subscription</structname>カタログから読み出せないからです。
   </para>
 
   <para>
@@ -843,7 +843,7 @@ walsenderプロセスはWALのロジカルデコーディング（<xref linkend=
    a published table (or be a superuser).
 -->
 テーブルの初期データをコピーできるためには、レプリケーション接続に使用されるロールは、パブリッシュされるテーブルに対して<literal>SELECT</literal>権限を持っていなければなりません。
-（あるいはスーパーユーザーでなければなりません。）
+（あるいはスーパーユーザでなければなりません。）
   </para>
 
   <para>
@@ -861,14 +861,14 @@ walsenderプロセスはWALのロジカルデコーディング（<xref linkend=
    the user must be a superuser.
 -->
 テーブルをパブリケーションに追加するためには、ユーザはテーブルの所有権限を持っていなければなりません。
-自動的にすべてのテーブルにパブリッシュするパブリケーションを作成するには、ユーザはスーパーユーザーでなければなりません。
+自動的にすべてのテーブルにパブリッシュするパブリケーションを作成するには、ユーザはスーパーユーザでなければなりません。
   </para>
 
   <para>
 <!--
    To create a subscription, the user must be a superuser.
 -->
-サブスクリプションを作成するためには、ユーザはスーパーユーザーでなければなりません。
+サブスクリプションを作成するためには、ユーザはスーパーユーザでなければなりません。
   </para>
 
   <para>
@@ -876,7 +876,7 @@ walsenderプロセスはWALのロジカルデコーディング（<xref linkend=
    The subscription apply process will run in the local database with the
    privileges of a superuser.
 -->
-ローカルデータベースで実行されるサブスクリプション適用プロセスは、スーパーユーザー権限で実行されます。
+ローカルデータベースで実行されるサブスクリプション適用プロセスは、スーパーユーザ権限で実行されます。
   </para>
 
   <para>

--- a/doc/src/sgml/pltcl.sgml
+++ b/doc/src/sgml/pltcl.sgml
@@ -1572,7 +1572,7 @@ Tcl内でそれまでに行われた操作は取り消されません。
         can be changed within a session, such changes will not affect Tcl
         interpreters that have already been created.
 -->
-スーパーユーザーだけがこの設定を変更できます。
+スーパーユーザだけがこの設定を変更できます。
 この設定はセッション内で変更できますが、すでに作成されたTclインタプリタには影響しません。
        </para>
       </listitem>


### PR DESCRIPTION
"superuser"の訳を多数派の「スーパーユーザ」に揃えました。