### PR TITLE
update monitoring for 13.1

### DIFF
--- a/doc/src/sgml/monitoring.sgml
+++ b/doc/src/sgml/monitoring.sgml
@@ -6676,6 +6676,7 @@ SLRUでの切り詰めの数です。
         subset of those in the <structname>pg_stat_activity</structname> view.
 -->
 指定されたプロセスIDに該当するバックエンドの情報のレコードを、<literal>NULL</literal>が指定された場合はシステム上のアクティブな各バックエンドに関するレコードを返します。
+返される情報内容は<structname>pg_stat_activity</structname>の一部と同じです。
        </para></entry>
       </row>
 
@@ -7307,7 +7308,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Current processing phase. See <xref linkend="analyze-phases"/>.
 -->
-現在処理中のインデックス作成のフェーズです。
+現在処理中のフェーズです。
 <xref linkend="analyze-phases"/>を参照してください。
       </para></entry>
      </row>

--- a/doc/src/sgml/monitoring.sgml
+++ b/doc/src/sgml/monitoring.sgml
@@ -837,7 +837,7 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
        <structname>pg_statio_all_indexes</structname></link> for details.
 -->
 現在のデータベース内のインデックスごとに１行の形式で、特定のインデックスに対するI/Oに関する統計情報を示します。
-詳細については<link linkend="monitoring-pg-statio-all-indexes-view"><link linkend="monitoring-pg-statio-all-indexes-view">を参照してください。
+詳細については<link linkend="monitoring-pg-statio-all-indexes-view"><structname>pg_statio_all_indexes</structname></link>を参照してください。
       </entry>
      </row>
 
@@ -2236,7 +2236,7 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
 <!--
       <entry>Waiting for a two phase state file to reach durable storage.</entry>
 -->
-      <entry>二相の状態ファイルが永続的ストレージに到達するのを待機しています。</entry></entry>
+      <entry>二相の状態ファイルが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>TwophaseFileWrite</literal></entry>
@@ -8648,7 +8648,7 @@ WAL送信プロセスのプロセスIDです。
        once the amount of data streamed exceeds the estimated
        total size. If the estimation is disabled in
        <application>pg_basebackup</application>
-       (i.e., <literal>&#45;--no-estimate-size</literal> option is specified),
+       (i.e., <literal>&#45;-no-estimate-size</literal> option is specified),
        this is <literal>NULL</literal>.
 -->
 ストリームされるデータの総量です。

--- a/doc/src/sgml/monitoring.sgml
+++ b/doc/src/sgml/monitoring.sgml
@@ -1472,6 +1472,7 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
        <literal>wait_event</literal> will identify the specific wait point;
        see <xref linkend="wait-event-io-table"/>.
 -->
+      <entry>
 サーバプロセスは入出力が完了するのを待機しています。
 <literal>wait_event</literal>によりその待機点が特定できます。<xref linkend="wait-event-io-table"/>を参照してください。
       </entry>

--- a/doc/src/sgml/monitoring.sgml
+++ b/doc/src/sgml/monitoring.sgml
@@ -189,7 +189,7 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
 <command>/bin/ps</command>ではなく、<command>/usr/ucb/ps</command>を使用しなければなりません。
 また、<command>w</command>フラグを1つではなく2つ使用しなければなりません。
 さらに、元の<command>postgres</command>の呼び出しに関する<command>ps</command>のステータス表示は、各サーバプロセスに関するステータス表示よりも短くなければなりません。
-この3条件を全て満たさないと、各サーバプロセスの<command>ps</command>の出力は、元の<application>postgres</application>のコマンドラインのものになってしまいます。
+この3条件を全て満たさないと、各サーバプロセスの<command>ps</command>の出力は、元の<command>postgres</command>のコマンドラインのものになってしまいます。
   </para>
   </tip>
  </sect1>
@@ -6675,7 +6675,7 @@ SLRUでの切り詰めの数です。
         if <literal>NULL</literal> is specified.  The fields returned are a
         subset of those in the <structname>pg_stat_activity</structname> view.
 -->
-指定されたプロセスIDに該当するバックエンドの情報のレコードを、<symbol>NULL</symbol>が指定された場合はシステム上のアクティブな各バックエンドに関するレコードを返します。
+指定されたプロセスIDに該当するバックエンドの情報のレコードを、<literal>NULL</literal>が指定された場合はシステム上のアクティブな各バックエンドに関するレコードを返します。
        </para></entry>
       </row>
 
@@ -6730,7 +6730,7 @@ SLRUでの切り詰めの数です。
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXCUTE権限を付与できます。
+この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXECUTE権限を付与できます。
        </para></entry>
       </row>
 
@@ -6759,7 +6759,7 @@ SLRUでの切り詰めの数です。
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXCUTE権限を付与できます。
+この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXECUTE権限を付与できます。
        </para></entry>
       </row>
 
@@ -6783,7 +6783,7 @@ SLRUでの切り詰めの数です。
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXCUTE権限を付与できます。
+この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXECUTE権限を付与できます。
        </para></entry>
       </row>
 
@@ -6807,7 +6807,7 @@ SLRUでの切り詰めの数です。
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXCUTE権限を付与できます。
+この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXECUTE権限を付与できます。
        </para></entry>
       </row>
 
@@ -6847,7 +6847,7 @@ SLRUでの切り詰めの数です。
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXCUTE権限を付与できます。
+この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXECUTE権限を付与できます。
        </para></entry>
       </row>
      </tbody>
@@ -7135,7 +7135,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
    locks in the lock manager. For example, this capability can be used
    to:
 -->
-この他に、データベース活動状況の監視に役立つツールとして<literal>pg_locks</literal>システムテーブルがあります。
+この他に、データベース活動状況の監視に役立つツールとして<structname>pg_locks</structname>システムテーブルがあります。
 これにより、データベース管理者はロックマネージャ内の未解決のロックに関する情報を参照することができます。
 例えば、この機能を使用すると以下のことができます。
 
@@ -8779,7 +8779,7 @@ WAL送信プロセスはデータベースファイルをベースバックア�
        <application>pg_basebackup</application>, the backup will end
        when this phase is completed.
 -->
-WAL送信プロセスは、バックアップを終了するために現在<function>pg_start_backup</function>を実行し、ベースバックアップに必要なWALファイルすべてのアーカイブに成功するのを待っています。
+WAL送信プロセスは、バックアップを終了するために現在<function>pg_stop_backup</function>を実行し、ベースバックアップに必要なWALファイルすべてのアーカイブに成功するのを待っています。
 <application>pg_basebackup</application>で<literal>--wal-method=none</literal>か<literal>--wal-method=stream</literal>のいずれかが指定されれば、バックアップはこのフェーズが完了したら終了します。
       </entry>
      </row>

--- a/doc/src/sgml/monitoring.sgml
+++ b/doc/src/sgml/monitoring.sgml
@@ -598,6 +598,7 @@ WAL送信プロセス毎に１行の形式で、送信サーバが接続した�
        showing current progress.
        See <xref linkend='basebackup-progress-reporting'/>.
 -->
+      <entry>
 ベースバックアップをストリームしている各WAL送信プロセスごとに1行の形式で、現在の進捗を表示します。
 <xref linkend='basebackup-progress-reporting'/>を参照してください。
       </entry>
@@ -2407,7 +2408,7 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
       <entry>Waiting for activity from a child process while
        executing a <literal>Gather</literal> plan node.</entry>
 -->
-      <entry<literal>Gather</literal>計画ノードの実行時に子プロセスの活動を待機しています。</entry>
+      <entry><literal>Gather</literal>計画ノードの実行時に子プロセスの活動を待機しています。</entry>
      </row>
      <row>
       <entry><literal>HashBatchAllocate</literal></entry>
@@ -4002,7 +4003,7 @@ WALレシーバが開始された時に使われる初期タイムライン番�
 <!--
        Last write-ahead log location already received and written to disk,
        but not flushed. This should not be used for data integrity checks.
---->
+-->
 すでに受信し、ディスクに書き出されたもののまだフラッシュされていない先行書き込みログの最新位置です。
 これはデータの完全性の確認のためには使うべきではありません。
       </para></entry>

--- a/doc/src/sgml/monitoring.sgml
+++ b/doc/src/sgml/monitoring.sgml
@@ -4,7 +4,7 @@
 <!--
  <title>Monitoring Database Activity</title>
 -->
-<title>データベース活動状況の監視</title>
+ <title>データベース活動状況の監視</title>
 
  <indexterm zone="monitoring">
 <!--
@@ -12,7 +12,7 @@
   <secondary>database activity</secondary>
 -->
   <primary>監視</primary>
-  <secondary>データベース活動情報の</secondary>
+  <secondary>データベース活動状況</secondary>
  </indexterm>
 
  <indexterm zone="monitoring">
@@ -21,7 +21,7 @@
   <secondary>monitoring</secondary>
 -->
   <primary>データベース活動状況</primary>
-  <secondary>の監視</secondary>
+  <secondary>監視</secondary>
  </indexterm>
 
  <para>
@@ -30,8 +30,8 @@
   doing right now?</quote>
   This chapter discusses how to find that out.
 -->
-データベース管理者はよく、<quote>システムは今現在正しく動作しているか</quote>を気にします。
-本章では監視方法について説明します。
+データベース管理者はよく、<quote>システムは今現在何をしているか</quote>を気にします。
+本章ではそれを知る方法について説明します。
  </para>
 
   <para>
@@ -48,7 +48,7 @@
    and other methods for understanding the behavior of an individual
    query.
 -->
-データベース活動状況の監視と性能解析用のツールは多く存在します。
+データベース活動状況の監視と性能解析用のツールはいくつか存在します。
 本章の大部分は<productname>PostgreSQL</productname>の統計情報コレクタの説明に費されていますが、<command>ps</command>や<command>top</command>、<command>iostat</command>、<command>vmstat</command>などの通常のUnix監視プログラムを無視すべきではありません。
 また、性能が悪い問い合わせであると認知された問い合わせは、その後、<productname>PostgreSQL</productname>の<xref linkend="sql-explain"/>コマンドを使用して調査を行う必要が発生します。
 <xref linkend="using-explain"/>では、個々の問い合わせの振舞いを理解するための、<command>EXPLAIN</command>やその他の方法について記載しています。
@@ -58,14 +58,14 @@
 <!--
   <title>Standard Unix Tools</title>
 -->
-<title>標準的なUnixツール</title>
+  <title>標準的なUnixツール</title>
 
   <indexterm zone="monitoring-ps">
    <primary>ps</primary>
 <!--
    <secondary>to monitor activity</secondary>
 -->
-   <secondary>活動状況監視用の</secondary>
+   <secondary>活動状況監視のための</secondary>
   </indexterm>
 
   <para>
@@ -109,7 +109,7 @@ postgres  15610  0.0  0.0  58772  3056 ?        Ss   18:07   0:00 postgres: tgl 
 この例は最近のLinuxシステムのものです。）
 この一覧の最初のプロセスはマスタサーバプロセスです。
 表示されているコマンド引数は、起動時に使用されたものと同じものです。
-次の5つのプロセスは、マスタプロセスから自動的に起動されるバックグラウンドワーカープロセスです。
+次の5つのプロセスは、マスタプロセスから自動的に起動されるバックグラウンドワーカプロセスです。
 （システムを統計情報コレクタが起動しないように設定していた場合は<quote>統計情報コレクタ</quote>はありません。同様に<quote>自動バキュームランチャ</quote>を無効にできます。）
 残るプロセスはそれぞれ、1つのクライアント接続を取り扱うサーバプロセスです。
 それぞれのプロセスは、次の形式のコマンドライン表示を設定します。
@@ -133,10 +133,10 @@ postgres: <replaceable>user</replaceable> <replaceable>database</replaceable> <r
   <link linkend="view-pg-locks"><structname>pg_locks</structname></link>
   system view to determine who is blocking whom.)
 -->
-ユーザ、データベース、(クライアント)ホストという項目はクライアントの存続期間中変更されることはありませんが、活動状況を示す部分は変わります。
+ユーザ、データベース、(クライアント)ホストという項目はクライアント接続の存続期間中変更されることはありませんが、活動状況を示す部分は変わります。
 活動状況は、<literal>idle</literal>（つまり、クライアントからのコマンド待ち状態）、<literal>idle in transaction</literal>（<command>BEGIN</command>ブロックの内側でのクライアントの待ち状態）、または<literal>SELECT</literal>のようなコマンド種類名のいずれかとなります。
 また、そのサーバプロセスが他のセッションによって保持されたロックを待っている状態の場合は、<literal>waiting</literal>が追加されます。
-上の例では、プロセス15606はプロセス15610におけるトランザクションの完了とそれに伴うロックの解放を待っていると推測することができます。
+上の例では、プロセス15606はプロセス15610におけるトランザクションの完了とそれに伴うロックの解放を待っていると推測できます。
 （他に実行中のセッションがありませんので、プロセス15610がブロックしている側であるはずです。
 もっと複雑な場合では<link linkend="view-pg-locks"><structname>pg_locks</structname></link>システムビューを検索し、どのプロセスがどのプロセスをブロックしているか決定しなければなりません。）
   </para>
@@ -168,7 +168,7 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
    amount of per-command overhead;  on others it's insignificant.
 -->
 <xref linkend="guc-update-process-title"/>を無効にした場合、活動情報を示す部分は更新されません。
-新しいプロセスが起動した時に一度、プロセスの表題は設定されます。
+新しいプロセスが起動した時に一度だけ、プロセスの表題は設定されます。
 プラットフォームの中には、これによりコマンドごとのオーバヘッドをかなり抑えられるものもありますし、まったく意味がないものもあります。
   </para>
 
@@ -198,13 +198,13 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
 <!--
   <title>The Statistics Collector</title>
 -->
-<title>統計情報コレクタ</title>
+  <title>統計情報コレクタ</title>
 
   <indexterm zone="monitoring-stats">
 <!--
    <primary>statistics</primary>
 -->
-<primary>統計情報</primary>
+   <primary>統計情報</primary>
   </indexterm>
 
   <para>
@@ -220,7 +220,7 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
 <productname>PostgreSQL</productname>の<firstterm>統計情報コレクタ</firstterm>はサーバの活動状況に関する情報を収集し、報告するサブシステムです。
 現在、コレクタはテーブルとインデックスへのアクセスをディスクブロックおよび個々の行単位で数えることができます。
 またこれは、各テーブル内の総行数、および、各テーブルでのバキュームやアナライズの実施情報を追跡します。
-また、ユーザ定義関数の呼ばれた回数、それぞれの消費した総時間をカウントします。
+また、ユーザ定義関数の呼ばれた回数、それぞれの消費した総時間を数えます。
   </para>
 
   <para>
@@ -239,7 +239,7 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
 <!--
   <title>Statistics Collection Configuration</title>
 -->
-<title>統計情報収集のための設定</title>
+  <title>統計情報収集のための設定</title>
 
   <para>
 <!--
@@ -249,9 +249,9 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
    <filename>postgresql.conf</filename>.  (See <xref linkend="runtime-config"/> for
    details about setting configuration parameters.)
 -->
-統計情報の収集によって問い合わせの実行に少しオーバーヘッドが加わりますので、システムは情報を収集するようにもしないようにも設定することができます。
-これは通常は<filename>postgresql.conf</filename>内で設定される、設定パラメータによって制御されます
-（設定パラメータの設定についての詳細は<xref linkend="runtime-config"/>を参照してください）。
+統計情報の収集によって問い合わせの実行に少しオーバーヘッドが加わりますので、システムは情報を収集するようにもしないようにも設定できます。
+これは通常は<filename>postgresql.conf</filename>内で設定される、設定パラメータによって制御されます。
+（設定パラメータの設定についての詳細は<xref linkend="runtime-config"/>を参照してください。）
   </para>
 
   <para>
@@ -298,7 +298,7 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
 -->
 通常、これらの変数は全てのサーバプロセスに適用できるように<filename>postgresql.conf</filename>内で設定されます。
 しかし、<xref linkend="sql-set"/>コマンドを使用して、個別のセッションで有効または無効にできます。
-（一般ユーザがその活動を管理者に隠すことを防止するために、スーパーユーザのみが<command>SET</command>を使用してこれらのパラメータを変更できます。）
+（一般ユーザがその活動を管理者から隠すことを防止するために、スーパーユーザのみが<command>SET</command>を使用してこれらのパラメータを変更できます。）
   </para>
 
   <para>
@@ -317,10 +317,10 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
    and point-in-time recovery), all statistics counters are reset.
 -->
 統計情報コレクタは収集した情報を他の<productname>PostgreSQL</productname>プロセスに一時ファイルを介して送信します。
-これらのファイルは<xref linkend="guc-stats-temp-directory"/>で指名されたディレクトリ、デフォルトは<filename>pg_stat_tmp</filename>内に格納されます。
+これらのファイルは<xref linkend="guc-stats-temp-directory"/>パラメータで指名されたディレクトリ、デフォルトは<filename>pg_stat_tmp</filename>内に格納されます。
 性能を向上させるために、<varname>stats_temp_directory</varname>をRAMベースのファイルシステムを指し示すようにして、物理的なI/O要求を減らすことができます。
 サーバが正しくシャットダウンした際は、統計情報がサーバの再起動を跨がって保持されるように、統計情報データの永続的なコピーが<filename>pg_stat</filename>サブディレクトリに格納されます。
-サーバ起動時にリカバリが実施される場合(例えば、即時シャットダウンやサーバクラッシュ、ポイントインタイムリカバリ)、統計カウンタをすべてリセットします。
+サーバ起動時にリカバリが実施される場合(例えば、即時シャットダウンやサーバクラッシュ、ポイントインタイムリカバリの後)、統計カウンタはすべてリセットされます。
   </para>
 
  </sect2>
@@ -329,7 +329,7 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
 <!--
   <title>Viewing Statistics</title>
 -->
-<title>統計情報の表示</title>
+  <title>統計情報の表示</title>
 
   <para>
 <!--
@@ -344,7 +344,7 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
 -->
 システムの現在の状態を表示するために、いくつかの定義済みのビューがあり、<xref linkend="monitoring-stats-dynamic-views-table"/>に一覧されています。
 また、統計情報の収集結果を表示するために、他にもいくつかのビューがあり、<xref linkend="monitoring-stats-views-table"/>に一覧されています。
-他にも、<xref linkend="monitoring-stats-functions"/>で説明する、基礎的な統計情報関数を使用した独自のビューを構築することもできます。
+あるいはまた、<xref linkend="monitoring-stats-functions"/>で説明する、基礎的な統計情報関数を使用した独自のビューを構築することもできます。
   </para>
 
   <para>
@@ -363,7 +363,7 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
 この統計情報を使用して、収集されるデータを監視する場合、この情報は即座に更新されないことを認識することが重要です。
 個別のサーバプロセスは、待機状態になる直前に、新しい統計情報に関する数をコレクタに送信します。
 ですので、実行中の問い合わせやトランザクションは表示上の総和には影響を与えません。
-また、コレクタ自体もおよそ<varname>PGSTAT_STAT_INTERVAL</varname>（サーバ構築時に変更しない限り500 ms）ミリ秒に一度新しい報告を出力します。
+また、コレクタ自体は<varname>PGSTAT_STAT_INTERVAL</varname>ミリ秒（サーバ構築時に変更しない限り500 ms）に多くても一度新しい報告を出力します。
 ですので、表示上の情報は実際の活動から遅れて表示されます。
 しかし、<varname>track_activities</varname>で収集される現在の問い合わせの情報は常に最新です。
   </para>
@@ -389,14 +389,14 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
    statistical information will cause a new snapshot to be fetched.
 -->
 この他の重要なポイントは、いつサーバプロセスが統計情報を表示するように尋ねられるかです。
-サーバプロセスは、まずコレクタによって発行された最も最近の報告を取り出します。
+サーバプロセスは、まずコレクタプロセスによって発行された最も最近の報告を取り出します。
 そして、現在のトランザクションが終わるまで、全ての統計情報ビューと関数においてこのスナップショットを使用し続けます。
 ですから、現在のトランザクションを続けている間、統計情報は一定の情報を示します。
 同様に、全セッションの現在の問い合わせに関する情報も、そうした情報がトランザクションで最初に要求された時に収集され、そのトランザクションの間同じ情報が表示されます。
 これはバグではなく、特徴です。
-なぜなら、これにより、知らない間に値が変更することを考慮することなく、統計情報に対して複数の問い合わせを実行し、その結果を相関することができるからです。
+なぜなら、これにより、知らない間に値が変わるのを考慮することなく、統計情報に対して複数の問い合わせを実行し、その結果を相関することができるからです。
 しかし、各問い合わせで新しい結果を取り出したい場合は、確実にトランザクションブロックの外側でその問い合わせを行ってください。
-他にも<function>pg_stat_clear_snapshot</function>()を呼び出すこともできます。
+あるいはまた、<function>pg_stat_clear_snapshot</function>()を呼び出すこともできます。
 これは現在のトランザクションの統計情報スナップショットを（もしあれば）破棄します。
 次に統計情報を使用する場合に新しいスナップショットを取り出すことになります。
   </para>
@@ -410,8 +410,8 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
    <structname>pg_stat_xact_user_functions</structname>.  These numbers do not act as
    stated above; instead they update continuously throughout the transaction.
 -->
-トランザクションからは、<structname>pg_stat_xact_all_tables</structname>、<structname>pg_stat_xact_sys_tables</structname>、<structname>pg_stat_xact_user_tables</structname>、<structname>pg_stat_xact_user_functions</structname>、およびこれらのビューの元となっている関数を通じて、自身の統計情報(まだコレクタに送られていない)も参照することができます。
-   これらの数値はトランザクション中に継続的に更新されていくため上記の様な(静的な情報を示す)振る舞いとはなりません。
+トランザクションからは、<structname>pg_stat_xact_all_tables</structname>、<structname>pg_stat_xact_sys_tables</structname>、<structname>pg_stat_xact_user_tables</structname>、および<structname>pg_stat_xact_user_functions</structname>を通じて、自身の統計情報(まだコレクタに送られていない)も参照することができます。
+これらの数値はトランザクション中に継続的に更新されていくため上記の様な(静的な情報を示す)振る舞いとはなりません。
   </para>
 
   <para>
@@ -426,7 +426,7 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
    built-in role <literal>pg_read_all_stats</literal> (see also <xref
    linkend="default-roles"/>) can see all the information about all sessions.
 -->
-<xref linkend="monitoring-stats-dynamic-views-table"/>で表示される一部の動的な統計ビューにはセキュリティ制限があります。
+<xref linkend="monitoring-stats-dynamic-views-table"/>で表示される動的な統計ビューの情報の中にはセキュリティ制限があるものがあります。
 一般ユーザは自身のセッション（メンバとなっているロールに属するセッション）に関する全情報だけを参照できます。
 他セッションに関する行では多くの列がNULLになるでしょう。
 しかしながら、セッションの存在とセッションのユーザとデータベースなどの一般的な属性は全ユーザに可視であることに注意してください。
@@ -437,7 +437,7 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
 <!--
    <title>Dynamic Statistics Views</title>
 -->
-<title>動的統計情報ビュー</title>
+   <title>動的統計情報ビュー</title>
 
    <tgroup cols="2">
     <thead>
@@ -446,8 +446,8 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
       <entry>View Name</entry>
       <entry>Description</entry>
 -->
-<entry>ビュー名</entry>
-<entry>説明</entry>
+      <entry>ビュー名</entry>
+      <entry>説明</entry>
      </row>
     </thead>
 
@@ -465,7 +465,7 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
        <structname>pg_stat_activity</structname></link> for details.
 -->
 サーバプロセスあたり１行の形式で、状態や現在の問い合わせ等のプロセスの現在の活動状況に関連した情報を表示します。
-詳細については<xref linkend="pg-stat-activity-view"/>を参照してください。
+詳細については<link linkend="monitoring-pg-stat-activity-view"><structname>pg_stat_activity</structname></link>を参照してください。
       </entry>
      </row>
 
@@ -479,7 +479,7 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
 -->
       <entry>
 WAL送信プロセス毎に１行の形式で、送信サーバが接続したスタンバイサーバへのレプリケーションに関する統計情報を表示します。
-詳細については<xref linkend="pg-stat-replication-view"/>を参照して下さい。
+詳細については<link linkend="monitoring-pg-stat-replication-view"><structname>pg_stat_replication</structname></link>を参照してください。
       </entry>
      </row>
 
@@ -492,8 +492,8 @@ WAL送信プロセス毎に１行の形式で、送信サーバが接続した�
        <structname>pg_stat_wal_receiver</structname></link> for details.
 -->
       <entry>
-１行の形式で、受信サーバが接続したサーバからWALレシーバに関する統計情報を表示します。
-詳細については<xref linkend="pg-stat-wal-receiver-view"/>を参照してください。
+１行の形式で、受信サーバが接続したサーバからWAL受信サーバに関する統計情報を表示します。
+詳細については<link linkend="monitoring-pg-stat-wal-receiver-view"><structname>pg_stat_wal_receiver</structname></link>を参照してください。
       </entry>
      </row>
 
@@ -507,7 +507,7 @@ WAL送信プロセス毎に１行の形式で、送信サーバが接続した�
 -->
       <entry>
 1つのサブスクリプションにつき少なくとも1行の形式で、サブスクリプションワーカに関する情報を表示します。
-詳細については<xref linkend="pg-stat-subscription"/>を参照してください。
+詳細については<link linkend="monitoring-pg-stat-subscription"><structname>pg_stat_subscription</structname></link>を参照してください。
       </entry>
      </row>
 
@@ -521,7 +521,7 @@ WAL送信プロセス毎に１行の形式で、送信サーバが接続した�
 -->
       <entry>
 接続（通常およびレプリケーション）あたり1行の形式で、接続に使われるSSLの情報を表示します。
-詳しくは<xref linkend="pg-stat-ssl-view"/>を参照して下さい。
+詳しくは<link linkend="monitoring-pg-stat-ssl-view"><structname>pg_stat_ssl</structname></link>を参照してください。
       </entry>
      </row>
 
@@ -535,15 +535,20 @@ WAL送信プロセス毎に１行の形式で、送信サーバが接続した�
 -->
      <entry>
 接続（通常およびレプリケーション）あたり1行の形式で、接続に使われるGSSAPI認証と暗号化に関する情報を表示します。
-詳しくは<xref linkend="pg-stat-gssapi-view"/>を参照してください。
+詳しくは<link linkend="monitoring-pg-stat-gssapi-view"><structname>pg_stat_gssapi</structname></link>を参照してください。
       </entry>
      </row>
 
      <row>
       <entry><structname>pg_stat_progress_analyze</structname><indexterm><primary>pg_stat_progress_analyze</primary></indexterm></entry>
+<!--
       <entry>One row for each backend (including autovacuum worker processes) running
        <command>ANALYZE</command>, showing current progress.
        See <xref linkend='analyze-progress-reporting'/>.
+-->
+      <entry>
+<command>ANALYZE</command>を実行している（自動バキュームワーカプロセスを含んだ）各バックエンドごとに1行の形式で、現在の進捗を表示します。
+<xref linkend='analyze-progress-reporting'/>を参照してください。
       </entry>
      </row>
 
@@ -555,7 +560,7 @@ WAL送信プロセス毎に１行の形式で、送信サーバが接続した�
       See <xref linkend='create-index-progress-reporting'/>.
 -->
      <entry>
-<command>CREATE INDEX</command>または<command>REINDEX</command>を実行する各バックエンド実行ごとに1行の形式で、現在の進捗を表示します。
+<command>CREATE INDEX</command>または<command>REINDEX</command>を実行している各バックエンドごとに1行の形式で、現在の進捗を表示します。
 <xref linkend='create-index-progress-reporting'/>を参照してください。
      </entry>
      </row>
@@ -568,7 +573,7 @@ WAL送信プロセス毎に１行の形式で、送信サーバが接続した�
        See <xref linkend='vacuum-progress-reporting'/>.
 -->
       <entry>
-VACUUMを実行している（自動バキュームワーカプロセスを含んだ）各バックエンドごとに１行の形式で、現在の進捗を表示します。
+<command>VACUUM</command>を実行している（自動バキュームワーカプロセスを含んだ）各バックエンドごとに１行の形式で、現在の進捗を表示します。
 <xref linkend='vacuum-progress-reporting'/>を参照してください。
       </entry>
      </row>
@@ -581,16 +586,20 @@ VACUUMを実行している（自動バキュームワーカプロセスを含�
        See <xref linkend='cluster-progress-reporting'/>.
 -->
       <entry>
-<command>CLUSTER</command>または<command>VACUUM FULL</command>を実行している各バックエンドごと1行の形式で、現在の進捗を表示します。
+<command>CLUSTER</command>または<command>VACUUM FULL</command>を実行している各バックエンドごとに1行の形式で、現在の進捗を表示します。
 <xref linkend='cluster-progress-reporting'/>を参照してください。
       </entry>
      </row>
 
      <row>
       <entry><structname>pg_stat_progress_basebackup</structname><indexterm><primary>pg_stat_progress_basebackup</primary></indexterm></entry>
+<!--
       <entry>One row for each WAL sender process streaming a base backup,
        showing current progress.
        See <xref linkend='basebackup-progress-reporting'/>.
+-->
+ベースバックアップをストリームしている各WAL送信プロセスごとに1行の形式で、現在の進捗を表示します。
+<xref linkend='basebackup-progress-reporting'/>を参照してください。
       </entry>
      </row>
 
@@ -626,8 +635,8 @@ VACUUMを実行している（自動バキュームワーカプロセスを含�
        <structname>pg_stat_archiver</structname></link> for details.
 -->
       <entry>
-WALアーカイバプロセスの活動状況に関する統計情報を１行のみで表示します
-詳細については<xref linkend="pg-stat-archiver-view"/>を参照してください。
+WALアーカイバプロセスの活動状況に関する統計情報を１行のみで表示します。
+詳細については<link linkend="monitoring-pg-stat-archiver-view"><structname>pg_stat_archiver</structname></link>を参照してください。
       </entry>
      </row>
 
@@ -641,7 +650,7 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
 -->
       <entry>
 バックグラウンドライタプロセスの活動状況に関する統計情報を１行のみで表示します。
-詳細については<xref linkend="pg-stat-bgwriter-view"/>を参照してください。
+詳細については<link linkend="monitoring-pg-stat-bgwriter-view"><structname>pg_stat_bgwriter</structname></link>を参照してください。
      </entry>
      </row>
 
@@ -653,8 +662,8 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
        <structname>pg_stat_database</structname></link> for details.
 -->
       <entry>
-データベース当たり１行の形で、データベース全体の情報を表示します。
-詳細については<xref linkend="pg-stat-database-view"/>を参照してください。
+データベース毎に１行の形式で、データベース全体の統計情報を表示します。
+詳細については<link linkend="monitoring-pg-stat-database-view"><structname>pg_stat_database</structname></link>を参照してください。
       </entry>
      </row>
 
@@ -668,7 +677,7 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
        <structname>pg_stat_database_conflicts</structname></link> for details.
 -->
 データベース毎に１行の形式で、スタンバイサーバにおける復旧との競合のためにキャンセルされた問い合わせについてのデータベース全体の統計情報を表示します。
-詳細については<xref linkend="pg-stat-database-conflicts-view"/>を参照して下さい。
+詳細については<link linkend="monitoring-pg-stat-database-conflicts-view"><structname>pg_stat_database_conflicts</structname></link>を参照してください。
       </entry>
      </row>
 
@@ -681,8 +690,8 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
        See <link linkend="monitoring-pg-stat-all-tables-view">
        <structname>pg_stat_all_tables</structname></link> for details.
 -->
-現在のデータベースの各テーブルごとに１行の形で、特定のテーブルへのアクセスに関する統計情報を示します。
-詳細については<xref linkend="pg-stat-all-tables-view"/>を参照してください。
+現在のデータベースの各テーブルごとに１行の形式で、特定のテーブルへのアクセスに関する統計情報を示します。
+詳細については<link linkend="monitoring-pg-stat-all-tables-view"><structname>pg_stat_all_tables</structname></link>を参照してください。
       </entry>
      </row>
 
@@ -710,38 +719,38 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
 
      <row>
       <entry><structname>pg_stat_xact_all_tables</structname><indexterm><primary>pg_stat_xact_all_tables</primary></indexterm></entry>
-      <!--
+<!--
       <entry>Similar to <structname>pg_stat_all_tables</structname>, but counts actions
       taken so far within the current transaction (which are <emphasis>not</emphasis>
       yet included in <structname>pg_stat_all_tables</structname> and related views).
       The columns for numbers of live and dead rows and vacuum and
       analyze actions are not present in this view.</entry>
-      -->
-     <entry>
+-->
+      <entry>
 <structname>pg_stat_all_tables</structname>と似ていますが、現在のトランザクションにて実施された処理結果をカウントします。(数値が見える時点では、これらの数値は<structname>pg_stat_all_tables</structname>と関連するビューに含まれて<emphasis>いません</emphasis>。)
 このビューでは、有効行数、無効行数、およびバキュームやアナライズの活動は表示しません。
-     </entry>
+      </entry>
      </row>
 
      <row>
       <entry><structname>pg_stat_xact_sys_tables</structname><indexterm><primary>pg_stat_xact_sys_tables</primary></indexterm></entry>
-      <!--
+<!--
       <entry>Same as <structname>pg_stat_xact_all_tables</structname>, except that only
       system tables are shown.</entry>
-      -->
+-->
       <entry>
-      システムテーブルのみが表示される点を除き、<structname>pg_stat_xact_all_tables</structname>と同じです。
+システムテーブルのみが表示される点を除き、<structname>pg_stat_xact_all_tables</structname>と同じです。
       </entry>
      </row>
 
      <row>
       <entry><structname>pg_stat_xact_user_tables</structname><indexterm><primary>pg_stat_xact_user_tables</primary></indexterm></entry>
-      <!--
+<!--
       <entry>Same as <structname>pg_stat_xact_all_tables</structname>, except that only
       user tables are shown.</entry>
-      -->
+-->
       <entry>
-      ユーザテーブルのみが表示される点を除き、<structname>pg_stat_xact_all_tables</structname>と同じです。
+ユーザテーブルのみが表示される点を除き、<structname>pg_stat_xact_all_tables</structname>と同じです。
       </entry>
      </row>
 
@@ -754,8 +763,8 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
        See <link linkend="monitoring-pg-stat-all-indexes-view">
        <structname>pg_stat_all_indexes</structname></link> for details.
 -->
-現在のデータベースのインデックスごとに１行の形で、特定のインデックスへのアクセスに関する統計情報を示します。
-詳細については<xref linkend="pg-stat-all-indexes-view"/>を参照してください。
+現在のデータベースのインデックスごとに１行の形式で、特定のインデックスへのアクセスに関する統計情報を示します。
+詳細については<link linkend="monitoring-pg-stat-all-indexes-view"><structname>pg_stat_all_indexes</structname></link>を参照してください。
       </entry>
      </row>
 
@@ -767,7 +776,7 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
 -->
       <entry>
 システムテーブルのインデックスのみが表示される点を除き、<structname>pg_stat_all_indexes</structname>と同じです。
-</entry>
+      </entry>
      </row>
 
      <row>
@@ -778,7 +787,7 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
 -->
       <entry>
 ユーザテーブルのインデックスのみが表示される点を除き、<structname>pg_stat_all_indexes</structname>と同じです。
-</entry>
+      </entry>
      </row>
 
      <row>
@@ -790,8 +799,8 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
        See <link linkend="monitoring-pg-statio-all-tables-view">
        <structname>pg_statio_all_tables</structname></link> for details.
 -->
-現在のデータベース内のテーブルごとに１行の形で、特定のテーブルに対するI/Oに関する統計情報を示します。
-詳細については<xref linkend="pg-statio-all-tables-view"/>を参照してください。
+現在のデータベース内のテーブルごとに１行の形式で、特定のテーブルに対するI/Oに関する統計情報を示します。
+詳細については<link linkend="monitoring-pg-statio-all-tables-view"><structname>pg_statio_all_tables</structname></link>を参照してください。
       </entry>
      </row>
 
@@ -814,7 +823,7 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
 -->
       <entry>
 ユーザテーブルのみが表示される点を除き、<structname>pg_statio_all_tables</structname>と同じです。
-</entry>
+      </entry>
      </row>
 
      <row>
@@ -826,8 +835,8 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
        See <link linkend="monitoring-pg-statio-all-indexes-view">
        <structname>pg_statio_all_indexes</structname></link> for details.
 -->
-現在のデータベース内のインデックスごとに１行の形で、特定のインデックスに対するI/Oに関する統計情報を示します。
-詳細については<xref linkend="pg-statio-all-indexes-view"/>を示します。
+現在のデータベース内のインデックスごとに１行の形式で、特定のインデックスに対するI/Oに関する統計情報を示します。
+詳細については<link linkend="monitoring-pg-statio-all-indexes-view"><link linkend="monitoring-pg-statio-all-indexes-view">を参照してください。
       </entry>
      </row>
 
@@ -839,7 +848,7 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
 -->
       <entry>
 システムテーブルのインデックスのみが表示される点を除き、<structname>pg_statio_all_indexes</structname> と同じです。
-</entry>
+      </entry>
      </row>
 
      <row>
@@ -850,7 +859,7 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
 -->
       <entry>
 ユーザテーブルのインデックスのみが表示される点を除き、<structname>pg_statio_all_indexes</structname>と同じです。
-</entry>
+      </entry>
      </row>
 
      <row>
@@ -862,8 +871,8 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
        See <link linkend="monitoring-pg-statio-all-sequences-view">
        <structname>pg_statio_all_sequences</structname></link> for details.
 -->
-現在のデータベース内のシーケンスごとに１行の形で、特定のシーケンスに対するI/Oに関する統計情報を示します。
-詳細については<xref linkend="pg-statio-all-sequences-view"/>を参照してください。
+現在のデータベース内のシーケンスごとに１行の形式で、特定のシーケンスに対するI/Oに関する統計情報を示します。
+詳細については<link linkend="monitoring-pg-statio-all-sequences-view"><structname>pg_statio_all_sequences</structname></link>を参照してください。
      </entry>
      </row>
 
@@ -874,10 +883,10 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
       system sequences are shown.  (Presently, no system sequences are defined,
       so this view is always empty.)</entry>
 -->
-<entry>
+      <entry>
 システムシーケンスのみが表示される点を除き、<structname>pg_statio_all_sequences</structname>と同じです
 （現時点では、システムシーケンスは定義されていませんので、このビューは常に空です）。
-</entry>
+      </entry>
      </row>
 
      <row>
@@ -888,7 +897,7 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
 -->
       <entry>
 ユーザシーケンスのみが表示される点を除き、<structname>pg_statio_all_sequences</structname>と同じです。
-</entry>
+      </entry>
      </row>
 
      <row>
@@ -900,8 +909,8 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
        <link linkend="monitoring-pg-stat-user-functions-view">
        <structname>pg_stat_user_functions</structname></link> for details.
 -->
-追跡された関数ごとに１行の形で、関数の実行に関する統計情報を示します。
-詳細については<xref linkend="pg-stat-user-functions-view"/>を参照してください。
+追跡された関数ごとに１行の形式で、関数の実行に関する統計情報を示します。
+詳細については<link linkend="monitoring-pg-stat-user-functions-view"><structname>pg_stat_user_functions</structname></link>を参照してください。
       </entry>
      </row>
 
@@ -920,9 +929,14 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
 
      <row>
       <entry><structname>pg_stat_slru</structname><indexterm><primary>pg_stat_slru</primary></indexterm></entry>
+<!--
       <entry>One row per SLRU, showing statistics of operations. See
        <link linkend="monitoring-pg-stat-slru-view">
        <structname>pg_stat_slru</structname></link> for details.
+-->
+      <entry>
+SLRUごとに1行の形で、操作に関する統計情報を示します。
+詳細は<link linkend="monitoring-pg-stat-slru-view"><structname>pg_stat_slru</structname></link>を参照してください。
       </entry>
      </row>
 
@@ -980,12 +994,18 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
   </para>
 
   <table id="pg-stat-activity-view" xreflabel="pg_stat_activity">
+<!--
    <title><structname>pg_stat_activity</structname> View</title>
+-->
+   <title><structname>pg_stat_activity</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -1038,9 +1058,13 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
        <structfield>leader_pid</structfield> <type>integer</type>
       </para>
       <para>
+<!--
        Process ID of the parallel group leader, if this process is a
        parallel query worker.  <literal>NULL</literal> if this process is a
        parallel group leader or does not participate in parallel query.
+-->
+このプロセスがパラレルクエリワーカであればパラレルグループリーダーのプロセスIDです。
+このプロセスがパラレルグループリーダーであるか、パラレルクエリに参加していないのであれば<literal>NULL</literal>です。
       </para></entry>
      </row>
 
@@ -1064,7 +1088,7 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
 <!--
        Name of the user logged into this backend
 -->
-バックエンドに接続したユーザの名前です。
+バックエンドにログインしたユーザの名前です。
       </para></entry>
      </row>
 
@@ -1093,7 +1117,7 @@ WALアーカイバプロセスの活動状況に関する統計情報を１行�
        internal process such as autovacuum.
 -->
 バックエンドに接続したクライアントのIPアドレスです。
-このフィールドがNULLである場合、これはクライアントがサーバマシン上のUnixソケット経由で接続されたか、自動バキュームなど内部処理であることを示します。
+このフィールドがNULLである場合、これはクライアントがサーバマシン上のUnixソケット経由で接続されたか、自動バキュームなど内部プロセスであることを示しています。
       </para></entry>
      </row>
 
@@ -1117,9 +1141,13 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
        <structfield>client_port</structfield> <type>integer</type>
       </para>
       <para>
+<!--
        TCP port number that the client is using for communication
        with this backend, or <literal>-1</literal> if a Unix socket is used.
        If this field is null, it indicates that this is an internal server process.
+-->
+クライアントがバックエンドとの通信に使用するTCPポート番号、もしくはUnixソケットを使用する場合は<literal>-1</literal>です。
+このフィールドがNULLであれば、内部のサーバプロセスであることを示しています。
       </para></entry>
      </row>
 
@@ -1148,8 +1176,7 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
        query is the first of its transaction, this column is equal to the
        <structfield>query_start</structfield> column.
 -->
-プロセスの現在のトランザクションが開始した時刻です。
-活動中のトランザクションがない場合はNULLです。
+プロセスの現在のトランザクションが開始した時刻です。活動中のトランザクションがない場合はNULLです。
 現在の問い合わせがトランザクションの先頭である場合、この列は<structfield>query_start</structfield>列と同じです。
       </para></entry>
      </row>
@@ -1164,8 +1191,7 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
        <structfield>state</structfield> is not <literal>active</literal>, when the last query
        was started
 -->
-現在有効な問い合わせが開始した時刻です。
-もし<structfield>state</structfield>が<literal>active</literal>でない場合は直前の問い合わせが開始した時刻です。
+現在活動中の問い合わせが開始した時刻です。もし<structfield>state</structfield>が<literal>active</literal>でない場合は直前の問い合わせが開始した時刻です。
       </para></entry>
      </row>
 
@@ -1186,8 +1212,12 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
        <structfield>wait_event_type</structfield> <type>text</type>
       </para>
       <para>
+<!--
        The type of event for which the backend is waiting, if any;
        otherwise NULL.  See <xref linkend="wait-event-table"/>.
+-->
+バックエンドが待機しているイベントがあれば、その型、なければNULLとなります。
+<xref linkend="wait-event-table"/>を参照してください。
       </para></entry>
      </row>
 
@@ -1196,9 +1226,13 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
        <structfield>wait_event</structfield> <type>text</type>
       </para>
       <para>
+<!--
        Wait event name if backend is currently waiting, otherwise NULL.
        See <xref linkend="wait-event-activity-table"/> through
        <xref linkend="wait-event-timeout-table"/>.
+-->
+バックエンドが現在待機している場合は待機イベント名、そうでなければNULLとなります。
+<xref linkend="wait-event-activity-table"/>から<xref linkend="wait-event-timeout-table"/>までを参照してください。
       </para></entry>
      </row>
 
@@ -1207,12 +1241,19 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
        <structfield>state</structfield> <type>text</type>
       </para>
       <para>
+<!--
        Current overall state of this backend.
        Possible values are:
+-->
+現在のバックエンドの総体的な状態です。
+以下のいずれかの値を取ることができます。
        <itemizedlist>
         <listitem>
         <para>
+<!--
           <literal>active</literal>: The backend is executing a query.
+-->
+<literal>active</literal>: バックエンドは問い合わせを実行中です。
          </para>
         </listitem>
         <listitem>
@@ -1271,7 +1312,7 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
 <!--
        Top-level transaction identifier of this backend, if any.
 -->
-もしあれば、このバックエンドの最上位のトランザクション識別子。
+もしあれば、このバックエンドの最上位のトランザクション識別子です。
       </para></entry>
      </row>
 
@@ -1283,7 +1324,7 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
 <!--
        The current backend's <literal>xmin</literal> horizon.
 -->
-現在のバックエンドの<literal>xmin</literal>。
+現在のバックエンドの<literal>xmin</literal>です。
       </para></entry>
      </row>
 
@@ -1301,9 +1342,9 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
        <xref linkend="guc-track-activity-query-size"/>.
 -->
 バックエンドの最も最近の問い合わせテキストです。
-<structfield>state</structfield>が<literal>active</literal>の場合、現在実行中の問い合わせを意味します。
+<structfield>state</structfield>が<literal>active</literal>の場合、このフィールドは現在実行中の問い合わせを示します。
 その他のすべての状態では、実行済みの最後の問い合わせを示します。
-デフォルトでは問い合わせのテキストは1024バイトで切り捨てられますが、この値はパラメータ<xref linkend="guc-track-activity-query-size"/>により変更できます。
+デフォルトでは問い合わせのテキストは1024バイトで切り詰められますが、この値はパラメータ<xref linkend="guc-track-activity-query-size"/>により変更できます。
       </para></entry>
      </row>
 
@@ -1350,65 +1391,106 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
   </note>
 
   <table id="wait-event-table">
+<!--
    <title>Wait Event Types</title>
+-->
+   <title>待機イベント型</title>
    <tgroup cols="2">
     <thead>
      <row>
+<!--
       <entry>Wait Event Type</entry>
       <entry>Description</entry>
+-->
+      <entry>待機イベント型</entry>
+      <entry>説明</entry>
      </row>
     </thead>
 
     <tbody>
      <row>
       <entry><literal>Activity</literal></entry>
+<!--
       <entry>The server process is idle.  This event type indicates a process
        waiting for activity in its main processing loop.
        <literal>wait_event</literal> will identify the specific wait point;
        see <xref linkend="wait-event-activity-table"/>.
+-->
+      <entry>
+サーバプロセスはアイドル状態です。
+このイベント型はプロセスがメインの処理ループ内で活動を待機していることを示します。
+<literal>wait_event</literal>によりその待機点が特定できます。
+<xref linkend="wait-event-activity-table"/>を参照してください。
       </entry>
      </row>
      <row>
       <entry><literal>BufferPin</literal></entry>
+<!--
       <entry>The server process is waiting for exclusive access to
        a data buffer.  Buffer pin waits can be protracted if
        another process holds an open cursor that last read data from the
        buffer in question. See <xref linkend="wait-event-bufferpin-table"/>.
+-->
+      <entry>
+サーバプロセスは、データバッファに排他的アクセスをするために待機しています。
+バッファピン待機は、他のプロセスが該当のバッファから最後に読み込んだデータのオープンカーソルを保持している場合に長引かされることがあります。
+<xref linkend="wait-event-bufferpin-table"/>を参照してください。
       </entry>
      </row>
      <row>
       <entry><literal>Client</literal></entry>
+<!--
       <entry>The server process is waiting for activity on a socket
        connected to a user application.  Thus, the server expects something
        to happen that is independent of its internal processes.
        <literal>wait_event</literal> will identify the specific wait point;
        see <xref linkend="wait-event-client-table"/>.
+-->
+      <entry>
+サーバプロセスはユーザアプリケーションに接続しているソケット上での活動を待機しています。
+それゆえ、サーバはその内部プロセスとは無関係の何かが起きることを期待しています。
+<literal>wait_event</literal>によりその待機点が特定できます。<xref linkend="wait-event-client-table"/>を参照してください。
       </entry>
      </row>
      <row>
       <entry><literal>Extension</literal></entry>
+<!--
       <entry>The server process is waiting for some condition defined by an
        extension module.
        See <xref linkend="wait-event-extension-table"/>.
+-->
+      <entry>
+サーバプロセスは拡張モジュールにより定義された条件を待機しています。
+<xref linkend="wait-event-extension-table"/>を参照してください。
       </entry>
      </row>
      <row>
       <entry><literal>IO</literal></entry>
+<!--
       <entry>The server process is waiting for an I/O operation to complete.
        <literal>wait_event</literal> will identify the specific wait point;
        see <xref linkend="wait-event-io-table"/>.
+-->
+サーバプロセスは入出力が完了するのを待機しています。
+<literal>wait_event</literal>によりその待機点が特定できます。<xref linkend="wait-event-io-table"/>を参照してください。
       </entry>
      </row>
      <row>
       <entry><literal>IPC</literal></entry>
+<!--
       <entry>The server process is waiting for some interaction with
        another server process.  <literal>wait_event</literal> will
        identify the specific wait point;
        see <xref linkend="wait-event-ipc-table"/>.
+-->
+サーバプロセスは、他のサーバプロセスとの相互作用を待機しています。
+<literal>wait_event</literal>によりその待機点が特定できます。<xref linkend="wait-event-ipc-table"/>を参照してください。
+      <entry>
       </entry>
      </row>
      <row>
       <entry><literal>Lock</literal></entry>
+<!--
       <entry>The server process is waiting for a heavyweight lock.
        Heavyweight locks, also known as lock manager locks or simply locks,
        primarily protect SQL-visible objects such as tables.  However,
@@ -1416,23 +1498,43 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
        operations such as relation extension.  <literal>wait_event</literal>
        will identify the type of lock awaited;
        see <xref linkend="wait-event-lock-table"/>.
+-->
+      <entry>
+サーバプロセスは重量ロックを待機しています。
+ロックマネージャロックや単にロックとしても知られている重量ロックは、主にテーブルのようなSQLで可視なオブジェクトを保護します。
+しかし、それらはリレーション拡張のような、なんらかの内部操作のために相互排他を確実にするためにも使用されます。
+<literal>wait_event</literal>は、待たせているロックの型を識別します。
+<xref linkend="wait-event-lock-table"/>を参照してください。
       </entry>
      </row>
      <row>
       <entry><literal>LWLock</literal></entry>
+<!--
       <entry> The server process is waiting for a lightweight lock.
        Most such locks protect a particular data structure in shared memory.
        <literal>wait_event</literal> will contain a name identifying the purpose
        of the lightweight lock.  (Some locks have specific names; others
        are part of a group of locks each with a similar purpose.)
        See <xref linkend="wait-event-lwlock-table"/>.
+-->
+      <entry>
+サーバプロセスは軽量ロックを待機しています。
+ほとんどのこのようなロックは、共有メモリ内の特定のデータ構造を保護します。
+<literal>wait_event</literal>には軽量ロックの目的を特定する名前が入ります。
+（特定の名前がついたロックもあれば、似たような目的のロックのグループの一部となっているものもあります。）
+<xref linkend="wait-event-lwlock-table"/>を参照してください。
       </entry>
      </row>
      <row>
       <entry><literal>Timeout</literal></entry>
+<!--
       <entry>The server process is waiting for a timeout
        to expire.  <literal>wait_event</literal> will identify the specific wait
        point; see <xref linkend="wait-event-timeout-table"/>.
+-->
+      <entry>
+サーバプロセスはタイムアウトが満了するのを待機しています。
+<literal>wait_event</literal>によりその待機点が特定できます。<xref linkend="wait-event-timeout-table"/>を参照してください。
       </entry>
      </row>
     </tbody>
@@ -1440,1101 +1542,1806 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
   </table>
 
   <table id="wait-event-activity-table">
+<!--
    <title>Wait Events of Type <literal>Activity</literal></title>
+-->
+   <title><literal>Activity</literal>型の待機イベント</title>
    <tgroup cols="2">
     <thead>
      <row>
+<!--
       <entry><literal>Activity</literal> Wait Event</entry>
       <entry>Description</entry>
+-->
+      <entry><literal>Activity</literal>待機イベント</entry>
+      <entry>説明</entry>
      </row>
     </thead>
 
     <tbody>
      <row>
       <entry><literal>ArchiverMain</literal></entry>
+<!--
       <entry>Waiting in main loop of archiver process.</entry>
+-->
+      <entry>アーカイバプロセスのメインループ内で待機しています。</entry>
      </row>
      <row>
       <entry><literal>AutoVacuumMain</literal></entry>
+<!--
       <entry>Waiting in main loop of autovacuum launcher process.</entry>
+-->
+      <entry>自動バキュームのランチャプロセスのメインループ内で待機しています。</entry>
      </row>
      <row>
       <entry><literal>BgWriterHibernate</literal></entry>
+<!--
       <entry>Waiting in background writer process, hibernating.</entry>
+-->
+      <entry>バックグラウンドライタプロセス内で待機し、休止状態になっています。</entry>
      </row>
      <row>
       <entry><literal>BgWriterMain</literal></entry>
+<!--
       <entry>Waiting in main loop of background writer process.</entry>
+-->
+      <entry>バックグラウンドライタプロセスのメインループ内で待機しています。</entry>
      </row>
      <row>
       <entry><literal>CheckpointerMain</literal></entry>
+<!--
       <entry>Waiting in main loop of checkpointer process.</entry>
+-->
+      <entry>チェックポインタプロセスのメインループ内で待機しています。</entry>
      </row>
      <row>
       <entry><literal>LogicalApplyMain</literal></entry>
+<!--
       <entry>Waiting in main loop of logical replication apply process.</entry>
+-->
+      <entry>論理レプリケーション適用プロセスのメインループ内で待機しています。</entry>
      </row>
      <row>
       <entry><literal>LogicalLauncherMain</literal></entry>
+<!--
       <entry>Waiting in main loop of logical replication launcher process.</entry>
+-->
+      <entry>論理レプリケーションランチャプロセスのメインループ内で待機しています。</entry>
      </row>
      <row>
       <entry><literal>PgStatMain</literal></entry>
+<!--
       <entry>Waiting in main loop of statistics collector process.</entry>
+-->
+      <entry>統計情報収集プロセスのメインループ内で待機しています。</entry>
      </row>
      <row>
       <entry><literal>RecoveryWalStream</literal></entry>
+<!--
       <entry>Waiting in main loop of startup process for WAL to arrive, during
        streaming recovery.</entry>
+-->
+      <entry>ストリーミングリカバリ中に、起動プロセスのメインループ内でWALが到着するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SysLoggerMain</literal></entry>
+<!--
       <entry>Waiting in main loop of syslogger process.</entry>
+-->
+      <entry>sysloggerプロセスのメインループ内で待機しています。</entry>
      </row>
      <row>
       <entry><literal>WalReceiverMain</literal></entry>
+<!--
       <entry>Waiting in main loop of WAL receiver process.</entry>
+-->
+      <entry>WAL受信プロセスのメインループ内で待機しています。</entry>
      </row>
      <row>
       <entry><literal>WalSenderMain</literal></entry>
+<!--
       <entry>Waiting in main loop of WAL sender process.</entry>
+-->
+      <entry>WAL送信プロセスのメインループ内で待機しています。</entry>
      </row>
      <row>
       <entry><literal>WalWriterMain</literal></entry>
+<!--
       <entry>Waiting in main loop of WAL writer process.</entry>
+-->
+      <entry>WAL書き込みプロセスのメインループ内で待機しています。</entry>
      </row>
     </tbody>
    </tgroup>
   </table>
 
   <table id="wait-event-bufferpin-table">
+<!--
    <title>Wait Events of Type <literal>BufferPin</literal></title>
+-->
+   <title><literal>BufferPin</literal>型の待機イベント</title>
    <tgroup cols="2">
     <thead>
      <row>
+<!--
       <entry><literal>BufferPin</literal> Wait Event</entry>
       <entry>Description</entry>
+-->
+      <entry><literal>BufferPin</literal>待機イベント</entry>
+      <entry>説明</entry>
      </row>
     </thead>
 
     <tbody>
      <row>
       <entry><literal>BufferPin</literal></entry>
+<!--
       <entry>Waiting to acquire an exclusive pin on a buffer.</entry>
+-->
+      <entry>バッファ上の排他ピンを獲得するのを待機しています。</entry>
      </row>
     </tbody>
    </tgroup>
   </table>
 
   <table id="wait-event-client-table">
+<!--
    <title>Wait Events of Type <literal>Client</literal></title>
+-->
+   <title><literal>Client</literal>型の待機イベント</title>
    <tgroup cols="2">
     <thead>
      <row>
+<!--
       <entry><literal>Client</literal> Wait Event</entry>
       <entry>Description</entry>
+-->
+      <entry><literal>Client</literal>待機イベント</entry>
+      <entry>説明</entry>
      </row>
     </thead>
 
     <tbody>
      <row>
       <entry><literal>ClientRead</literal></entry>
+<!--
       <entry>Waiting to read data from the client.</entry>
+-->
+      <entry>クライアントからのデータの読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ClientWrite</literal></entry>
+<!--
       <entry>Waiting to write data to the client.</entry>
+-->
+      <entry>クライアントへのデータの書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>GSSOpenServer</literal></entry>
+<!--
       <entry>Waiting to read data from the client while establishing a GSSAPI
        session.</entry>
+-->
+      <entry>GSSAPIセッションを確立する際にクライアントからのデータ読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>LibPQWalReceiverConnect</literal></entry>
+<!--
       <entry>Waiting in WAL receiver to establish connection to remote
        server.</entry>
+-->
+      <entry>WAL受信プロセス内でリモートサーバへの接続が確立するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>LibPQWalReceiverReceive</literal></entry>
+<!--
       <entry>Waiting in WAL receiver to receive data from remote server.</entry>
+-->
+      <entry>WAL受信プロセス内でリモートサーバからデータを受信するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SSLOpenServer</literal></entry>
+<!--
       <entry>Waiting for SSL while attempting connection.</entry>
+-->
+      <entry>接続試行中にSSLを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WalReceiverWaitStart</literal></entry>
+<!--
       <entry>Waiting for startup process to send initial data for streaming
        replication.</entry>
+-->
+      <entry>起動プロセスがストリーミングレプリケーションの初期データを送信するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WalSenderWaitForWAL</literal></entry>
+<!--
       <entry>Waiting for WAL to be flushed in WAL sender process.</entry>
+-->
+      <entry>WAL送信プロセス内でWALがフラッシュされるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WalSenderWriteData</literal></entry>
+<!--
       <entry>Waiting for any activity when processing replies from WAL
        receiver in WAL sender process.</entry>
+-->
+      <entry>WAL送信プロセス内でWAL受信者からの応答を処理している時に、何らかの活動を待機しています。</entry>
      </row>
     </tbody>
    </tgroup>
   </table>
 
   <table id="wait-event-extension-table">
+<!--
    <title>Wait Events of Type <literal>Extension</literal></title>
+-->
+   <title><literal>Extension</literal>型の待機イベント</title>
    <tgroup cols="2">
     <thead>
      <row>
+<!--
       <entry><literal>Extension</literal> Wait Event</entry>
       <entry>Description</entry>
+-->
+      <entry><literal>Extension</literal>待機イベント</entry>
+      <entry>説明</entry>
      </row>
     </thead>
 
     <tbody>
      <row>
       <entry><literal>Extension</literal></entry>
+<!--
       <entry>Waiting in an extension.</entry>
+-->
+      <entry>拡張内で待機しています。</entry>
      </row>
     </tbody>
    </tgroup>
   </table>
 
   <table id="wait-event-io-table">
+<!--
    <title>Wait Events of Type <literal>IO</literal></title>
+-->
+   <title><literal>IO</literal>型の待機イベント</title>
    <tgroup cols="2">
     <thead>
      <row>
+<!--
       <entry><literal>IO</literal> Wait Event</entry>
       <entry>Description</entry>
+-->
+      <entry><literal>IO</literal>待機イベント</entry>
+      <entry>説明</entry>
      </row>
     </thead>
 
     <tbody>
      <row>
       <entry><literal>BufFileRead</literal></entry>
+<!--
       <entry>Waiting for a read from a buffered file.</entry>
+-->
+      <entry>バッファファイルからの読み取りを待機しています。</entry>
      </row>
      <row>
       <entry><literal>BufFileWrite</literal></entry>
+<!--
       <entry>Waiting for a write to a buffered file.</entry>
+-->
+      <entry>バッファファイルへの書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ControlFileRead</literal></entry>
+<!--
       <entry>Waiting for a read from the <filename>pg_control</filename>
        file.</entry>
+-->
+      <entry><filename>pg_control</filename>ファイルからの読み取りを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ControlFileSync</literal></entry>
+<!--
       <entry>Waiting for the <filename>pg_control</filename> file to reach
        durable storage.</entry>
+-->
+      <entry><filename>pg_control</filename>ファイルが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ControlFileSyncUpdate</literal></entry>
+<!--
       <entry>Waiting for an update to the <filename>pg_control</filename> file
        to reach durable storage.</entry>
+-->
+      <entry><filename>pg_control</filename>ファイルの更新が永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ControlFileWrite</literal></entry>
+<!--
       <entry>Waiting for a write to the <filename>pg_control</filename>
        file.</entry>
+-->
+      <entry><filename>pg_control</filename>ファイルへの書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ControlFileWriteUpdate</literal></entry>
+<!--
       <entry>Waiting for a write to update the <filename>pg_control</filename>
        file.</entry>
+-->
+      <entry><filename>pg_control</filename>ファイルの更新の書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>CopyFileRead</literal></entry>
+<!--
       <entry>Waiting for a read during a file copy operation.</entry>
+-->
+      <entry>ファイルコピーの操作の間、読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>CopyFileWrite</literal></entry>
+<!--
       <entry>Waiting for a write during a file copy operation.</entry>
+-->
+      <entry>ファイルコピーの操作の間、書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>DSMFillZeroWrite</literal></entry>
+<!--
       <entry>Waiting to fill a dynamic shared memory backing file with
        zeroes.</entry>
+-->
+      <entry>動的共有メモリの背後のファイルにゼロのバイトを書き込むのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>DataFileExtend</literal></entry>
+<!--
       <entry>Waiting for a relation data file to be extended.</entry>
+-->
+      <entry>リレーションのデータファイルが拡張されるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>DataFileFlush</literal></entry>
+<!--
       <entry>Waiting for a relation data file to reach durable storage.</entry>
+-->
+      <entry>リレーションのデータファイルが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>DataFileImmediateSync</literal></entry>
+<!--
       <entry>Waiting for an immediate synchronization of a relation data file to
        durable storage.</entry>
+-->
+      <entry>リレーションのデータファイルが永続的ストレージに即座に同期されるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>DataFilePrefetch</literal></entry>
+<!--
       <entry>Waiting for an asynchronous prefetch from a relation data
        file.</entry>
+-->
+      <entry>リレーションのデータファイルからの非同期プリフェッチを待機しています。</entry>
      </row>
      <row>
       <entry><literal>DataFileRead</literal></entry>
+<!--
       <entry>Waiting for a read from a relation data file.</entry>
+-->
+      <entry>リレーションのデータファイルからの読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>DataFileSync</literal></entry>
+<!--
       <entry>Waiting for changes to a relation data file to reach durable storage.</entry>
+-->
+      <entry>リレーションのデータファイルへの変更が永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>DataFileTruncate</literal></entry>
+<!--
       <entry>Waiting for a relation data file to be truncated.</entry>
+-->
+      <entry>リレーションのデータファイルが切り詰められるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>DataFileWrite</literal></entry>
+<!--
       <entry>Waiting for a write to a relation data file.</entry>
+-->
+      <entry>リレーションのデータファイルへの書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>LockFileAddToDataDirRead</literal></entry>
+<!--
       <entry>Waiting for a read while adding a line to the data directory lock
        file.</entry>
+-->
+      <entry>データディレクトリのロックファイルに行を追加する間の読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>LockFileAddToDataDirSync</literal></entry>
+<!--
       <entry>Waiting for data to reach durable storage while adding a line to the
        data directory lock file.</entry>
+-->
+      <entry>データディレクトリのロックファイルに行を追加する間、データが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>LockFileAddToDataDirWrite</literal></entry>
+<!--
       <entry>Waiting for a write while adding a line to the data directory
        lock file.</entry>
+-->
+      <entry>データディレクトリのロックファイルに行を追加する間の書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>LockFileCreateRead</literal></entry>
+<!--
       <entry>Waiting to read while creating the data directory lock
        file.</entry>
+-->
+      <entry>データディレクトリのロックファイルを作成する間の読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>LockFileCreateSync</literal></entry>
+<!--
       <entry>Waiting for data to reach durable storage while creating the data
        directory lock file.</entry>
+-->
+      <entry>データディレクトリのロックファイルを作成する間、データが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>LockFileCreateWrite</literal></entry>
+<!--
       <entry>Waiting for a write while creating the data directory lock
        file.</entry>
+-->
+      <entry>データディレクトリのロックファイルを作成する間の書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>LockFileReCheckDataDirRead</literal></entry>
+<!--
       <entry>Waiting for a read during recheck of the data directory lock
        file.</entry>
+-->
+      <entry>データディレクトリのロックファイルを再検査する間の読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>LogicalRewriteCheckpointSync</literal></entry>
+<!--
       <entry>Waiting for logical rewrite mappings to reach durable storage
        during a checkpoint.</entry>
+-->
+      <entry>チェックポイントの間に、論理的な再書き込みのマッピングが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>LogicalRewriteMappingSync</literal></entry>
+<!--
       <entry>Waiting for mapping data to reach durable storage during a logical
        rewrite.</entry>
+-->
+      <entry>論理的な再書き込みの間に、マッピングデータが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>LogicalRewriteMappingWrite</literal></entry>
+<!--
       <entry>Waiting for a write of mapping data during a logical
        rewrite.</entry>
+-->
+      <entry>論理的な再書き込みの間に、マッピングデータの書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>LogicalRewriteSync</literal></entry>
+<!--
       <entry>Waiting for logical rewrite mappings to reach durable
        storage.</entry>
+-->
+      <entry>論理的な再書き込みのマッピングが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>LogicalRewriteTruncate</literal></entry>
+<!--
       <entry>Waiting for truncate of mapping data during a logical
        rewrite.</entry>
+-->
+      <entry>論理的な再書き込みの際にマッピングデータが切り詰められるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>LogicalRewriteWrite</literal></entry>
+<!--
       <entry>Waiting for a write of logical rewrite mappings.</entry>
+-->
+      <entry>論理的な再書き込みのマッピングの書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>RelationMapRead</literal></entry>
+<!--
       <entry>Waiting for a read of the relation map file.</entry>
+-->
+      <entry>リレーションのマップファイルの読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>RelationMapSync</literal></entry>
+<!--
       <entry>Waiting for the relation map file to reach durable storage.</entry>
+-->
+      <entry>リレーションのマップファイルが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>RelationMapWrite</literal></entry>
+<!--
       <entry>Waiting for a write to the relation map file.</entry>
+-->
+      <entry>リレーションのマップファイルの書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ReorderBufferRead</literal></entry>
+<!--
       <entry>Waiting for a read during reorder buffer management.</entry>
+-->
+      <entry>並べ替えのバッファ管理の間に読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ReorderBufferWrite</literal></entry>
+<!--
       <entry>Waiting for a write during reorder buffer management.</entry>
+-->
+      <entry>並べ替えのバッファ管理の間に書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ReorderLogicalMappingRead</literal></entry>
+<!--
       <entry>Waiting for a read of a logical mapping during reorder buffer
        management.</entry>
+-->
+      <entry>並べ替えのバッファ管理の間に、論理マッピングの読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ReplicationSlotRead</literal></entry>
+<!--
       <entry>Waiting for a read from a replication slot control file.</entry>
+-->
+      <entry>レプリケーションスロットの制御ファイルからの読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ReplicationSlotRestoreSync</literal></entry>
+<!--
       <entry>Waiting for a replication slot control file to reach durable storage
        while restoring it to memory.</entry>
+-->
+      <entry>レプリケーションスロットの制御ファイルをメモリにリストアする間、それが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ReplicationSlotSync</literal></entry>
+<!--
       <entry>Waiting for a replication slot control file to reach durable
        storage.</entry>
+-->
+      <entry>レプリケーションスロットの制御ファイルが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ReplicationSlotWrite</literal></entry>
+<!--
       <entry>Waiting for a write to a replication slot control file.</entry>
+-->
+      <entry>レプリケーションスロットの制御ファイルへの書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SLRUFlushSync</literal></entry>
+<!--
       <entry>Waiting for SLRU data to reach durable storage during a checkpoint
        or database shutdown.</entry>
+-->
+      <entry>チェックポイントまたはデータベースのシャットダウン中に、SLRUデータが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SLRURead</literal></entry>
+<!--
       <entry>Waiting for a read of an SLRU page.</entry>
+-->
+      <entry>SLRUページの読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SLRUSync</literal></entry>
+<!--
       <entry>Waiting for SLRU data to reach durable storage following a page
        write.</entry>
+-->
+      <entry>ページ書き込みの後、SLRUデータが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SLRUWrite</literal></entry>
+<!--
       <entry>Waiting for a write of an SLRU page.</entry>
+-->
+      <entry>SLRUページの書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SnapbuildRead</literal></entry>
+<!--
       <entry>Waiting for a read of a serialized historical catalog
        snapshot.</entry>
+-->
+      <entry>シリアライズされた通時的カタログのスナップショットの読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SnapbuildSync</literal></entry>
+<!--
       <entry>Waiting for a serialized historical catalog snapshot to reach
        durable storage.</entry>
+-->
+      <entry>シリアライズされた通時的カタログのスナップショットが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SnapbuildWrite</literal></entry>
+<!--
       <entry>Waiting for a write of a serialized historical catalog
        snapshot.</entry>
+-->
+      <entry>シリアライズされた通時的カタログのスナップショットの書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>TimelineHistoryFileSync</literal></entry>
+<!--
       <entry>Waiting for a timeline history file received via streaming
        replication to reach durable storage.</entry>
+-->
+      <entry>ストリーミングレプリケーションを経由して受け取ったタイムラインの履歴ファイルが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>TimelineHistoryFileWrite</literal></entry>
+<!--
       <entry>Waiting for a write of a timeline history file received via
        streaming replication.</entry>
+-->
+      <entry>ストリーミングレプリケーションを経由して受け取ったタイムラインの履歴ファイルの書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>TimelineHistoryRead</literal></entry>
+<!--
       <entry>Waiting for a read of a timeline history file.</entry>
+-->
+      <entry>タイムラインの履歴ファイルの読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>TimelineHistorySync</literal></entry>
+<!--
       <entry>Waiting for a newly created timeline history file to reach durable
        storage.</entry>
+-->
+      <entry>新しく作成されたタイムラインの履歴ファイルが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>TimelineHistoryWrite</literal></entry>
+<!--
       <entry>Waiting for a write of a newly created timeline history
        file.</entry>
+-->
+      <entry>新しく作成されたタイムラインの履歴ファイルの書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>TwophaseFileRead</literal></entry>
+<!--
       <entry>Waiting for a read of a two phase state file.</entry>
+-->
+      <entry>二相の状態ファイルの読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>TwophaseFileSync</literal></entry>
+<!--
       <entry>Waiting for a two phase state file to reach durable storage.</entry>
+-->
+      <entry>二相の状態ファイルが永続的ストレージに到達するのを待機しています。</entry></entry>
      </row>
      <row>
       <entry><literal>TwophaseFileWrite</literal></entry>
+<!--
       <entry>Waiting for a write of a two phase state file.</entry>
+-->
+      <entry>二相の状態ファイルの書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WALBootstrapSync</literal></entry>
+<!--
       <entry>Waiting for WAL to reach durable storage during
        bootstrapping.</entry>
+-->
+      <entry>ブートストラップ時にWALが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WALBootstrapWrite</literal></entry>
+<!--
       <entry>Waiting for a write of a WAL page during bootstrapping.</entry>
+-->
+      <entry>ブートストラップ時にWALページの書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WALCopyRead</literal></entry>
+<!--
       <entry>Waiting for a read when creating a new WAL segment by copying an
        existing one.</entry>
+-->
+      <entry>既存のWALセグメントをコピーして新しいWALセグメントを作成する時に読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WALCopySync</literal></entry>
+<!--
       <entry>Waiting for a new WAL segment created by copying an existing one to
        reach durable storage.</entry>
+-->
+      <entry>既存のWALセグメントをコピーして作成した新しいWALセグメントが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WALCopyWrite</literal></entry>
+<!--
       <entry>Waiting for a write when creating a new WAL segment by copying an
        existing one.</entry>
+-->
+      <entry>既存のWALセグメントをコピーして新しいWALセグメントを作成する時に書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WALInitSync</literal></entry>
+<!--
       <entry>Waiting for a newly initialized WAL file to reach durable
        storage.</entry>
+-->
+      <entry>新しく初期化されたWALファイルが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WALInitWrite</literal></entry>
+<!--
       <entry>Waiting for a write while initializing a new WAL file.</entry>
+-->
+      <entry>新しいWALファイルを初期化している時に書き込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WALRead</literal></entry>
+<!--
       <entry>Waiting for a read from a WAL file.</entry>
+-->
+      <entry>WALファイルからの読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WALSenderTimelineHistoryRead</literal></entry>
+<!--
       <entry>Waiting for a read from a timeline history file during a walsender
        timeline command.</entry>
+-->
+      <entry>WAL送信サーバのタイムラインコマンドで、タイムラインの履歴ファイルの読み込みを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WALSync</literal></entry>
+<!--
       <entry>Waiting for a WAL file to reach durable storage.</entry>
+-->
+      <entry>WALファイルが永続的ストレージに達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WALSyncMethodAssign</literal></entry>
+<!--
       <entry>Waiting for data to reach durable storage while assigning a new
        WAL sync method.</entry>
+-->
+      <entry>新しいWALの同期方法を割り当てている時にデータが永続的ストレージに到達するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WALWrite</literal></entry>
+<!--
       <entry>Waiting for a write to a WAL file.</entry>
+-->
+      <entry>WALファイルへの書き込みを待機しています。</entry>
      </row>
     </tbody>
    </tgroup>
   </table>
 
   <table id="wait-event-ipc-table">
+<!--
    <title>Wait Events of Type <literal>IPC</literal></title>
+-->
+   <title><literal>IPC</literal>型の待機イベント</title>
    <tgroup cols="2">
     <thead>
      <row>
+<!--
       <entry><literal>IPC</literal> Wait Event</entry>
       <entry>Description</entry>
+-->
+      <entry><literal>IPC</literal>待機イベント</entry>
+      <entry>説明</entry>
      </row>
     </thead>
 
     <tbody>
      <row>
       <entry><literal>BackupWaitWalArchive</literal></entry>
+<!--
       <entry>Waiting for WAL files required for a backup to be successfully
        archived.</entry>
+-->
+      <entry>バックアップに必要なWALファイルがアーカイブに成功するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>BgWorkerShutdown</literal></entry>
+<!--
       <entry>Waiting for background worker to shut down.</entry>
+-->
+      <entry>バックグラウンドワーカがシャットダウンするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>BgWorkerStartup</literal></entry>
+<!--
       <entry>Waiting for background worker to start up.</entry>
+-->
+      <entry>バックグラウンドワーカが起動するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>BtreePage</literal></entry>
+<!--
       <entry>Waiting for the page number needed to continue a parallel B-tree
        scan to become available.</entry>
+-->
+      <entry>パラレルB-treeスキャンを継続するのに必要なページ番号が利用可能になるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>CheckpointDone</literal></entry>
+<!--
       <entry>Waiting for a checkpoint to complete.</entry>
+-->
+      <entry>チェックポイントが完了するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>CheckpointStart</literal></entry>
+<!--
       <entry>Waiting for a checkpoint to start.</entry>
+-->
+      <entry>チェックポイントが開始するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ExecuteGather</literal></entry>
+<!--
       <entry>Waiting for activity from a child process while
        executing a <literal>Gather</literal> plan node.</entry>
+-->
+      <entry<literal>Gather</literal>計画ノードの実行時に子プロセスの活動を待機しています。</entry>
      </row>
      <row>
       <entry><literal>HashBatchAllocate</literal></entry>
+<!--
       <entry>Waiting for an elected Parallel Hash participant to allocate a hash
        table.</entry>
+-->
+      <entry>選ばれたパラレルハッシュ参加者がハッシュテーブルを獲得するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>HashBatchElect</literal></entry>
+<!--
       <entry>Waiting to elect a Parallel Hash participant to allocate a hash
        table.</entry>
+-->
+      <entry>ハッシュテーブルを獲得するパラレルハッシュ参加者を選ぶのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>HashBatchLoad</literal></entry>
+<!--
       <entry>Waiting for other Parallel Hash participants to finish loading a
        hash table.</entry>
+-->
+      <entry>他のパラレルハッシュ参加者がハッシュテーブルのロードを完了させるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>HashBuildAllocate</literal></entry>
+<!--
       <entry>Waiting for an elected Parallel Hash participant to allocate the
        initial hash table.</entry>
+-->
+      <entry>選ばれたパラレルハッシュ参加者が初期ハッシュテーブルを獲得するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>HashBuildElect</literal></entry>
+<!--
       <entry>Waiting to elect a Parallel Hash participant to allocate the
        initial hash table.</entry>
+-->
+      <entry>初期ハッシュテーブルを獲得するパラレルハッシュ参加者を選ぶのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>HashBuildHashInner</literal></entry>
+<!--
       <entry>Waiting for other Parallel Hash participants to finish hashing the
        inner relation.</entry>
+-->
+      <entry>他のパラレルハッシュ参加者がインナーリレーションのハッシュを完了させるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>HashBuildHashOuter</literal></entry>
+<!--
       <entry>Waiting for other Parallel Hash participants to finish partitioning
        the outer relation.</entry>
+-->
+      <entry>他のパラレルハッシュ参加者がアウターリレーションのパーティショニングを完了させるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>HashGrowBatchesAllocate</literal></entry>
+<!--
       <entry>Waiting for an elected Parallel Hash participant to allocate more
        batches.</entry>
+-->
+      <entry>選ばれたパラレルハッシュ参加者が追加バッチを獲得するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>HashGrowBatchesDecide</literal></entry>
+<!--
       <entry>Waiting to elect a Parallel Hash participant to decide on future
        batch growth.</entry>
+-->
+      <entry>将来のバッチの増加を決めるパラレルハッシュ参加者を選ぶのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>HashGrowBatchesElect</literal></entry>
+<!--
       <entry>Waiting to elect a Parallel Hash participant to allocate more
        batches.</entry>
+-->
+      <entry>追加バッチを獲得するパラレルハッシュ参加者を選ぶのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>HashGrowBatchesFinish</literal></entry>
+<!--
       <entry>Waiting for an elected Parallel Hash participant to decide on
        future batch growth.</entry>
+-->
+      <entry>選ばれたパラレルハッシュ参加者が将来のバッチの増加を決めるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>HashGrowBatchesRepartition</literal></entry>
+<!--
       <entry>Waiting for other Parallel Hash participants to finish
        repartitioning.</entry>
+-->
+      <entry>他のパラレルハッシュ参加者がリパーティショニングを完了させるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>HashGrowBucketsAllocate</literal></entry>
+<!--
       <entry>Waiting for an elected Parallel Hash participant to finish
        allocating more buckets.</entry>
+-->
+      <entry>選ばれたパラレルハッシュ参加者が追加バケット獲得を完了するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>HashGrowBucketsElect</literal></entry>
+<!--
       <entry>Waiting to elect a Parallel Hash participant to allocate more
        buckets.</entry>
+-->
+      <entry>追加バケットを獲得するパラレルハッシュ参加者を選ぶのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>HashGrowBucketsReinsert</literal></entry>
+<!--
       <entry>Waiting for other Parallel Hash participants to finish inserting
        tuples into new buckets.</entry>
+-->
+      <entry>他のパラレルハッシュ参加者が新しいバケットに対するタプル挿入を完了させるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>LogicalSyncData</literal></entry>
+<!--
       <entry>Waiting for a logical replication remote server to send data for
        initial table synchronization.</entry>
+-->
+      <entry>論理レプリケーションのリモートサーバが最初のテーブル同期のためのデータを送信するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>LogicalSyncStateChange</literal></entry>
+<!--
       <entry>Waiting for a logical replication remote server to change
        state.</entry>
+-->
+      <entry>論理レプリケーションのリモートサーバが状態を変更するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>MessageQueueInternal</literal></entry>
+<!--
       <entry>Waiting for another process to be attached to a shared message
        queue.</entry>
+-->
+      <entry>他のプロセスが共有メッセージキューにアタッチされるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>MessageQueuePutMessage</literal></entry>
+<!--
       <entry>Waiting to write a protocol message to a shared message queue.</entry>
+-->
+      <entry>共有メッセージキューにプロトコルのメッセージを書くのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>MessageQueueReceive</literal></entry>
+<!--
       <entry>Waiting to receive bytes from a shared message queue.</entry>
+-->
+      <entry>共有メッセージキューからバイトを受信するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>MessageQueueSend</literal></entry>
+<!--
       <entry>Waiting to send bytes to a shared message queue.</entry>
+-->
+      <entry>共有メッセージキューにバイトを送信するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ParallelBitmapScan</literal></entry>
+<!--
       <entry>Waiting for parallel bitmap scan to become initialized.</entry>
+-->
+      <entry>パラレルビットマップスキャンが初期化されるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ParallelCreateIndexScan</literal></entry>
+<!--
       <entry>Waiting for parallel <command>CREATE INDEX</command> workers to
        finish heap scan.</entry>
+-->
+      <entry>パラレル<command>CREATE INDEX</command>ワーカがヒープスキャンを完了するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ParallelFinish</literal></entry>
+<!--
       <entry>Waiting for parallel workers to finish computing.</entry>
+-->
+      <entry>パラレルワーカが計算を完了するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ProcArrayGroupUpdate</literal></entry>
+<!--
       <entry>Waiting for the group leader to clear the transaction ID at
        end of a parallel operation.</entry>
+-->
+      <entry>グループリーダーが並列操作の最後にトランザクションIDをクリアするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ProcSignalBarrier</literal></entry>
+<!--
       <entry>Waiting for a barrier event to be processed by all
        backends.</entry>
+-->
+      <entry>バックエンドすべてでバリアイベントが処理されるのを待機しています。</entry>
+
      </row>
      <row>
       <entry><literal>Promote</literal></entry>
+<!--
       <entry>Waiting for standby promotion.</entry>
+-->
+      <entry>スタンバイの昇格を待機しています。</entry>
      </row>
      <row>
       <entry><literal>RecoveryConflictSnapshot</literal></entry>
+<!--
       <entry>Waiting for recovery conflict resolution for a vacuum
        cleanup.</entry>
+-->
+      <entry>バキュームクリーンアップに対するリカバリ競合の解決を待機しています。</entry>
      </row>
      <row>
       <entry><literal>RecoveryConflictTablespace</literal></entry>
+<!--
       <entry>Waiting for recovery conflict resolution for dropping a
        tablespace.</entry>
+-->
+      <entry>テーブル空間の削除に対するリカバリ競合の解決を待機しています。</entry>
      </row>
      <row>
       <entry><literal>RecoveryPause</literal></entry>
+<!--
       <entry>Waiting for recovery to be resumed.</entry>
+-->
+      <entry>リカバリが再開するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ReplicationOriginDrop</literal></entry>
+<!--
       <entry>Waiting for a replication origin to become inactive so it can be
        dropped.</entry>
+-->
+      <entry>レプリケーションオリジンが削除できるよう非活動状態になるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ReplicationSlotDrop</literal></entry>
+<!--
       <entry>Waiting for a replication slot to become inactive so it can be
        dropped.</entry>
+-->
+      <entry>レプリケーションスロットが削除できるよう非活動状態になるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SafeSnapshot</literal></entry>
+<!--
       <entry>Waiting to obtain a valid snapshot for a <literal>READ ONLY
        DEFERRABLE</literal> transaction.</entry>
+-->
+      <entry><literal>READ ONLY DEFERRABLE</literal>のトランザクションに対する有効なスナップショットの獲得を待機しています。</entry>
      </row>
      <row>
       <entry><literal>SyncRep</literal></entry>
+<!--
       <entry>Waiting for confirmation from a remote server during synchronous
        replication.</entry>
+-->
+      <entry>同期レプリケーション中に、リモートサーバからの確認を待機しています。</entry>
      </row>
      <row>
       <entry><literal>XactGroupUpdate</literal></entry>
+<!--
       <entry>Waiting for the group leader to update transaction status at
        end of a parallel operation.</entry>
+-->
+      <entry>グループリーダーが並列操作の最後にトランザクション状態を更新するのを待機しています。</entry>
      </row>
     </tbody>
    </tgroup>
   </table>
 
   <table id="wait-event-lock-table">
+<!--
    <title>Wait Events of Type <literal>Lock</literal></title>
+-->
+   <title><literal>Lock</literal>型の待機イベント</title>
    <tgroup cols="2">
     <thead>
      <row>
+<!--
       <entry><literal>Lock</literal> Wait Event</entry>
       <entry>Description</entry>
+-->
+      <entry><literal>Lock</literal>待機イベント</entry>
+      <entry>説明</entry>
      </row>
     </thead>
 
     <tbody>
      <row>
       <entry><literal>advisory</literal></entry>
+<!--
       <entry>Waiting to acquire an advisory user lock.</entry>
+-->
+      <entry>勧告的ユーザロックを獲得するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>extend</literal></entry>
+<!--
       <entry>Waiting to extend a relation.</entry>
+-->
+      <entry>リレーションを拡張するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>frozenid</literal></entry>
+<!--
       <entry>Waiting to
        update <structname>pg_database</structname>.<structfield>datfrozenxid</structfield>
        and <structname>pg_database</structname>.<structfield>datminmxid</structfield>.</entry>
+-->
+      <entry><structname>pg_database</structname>.<structfield>datfrozenxid</structfield>と<structname>pg_database</structname>.<structfield>datminmxid</structfield>を更新するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>object</literal></entry>
+<!--
       <entry>Waiting to acquire a lock on a non-relation database object.</entry>
+-->
+      <entry>非リレーションデータベースオブジェクト上のロックを獲得するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>page</literal></entry>
+<!--
       <entry>Waiting to acquire a lock on a page of a relation.</entry>
+-->
+      <entry>リレーションのページ上のロックを獲得するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>relation</literal></entry>
+<!--
       <entry>Waiting to acquire a lock on a relation.</entry>
+-->
+      <entry>リレーション上のロックを獲得するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>spectoken</literal></entry>
+<!--
       <entry>Waiting to acquire a speculative insertion lock.</entry>
+-->
+      <entry>投機的挿入ロックを獲得するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>transactionid</literal></entry>
+<!--
       <entry>Waiting for a transaction to finish.</entry>
+-->
+      <entry>トランザクションが終了するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>tuple</literal></entry>
+<!--
       <entry>Waiting to acquire a lock on a tuple.</entry>
+-->
+      <entry>タプル上のロックを獲得するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>userlock</literal></entry>
+<!--
       <entry>Waiting to acquire a user lock.</entry>
+-->
+      <entry>ユーザロックを獲得するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>virtualxid</literal></entry>
+<!--
       <entry>Waiting to acquire a virtual transaction ID lock.</entry>
+-->
+      <entry>仮想トランザクションIDロックを獲得するのを待機しています。</entry>
      </row>
     </tbody>
    </tgroup>
   </table>
 
   <table id="wait-event-lwlock-table">
+<!--
    <title>Wait Events of Type <literal>LWLock</literal></title>
+-->
+   <title><literal>LWLock</literal>型の待機イベント</title>
    <tgroup cols="2">
     <thead>
      <row>
+<!--
       <entry><literal>LWLock</literal> Wait Event</entry>
       <entry>Description</entry>
+-->
+      <entry><literal>LWLock</literal>待機イベント</entry>
+      <entry>説明</entry>
      </row>
     </thead>
 
     <tbody>
      <row>
       <entry><literal>AddinShmemInit</literal></entry>
+<!--
       <entry>Waiting to manage an extension's space allocation in shared
        memory.</entry>
+-->
+      <entry>共有メモリの拡張の領域確保を管理するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>AutoFile</literal></entry>
+<!--
       <entry>Waiting to update the <filename>postgresql.auto.conf</filename>
        file.</entry>
+-->
+      <entry><filename>postgresql.auto.conf</filename>ファイルを更新するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>Autovacuum</literal></entry>
+<!--
       <entry>Waiting to read or update the current state of autovacuum
        workers.</entry>
+-->
+      <entry>自動バキュームワーカの現在の状態の読み込み、または更新を待機しています。</entry>
      </row>
      <row>
       <entry><literal>AutovacuumSchedule</literal></entry>
+<!--
       <entry>Waiting to ensure that a table selected for autovacuum
        still needs vacuuming.</entry>
+-->
+      <entry>自動バキューム対象として選定されたテーブルが、まだバキューム処理が必要であることを確認するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>BackgroundWorker</literal></entry>
+<!--
       <entry>Waiting to read or update background worker state.</entry>
+-->
+      <entry>バックグラウンドワーカ状態の読み込み、または更新を待機しています。</entry>
      </row>
      <row>
       <entry><literal>BtreeVacuum</literal></entry>
+<!--
       <entry>Waiting to read or update vacuum-related information for a
        B-tree index.</entry>
+-->
+      <entry>B-treeインデックスのバキュームに関連した情報の読み込み、または更新を待機しています。</entry>
      </row>
      <row>
       <entry><literal>BufferContent</literal></entry>
+<!--
       <entry>Waiting to access a data page in memory.</entry>
+-->
+      <entry>メモリ内のデータページへアクセスするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>BufferIO</literal></entry>
+<!--
       <entry>Waiting for I/O on a data page.</entry>
+-->
+      <entry>データページ上のI/Oを待機しています。</entry>
      </row>
      <row>
       <entry><literal>BufferMapping</literal></entry>
+<!--
       <entry>Waiting to associate a data block with a buffer in the buffer
        pool.</entry>
+-->
+      <entry>データブロックをバッファプール内のバッファと関連付けるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>Checkpoint</literal></entry>
+<!--
       <entry>Waiting to begin a checkpoint.</entry>
+-->
+      <entry>チェックポイントを開始するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>CheckpointerComm</literal></entry>
+<!--
       <entry>Waiting to manage fsync requests.</entry>
+-->
+      <entry>fsyncリクエストを管理するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>CommitTs</literal></entry>
+<!--
       <entry>Waiting to read or update the last value set for a
        transaction commit timestamp.</entry>
+-->
+      <entry>トランザクションコミットタイムスタンプのために設定された最新の値の読み込み、または更新を待機しています。</entry>
      </row>
      <row>
       <entry><literal>CommitTsBuffer</literal></entry>
+<!--
       <entry>Waiting for I/O on a commit timestamp SLRU buffer.</entry>
+-->
+      <entry>コミットタイムスタンプSLRUバッファでのI/Oを待機しています。</entry>
      </row>
      <row>
       <entry><literal>CommitTsSLRU</literal></entry>
+<!--
       <entry>Waiting to access the commit timestamp SLRU cache.</entry>
+-->
+      <entry>コミットタイムスタンプSLRUキャッシュにアクセスするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ControlFile</literal></entry>
+<!--
       <entry>Waiting to read or update the <filename>pg_control</filename>
        file or create a new WAL file.</entry>
+-->
+      <entry><filename>pg_control</filename>ファイルの読み込みもしくは更新、または新しいWALファイルの作成を待機しています。</entry>
      </row>
      <row>
       <entry><literal>DynamicSharedMemoryControl</literal></entry>
+<!--
       <entry>Waiting to read or update dynamic shared memory allocation
        information.</entry>
+-->
+      <entry>動的共有メモリの割り当て情報の読み込み、または更新を待機しています。</entry>
      </row>
      <row>
       <entry><literal>LockFastPath</literal></entry>
+<!--
       <entry>Waiting to read or update a process' fast-path lock
        information.</entry>
+-->
+      <entry>プロセスのファストパスロック情報の読み込み、または更新を待機しています。</entry>
      </row>
      <row>
       <entry><literal>LockManager</literal></entry>
+<!--
       <entry>Waiting to read or update information
        about <quote>heavyweight</quote> locks.</entry>
+-->
+      <entry><quote>重量</quote>ロックに関する情報の読み込み、または更新を待機しています。</entry>
      </row>
      <row>
       <entry><literal>LogicalRepWorker</literal></entry>
+<!--
       <entry>Waiting to read or update the state of logical replication
        workers.</entry>
+-->
+      <entry>論理レプリケーションワーカの状態の読み込み、または更新を待機しています。</entry>
      </row>
      <row>
       <entry><literal>MultiXactGen</literal></entry>
+<!--
       <entry>Waiting to read or update shared multixact state.</entry>
+-->
+      <entry>共有マルチトランザクション状態の読み込み、または更新を待機しています。</entry>
      </row>
      <row>
       <entry><literal>MultiXactMemberBuffer</literal></entry>
+<!--
       <entry>Waiting for I/O on a multixact member SLRU buffer.</entry>
+-->
+      <entry>マルチトランザクションメンバSLRUバッファでのI/Oを待機しています。</entry>
      </row>
      <row>
       <entry><literal>MultiXactMemberSLRU</literal></entry>
+<!--
       <entry>Waiting to access the multixact member SLRU cache.</entry>
+-->
+      <entry>マルチトランザクションメンバSLRUキャッシュにアクセスするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>MultiXactOffsetBuffer</literal></entry>
+<!--
       <entry>Waiting for I/O on a multixact offset SLRU buffer.</entry>
+-->
+      <entry>マルチトランザクションオフセットSLRUバッファでのI/Oを待機しています。</entry>
      </row>
      <row>
       <entry><literal>MultiXactOffsetSLRU</literal></entry>
+<!--
       <entry>Waiting to access the multixact offset SLRU cache.</entry>
+-->
+      <entry>マルチトランザクションオフセットSLRUキャッシュにアクセスするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>MultiXactTruncation</literal></entry>
+<!--
       <entry>Waiting to read or truncate multixact information.</entry>
+-->
+      <entry>マルチトランザクション情報の読み込み、または切り詰めを待機しています。</entry>
      </row>
      <row>
       <entry><literal>NotifyBuffer</literal></entry>
+<!--
       <entry>Waiting for I/O on a <command>NOTIFY</command> message SLRU
        buffer.</entry>
+-->
+      <entry><command>NOTIFY</command>メッセージSLRUバッファでのI/Oを待機しています。</entry>
      </row>
      <row>
       <entry><literal>NotifyQueue</literal></entry>
+<!--
       <entry>Waiting to read or update <command>NOTIFY</command> messages.</entry>
+-->
+      <entry><command>NOTIFY</command>メッセージの読み込み、または更新を待機しています。</entry>
      </row>
      <row>
       <entry><literal>NotifyQueueTail</literal></entry>
+<!--
       <entry>Waiting to update limit on <command>NOTIFY</command> message
        storage.</entry>
+-->
+      <entry><command>NOTIFY</command>メッセージストレージの制限が更新されるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>NotifySLRU</literal></entry>
+<!--
       <entry>Waiting to access the <command>NOTIFY</command> message SLRU
        cache.</entry>
+-->
+      <entry><command>NOTIFY</command>メッセージSLRUキャッシュにアクセスするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>OidGen</literal></entry>
+<!--
       <entry>Waiting to allocate a new OID.</entry>
+-->
+      <entry>新しいOIDを割り当てるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>OldSnapshotTimeMap</literal></entry>
+<!--
       <entry>Waiting to read or update old snapshot control information.</entry>
+-->
+      <entry>古いスナップショット制御情報の読み込み、または更新を待機しています。</entry>
      </row>
      <row>
       <entry><literal>ParallelAppend</literal></entry>
+<!--
       <entry>Waiting to choose the next subplan during Parallel Append plan
        execution.</entry>
+-->
+      <entry>パラレルアペンド計画を実行中に次のサブプランの選択を待機しています。</entry>
      </row>
      <row>
       <entry><literal>ParallelHashJoin</literal></entry>
+<!--
       <entry>Waiting to synchronize workers during Parallel Hash Join plan
        execution.</entry>
+-->
+      <entry>パラレルハッシュ結合計画を実行中に、ワーカの同期を待機しています。</entry>
      </row>
      <row>
       <entry><literal>ParallelQueryDSA</literal></entry>
+<!--
       <entry>Waiting for parallel query dynamic shared memory allocation.</entry>
+-->
+      <entry>パラレルクエリの動的共有メモリ割り当てを待機しています。</entry>
      </row>
      <row>
       <entry><literal>PerSessionDSA</literal></entry>
+<!--
       <entry>Waiting for parallel query dynamic shared memory allocation.</entry>
+-->
+      <entry>パラレルクエリの動的共有メモリ割り当てを待機しています。</entry>
      </row>
      <row>
       <entry><literal>PerSessionRecordType</literal></entry>
+<!--
       <entry>Waiting to access a parallel query's information about composite
        types.</entry>
+-->
+      <entry>複合型に関するパラレルクエリの情報にアクセスするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>PerSessionRecordTypmod</literal></entry>
+<!--
       <entry>Waiting to access a parallel query's information about type
        modifiers that identify anonymous record types.</entry>
+-->
+      <entry>匿名レコード型を特定する型修飾子に関するパラレルクエリの情報にアクセスするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>PerXactPredicateList</literal></entry>
+<!--
       <entry>Waiting to access the list of predicate locks held by the current
        serializable transaction during a parallel query.</entry>
+-->
+      <entry>パラレルクエリの間に、現在のシリアライザブルトランザクションによって保持された述語ロックの一覧へアクセスするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>PredicateLockManager</literal></entry>
+<!--
       <entry>Waiting to access predicate lock information used by
        serializable transactions.</entry>
+-->
+      <entry>シリアライザブルトランザクションによって使われる述語ロックの情報にアクセスするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ProcArray</literal></entry>
+<!--
       <entry>Waiting to access the shared per-process data structures
        (typically, to get a snapshot or report a session's transaction
        ID).</entry>
+-->
+      <entry>(典型的には、スナップショットを得たりセッションのトランザクションIDを報告するために)共有のプロセスごとのデータ構造にアクセスするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>RelationMapping</literal></entry>
+<!--
       <entry>Waiting to read or update
        a <filename>pg_filenode.map</filename> file (used to track the
        filenode assignments of certain system catalogs).</entry>
+-->
+      <entry>(特定のシステムカタログのファイルノードの割り当てを追跡するのに使われる)<filename>pg_filenode.map</filename>ファイルの読み込み、または更新を待機しています。</entry>
      </row>
      <row>
       <entry><literal>RelCacheInit</literal></entry>
+<!--
       <entry>Waiting to read or update a <filename>pg_internal.init</filename>
        relation cache initialization file.</entry>
+-->
+      <entry><filename>pg_internal.init</filename>リレーションキャッシュ初期化ファイルの読み込み、または更新を待機しています。</entry>
      </row>
      <row>
       <entry><literal>ReplicationOrigin</literal></entry>
+<!--
       <entry>Waiting to create, drop or use a replication origin.</entry>
+-->
+      <entry>レプリケーションオリジンの作成、削除、または使用を待機しています。</entry>
      </row>
      <row>
       <entry><literal>ReplicationOriginState</literal></entry>
+<!--
       <entry>Waiting to read or update the progress of one replication
        origin.</entry>
+-->
+      <entry>あるレプリケーションオリジンの進捗の読み込み、または更新を待機しています。</entry>
      </row>
      <row>
       <entry><literal>ReplicationSlotAllocation</literal></entry>
+<!--
       <entry>Waiting to allocate or free a replication slot.</entry>
+-->
+      <entry>レプリケーションスロットの割り当て、または解放を待機しています。</entry>
      </row>
      <row>
       <entry><literal>ReplicationSlotControl</literal></entry>
+<!--
       <entry>Waiting to read or update replication slot state.</entry>
+-->
+      <entry>レプリケーションスロット状態の読み込み、または更新を待機しています。</entry>
      </row>
      <row>
       <entry><literal>ReplicationSlotIO</literal></entry>
+<!--
       <entry>Waiting for I/O on a replication slot.</entry>
+-->
+      <entry>レプリケーションスロットでのI/Oを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SerialBuffer</literal></entry>
+<!--
       <entry>Waiting for I/O on a serializable transaction conflict SLRU
        buffer.</entry>
+-->
+      <entry>シリアライザブルトランザクション競合SLRUバッファでのI/Oを待機しています</entry>
      </row>
      <row>
       <entry><literal>SerializableFinishedList</literal></entry>
+<!--
       <entry>Waiting to access the list of finished serializable
        transactions.</entry>
+-->
+      <entry>完了したシリアライザブルトランザクションの一覧へアクセスするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SerializablePredicateList</literal></entry>
+<!--
       <entry>Waiting to access the list of predicate locks held by
        serializable transactions.</entry>
+-->
+      <entry>シリアライザブルトランザクションによって保持された述語ロックの一覧へアクセスするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SerializableXactHash</literal></entry>
+<!--
       <entry>Waiting to read or update information about serializable
        transactions.</entry>
+-->
+      <entry>シリアライザブルトランザクションに関する情報の読み込み、または更新を待機しています。</entry>
      </row>
      <row>
       <entry><literal>SerialSLRU</literal></entry>
+<!--
       <entry>Waiting to access the serializable transaction conflict SLRU
        cache.</entry>
+-->
+      <entry>シリアライザブルトランザクション競合SLRUキャッシュにアクセスするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SharedTidBitmap</literal></entry>
+<!--
       <entry>Waiting to access a shared TID bitmap during a parallel bitmap
        index scan.</entry>
+-->
+      <entry>パラレルビットマップインデックススキャンの間に、共有TIDにアクセスするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SharedTupleStore</literal></entry>
+<!--
       <entry>Waiting to access a shared tuple store during parallel
        query.</entry>
+-->
+      <entry>パラレルクエリの間に共有タプルストアにアクセスするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>ShmemIndex</literal></entry>
+<!--
       <entry>Waiting to find or allocate space in shared memory.</entry>
+-->
+      <entry>共有メモリ内に領域を発見する、もしくは割り当てるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SInvalRead</literal></entry>
+<!--
       <entry>Waiting to retrieve messages from the shared catalog invalidation
        queue.</entry>
+-->
+      <entry>共有カタログ無効化キューからメッセージを取り出すのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SInvalWrite</literal></entry>
+<!--
       <entry>Waiting to add a message to the shared catalog invalidation
       queue.</entry>
+-->
+      <entry>共有カタログ無効化キューにメッセージを追加するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SubtransBuffer</literal></entry>
+<!--
       <entry>Waiting for I/O on a sub-transaction SLRU buffer.</entry>
+-->
+      <entry>サブトランザクションSLRUバッファのI/Oを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SubtransSLRU</literal></entry>
+<!--
       <entry>Waiting to access the sub-transaction SLRU cache.</entry>
+-->
+      <entry>サブトランザクションSLRUキャッシュにアクセスするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>SyncRep</literal></entry>
+<!--
       <entry>Waiting to read or update information about the state of
        synchronous replication.</entry>
+-->
+      <entry>同期レプリケーションの状態に関する情報を読み込む、または更新するの待機しています。</entry>
      </row>
      <row>
       <entry><literal>SyncScan</literal></entry>
+<!--
       <entry>Waiting to select the starting location of a synchronized table
        scan.</entry>
+-->
+      <entry>同期テーブルスキャンの開始位置を選ぶのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>TablespaceCreate</literal></entry>
+<!--
       <entry>Waiting to create or drop a tablespace.</entry>
+-->
+      <entry>テーブルスペースの作成、または削除を待機しています。</entry>
      </row>
      <row>
       <entry><literal>TwoPhaseState</literal></entry>
+<!--
       <entry>Waiting to read or update the state of prepared transactions.</entry>
+-->
+      <entry>プリペアドトランザクションの状態の読み込み、または更新を待機しています。</entry>
      </row>
      <row>
       <entry><literal>WALBufMapping</literal></entry>
+<!--
       <entry>Waiting to replace a page in WAL buffers.</entry>
+-->
+      <entry>WALバッファ内のページの置き換えを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WALInsert</literal></entry>
+<!--
       <entry>Waiting to insert WAL data into a memory buffer.</entry>
+-->
+      <entry>WALデータをメモリバッファに挿入するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WALWrite</literal></entry>
+<!--
       <entry>Waiting for WAL buffers to be written to disk.</entry>
+-->
+      <entry>WALバッファがディスクに書き込まれるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>WrapLimitsVacuum</literal></entry>
+<!--
       <entry>Waiting to update limits on transaction id and multixact
        consumption.</entry>
+-->
+      <entry>トランザクションIDとマルチトランザクションの消費の制限が更新されるのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>XactBuffer</literal></entry>
+<!--
       <entry>Waiting for I/O on a transaction status SLRU buffer.</entry>
+-->
+      <entry>トランザクション状態SLRUバッファでのI/Oを待機しています。</entry>
      </row>
      <row>
       <entry><literal>XactSLRU</literal></entry>
+<!--
       <entry>Waiting to access the transaction status SLRU cache.</entry>
+-->
+      <entry>トランザクション状態SLRUキャッシュにアクセスするのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>XactTruncation</literal></entry>
+<!--
       <entry>Waiting to execute <function>pg_xact_status</function> or update
        the oldest transaction ID available to it.</entry>
+-->
+      <entry><function>pg_xact_status</function>を実行する、またはその関数で利用可能な最古のトランザクションIDを更新するのを待機しています。</entry>
      </row>
      <row>
       <entry><literal>XidGen</literal></entry>
+<!--
       <entry>Waiting to allocate a new transaction ID.</entry>
+-->
+      <entry>新しいトランザクションIDを割り当てるのを待機しています。</entry>
      </row>
     </tbody>
    </tgroup>
@@ -2542,55 +3349,85 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
 
    <note>
     <para>
+<!--
      Extensions can add <literal>LWLock</literal> types to the list shown in
      <xref linkend="wait-event-lwlock-table"/>.  In some cases, the name
      assigned by an extension will not be available in all server processes;
      so an <literal>LWLock</literal> wait event might be reported as
      just <quote><literal>extension</literal></quote> rather than the
      extension-assigned name.
+-->
+拡張は<xref linkend="wait-event-lwlock-table"/>に示す一覧に<literal>LWLock</literal>型を追加できます。
+拡張によって割り当てられた名前がすべてのサーバプロセスでは利用可能でない場合があります。そのため<literal>LWLock</literal>待機イベントは、拡張が割り当てた名前ではなく単に<quote><literal>extension</literal></quote>と報告されるかもしれません。
     </para>
    </note>
 
   <table id="wait-event-timeout-table">
+<!--
    <title>Wait Events of Type <literal>Timeout</literal></title>
+-->
+   <title><literal>Timeout</literal>型の待機イベント</title>
+
    <tgroup cols="2">
     <thead>
      <row>
+<!--
       <entry><literal>Timeout</literal> Wait Event</entry>
       <entry>Description</entry>
+-->
+      <entry><literal>Timeout</literal>待機イベント</entry>
+      <entry>説明</entry>
      </row>
     </thead>
 
     <tbody>
      <row>
       <entry><literal>BaseBackupThrottle</literal></entry>
+<!--
       <entry>Waiting during base backup when throttling activity.</entry>
+-->
+      <entry>スロットル活動時にベースバックアップで待機しています。</entry>
      </row>
      <row>
       <entry><literal>PgSleep</literal></entry>
+<!--
       <entry>Waiting due to a call to <function>pg_sleep</function> or
        a sibling function.</entry>
+-->
+      <entry><function>pg_sleep</function>または同系列の関数を呼び出したため待機しています。</entry>
      </row>
      <row>
       <entry><literal>RecoveryApplyDelay</literal></entry>
+<!--
       <entry>Waiting to apply WAL during recovery because of a delay
        setting.</entry>
+-->
+      <entry>遅延設定によりリカバリ時のWAL適用を待機しています。</entry>
      </row>
      <row>
       <entry><literal>RecoveryRetrieveRetryInterval</literal></entry>
+<!--
       <entry>Waiting during recovery when WAL data is not available from any
        source (<filename>pg_wal</filename>, archive or stream).</entry>
+-->
+      <entry>WALデータがまだあらゆる種類のソース(<filename>pg_wal</filename>、アーカイブまたはストリーム)から得られない時にリカバリで待機しています。</entry>
      </row>
      <row>
       <entry><literal>VacuumDelay</literal></entry>
+<!--
       <entry>Waiting in a cost-based vacuum delay point.</entry>
+-->
+      <entry>コストに基づくバキューム遅延ポイントで待機しています。</entry>
      </row>
     </tbody>
    </tgroup>
   </table>
 
    <para>
+<!--
      Here is an example of how wait events can be viewed:
+-->
+以下に、待機イベントが表示される例を示します。
 
 <programlisting>
 SELECT pid, wait_event_type, wait_event FROM pg_stat_activity WHERE wait_event is NOT NULL;
@@ -2619,17 +3456,23 @@ SELECT pid, wait_event_type, wait_event FROM pg_stat_activity WHERE wait_event i
    listed; no information is available about downstream standby servers.
 -->
 <structname>pg_stat_replication</structname>ビューには、WAL送信プロセス毎に、送信処理に接続したスタンバイサーバへのレプリケーションに関する統計情報を示す１行を保持します。
-直接接続されたサーバのみが一覧表示されます。
+直接接続されたスタンバイサーバのみが一覧表示されます。
 下流のスタンバイサーバに関する情報はありません。
   </para>
 
   <table id="pg-stat-replication-view" xreflabel="pg_stat_replication">
+<!--
    <title><structname>pg_stat_replication</structname> View</title>
+-->
+   <title><structname>pg_stat_replication</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -2716,7 +3559,7 @@ WAL送信処理に接続したクライアントのIPアドレスです。
        only be non-null for IP connections, and only when <xref linkend="guc-log-hostname"/> is enabled.
 -->
 <structfield>client_addr</structfield>のDNS逆引き検索により報告された、接続クライアントのホスト名です。
-IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合にのみこのフィールドは非NULLになります。
+IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合にのみ、このフィールドは非NULLになります。
       </para></entry>
      </row>
 
@@ -2773,7 +3616,10 @@ WAL送信サーバの現在の状態です。
        <itemizedlist>
         <listitem>
          <para>
+<!--
           <literal>startup</literal>: This WAL sender is starting up.
+-->
+<literal>startup</literal>: このWAL送信サーバは起動するところです。
          </para>
         </listitem>
         <listitem>
@@ -2791,7 +3637,7 @@ WAL送信サーバの現在の状態です。
           <literal>streaming</literal>: This WAL sender is streaming changes
           after its connected standby server has caught up with the primary.
 -->
-<literal>streaming</literal>: このWAL送信サーバは、接続先のスタンバイサーバがプライマリに追いついた後、変更をストリーミングしています。
+<literal>streaming</literal>: このWAL送信サーバは、接続先のスタンバイサーバがプライマリに追いついた後、変更をストリームしています。
          </para>
         </listitem>
         <listitem>
@@ -2835,7 +3681,7 @@ WAL送信サーバの現在の状態です。
        Last write-ahead log location written to disk by this standby
        server
 -->
-このスタンバイサーバによってディスクに書き出された最後の先行書き込みログ位置です。
+このスタンバイサーバによってディスクに書き出された最後の先行書き込みログの位置です。
       </para></entry>
      </row>
 
@@ -2848,7 +3694,7 @@ WAL送信サーバの現在の状態です。
        Last write-ahead log location flushed to disk by this standby
        server
 -->
-このスタンバイサーバによってディスクに吐き出された最後の先行書き込みログ位置です。
+このスタンバイサーバによってディスクに吐き出された最後の先行書き込みログの位置です。
       </para></entry>
      </row>
 
@@ -2861,7 +3707,7 @@ WAL送信サーバの現在の状態です。
        Last write-ahead log location replayed into the database on this
        standby server
 -->
-このスタンバイサーバ上のデータベースに再生された最後の先行書き込みログ位置です。
+このスタンバイサーバ上のデータベースに再生された最後の先行書き込みログの位置です。
       </para></entry>
      </row>
 
@@ -2929,8 +3775,8 @@ WAL送信サーバの現在の状態です。
        synchronous standby in a priority-based synchronous replication.
        This has no effect in a quorum-based synchronous replication.
 -->
-優先度に基づくの同期レプリケーションで、このスタンバイサーバが同期スタンバイとして選択される優先度です。
-クォーラムに基づくの同期レプリケーションでは効果がありません。
+優先度に基づく同期レプリケーションで、このスタンバイサーバが同期スタンバイとして選択される優先度です。
+クォーラムに基づく同期レプリケーションでは効果がありません。
       </para></entry>
      </row>
 
@@ -2939,6 +3785,7 @@ WAL送信サーバの現在の状態です。
        <structfield>sync_state</structfield> <type>text</type>
       </para>
       <para>
+<!--
        Synchronous state of this standby server.
        Possible values are:
 -->
@@ -2947,7 +3794,10 @@ WAL送信サーバの現在の状態です。
        <itemizedlist>
         <listitem>
          <para>
+<!--
           <literal>async</literal>: This standby server is asynchronous.
+-->
+<literal>async</literal>: このスタンバイサーバは非同期です。
          </para>
         </listitem>
         <listitem>
@@ -3072,12 +3922,18 @@ WAL送信サーバの現在の状態です。
   </para>
 
   <table id="pg-stat-wal-receiver-view" xreflabel="pg_stat_wal_receiver">
+<!--
    <title><structname>pg_stat_wal_receiver</structname> View</title>
+-->
+   <title><structname>pg_stat_wal_receiver</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -3097,7 +3953,7 @@ WAL送信サーバの現在の状態です。
 <!--
        Process ID of the WAL receiver process
 -->
-WALレシーバプロセスのプロセスID
+WALレシーバプロセスのプロセスIDです。
       </para></entry>
      </row>
 
@@ -3109,7 +3965,7 @@ WALレシーバプロセスのプロセスID
 <!--
        Activity status of the WAL receiver process
 -->
-WALレシーバプロセスの活動状態
+WALレシーバプロセスの活動状態です。
       </para></entry>
      </row>
 
@@ -3122,7 +3978,7 @@ WALレシーバプロセスの活動状態
        First write-ahead log location used when WAL receiver is
        started
 -->
-WALレシーバが開始された時に使われる先行書き込みログの最初の位置
+WALレシーバが開始された時に使われる先行書き込みログの最初の位置です。
       </para></entry>
      </row>
 
@@ -3134,7 +3990,7 @@ WALレシーバが開始された時に使われる先行書き込みログの�
 <!--
        First timeline number used when WAL receiver is started
 -->
-WALレシーバが開始された時に使われる初期タイムライン番号
+WALレシーバが開始された時に使われる初期タイムライン番号です。
       </para></entry>
      </row>
 
@@ -3143,8 +3999,12 @@ WALレシーバが開始された時に使われる初期タイムライン番�
        <structfield>written_lsn</structfield> <type>pg_lsn</type>
       </para>
       <para>
+<!--
        Last write-ahead log location already received and written to disk,
        but not flushed. This should not be used for data integrity checks.
+--->
+すでに受信し、ディスクに書き出されたもののまだフラッシュされていない先行書き込みログの最新位置です。
+これはデータの完全性の確認のためには使うべきではありません。
       </para></entry>
      </row>
 
@@ -3158,8 +4018,8 @@ WALレシーバが開始された時に使われる初期タイムライン番�
        disk, the initial value of this field being the first log location used
        when WAL receiver is started
 -->
-すでに受信し、ディスクにフラッシュされた先行書き込みログの最新位置。
-     この列の初期値は、WALレシーバが開始された時に使用される、最初のログ位置です。
+すでに受信し、ディスクにフラッシュされた先行書き込みログの最新位置です。
+この列の初期値は、WALレシーバが開始された時に使用される、最初のログ位置です。
       </para></entry>
      </row>
 
@@ -3173,7 +4033,7 @@ WALレシーバが開始された時に使われる初期タイムライン番�
        flushed to disk, the initial value of this field being the timeline
        number of the first log location used when WAL receiver is started
 -->
-受信済みでディスクにフラッシュされた先行書き込みログの最新位置のタイムライン番号。
+受信済みでディスクにフラッシュされた先行書き込みログの最新位置のタイムライン番号です。
 この列の初期値は、WALレシーバが開始された時に使用される、最初のログ位置のタイムライン番号です。
       </para></entry>
      </row>
@@ -3186,7 +4046,7 @@ WALレシーバが開始された時に使われる初期タイムライン番�
 <!--
        Send time of last message received from origin WAL sender
 -->
-オリジンWAL送信サーバから受け取った最後のメッセージの送信時刻
+オリジンWAL送信サーバから受け取った最後のメッセージの送信時刻です。
       </para></entry>
      </row>
 
@@ -3198,7 +4058,7 @@ WALレシーバが開始された時に使われる初期タイムライン番�
 <!--
        Receipt time of last message received from origin WAL sender
 -->
-オリジンWAL送信サーバから受け取った最後のメッセージの受信時刻
+オリジンWAL送信サーバから受け取った最後のメッセージの受信時刻です。
       </para></entry>
      </row>
 
@@ -3210,7 +4070,7 @@ WALレシーバが開始された時に使われる初期タイムライン番�
 <!--
        Last write-ahead log location reported to origin WAL sender
 -->
-オリジンWAL送信サーバに最後に報告された先行書き込みログ位置
+オリジンWAL送信サーバに最後に報告された先行書き込みログ位置です。
       </para></entry>
      </row>
 
@@ -3222,7 +4082,7 @@ WALレシーバが開始された時に使われる初期タイムライン番�
 <!--
        Time of last write-ahead log location reported to origin WAL sender
 -->
-オリジンWALセンダへ最新の先行書き込みログ位置が報告された時間
+オリジンWAL送信サーバへ最新の先行書き込みログ位置が報告された時間です。
       </para></entry>
      </row>
 
@@ -3234,7 +4094,7 @@ WALレシーバが開始された時に使われる初期タイムライン番�
 <!--
        Replication slot name used by this WAL receiver
 -->
-WALレシーバによって使用されたレプリケーションスロット名
+WALレシーバによって使用されたレプリケーションスロット名です。
       </para></entry>
      </row>
 
@@ -3250,7 +4110,7 @@ WALレシーバによって使用されたレプリケーションスロット�
        Unix socket.  (The path case can be distinguished because it
        will always be an absolute path, beginning with <literal>/</literal>.)
 -->
-WALレシーバーが接続している<productname>PostgreSQL</productname>インスタンスのホスト。
+WALレシーバーが接続している<productname>PostgreSQL</productname>インスタンスのホストです。
 これはホスト名、IPアドレス、あるいはUNIXソケットで接続している場合はディレクトリのパスです。
 （パスは、常に<literal>/</literal>で始まる絶対パスなので、パスであることを識別できます。）
       </para></entry>
@@ -3265,7 +4125,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
        Port number of the <productname>PostgreSQL</productname> instance
        this WAL receiver is connected to.
 -->
-WALレシーバーが接続している<productname>PostgreSQL</productname>インスタンスのポート番号
+WALレシーバーが接続している<productname>PostgreSQL</productname>インスタンスのポート番号です。
       </para></entry>
      </row>
 
@@ -3278,7 +4138,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
        Connection string used by this WAL receiver,
        with security-sensitive fields obfuscated.
 -->
-セキュリティに重要な値が難読化された文字列を含む、WALレシーバによって使用された接続文字列。
+セキュリティに重要な値が難読化された文字列を含む、WALレシーバによって使用された接続文字列です。
       </para></entry>
      </row>
     </tbody>
@@ -3301,18 +4161,22 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
    not running), and additional rows for workers handling the initial data
    copy of the subscribed tables.
 -->
-<structname>pg_stat_replication</structname>ビューには、WAL送信プロセス毎に、送信処理に接続したスタンバイサーバへのレプリケーションに関する統計情報を示す１行を保持します。
-直接接続されたサーバのみが一覧表示されます。
-下流のスタンバイサーバに関する情報はありません。
+<structname>pg_stat_subscription</structname>ビューには、各サブスクリプションのメインワーカに対して1行が含まれ（ワーカが実行中でないときはPIDがNULLになります）、さらにサブスクライブされたテーブルの初期データコピーを処理するワーカについて別の行があります。
   </para>
 
   <table id="pg-stat-subscription" xreflabel="pg_stat_subscription">
+<!--
    <title><structname>pg_stat_subscription</structname> View</title>
+-->
+   <title><structname>pg_stat_subscription</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -3332,7 +4196,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
 <!--
        OID of the subscription
 -->
-サブスクリプションのOID
+サブスクリプションのOIDです。
       </para></entry>
      </row>
 
@@ -3344,7 +4208,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
 <!--
        Name of the subscription
 -->
-サブスクリプションの名前
+サブスクリプションの名前です。
       </para></entry>
      </row>
 
@@ -3356,7 +4220,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
 <!--
        Process ID of the subscription worker process
 -->
-サブスクリプションのワーカプロセスのプロセスID
+サブスクリプションのワーカプロセスのプロセスIDです。
       </para></entry>
      </row>
 
@@ -3369,7 +4233,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
        OID of the relation that the worker is synchronizing; null for the
        main apply worker
 -->
-ワーカが同期しているリレーションのOID、メインの適用ワーカの場合はNULL
+ワーカが同期しているリレーションのOIDです。メインの適用ワーカの場合はNULLです。
       </para></entry>
      </row>
 
@@ -3382,7 +4246,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
        Last write-ahead log location received, the initial value of
        this field being 0
 -->
-最後に受け取った先行書き込みログ位置、このフィールドの初期値は0
+最後に受け取った先行書き込みログ位置です。このフィールドの初期値は0です。
       </para></entry>
      </row>
 
@@ -3394,7 +4258,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
 <!--
        Send time of last message received from origin WAL sender
 -->
-オリジンWAL送信サーバから受け取った最後のメッセージの送信時刻
+オリジンWAL送信サーバから受け取った最後のメッセージの送信時刻です。
       </para></entry>
      </row>
 
@@ -3406,7 +4270,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
 <!--
        Receipt time of last message received from origin WAL sender
 -->
-オリジンWAL送信サーバから受け取った最後のメッセージの受信時刻
+オリジンWAL送信サーバから受け取った最後のメッセージの受信時刻です。
       </para></entry>
      </row>
 
@@ -3418,7 +4282,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
 <!--
        Last write-ahead log location reported to origin WAL sender
 -->
-オリジンWAL送信サーバに最後に報告された先行書き込みログ位置
+オリジンWAL送信サーバに最後に報告された先行書き込みログ位置です。
       </para></entry>
      </row>
 
@@ -3431,7 +4295,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
        Time of last write-ahead log location reported to origin WAL
        sender
 -->
-オリジンWAL送信サーバかに最後の先行書き込みログ位置が報告された時刻
+オリジンWAL送信サーバに最後の先行書き込みログ位置が報告された時刻です。
       </para></entry>
      </row>
     </tbody>
@@ -3457,16 +4321,22 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
    connection.
 -->
 <structname>pg_stat_ssl</structname>ビューは、バックエンドプロセスおよびWAL送信プロセスごとに1行を保持し、接続上でのSSLの使用に関する統計情報を示します。
-<structname>pg_stat_activity</structname>または<structname>pg_stat_replication</structname>と<structfield>pid</structfield>列で結合することで、接続に関するより詳細な情報を取得することができます。
+<structname>pg_stat_activity</structname>または<structname>pg_stat_replication</structname>と<structfield>pid</structfield>列で結合することで、接続に関するより詳細な情報を取得できます。
   </para>
 
   <table id="pg-stat-ssl-view" xreflabel="pg_stat_ssl">
+<!--
    <title><structname>pg_stat_ssl</structname> View</title>
+-->
+   <title><structname>pg_stat_ssl</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -3511,7 +4381,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
        Version of SSL in use, or NULL if SSL is not in use
        on this connection
 -->
-使用されているSSLのバージョン、この接続でSSLが使用されていなければNULLになります。
+使用されているSSLのバージョンです。この接続でSSLが使用されていなければNULLになります。
       </para></entry>
      </row>
 
@@ -3524,7 +4394,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
        Name of SSL cipher in use, or NULL if SSL is not in use
        on this connection
 -->
-使用されているSSL暗号の名前、この接続でSSLが使用されていなければNULLになります。
+使用されているSSL暗号の名前です。この接続でSSLが使用されていなければNULLになります。
       </para></entry>
      </row>
 
@@ -3537,7 +4407,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
        Number of bits in the encryption algorithm used, or NULL
        if SSL is not used on this connection
 -->
-使用されている暗号アルゴリズムのビット数、この接続でSSLが使用されていなければNULLになります。
+使用されている暗号アルゴリズムのビット数です。この接続でSSLが使用されていなければNULLになります。
       </para></entry>
      </row>
 
@@ -3550,7 +4420,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
        True if SSL compression is in use, false if not,
        or NULL if SSL is not in use on this connection
 -->
-SSL圧縮が使用されていれば真、使用されていなければ偽、この接続でSSLが使用されていなければNULLになります。
+SSL圧縮が使用されていれば真、使用されていなければ偽です。この接続でSSLが使用されていなければNULLになります。
       </para></entry>
      </row>
 
@@ -3566,7 +4436,7 @@ SSL圧縮が使用されていれば真、使用されていなければ偽、�
        DN field is longer than <symbol>NAMEDATALEN</symbol> (64 characters
        in a standard build).
 -->
-使用されているクライアント証明書の識別名(DN)フィールド、クライアント証明書が提供されなかった場合、およびこの接続でSSLが使用されていない場合はNULLになります。
+使用されているクライアント証明書の識別名(DN)フィールドです。クライアント証明書が提供されなかった場合、およびこの接続でSSLが使用されていない場合はNULLになります。
 このフィールドは、DNフィールドが<symbol>NAMEDATALEN</symbol>（標準ビルドでは64文字）より長いと切り詰められます。
       </para></entry>
      </row>
@@ -3583,8 +4453,8 @@ SSL圧縮が使用されていれば真、使用されていなければ偽、�
        identifies a certificate (unless the issuer erroneously reuses serial
        numbers).
 -->
-クライアント証明書のシリアル番号、または、この接続でクライアント証明書が提供されていないかSSLが使われていない場合にNULLになります。
-証明書のシリアル番号と証明書発行者の組み合わせは（発行者が誤ってシリアル番号を再使用しない限り）証明書を唯一に識別します。
+クライアント証明書のシリアル番号です。この接続でクライアント証明書が提供されていないかSSLが使われていない場合にNULLになります。
+証明書のシリアル番号と証明書発行者の組み合わせは（発行者が誤ってシリアル番号を再使用しない限り）証明書を一意に識別します。
       </para></entry>
      </row>
 
@@ -3598,7 +4468,7 @@ SSL圧縮が使用されていれば真、使用されていなければ偽、�
        certificate was supplied or if SSL is not in use on this connection.
        This field is truncated like <structfield>client_dn</structfield>.
 -->
-クライアント証明書の発行者のDN、または、この接続でクライアント証明書が提供されていないかSSLが使われていない場合にNULLになります。
+クライアント証明書の発行者のDNです。この接続でクライアント証明書が提供されていないかSSLが使われていない場合にNULLになります。
 このフィールドは<structfield>client_dn</structfield>と同様に切り詰められます。
       </para></entry>
      </row>
@@ -3625,16 +4495,23 @@ SSL圧縮が使用されていれば真、使用されていなければ偽、�
    connection.
 -->
 <structname>pg_stat_gssapi</structname>ビューはバックエンド毎に1行で構成され、接続でのGSSAPI使用に関する情報を表示します。
-接続に関する更なる詳細を得るため、これを<structname>pg_stat_activity</structname>や<structname>pg_stat_replication</structname>と<structfield>pid</structfield>列で結合することができます。
+接続に関する更なる詳細を得るため、これを<structname>pg_stat_activity</structname>や<structname>pg_stat_replication</structname>と<structfield>pid</structfield>列で結合できます。
   </para>
 
   <table id="pg-stat-gssapi-view" xreflabel="pg_stat_gssapi">
+<!--
    <title><structname>pg_stat_gssapi</structname> View</title>
+-->
+   <title><structname>pg_stat_gssapi</structname>ビュー</title>
+
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -3654,7 +4531,7 @@ SSL圧縮が使用されていれば真、使用されていなければ偽、�
 <!--
        Process ID of a backend
 -->
-バックエンドのプロセスID
+バックエンドのプロセスIDです。
       </para></entry>
      </row>
 
@@ -3666,7 +4543,7 @@ SSL圧縮が使用されていれば真、使用されていなければ偽、�
 <!--
        True if GSSAPI authentication was used for this connection
 -->
-この接続にGSSAPI認証が使われていたなら真
+この接続にGSSAPI認証が使われていたなら真です。
       </para></entry>
      </row>
 
@@ -3681,7 +4558,7 @@ SSL圧縮が使用されていれば真、使用されていなければ偽、�
        field is truncated if the principal is longer than
        <symbol>NAMEDATALEN</symbol> (64 characters in a standard build).
 -->
-この接続の認証に使われているプリンシパル、または、接続の認証にGSSAPIが使われていない場合にはNULLです。
+この接続の認証に使われているプリンシパルです。接続の認証にGSSAPIが使われていない場合にはNULLです。
 このフィールドはプリンシパルが<symbol>NAMEDATALEN</symbol>（標準ビルドでは64文字）よりも長い場合には切り詰められます。
       </para></entry>
      </row>
@@ -3694,7 +4571,7 @@ SSL圧縮が使用されていれば真、使用されていなければ偽、�
 <!--
        True if GSSAPI encryption is in use on this connection
 -->
-この接続でGSSAPI暗号化が使われているなら真
+この接続でGSSAPI暗号化が使われているなら真です。
       </para></entry>
      </row>
     </tbody>
@@ -3715,16 +4592,22 @@ SSL圧縮が使用されていれば真、使用されていなければ偽、�
    The <structname>pg_stat_archiver</structname> view will always have a
    single row, containing data about the archiver process of the cluster.
 -->
-<structname>pg_stat_archiver</structname>は常に、クラスタのアーカイバプロセスに関するデータを含む１つの行を持ちます。
+<structname>pg_stat_archiver</structname>ビューは常に、クラスタのアーカイバプロセスに関するデータを含む１つの行を持ちます。
   </para>
 
   <table id="pg-stat-archiver-view" xreflabel="pg_stat_archiver">
+<!--
    <title><structname>pg_stat_archiver</structname> View</title>
+-->
+   <title><structname>pg_stat_archiver</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -3744,7 +4627,7 @@ SSL圧縮が使用されていれば真、使用されていなければ偽、�
 <!--
        Number of WAL files that have been successfully archived
 -->
-アーカイブに成功したWALファイルの数
+アーカイブに成功したWALファイルの数です。
       </para></entry>
      </row>
 
@@ -3756,7 +4639,7 @@ SSL圧縮が使用されていれば真、使用されていなければ偽、�
 <!--
        Name of the last WAL file successfully archived
 -->
-アーカイブに成功した最後のWALファイルの名前
+アーカイブに成功した最後のWALファイルの名前です。
       </para></entry>
      </row>
 
@@ -3768,7 +4651,7 @@ SSL圧縮が使用されていれば真、使用されていなければ偽、�
 <!--
        Time of the last successful archive operation
 -->
-最後に成功したアーカイブ操作の時刻
+最後に成功したアーカイブ操作の時刻です。
       </para></entry>
      </row>
 
@@ -3780,7 +4663,7 @@ SSL圧縮が使用されていれば真、使用されていなければ偽、�
 <!--
        Number of failed attempts for archiving WAL files
 -->
-WALファイルのアーカイブに失敗した回数
+WALファイルのアーカイブに失敗した回数です。
       </para></entry>
      </row>
 
@@ -3792,7 +4675,7 @@ WALファイルのアーカイブに失敗した回数
 <!--
        Name of the WAL file of the last failed archival operation
 -->
-最後にアーカイブ操作に失敗したWALファイルの名前
+最後にアーカイブ操作に失敗したWALファイルの名前です。
       </para></entry>
      </row>
 
@@ -3804,7 +4687,7 @@ WALファイルのアーカイブに失敗した回数
 <!--
        Time of the last failed archival operation
 -->
-最後にアーカイブ操作に失敗した時刻
+最後にアーカイブ操作に失敗した時刻です。
       </para></entry>
      </row>
 
@@ -3841,12 +4724,18 @@ WALファイルのアーカイブに失敗した回数
   </para>
 
   <table id="pg-stat-bgwriter-view" xreflabel="pg_stat_bgwriter">
+<!--
    <title><structname>pg_stat_bgwriter</structname> View</title>
+-->
+   <title><structname>pg_stat_bgwriter</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -4010,18 +4899,27 @@ WALファイルのアーカイブに失敗した回数
   </indexterm>
 
   <para>
+<!--
    The <structname>pg_stat_database</structname> view will contain one row
    for each database in the cluster, plus one for shared objects, showing
    database-wide statistics.
+-->
+<structname>pg_stat_database</structname>ビューには、クラスタ内のデータベース毎に1行と加えて共有オブジェクトのための1行が含まれ、データベース全体の統計情報を示します。
   </para>
 
   <table id="pg-stat-database-view" xreflabel="pg_stat_database">
+<!--
    <title><structname>pg_stat_database</structname> View</title>
+-->
+   <title><structname>pg_stat_database</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -4042,7 +4940,7 @@ WALファイルのアーカイブに失敗した回数
        OID of this database, or 0 for objects belonging to a shared
        relation
 -->
-データベースのOID、共有リレーションに属するオブジェクトについては0
+データベースのOIDです。共有リレーションに属するオブジェクトについては0になります。
       </para></entry>
      </row>
 
@@ -4051,8 +4949,11 @@ WALファイルのアーカイブに失敗した回数
        <structfield>datname</structfield> <type>name</type>
       </para>
       <para>
+<!--
        Name of this database, or <literal>NULL</literal> for shared
        objects.
+-->
+データベース名です。共有オブジェクトについては<literal>NULL</literal>になります。
       </para></entry>
      </row>
 
@@ -4061,10 +4962,15 @@ WALファイルのアーカイブに失敗した回数
        <structfield>numbackends</structfield> <type>integer</type>
       </para>
       <para>
+<!--
        Number of backends currently connected to this database, or
        <literal>NULL</literal> for shared objects.  This is the only column
        in this view that returns a value reflecting current state; all other
        columns return the accumulated values since the last reset.
+-->
+現在データベースに接続しているバックエンドの個数です。共有オブジェクトについては<literal>NULL</literal>になります。
+これは、このビューの中で、現在の状態を反映した値を返す唯一の列です。
+他の列はすべて、最後にリセットされてから累積された値を返します。
       </para></entry>
      </row>
 
@@ -4077,7 +4983,7 @@ WALファイルのアーカイブに失敗した回数
        Number of transactions in this database that have been
        committed
 -->
-このデータベースの中でコミットされたトランザクション数です。
+データベース内でコミットされたトランザクション数です。
       </para></entry>
      </row>
 
@@ -4090,7 +4996,7 @@ WALファイルのアーカイブに失敗した回数
        Number of transactions in this database that have been
        rolled back
 -->
-このデータベースの中でロールバックされたトランザクション数です。
+データベース内でロールバックされたトランザクション数です。
       </para></entry>
      </row>
 
@@ -4116,7 +5022,7 @@ WALファイルのアーカイブに失敗した回数
        cache, so that a read was not necessary (this only includes hits in the
        PostgreSQL buffer cache, not the operating system's file system cache)
 -->
-バッファキャッシュに既にあることが分かっているために読み取りが不要だったディスクブロック数です（これにはPostgreSQLのバッファキャッシュにおけるヒットのみが含まれ、オペレーティングシステムのファイルシステムキャッシュは含まれません）。
+バッファキャッシュに既にあることが分かっているためにディスクブロックの読み取りが不要だった回数です（これにはPostgreSQLのバッファキャッシュにおけるヒットのみが含まれ、オペレーティングシステムのファイルシステムキャッシュは含まれません）。
       </para></entry>
      </row>
 
@@ -4185,10 +5091,14 @@ WALファイルのアーカイブに失敗した回数
        <structfield>conflicts</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Number of queries canceled due to conflicts with recovery
        in this database. (Conflicts occur only on standby servers; see
        <link linkend="monitoring-pg-stat-database-conflicts-view">
        <structname>pg_stat_database_conflicts</structname></link> for details.)
+-->
+データベース内のリカバリで競合したためキャンセルされた問い合わせ数です。
+(競合はスタンバイサーバ上でのみ起こります。詳細については<link linkend="monitoring-pg-stat-database-conflicts-view"><structname>pg_stat_database_conflicts</structname></link>を参照してください。)
       </para></entry>
      </row>
 
@@ -4246,7 +5156,7 @@ WALファイルのアーカイブに失敗した回数
        database (or on a shared object), or NULL if data checksums are not
        enabled.
 -->
-データベース（あるいは共有オブジェクト）内で検出されたデータページチェックサムの検査失敗数、あるいはデータチェックサムが無効の場合にはNULLです。
+データベース（あるいは共有オブジェクト）内で検出されたデータページチェックサムの検査失敗数です。データチェックサムが無効の場合にはNULLです。
       </para></entry>
      </row>
 
@@ -4260,7 +5170,7 @@ WALファイルのアーカイブに失敗した回数
        this database (or on a shared object), or NULL if data checksums are not
        enabled.
 -->
-データベース（または共有オブジェクト）内で最後にデータページチェックサムの検査失敗が検知された時刻、あるいはデータチェックサムが無効の場合にはNULLです。
+データベース（または共有オブジェクト）内で最後にデータページチェックサムの検査失敗が検知された時刻です。データチェックサムが無効の場合にはNULLです。
       </para></entry>
      </row>
 
@@ -4269,9 +5179,12 @@ WALファイルのアーカイブに失敗した回数
        <structfield>blk_read_time</structfield> <type>double precision</type>
       </para>
       <para>
+<!--
        Time spent reading data file blocks by backends in this database,
        in milliseconds (if <xref linkend="guc-track-io-timing"/> is enabled,
        otherwise zero)
+-->
+データベース内でバックエンドによりデータファイルブロックの読み取りに費やされた、ミリ秒単位の時間です(<xref linkend="guc-track-io-timing"/>が有効な場合。そうでなければゼロです)。
       </para></entry>
      </row>
 
@@ -4280,9 +5193,12 @@ WALファイルのアーカイブに失敗した回数
        <structfield>blk_write_time</structfield> <type>double precision</type>
       </para>
       <para>
+<!--
        Time spent writing data file blocks by backends in this database,
        in milliseconds (if <xref linkend="guc-track-io-timing"/> is enabled,
        otherwise zero)
+-->
+データベース内でバックエンドによりデータファイルブロックの書き出しに費やされた、ミリ秒単位の時間です(<xref linkend="guc-track-io-timing"/>が有効な場合。そうでなければゼロです)。
       </para></entry>
      </row>
 
@@ -4323,12 +5239,18 @@ WALファイルのアーカイブに失敗した回数
   </para>
 
   <table id="pg-stat-database-conflicts-view" xreflabel="pg_stat_database_conflicts">
+<!--
    <title><structname>pg_stat_database_conflicts</structname> View</title>
+-->
+   <title><structname>pg_stat_database_conflicts</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -4456,12 +5378,18 @@ WALファイルのアーカイブに失敗した回数
   </para>
 
   <table id="pg-stat-all-tables-view" xreflabel="pg_stat_all_tables">
+<!--
    <title><structname>pg_stat_all_tables</structname> View</title>
+-->
+   <title><structname>pg_stat_all_tables</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -4614,7 +5542,7 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
 <!--
        Estimated number of live rows
 -->
-有効行の推定値です。
+有効行数の推定値です。
       </para></entry>
      </row>
 
@@ -4626,7 +5554,7 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
 <!--
        Estimated number of dead rows
 -->
-不要行の推定値です。
+無効行数の推定値です。
       </para></entry>
      </row>
 
@@ -4638,7 +5566,7 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
 <!--
        Estimated number of rows modified since this table was last analyzed
 -->
-このテーブルが最後に解析されてから変更された行の推定値
+このテーブルが最後に解析されてから変更された行数の推定値です。
       </para></entry>
      </row>
 
@@ -4647,7 +5575,10 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
        <structfield>n_ins_since_vacuum</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Estimated number of rows inserted since this table was last vacuumed
+-->
+このテーブルが最後にバキュームされてから挿入された行数の推定値です。
       </para></entry>
      </row>
 
@@ -4780,12 +5711,18 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
   </para>
 
   <table id="pg-stat-all-indexes-view" xreflabel="pg_stat_all_indexes">
+<!--
    <title><structname>pg_stat_all_indexes</structname> View</title>
+-->
+   <title><structname>pg_stat_all_indexes</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -4935,7 +5872,7 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
 -->
 <structfield>idx_tup_read</structfield>と<structfield>idx_tup_fetch</structfield>個数は、ビットマップスキャンがまったく使用されていない場合でも異なります。
 <structfield>idx_tup_read</structfield>はインデックスから取り出したインデックス項目を計上し、<structfield>idx_tup_fetch</structfield>はテーブルから取り出した有効行を計上するからです。
-インデックスを用いて不要行やまだコミットされていない行が取り出された場合やインデックスオンリースキャン法によりヒープの取り出しが回避された場合に、後者は減少します。
+インデックスを用いて無効行やまだコミットされていない行が取り出された場合やインデックスオンリースキャン法によりヒープの取り出しが回避された場合に、後者は減少します。
    </para>
   </note>
 
@@ -4963,12 +5900,18 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
   </para>
 
   <table id="pg-statio-all-tables-view" xreflabel="pg_statio_all_tables">
+<!--
    <title><structname>pg_statio_all_tables</structname> View</title>
+-->
+   <title><structname>pg_statio_all_tables</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -5139,12 +6082,18 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
   </para>
 
   <table id="pg-statio-all-indexes-view" xreflabel="pg_statio_all_indexes">
+<!--
    <title><structname>pg_statio_all_indexes</structname> View</title>
+-->
+   <title><structname>pg_statio_all_indexes</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -5262,12 +6211,18 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
   </para>
 
   <table id="pg-statio-all-sequences-view" xreflabel="pg_statio_all_sequences">
+<!--
    <title><structname>pg_statio_all_sequences</structname> View</title>
+-->
+   <title><structname>pg_statio_all_sequences</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -5363,12 +6318,18 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
   </para>
 
   <table id="pg-stat-user-functions-view" xreflabel="pg_stat_user_functions">
+<!--
    <title><structname>pg_stat_user_functions</structname> View</title>
+-->
+   <title><structname>pg_stat_user_functions</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -5471,20 +6432,30 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
   </indexterm>
 
   <para>
+<!--
    <productname>PostgreSQL</productname> accesses certain on-disk information
    via <firstterm>SLRU</firstterm> (simple least-recently-used) caches.
    The <structname>pg_stat_slru</structname> view will contain
    one row for each tracked SLRU cache, showing statistics about access
    to cached pages.
+-->
+<productname>PostgreSQL</productname>は<firstterm>SLRU</firstterm>(simple least-recently-used)キャッシュ経由で特定のディスク上の情報にアクセスします。
+<structname>pg_stat_slru</structname>ビューは、追跡されたSLRUキャッシュ毎にキャッシュされたページへのアクセスに関する統計情報を1行保持します。
   </para>
 
   <table id="pg-stat-slru-view" xreflabel="pg_stat_slru">
+<!--
    <title><structname>pg_stat_slru</structname> View</title>
+-->
+   <title><structname>pg_stat_slru</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -5501,7 +6472,10 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
        <structfield>name</structfield> <type>text</type>
       </para>
       <para>
+<!--
        Name of the SLRU
+-->
+SLRUの名前です。
       </para></entry>
      </row>
 
@@ -5510,7 +6484,10 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
        <structfield>blks_zeroed</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Number of blocks zeroed during initializations
+-->
+初期化中にゼロにされたブロックの数です。
       </para></entry>
      </row>
 
@@ -5519,9 +6496,12 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
        <structfield>blks_hit</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Number of times disk blocks were found already in the SLRU,
        so that a read was not necessary (this only includes hits in the
        SLRU, not the operating system's file system cache)
+-->
+SLRUに既にあることが分かっているためにディスクブロックの読み取りが不要だった回数です（これにはSLRUにおけるヒットのみが含まれ、オペレーティングシステムのファイルシステムキャッシュは含まれません）。
       </para></entry>
      </row>
 
@@ -5530,7 +6510,10 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
        <structfield>blks_read</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Number of disk blocks read for this SLRU
+-->
+SLRUから読み取られたディスクブロック数です。
       </para></entry>
      </row>
 
@@ -5539,7 +6522,10 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
        <structfield>blks_written</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Number of disk blocks written for this SLRU
+-->
+SLRUに書き込まれたディスクブロック数です。
       </para></entry>
      </row>
 
@@ -5548,7 +6534,10 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
        <structfield>blks_exists</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Number of blocks checked for existence for this SLRU
+-->
+SLRUで存在を検査されたブロック数です。
       </para></entry>
      </row>
 
@@ -5557,7 +6546,10 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
        <structfield>flushes</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Number of flushes of dirty data for this SLRU
+-->
+SLRUでのダーティデータのフラッシュ数です。
       </para></entry>
      </row>
 
@@ -5566,7 +6558,10 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
        <structfield>truncates</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Number of truncates for this SLRU
+-->
+SLRUでの切り詰めの数です。
       </para></entry>
      </row>
 
@@ -5588,7 +6583,10 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
  </sect2>
 
  <sect2 id="monitoring-stats-functions">
+<!--
   <title>Statistics Functions</title>
+-->
+  <title>統計情報関数</title>
 
   <para>
 <!--
@@ -5622,12 +6620,18 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
   </para>
 
    <table id="monitoring-stats-funcs-table">
+<!--
     <title>Additional Statistics Functions</title>
+-->
+    <title>その他の統計情報関数</title>
     <tgroup cols="1">
      <thead>
       <row>
        <entry role="func_table_entry"><para role="func_signature">
+<!--
         Function
+-->
+関数
        </para>
        <para>
 <!--
@@ -5646,8 +6650,11 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
         <returnvalue>integer</returnvalue>
        </para>
        <para>
+<!--
         Returns the process ID of the server process attached to the current
         session.
+-->
+現在のセッションにアタッチされたサーバプロセスのプロセスIDを返します。
        </para></entry>
       </row>
 
@@ -5660,10 +6667,13 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
         <returnvalue>setof record</returnvalue>
        </para>
        <para>
+<!--
         Returns a record of information about the backend with the specified
         process ID, or one record for each active backend in the system
         if <literal>NULL</literal> is specified.  The fields returned are a
         subset of those in the <structname>pg_stat_activity</structname> view.
+-->
+指定されたプロセスIDに該当するバックエンドの情報のレコードを、<symbol>NULL</symbol>が指定された場合はシステム上のアクティブな各バックエンドに関するレコードを返します。
        </para></entry>
       </row>
 
@@ -5676,7 +6686,10 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
         <returnvalue>timestamp with time zone</returnvalue>
        </para>
        <para>
+<!--
         Returns the timestamp of the current statistics snapshot.
+-->
+現在の統計情報のスナップショットのタイムスタンプを返します。
        </para></entry>
       </row>
 
@@ -5689,7 +6702,10 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
         <returnvalue>void</returnvalue>
        </para>
        <para>
+<!--
         Discards the current statistics snapshot.
+-->
+現在の統計情報スナップショットを破棄します。
        </para></entry>
       </row>
 
@@ -5702,11 +6718,17 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
         <returnvalue>void</returnvalue>
        </para>
        <para>
+<!--
         Resets all statistics counters for the current database to zero.
+-->
+現在のデータベースに関する統計情報カウンタすべてをゼロにリセットします。
        </para>
        <para>
+<!--
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
+-->
+この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXCUTE権限を付与できます。
        </para></entry>
       </row>
 
@@ -5719,16 +6741,23 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
         <returnvalue>void</returnvalue>
        </para>
        <para>
+<!--
         Resets some cluster-wide statistics counters to zero, depending on the
         argument.  The argument can be <literal>bgwriter</literal> to reset
         all the counters shown in
         the <structname>pg_stat_bgwriter</structname>
         view, or <literal>archiver</literal> to reset all the counters shown in
         the <structname>pg_stat_archiver</structname> view.
+-->
+引数に応じて、クラスタ全体の統計情報カウンタの一部をゼロにリセットします。
+引数に<literal>bgwriter</literal>を指定すると、<structname>pg_stat_bgwriter</structname>ビューで示されるカウンタがすべてリセットされ、<literal>archiver</literal>を指定すると<structname>pg_stat_archiver</structname>ビューで示されるカウンタがすべてリセットされます。
        </para>
        <para>
+<!--
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
+-->
+この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXCUTE権限を付与できます。
        </para></entry>
       </row>
 
@@ -5741,12 +6770,18 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
         <returnvalue>void</returnvalue>
        </para>
        <para>
+<!--
         Resets statistics for a single table or index in the current database
         to zero.
+-->
+現在のデータベース内にある、ひとつのテーブルあるいはインデックスの統計情報をゼロにリセットします。
        </para>
        <para>
+<!--
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
+-->
+この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXCUTE権限を付与できます。
        </para></entry>
       </row>
 
@@ -5759,12 +6794,18 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
         <returnvalue>void</returnvalue>
        </para>
        <para>
+<!--
         Resets statistics for a single function in the current database to
         zero.
+-->
+現在のデータベース内にある、ひとつの関数の統計情報をゼロにリセットします。
        </para>
        <para>
+<!--
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
+-->
+この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXCUTE権限を付与できます。
        </para></entry>
       </row>
 
@@ -5777,6 +6818,7 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
         <returnvalue>void</returnvalue>
        </para>
        <para>
+<!--
         Resets statistics to zero for a single SLRU cache, or for all SLRUs in
         the cluster.  If the argument is NULL, all counters shown in
         the <structname>pg_stat_slru</structname> view for all SLRU caches are
@@ -5792,10 +6834,18 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
         If the argument is <literal>other</literal> (or indeed, any
         unrecognized name), then the counters for all other SLRU caches, such
         as extension-defined caches, are reset.
+-->
+ひとつのSLRUキャッシュ、またはクラスタ内のすべてのSLRUの統計情報をゼロにリセットします。
+引数がNULLであれば、<structname>pg_stat_slru</structname>ビューで示されているすべてのSLRUキャッシュに対するカウンタがリセットされます。
+引数は、そのエントリのみに対応するカウンタをリセットするよう<literal>CommitTs</literal>、<literal>MultiXactMember</literal>、<literal>MultiXactOffset</literal>、<literal>Notify</literal>、<literal>Serial</literal>、<literal>Subtrans</literal>、<literal>Xact</literal>の1つを指定できます。
+引数が<literal>other</literal>(実際のところは、認められていない名前であれば何でも)であれば、拡張が定義したキャッシュのような、それ以外のSLRUキャッシュに対するカウンタがリセットされます。
        </para>
        <para>
+<!--
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
+-->
+この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXCUTE権限を付与できます。
        </para></entry>
       </row>
      </tbody>
@@ -5818,8 +6868,7 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
    invoking these functions.  For example, to show the <acronym>PID</acronym>s and
    current queries of all backends:
 -->
-<structname>pg_stat_activity</structname>ビューの基礎となる<function>pg_stat_get_activity</function>関数は、
-各バックエンドプロセスに関して利用可能な情報をすべて含むレコード集合を返します。
+<structname>pg_stat_activity</structname>ビューの基礎となる<function>pg_stat_get_activity</function>関数は、各バックエンドプロセスに関して利用可能な情報をすべて含むレコード集合を返します。
 この情報の一部のみを入手することがより簡便である場合があるかもしれません。
 このような場合、<xref linkend="monitoring-stats-backend-funcs-table"/>に示す、古めのバックエンド単位の統計情報アクセス関数を使用することができます。
 これらのアクセス関数は、１から現在活動中のバックエンドの個数までの値を取る、バックエンドID番号を使用します。
@@ -5834,12 +6883,18 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
   </para>
 
    <table id="monitoring-stats-backend-funcs-table">
+<!--
     <title>Per-Backend Statistics Functions</title>
+-->
+    <title>バックエンド単位の統計情報関数</title>
     <tgroup cols="1">
      <thead>
       <row>
        <entry role="func_table_entry"><para role="func_signature">
+<!--
         Function
+-->
+関数
        </para>
        <para>
 <!--
@@ -5860,8 +6915,11 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
         <returnvalue>setof integer</returnvalue>
        </para>
        <para>
+<!--
         Returns the set of currently active backend ID numbers (from 1 to the
         number of active backends).
+-->
+現在活動中のバックエンドID番号（１から活動中のバックエンドの個数まで）の集合を返します。
        </para></entry>
       </row>
 
@@ -5874,7 +6932,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
         <returnvalue>text</returnvalue>
        </para>
        <para>
+<!--
         Returns the text of this backend's most recent query.
+-->
+バックエンドが最後に行った問い合わせテキストを返します。
        </para></entry>
       </row>
 
@@ -5887,7 +6948,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
         <returnvalue>timestamp with time zone</returnvalue>
        </para>
        <para>
+<!--
         Returns the time when the backend's most recent query was started.
+-->
+バックエンドの最後の問い合わせが開始された時刻を返します。
        </para></entry>
       </row>
 
@@ -5900,7 +6964,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
         <returnvalue>inet</returnvalue>
        </para>
        <para>
+<!--
         Returns the IP address of the client connected to this backend.
+-->
+バックエンドに接続したクライアントのIPアドレスを返します。
        </para></entry>
       </row>
 
@@ -5913,7 +6980,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
         <returnvalue>integer</returnvalue>
        </para>
        <para>
+<!--
         Returns the TCP port number that the client is using for communication.
+-->
+クライアントが通信に使用しているTCPポート番号を返します。
        </para></entry>
       </row>
 
@@ -5926,7 +6996,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
         <returnvalue>oid</returnvalue>
        </para>
        <para>
+<!--
         Returns the OID of the database this backend is connected to.
+-->
+バックエンドが接続するデータベースのOIDを返します。
        </para></entry>
       </row>
 
@@ -5939,7 +7012,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
         <returnvalue>integer</returnvalue>
        </para>
        <para>
+<!--
         Returns the process ID of this backend.
+-->
+バックエンドのプロセスIDを返します。
        </para></entry>
       </row>
 
@@ -5952,7 +7028,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
         <returnvalue>timestamp with time zone</returnvalue>
        </para>
        <para>
+<!--
         Returns the time when this process was started.
+-->
+プロセスが開始された時刻を返します。
        </para></entry>
       </row>
 
@@ -5965,7 +7044,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
         <returnvalue>oid</returnvalue>
        </para>
        <para>
+<!--
         Returns the OID of the user logged into this backend.
+-->
+バックエンドにログインしたユーザのOIDを返します。
        </para></entry>
       </row>
 
@@ -5978,8 +7060,12 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
         <returnvalue>text</returnvalue>
        </para>
        <para>
+<!--
         Returns the wait event type name if this backend is currently waiting,
         otherwise NULL.  See <xref linkend="wait-event-table"/> for details.
+-->
+バックエンドが現在待機中であれば、待機イベント型名を、さもなくばNULLを返します。
+詳細は<xref linkend="wait-event-table"/>を参照してください。
        </para></entry>
       </row>
 
@@ -5992,9 +7078,13 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
         <returnvalue>text</returnvalue>
        </para>
        <para>
+<!--
         Returns the wait event name if this backend is currently waiting,
         otherwise NULL. See <xref linkend="wait-event-activity-table"/> through
         <xref linkend="wait-event-timeout-table"/>.
+-->
+バックエンドが現在待機中であれば、待機イベント名を、さもなくばNULLを返します。
+詳細は<xref linkend="wait-event-activity-table"/>から<xref linkend="wait-event-timeout-table"/>までを参照してください。
        </para></entry>
       </row>
 
@@ -6007,7 +7097,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
         <returnvalue>timestamp with time zone</returnvalue>
        </para>
        <para>
+<!--
         Returns the time when the backend's current transaction was started.
+-->
+バックエンドの現在のトランザクションが開始された時刻を返します。
        </para></entry>
       </row>
      </tbody>
@@ -6021,7 +7114,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
   <title>Viewing Locks</title>
 -->
-<title>ロックの表示</title>
+  <title>ロックの表示</title>
 
   <indexterm zone="monitoring-locks">
 <!--
@@ -6040,7 +7133,9 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
    locks in the lock manager. For example, this capability can be used
    to:
 -->
-この他に、データベース活動状況の監視に役立つツールとして<literal>pg_locks</literal>システムテーブルがあります。これにより、データベース管理者はロックマネージャ内の未解決のロックに関する情報を参照することができます。例えば、この機能を使用すると以下のことができます。
+この他に、データベース活動状況の監視に役立つツールとして<literal>pg_locks</literal>システムテーブルがあります。
+これにより、データベース管理者はロックマネージャ内の未解決のロックに関する情報を参照することができます。
+例えば、この機能を使用すると以下のことができます。
 
    <itemizedlist>
     <listitem>
@@ -6096,6 +7191,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
   <title>進捗状況のレポート</title>
 
   <para>
+<!--
    <productname>PostgreSQL</productname> has the ability to report the progress of
    certain commands during command execution.  Currently, the only commands
    which support progress reporting are <command>ANALYZE</command>,
@@ -6105,26 +7201,43 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
    command that <xref linkend="app-pgbasebackup"/> issues to take
    a base backup).
    This may be expanded in the future.
+-->
+<productname>PostgreSQL</productname>は、何らかのコマンドの実行中に進捗状況をレポートする能力があります。
+現在、進捗状況のレポートをサポートしているのは、<command>ANALYZE</command>、<command>CLUSTER</command>、<command>CREATE INDEX</command>、<command>VACUUM</command>、および、<xref linkend="protocol-replication-base-backup"/>(すなわち、<xref linkend="app-pgbasebackup"/>がベースバックアップのために発行するレプリケーションコマンド)のみです。
+将来的にサポートされるコマンドが拡大される可能性があります。
   </para>
 
  <sect2 id="analyze-progress-reporting">
+<!--
   <title>ANALYZE Progress Reporting</title>
+-->
+  <title>ANALYZEの進捗状況のレポート</title>
 
   <para>
+<!--
    Whenever <command>ANALYZE</command> is running, the
    <structname>pg_stat_progress_analyze</structname> view will contain a
    row for each backend that is currently running that command.  The tables
    below describe the information that will be reported and provide
    information about how to interpret it.
+-->
+<command>ANALYZE</command>が実行されているときにはいつでも、<structname>pg_stat_progress_analyze</structname>ビューには現在コマンドを実行している各バックエンドごとの行が含まれます。
+以下の表は、報告される情報を説明し、どのように解釈するかの情報を提供します。
   </para>
 
   <table id="pg-stat-progress-analyze-view" xreflabel="pg_stat_progress_analyze">
+<!--
    <title><structname>pg_stat_progress_analyze</structname> View</title>
+-->
+   <title><structname>pg_stat_progress_analyze</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -6144,7 +7257,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Process ID of backend.
 -->
-バックエンドのプロセスID。
+バックエンドのプロセスIDです。
       </para></entry>
      </row>
 
@@ -6156,7 +7269,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        OID of the database to which this backend is connected.
 -->
-バックエンドが接続されているデータベースのOID。
+バックエンドが接続されているデータベースのOIDです。
       </para></entry>
      </row>
 
@@ -6168,7 +7281,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Name of the database to which this backend is connected.
 -->
-バックエンドが接続されているデータベース名。
+バックエンドが接続されているデータベース名です。
       </para></entry>
      </row>
 
@@ -6177,7 +7290,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>relid</structfield> <type>oid</type>
       </para>
       <para>
+<!--
        OID of the table being analyzed.
+-->
+解析されているテーブルのOIDです。
       </para></entry>
      </row>
 
@@ -6186,7 +7302,11 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>phase</structfield> <type>text</type>
       </para>
       <para>
+<!--
        Current processing phase. See <xref linkend="analyze-phases"/>.
+-->
+現在処理中のインデックス作成のフェーズです。
+<xref linkend="analyze-phases"/>を参照してください。
       </para></entry>
      </row>
 
@@ -6195,7 +7315,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>sample_blks_total</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Total number of heap blocks that will be sampled.
+-->
+サンプルされるヒープブロックの総数です。
       </para></entry>
      </row>
 
@@ -6204,7 +7327,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>sample_blks_scanned</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Number of heap blocks scanned.
+-->
+スキャンされたヒープブロックの数です。
       </para></entry>
      </row>
 
@@ -6213,7 +7339,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>ext_stats_total</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Number of extended statistics.
+-->
+拡張統計情報の個数です。
       </para></entry>
      </row>
 
@@ -6222,8 +7351,12 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>ext_stats_computed</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Number of extended statistics computed. This counter only advances
        when the phase is <literal>computing extended statistics</literal>.
+-->
+計算された拡張統計情報の個数です。
+このカウンタはフェーズが<literal>computing extended statistics</literal>の時にのみ増加します。
       </para></entry>
      </row>
 
@@ -6232,7 +7365,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>child_tables_total</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Number of child tables.
+-->
+子テーブルの数です。
       </para></entry>
      </row>
 
@@ -6241,8 +7377,12 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>child_tables_done</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Number of child tables scanned. This counter only advances when the
        phase is <literal>acquiring inherited sample rows</literal>.
+-->
+スキャンされた子テーブルの数です。
+このカウンタはフェーズが<literal>acquiring inherited sample rows</literal>の時にのみ増加します。
       </para></entry>
      </row>
 
@@ -6251,9 +7391,13 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>current_child_table_relid</structfield> <type>oid</type>
       </para>
       <para>
+<!--
        OID of the child table currently being scanned. This field is
        only valid when the phase is
        <literal>acquiring inherited sample rows</literal>.
+-->
+現在スキャンされている子テーブルのOIDです。
+このフィールドはフェーズが<literal>acquiring inherited sample rows</literal>の時のみ有効です。
       </para></entry>
      </row>
     </tbody>
@@ -6261,60 +7405,88 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
   </table>
 
   <table id="analyze-phases">
+<!--
    <title>ANALYZE phases</title>
+-->
+   <title>ANALYZEのフェーズ</title>
    <tgroup cols="2">
     <colspec colname="col1" colwidth="1*"/>
     <colspec colname="col2" colwidth="2*"/>
     <thead>
      <row>
+<!--
       <entry>Phase</entry>
       <entry>Description</entry>
+-->
+      <entry>フェーズ</entry>
+      <entry>説明</entry>
      </row>
     </thead>
     <tbody>
      <row>
       <entry><literal>initializing</literal></entry>
       <entry>
+<!--
        The command is preparing to begin scanning the heap.  This phase is
        expected to be very brief.
+-->
+コマンドはヒープをスキャンし始める準備をしています。
+このフェーズは非常に短時間であると予想されます。
       </entry>
      </row>
      <row>
       <entry><literal>acquiring sample rows</literal></entry>
       <entry>
+<!--
        The command is currently scanning the table given by
        <structfield>relid</structfield> to obtain sample rows.
+-->
+コマンドはサンプル行を得るため、<structfield>relid</structfield>で指定されたテーブルを現在スキャンしています。
       </entry>
      </row>
      <row>
       <entry><literal>acquiring inherited sample rows</literal></entry>
       <entry>
+<!--
        The command is currently scanning child tables to obtain sample rows.
        Columns <structfield>child_tables_total</structfield>,
        <structfield>child_tables_done</structfield>, and
        <structfield>current_child_table_relid</structfield> contain the
        progress information for this phase.
+-->
+コマンドはサンプル行を得るため、子テーブルを現在スキャンしています。
+列<structfield>child_tables_total</structfield>、<structfield>child_tables_done</structfield>、<structfield>current_child_table_relid</structfield>はこのフェーズの進捗情報を含みます。
       </entry>
      </row>
      <row>
       <entry><literal>computing statistics</literal></entry>
       <entry>
+<!--
        The command is computing statistics from the sample rows obtained
        during the table scan.
+-->
+コマンドはテーブルスキャンの間に得られたサンプルから統計情報を計算しています。
       </entry>
      </row>
      <row>
       <entry><literal>computing extended statistics</literal></entry>
       <entry>
+<!--
        The command is computing extended statistics from the sample rows
        obtained during the table scan.
+-->
+コマンドはテーブルスキャンの間に得られたサンプルから拡張統計情報を計算しています。
       </entry>
      </row>
      <row>
       <entry><literal>finalizing analyze</literal></entry>
       <entry>
+<!--
        The command is updating <structname>pg_class</structname>. When this
        phase is completed, <command>ANALYZE</command> will end.
+-->
+コマンドは<structname>pg_class</structname>を更新しています。
+このフェーズが完了すれば、<command>ANALYZE</command>は終わります。
       </entry>
      </row>
     </tbody>
@@ -6323,11 +7495,15 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 
   <note>
    <para>
+<!--
     Note that when <command>ANALYZE</command> is run on a partitioned table,
     all of its partitions are also recursively analyzed as also mentioned in
     <xref linkend="sql-analyze"/>.  In that case, <command>ANALYZE</command>
     progress is reported first for the parent table, whereby its inheritance
     statistics are collected, followed by that for each partition.
+-->
+<command>ANALYZE</command>がパーティションテーブルで実行される場合は、そのパーティションテーブルのすべても<xref linkend="sql-analyze"/>に書かれているように再帰的に解析されることに注意してください。
+その場合、<command>ANALYZE</command>の進捗はまず親テーブルについて報告され、それによってその継承の統計情報が集められ、各パーティションの報告が続きます。
    </para>
   </note>
  </sect2>
@@ -6336,7 +7512,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
   <title>CREATE INDEX Progress Reporting</title>
 -->
-  <title>CREATE INDEX進捗状況のレポート</title>
+  <title>CREATE INDEXの進捗状況のレポート</title>
 
   <para>
 <!--
@@ -6347,15 +7523,22 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
    about how to interpret it.
 -->
 <command>CREATE INDEX</command>や<command>REINDEX</command>が実行中であるときにはいつでも、<structname>pg_stat_progress_create_index</structname>ビューには現在インデックスを作成している各バックエンドごとの行が含まれます。
+以下の表は、報告される情報を説明し、どのように解釈するかの情報を提供します。
   </para>
 
   <table id="pg-stat-progress-create-index-view" xreflabel="pg_stat_progress_create_index">
+<!--
    <title><structname>pg_stat_progress_create_index</structname> View</title>
+-->
+   <title><structname>pg_stat_progress_create_index</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -6375,7 +7558,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Process ID of backend.
 -->
-バックエンドのプロセスID。
+バックエンドのプロセスIDです。
       </para></entry>
      </row>
 
@@ -6387,7 +7570,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        OID of the database to which this backend is connected.
 -->
-バックエンドが接続されているデータベースのOID。
+バックエンドが接続されているデータベースのOIDです。
       </para></entry>
      </row>
 
@@ -6399,7 +7582,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Name of the database to which this backend is connected.
 -->
-バックエンドが接続されているデータベース名。
+バックエンドが接続されているデータベースの名前です。
       </para></entry>
      </row>
 
@@ -6411,7 +7594,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        OID of the table on which the index is being created.
 -->
-インデックスが作られているテーブルのOID。
+インデックスが作られているテーブルのOIDです。
       </para></entry>
      </row>
 
@@ -6424,7 +7607,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        OID of the index being created or reindexed.  During a
        non-concurrent <command>CREATE INDEX</command>, this is 0.
 -->
-作成または再作成されているインデックスのOID。
+作成または再作成されているインデックスのOIDです。
 同時作成ではない<command>CREATE INDEX</command>のときは、これは0です。
       </para></entry>
      </row>
@@ -6451,7 +7634,11 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>phase</structfield> <type>text</type>
       </para>
       <para>
+<!--
        Current processing phase of index creation.  See <xref linkend="create-index-phases"/>.
+-->
+現在処理中のインデックス作成のフェーズです。
+<xref linkend="create-index-phases"/>を参照してください。
       </para></entry>
      </row>
 
@@ -6463,7 +7650,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Total number of lockers to wait for, when applicable.
 -->
-該当するときに、待機するロック取得者の総数。
+該当するときに、待機するロック取得者の総数です。
       </para></entry>
      </row>
 
@@ -6475,7 +7662,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Number of lockers already waited for.
 -->
-既に待機したロック取得者の数。
+既に待機したロック取得者の数です。
       </para></entry>
      </row>
 
@@ -6487,7 +7674,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Process ID of the locker currently being waited for.
 -->
-現在待機しているロック取得者のプロセスID。
+現在待機しているロック取得者のプロセスIDです。
       </para></entry>
      </row>
 
@@ -6499,7 +7686,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Total number of blocks to be processed in the current phase.
 -->
-現在のフェーズで処理されることになっているブロックの総数。
+現在のフェーズで処理されることになっているブロックの総数です。
       </para></entry>
      </row>
 
@@ -6511,7 +7698,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Number of blocks already processed in the current phase.
 -->
-現在のフェーズで既に処理されたブロック数。
+現在のフェーズで既に処理されたブロック数です。
       </para></entry>
      </row>
 
@@ -6523,7 +7710,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Total number of tuples to be processed in the current phase.
 -->
-現在のフェーズで処理されることになっているタプルの総数。
+現在のフェーズで処理されることになっているタプルの総数です。
       </para></entry>
      </row>
 
@@ -6535,7 +7722,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Number of tuples already processed in the current phase.
 -->
-現在のフェーズで既に処理されたタプル数。
+現在のフェーズで既に処理されたタプル数です。
       </para></entry>
      </row>
 
@@ -6569,7 +7756,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
   </table>
 
   <table id="create-index-phases">
+<!--
    <title>CREATE INDEX Phases</title>
+-->
+   <title>CREATE INDEXのフェーズ</title>
    <tgroup cols="2">
     <colspec colname="col1" colwidth="1*"/>
     <colspec colname="col2" colwidth="2*"/>
@@ -6741,7 +7931,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
   <title>VACUUM Progress Reporting</title>
 -->
-  <title>VACUUM進捗状況のレポート</title>
+  <title>VACUUMの進捗状況のレポート</title>
 
   <para>
 <!--
@@ -6757,18 +7947,24 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
    in place. See <xref linkend='cluster-progress-reporting'/>.
 -->
 <command>VACUUM</command>を実行するときはいつでも、<structname>pg_stat_progress_vacuum</structname>ビューは、現在バキューム処理している（自動バキュームワーカプロセスを含む）それぞれのバックエンドごとに１行を格納します。
-その情報を説明している以下のテーブルにおいて、何がレポートされ、どのように解釈するかについての情報を提供します。
+以下の表は、報告される情報を説明し、どのように解釈するかの情報を提供します。
 <command>VACUUM FULL</command>コマンドの進捗は<structname>pg_stat_progress_cluster</structname>でレポートされます。これは、通常の<command>VACUUM</command>はテーブル内を書き換えするのみである一方、<command>VACUUM FULL</command>と<command>CLUSTER</command>はいずれもテーブルを再作成するためです。
 <xref linkend='cluster-progress-reporting'/>を参照してください。
   </para>
 
   <table id="pg-stat-progress-vacuum-view" xreflabel="pg_stat_progress_vacuum">
+<!--
    <title><structname>pg_stat_progress_vacuum</structname> View</title>
+-->
+   <title><structname>pg_stat_progress_vacuum</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -6788,7 +7984,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Process ID of backend.
 -->
-バックエンドのプロセスID。
+バックエンドのプロセスIDです。
       </para></entry>
      </row>
 
@@ -6800,7 +7996,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        OID of the database to which this backend is connected.
 -->
-バックエンドが接続されているデータベースのOID。
+バックエンドが接続されているデータベースのOIDです。
       </para></entry>
      </row>
 
@@ -6812,7 +8008,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Name of the database to which this backend is connected.
 -->
-バックエンドが接続されているデータベース名。
+バックエンドが接続されているデータベースの名前です。
       </para></entry>
      </row>
 
@@ -6824,7 +8020,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        OID of the table being vacuumed.
 -->
-バキューム処理が行われているテーブルのOID。
+バキューム処理が行われているテーブルのOIDです。
       </para></entry>
      </row>
 
@@ -6833,7 +8029,11 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>phase</structfield> <type>text</type>
       </para>
       <para>
+<!--
        Current processing phase of vacuum.  See <xref linkend="vacuum-phases"/>.
+-->
+現在処理しているバキュームのフェーズです。
+<xref linkend="vacuum-phases"/>を参照してください。
       </para></entry>
      </row>
 
@@ -6847,7 +8047,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        as of the beginning of the scan; blocks added later will not be (and
        need not be) visited by this <command>VACUUM</command>.
 -->
-テーブルのヒープブロックの総数。
+テーブルのヒープブロックの総数です。
 この数字は、スキャンの開始を基点としてレポートされます。
 後に追加されるブロックは、この<command>VACUUM</command>によって処理されません（必要もありません）。
       </para></entry>
@@ -6866,7 +8066,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        equal to <structfield>heap_blks_total</structfield> when the vacuum is complete.
        This counter only advances when the phase is <literal>scanning heap</literal>.
 -->
-スキャンされたヒープブロックの数。
+スキャンされたヒープブロックの数です。
 <link linkend="storage-vm">可視性マップ</link>がスキャンを最適化するために使用されるため、いくつかのブロックが検査されずに読み飛ばされます。
 読み飛ばされたブロックはこの総数に含まれ、そのためこの数字はバキューム処理が完了した時に、最終的に<structfield>heap_blks_total</structfield>と同じになります。
 このカウンタは、フェーズが<literal>scanning heap</literal>の時にのみ増加します。
@@ -6884,7 +8084,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        Blocks that contain no dead tuples are skipped, so the counter may
        sometimes skip forward in large increments.
 -->
-バキューム処理されたヒープブロックの数。
+バキューム処理されたヒープブロックの数です。
 テーブルにインデックスが１つでも存在するなら、このカウンタはフェーズが<literal>vacuuming heap</literal>の時にのみ増加します。
 無効なタプルが含まれていないブロックは読み飛ばされ、それゆえカウンタは時々大きな増加量で早送りされます。
       </para></entry>
@@ -6898,7 +8098,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Number of completed index vacuum cycles.
 -->
-完了したインデックスバキュームサイクルの数。
+完了したインデックスバキュームサイクルの数です。
       </para></entry>
      </row>
 
@@ -6912,7 +8112,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        an index vacuum cycle, based on
        <xref linkend="guc-maintenance-work-mem"/>.
 -->
-インデックスバキュームサイクルの実行に必要となる前に格納することが出来る、<xref linkend="guc-maintenance-work-mem"/>に基づいた、無効なタプルの数。
+インデックスバキュームサイクルの実行に必要となる前に格納できる、<xref linkend="guc-maintenance-work-mem"/>に基づいた、無効なタプルの数です。
       </para></entry>
      </row>
 
@@ -6924,7 +8124,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Number of dead tuples collected since the last index vacuum cycle.
 -->
-最後のインデックスバキュームサイクルから収集された無効タプルの数。
+最後のインデックスバキュームサイクルから収集された無効タプルの数です。
       </para></entry>
      </row>
     </tbody>
@@ -7028,7 +8228,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        empty pages at the end of the relation to the operating system.  This
        occurs after cleaning up indexes.
 -->
-<command>VACUUM</command>は、現在リレーションの終点の空のページをオペレーティングシステムに戻すためにヒープを削除しています。
+<command>VACUUM</command>は、現在リレーションの終点の空のページをオペレーティングシステムに戻すためにヒープを切り詰めています。
 これは、インデックスの整理処理後に発生します。
      </entry>
     </row>
@@ -7056,7 +8256,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
   <title>CLUSTER Progress Reporting</title>
 -->
-  <title>CLUSTER進捗状況のレポート</title>
+  <title>CLUSTERの進捗状況のレポート</title>
 
   <para>
 <!--
@@ -7071,12 +8271,18 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
   </para>
 
   <table id="pg-stat-progress-cluster-view" xreflabel="pg_stat_progress_cluster">
+<!--
    <title><structname>pg_stat_progress_cluster</structname> View</title>
+-->
+   <title><structname>pg_stat_progress_cluster</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -7096,7 +8302,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Process ID of backend.
 -->
-バックエンドのプロセスID。
+バックエンドのプロセスIDです。
       </para></entry>
      </row>
 
@@ -7108,7 +8314,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        OID of the database to which this backend is connected.
 -->
-バックエンドが接続されているデータベースのOID。
+バックエンドが接続されているデータベースのOIDです。
       </para></entry>
      </row>
 
@@ -7120,7 +8326,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        Name of the database to which this backend is connected.
 -->
-バックエンドが接続されているデータベース名。
+バックエンドが接続されているデータベースの名前です。
       </para></entry>
      </row>
 
@@ -7132,7 +8338,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        OID of the table being clustered.
 -->
-クラスタ化されているテーブルのOID。
+クラスタ化されているテーブルのOIDです。
       </para></entry>
      </row>
 
@@ -7144,7 +8350,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        The command that is running. Either <literal>CLUSTER</literal> or <literal>VACUUM FULL</literal>.
 -->
-実行しているコマンド。
+実行しているコマンドです。
 <literal>CLUSTER</literal>か<literal>VACUUM FULL</literal>のいずれかです。
       </para></entry>
      </row>
@@ -7154,7 +8360,11 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>phase</structfield> <type>text</type>
       </para>
       <para>
+<!--
        Current processing phase. See <xref linkend="cluster-phases"/>.
+-->
+現在処理しているフェーズです。
+<xref linkend="cluster-phases"/>を参照してください。
       </para></entry>
      </row>
 
@@ -7183,8 +8393,8 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <literal>index scanning heap</literal>
        or <literal>writing new heap</literal>.
 -->
-スキャンされたヒープタプルの数。
-このカウンタは、フェーズが<literal>seq scanning heap</literal>、<literal>index scanning heap</literal>、または、<literal>writing new heap</literal>であるときのみ前進します。
+スキャンされたヒープタプルの数です。
+このカウンタは、フェーズが<literal>seq scanning heap</literal>、<literal>index scanning heap</literal>、または、<literal>writing new heap</literal>であるときのみ増加します。
       </para></entry>
      </row>
 
@@ -7200,8 +8410,8 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <literal>index scanning heap</literal>
        or <literal>writing new heap</literal>.
 -->
-書かれたヒープタプルの数。
-このカウンタは、フェーズが<literal>seq scanning heap</literal>、<literal>index scanning heap</literal>、または、<literal>writing new heap</literal>であるときのみ前進します。
+書かれたヒープタプルの数です。
+このカウンタは、フェーズが<literal>seq scanning heap</literal>、<literal>index scanning heap</literal>、または、<literal>writing new heap</literal>であるときのみ増加します。
       </para></entry>
      </row>
 
@@ -7214,7 +8424,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        Total number of heap blocks in the table.  This number is reported
        as of the beginning of <literal>seq scanning heap</literal>.
 -->
-テーブル内のヒープブロックの総数。
+テーブル内のヒープブロックの総数です。
 この数には<literal>seq scanning heap</literal>の開始時の値が報告されます。
       </para></entry>
      </row>
@@ -7228,8 +8438,8 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        Number of heap blocks scanned.  This counter only advances when the
        phase is <literal>seq scanning heap</literal>.
 -->
-スキャンされたヒープブロックの数。
-このカウンタは、フェーズが<literal>seq scanning heap</literal>であるときのみ前進します。
+スキャンされたヒープブロックの数です。
+このカウンタは、フェーズが<literal>seq scanning heap</literal>であるときのみ増加します。
       </para></entry>
      </row>
 
@@ -7242,8 +8452,8 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        Number of indexes rebuilt.  This counter only advances when the phase
        is <literal>rebuilding index</literal>.
 -->
-インデックス再作成の数。
-このカウンタはフェーズが<literal>rebuilding index</literal>であるときのみ前進します。
+インデックス再作成の数です。
+このカウンタはフェーズが<literal>rebuilding index</literal>であるときのみ増加します。
       </para></entry>
      </row>
     </tbody>
@@ -7314,7 +8524,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
        <command>CLUSTER</command> is currently writing the new heap.
 -->
-       <command>CLUSTER</command>が新しいヒープに書き込んでいます。
+<command>CLUSTER</command>が新しいヒープに書き込んでいます。
      </entry>
     </row>
     <row>
@@ -7353,9 +8563,13 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
  </sect2>
 
  <sect2 id="basebackup-progress-reporting">
+<!--
   <title>Base Backup Progress Reporting</title>
+-->
+  <title>ベースバックアップの進捗状況のレポート</title>
 
   <para>
+<!--
    Whenever an application like <application>pg_basebackup</application>
    is taking a base backup, the
    <structname>pg_stat_progress_basebackup</structname>
@@ -7363,15 +8577,24 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
    running the <command>BASE_BACKUP</command> replication command
    and streaming the backup. The tables below describe the information
    that will be reported and provide information about how to interpret it.
+-->
+<application>pg_basebackup</application>のようなアプリケーションがベースバックアップを取る時はいつでも、<structname>pg_stat_progress_basebackup</structname>ビューには現在<command>BASE_BACKUP</command>レプリケーションコマンドを実行し、バックアップをストリームしている各WAL送信プロセスごとの行が含まれます。
+以下の表は、報告される情報を説明し、どのように解釈するかの情報を提供します。
   </para>
 
   <table id="pg-stat-progress-basebackup-view" xreflabel="pg_stat_progress_basebackup">
+<!--
    <title><structname>pg_stat_progress_basebackup</structname> View</title>
+-->
+   <title><structname>pg_stat_progress_basebackup</structname>ビュー</title>
    <tgroup cols="1">
     <thead>
      <row>
       <entry role="catalog_table_entry"><para role="column_definition">
+<!--
        Column Type
+-->
+列 型
       </para>
       <para>
 <!--
@@ -7388,7 +8611,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>pid</structfield> <type>integer</type>
       </para>
       <para>
+<!--
        Process ID of a WAL sender process.
+-->
+WAL送信プロセスのプロセスIDです。
       </para></entry>
      </row>
 
@@ -7397,7 +8623,11 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>phase</structfield> <type>text</type>
       </para>
       <para>
+<!--
        Current processing phase. See <xref linkend="basebackup-phases"/>.
+-->
+現在処理中のフェーズです。
+<xref linkend="basebackup-phases"/>を参照してください。
       </para></entry>
      </row>
 
@@ -7406,6 +8636,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>backup_total</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Total amount of data that will be streamed. This is estimated and
        reported as of the beginning of
        <literal>streaming database files</literal> phase. Note that
@@ -7416,8 +8647,14 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        once the amount of data streamed exceeds the estimated
        total size. If the estimation is disabled in
        <application>pg_basebackup</application>
-       (i.e., <literal>--no-estimate-size</literal> option is specified),
+       (i.e., <literal>&#45;--no-estimate-size</literal> option is specified),
        this is <literal>NULL</literal>.
+-->
+ストリームされるデータの総量です。
+これは推定され、<literal>streaming database files</literal>フェーズの最初に報告されます。
+データベースは<literal>streaming database files</literal>フェーズの間に変化するかもしれませんし、WALログが後ほどバックアップに含められますので、これは近似でしかないことに注意してください。
+ストリームされたデータ量が推定された総量を超えたら、これは常に<structfield>backup_streamed</structfield>と同じ値です。
+<application>pg_basebackup</application>で推定が無効にされて(すなわち、<literal>--no-estimate-size</literal>オプションが指定されて)いれば、<literal>NULL</literal>です。
       </para></entry>
      </row>
 
@@ -7426,9 +8663,13 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>backup_streamed</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Amount of data streamed. This counter only advances
        when the phase is <literal>streaming database files</literal> or
        <literal>transferring wal files</literal>.
+-->
+ストリームされるデータの量です。
+このカウンタはフェーズが<literal>streaming database files</literal>または<literal>transferring wal files</literal>の時にのみ増加します。
       </para></entry>
      </row>
 
@@ -7437,7 +8678,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>tablespaces_total</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Total number of tablespaces that will be streamed.
+-->
+ストリームされるテーブル空間の総数です。
       </para></entry>
      </row>
 
@@ -7446,8 +8690,12 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
        <structfield>tablespaces_streamed</structfield> <type>bigint</type>
       </para>
       <para>
+<!--
        Number of tablespaces streamed. This counter only
        advances when the phase is <literal>streaming database files</literal>.
+-->
+ストリームされたテーブル空間の数です。
+このカウンタはフェーズが<literal>streaming database files</literal>の時にのみ増加します。
       </para></entry>
      </row>
     </tbody>
@@ -7455,69 +8703,98 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
   </table>
 
   <table id="basebackup-phases">
+<!--
    <title>Base backup phases</title>
+-->
+   <title>ベースバックアップのフェーズ</title>
    <tgroup cols="2">
     <colspec colname="col1" colwidth="1*"/>
     <colspec colname="col2" colwidth="2*"/>
     <thead>
      <row>
+<!--
       <entry>Phase</entry>
       <entry>Description</entry>
+-->
+      <entry>フェーズ</entry>
+      <entry>説明</entry>
      </row>
     </thead>
     <tbody>
      <row>
       <entry><literal>initializing</literal></entry>
       <entry>
+<!--
        The WAL sender process is preparing to begin the backup.
        This phase is expected to be very brief.
+-->
+WAL送信プロセスはバックアップを開始する準備をしています。
+このフェーズはごく短時間になると予想されます。
       </entry>
      </row>
      <row>
       <entry><literal>waiting for checkpoint to finish</literal></entry>
       <entry>
+<!--
        The WAL sender process is currently performing
        <function>pg_start_backup</function> to prepare to
        take a base backup, and waiting for the start-of-backup
        checkpoint to finish.
+-->
+WAL送信プロセスは、ベースバックアップを取る準備をするために現在<function>pg_start_backup</function>を実行し、バックアップ開始チェックポイントが完了するのを待っています。
       </entry>
      </row>
      <row>
       <entry><literal>estimating backup size</literal></entry>
       <entry>
+<!--
        The WAL sender process is currently estimating the total amount
        of database files that will be streamed as a base backup.
+-->
+WAL送信プロセスは、ベースバックアップとしてストリームされるデータベースファイルの総量を現在推定しています。
       </entry>
      </row>
      <row>
       <entry><literal>streaming database files</literal></entry>
       <entry>
+<!--
        The WAL sender process is currently streaming database files
        as a base backup.
+-->
+WAL送信プロセスはデータベースファイルをベースバックアップとして現在ストリームしています。
       </entry>
      </row>
      <row>
       <entry><literal>waiting for wal archiving to finish</literal></entry>
       <entry>
+<!--
        The WAL sender process is currently performing
        <function>pg_stop_backup</function> to finish the backup,
        and waiting for all the WAL files required for the base backup
        to be successfully archived.
-       If either <literal>--wal-method=none</literal> or
-       <literal>--wal-method=stream</literal> is specified in
+       If either <literal>&#45;-wal-method=none</literal> or
+       <literal>&#45;-wal-method=stream</literal> is specified in
        <application>pg_basebackup</application>, the backup will end
        when this phase is completed.
+-->
+WAL送信プロセスは、バックアップを終了するために現在<function>pg_start_backup</function>を実行し、ベースバックアップに必要なWALファイルすべてのアーカイブに成功するのを待っています。
+<application>pg_basebackup</application>で<literal>--wal-method=none</literal>か<literal>--wal-method=stream</literal>のいずれかが指定されれば、バックアップはこのフェーズが完了したら終了します。
       </entry>
      </row>
      <row>
       <entry><literal>transferring wal files</literal></entry>
       <entry>
+<!--
        The WAL sender process is currently transferring all WAL logs
        generated during the backup. This phase occurs after
        <literal>waiting for wal archiving to finish</literal> phase if
-       <literal>--wal-method=fetch</literal> is specified in
+       <literal>&#45;-wal-method=fetch</literal> is specified in
        <application>pg_basebackup</application>. The backup will end
        when this phase is completed.
+-->
+WAL送信プロセスはバックアップ中に生成されたWALログをすべて現在転送しています。
+<application>pg_basebackup</application>で<literal>--wal-method=fetch</literal>が指定されていれば、このフェーズが<literal>waiting for wal archiving to finish</literal>の次に来ます。
+バックアップはこのフェーズが完了したら終了します。
       </entry>
      </row>
     </tbody>
@@ -7544,7 +8821,8 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
    utility to be called at specific points in the code and thereby trace
    execution.
 -->
-<productname>PostgreSQL</productname>は、データベースサーバの動的追跡をサポートする機能を提供します。これにより、外部ユーティリティをコードの特定のポイントで呼び出すことができ、追跡を行うことができるようになります。
+<productname>PostgreSQL</productname>は、データベースサーバの動的追跡をサポートする機能を提供します。
+これにより、外部ユーティリティをコードの特定のポイントで呼び出すことができ、追跡を行うことができるようになります。
   </para>
 
   <para>
@@ -7556,7 +8834,9 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
    the configure script to make the probes available.
 
 -->
-多くの追跡やプローブ用のポイントは、すでにソースコード内部に存在します。これらのプローブはデータベースの開発者や管理者が使うことを意図しています。デフォルトでは、これらのプローブは<productname>PostgreSQL</productname>にコンパイルされません。ユーザは明示的にconfigureスクリプトでプローブを有効にするように設定する必要があります。
+多くの追跡やプローブ用のポイントは、すでにソースコード内部に存在します。
+これらのプローブはデータベースの開発者や管理者が使うことを意図しています。
+デフォルトでは、これらのプローブは<productname>PostgreSQL</productname>にコンパイルされません。ユーザは明示的にconfigureスクリプトでプローブを有効にするように設定する必要があります。
   </para>
 
   <para>
@@ -7589,7 +8869,9 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
    specify <option>&#045;-enable-dtrace</option> to configure.  See <xref
    linkend="install-procedure"/> for further information.
 -->
-デフォルトでは、プローブは有効ではありません。そのため、<productname>PostgreSQL</productname>でプローブが利用できるようにするためにconfigureスクリプトで明示的に設定しなければなりません。DTraceサポートを含めるには、configureに<option>--enable-dtrace</option>を指定します。詳細は<xref linkend="install-procedure"/>を参照してください。
+デフォルトでは、プローブは有効ではありません。そのため、<productname>PostgreSQL</productname>でプローブが利用できるようにするためにconfigureスクリプトで明示的に設定しなければなりません。
+DTraceサポートを含めるには、configureに<option>--enable-dtrace</option>を指定します。
+詳細は<xref linkend="install-procedure"/>を参照してください。
   </para>
   </sect2>
 
@@ -7607,7 +8889,8 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
    shows the types used in the probes.  More probes can certainly be
    added to enhance <productname>PostgreSQL</productname>'s observability.
 -->
-<xref linkend="dtrace-probe-point-table"/>で示されるように、多くの標準的なプローブがソースコード内で提供されています。<xref linkend="typedefs-table"/>はプローブで使用している型を示しています。また、<productname>PostgreSQL</productname>内の可観測性を強化するためのプローブ追加が可能です。
+<xref linkend="dtrace-probe-point-table"/>で示されるように、多くの標準的なプローブがソースコード内で提供されています。<xref linkend="typedefs-table"/>はプローブで使用している型を示しています。
+また、<productname>PostgreSQL</productname>内の可観測性を強化するためのプローブ追加が可能です。
   </para>
 
  <table id="dtrace-probe-point-table">
@@ -7641,7 +8924,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
      <entry>Probe that fires at the start of a new transaction.
       arg0 is the transaction ID.</entry>
 -->
-     <entry>新しいトランザクションの開始を捕捉するプローブ。arg0はトランザクションIDです。</entry>
+     <entry>新しいトランザクションの開始を捕捉するプローブです。arg0はトランザクションIDです。</entry>
     </row>
     <row>
      <entry><literal>transaction-commit</literal></entry>
@@ -7650,7 +8933,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
      <entry>Probe that fires when a transaction completes successfully.
       arg0 is the transaction ID.</entry>
 -->
-     <entry>トランザクションの正常終了を捕捉するプローブ。arg0はトランザクションIDです。</entry>
+     <entry>トランザクションの正常終了を捕捉するプローブです。arg0はトランザクションIDです。</entry>
     </row>
     <row>
      <entry><literal>transaction-abort</literal></entry>
@@ -7659,7 +8942,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
      <entry>Probe that fires when a transaction completes unsuccessfully.
       arg0 is the transaction ID.</entry>
 -->
-     <entry>トランザクションの異常終了を捕捉するプローブ。arg0はトランザクションIDです。</entry>
+     <entry>トランザクションの異常終了を捕捉するプローブです。arg0はトランザクションIDです。</entry>
     </row>
     <row>
      <entry><literal>query-start</literal></entry>
@@ -7668,7 +8951,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
      <entry>Probe that fires when the processing of a query is started.
       arg0 is the query string.</entry>
 -->
-     <entry>問い合わせ処理の開始を捕捉するプローブ。arg0は問い合わせ文字列です。</entry>
+     <entry>問い合わせ処理の開始を捕捉するプローブです。arg0は問い合わせ文字列です。</entry>
     </row>
     <row>
      <entry><literal>query-done</literal></entry>
@@ -7677,7 +8960,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
      <entry>Probe that fires when the processing of a query is complete.
       arg0 is the query string.</entry>
 -->
-     <entry>問い合わせ処理の正常終了を捕捉するプローブ。arg0は問い合わせ文字列です。</entry>
+     <entry>問い合わせ処理の正常終了を捕捉するプローブです。arg0は問い合わせ文字列です。</entry>
     </row>
     <row>
      <entry><literal>query-parse-start</literal></entry>
@@ -7686,7 +8969,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
      <entry>Probe that fires when the parsing of a query is started.
       arg0 is the query string.</entry>
 -->
-     <entry>問い合わせのパース処理の開始を捕捉するプローブ。arg0は問い合わせ文字列です。</entry>
+     <entry>問い合わせのパース処理の開始を捕捉するプローブです。arg0は問い合わせ文字列です。</entry>
     </row>
     <row>
      <entry><literal>query-parse-done</literal></entry>
@@ -7695,7 +8978,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
      <entry>Probe that fires when the parsing of a query is complete.
       arg0 is the query string.</entry>
 -->
-     <entry>問い合わせのパース処理の正常終了を捕捉するプローブ。arg0は問い合わせ文字列です。</entry>
+     <entry>問い合わせのパース処理の正常終了を捕捉するプローブです。arg0は問い合わせ文字列です。</entry>
     </row>
     <row>
      <entry><literal>query-rewrite-start</literal></entry>
@@ -7704,7 +8987,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
      <entry>Probe that fires when the rewriting of a query is started.
       arg0 is the query string.</entry>
 -->
-     <entry>問い合わせの書き換え処理の開始を捕捉するプローブ。arg0は問い合わせ文字列です。</entry>
+     <entry>問い合わせの書き換え処理の開始を捕捉するプローブです。arg0は問い合わせ文字列です。</entry>
     </row>
     <row>
      <entry><literal>query-rewrite-done</literal></entry>
@@ -7713,7 +8996,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
      <entry>Probe that fires when the rewriting of a query is complete.
       arg0 is the query string.</entry>
 -->
-     <entry>問い合わせの書き換え処理の正常終了を捕捉するプローブ。arg0は問い合わせ文字列です。</entry>
+     <entry>問い合わせの書き換え処理の正常終了を捕捉するプローブです。arg0は問い合わせ文字列です。</entry>
     </row>
     <row>
      <entry><literal>query-plan-start</literal></entry>
@@ -7721,7 +9004,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
      <entry>Probe that fires when the planning of a query is started.</entry>
 -->
-     <entry>問い合わせのプランナ処理の開始を捕捉するプローブ。</entry>
+     <entry>問い合わせのプランナ処理の開始を捕捉するプローブです。</entry>
     </row>
     <row>
      <entry><literal>query-plan-done</literal></entry>
@@ -7729,7 +9012,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
      <entry>Probe that fires when the planning of a query is complete.</entry>
 -->
-     <entry>問い合わせのプランナ処理の正常終了を捕捉するプローブ。</entry>
+     <entry>問い合わせのプランナ処理の正常終了を捕捉するプローブです。</entry>
     </row>
     <row>
      <entry><literal>query-execute-start</literal></entry>
@@ -7737,7 +9020,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
      <entry>Probe that fires when the execution of a query is started.</entry>
 -->
-     <entry>問い合わせの実行(エクゼキュータ)処理の開始を捕捉するプローブ。</entry>
+     <entry>問い合わせの実行(エクゼキュータ)処理の開始を捕捉するプローブです。</entry>
     </row>
     <row>
      <entry><literal>query-execute-done</literal></entry>
@@ -7745,7 +9028,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
 <!--
      <entry>Probe that fires when the execution of a query is complete.</entry>
 -->
-     <entry>問い合わせの実行(エクゼキュータ)処理の正常終了を捕捉するプローブ。</entry>
+     <entry>問い合わせの実行(エクゼキュータ)処理の正常終了を捕捉するプローブです。</entry>
     </row>
     <row>
      <entry><literal>statement-status</literal></entry>
@@ -7756,7 +9039,7 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
       arg0 is the new status string.</entry>
 -->
      <entry>
-サーバプロセスによる<structname>pg_stat_activity</structname>.<structfield>status</structfield>の状態の更新を捕捉するプローブ。
+サーバプロセスによる<structname>pg_stat_activity</structname>.<structfield>status</structfield>の状態の更新を捕捉するプローブです。
 arg0は新しい状態の文字列です。
      </entry>
     </row>
@@ -7784,7 +9067,7 @@ arg0はチェックポイントの種類の違い(shutdown、immediate、force)�
       removed and recycled respectively.</entry>
 -->
      <entry>
-チェックポイントの正常終了を捕捉するプローブ。
+チェックポイントの正常終了を捕捉するプローブです。
 (以下に示すプローブはチェックポイント進行に従い順番に捕捉されます。)
 arg0は書き込まれたバッファ数、arg1はバッファの総数、arg2、3、4はそれぞれ追加、削除、再利用されたWALファイルの数です。
      </entry>
@@ -7798,7 +9081,7 @@ arg0は書き込まれたバッファ数、arg1はバッファの総数、arg2�
       checkpoint.</entry>
 -->
      <entry>
-CLOG部分のチェックポイントの開始を捕捉するプローブ。
+CLOG部分のチェックポイントの開始を捕捉するプローブです。
 arg0がtrueならば通常のチェックポイントであり、falseならばシャットダウン時のチェックポイントを示します。
      </entry>
     </row>
@@ -7810,7 +9093,7 @@ arg0がtrueならば通常のチェックポイントであり、falseならば�
       complete. arg0 has the same meaning as for <literal>clog-checkpoint-start</literal>.</entry>
 -->
      <entry>
-CLOG部分のチェックポイントの正常終了を捕捉するプローブ。
+CLOG部分のチェックポイントの正常終了を捕捉するプローブです。
 arg0は<literal>clog-checkpoint-start</literal>と同じ意味を持ちます。
      </entry>
     </row>
@@ -7824,7 +9107,7 @@ arg0は<literal>clog-checkpoint-start</literal>と同じ意味を持ちます。
       checkpoint.</entry>
 -->
      <entry>
-サブトランザクション部分のチェックポイントの開始を捕捉するプローブ。
+サブトランザクション部分のチェックポイントの開始を捕捉するプローブです。
 arg0がtrueならば通常のチェックポイントであり、falseならばシャットダウン時のチェックポイントを示します。
      </entry>
     </row>
@@ -7837,7 +9120,7 @@ arg0がtrueならば通常のチェックポイントであり、falseならば�
       <literal>subtrans-checkpoint-start</literal>.</entry>
 -->
      <entry>
-サブトランザクション部分のチェックポイントの正常終了を捕捉するプローブ。
+サブトランザクション部分のチェックポイントの正常終了を捕捉するプローブです。
 arg0は<literal>subtrans-checkpoint-start</literal>と同じ意味を持ちます。
      </entry>
     </row>
@@ -7851,7 +9134,7 @@ arg0は<literal>subtrans-checkpoint-start</literal>と同じ意味を持ちま�
       checkpoint.</entry>
 -->
      <entry>
-マルチトランザクション部分のチェックポイントの開始を捕捉するプローブ。
+マルチトランザクション部分のチェックポイントの開始を捕捉するプローブです。
 arg0がtrueならば通常のチェックポイントであり、falseならばシャットダウン時のチェックポイントを示します。
      </entry>
     </row>
@@ -7864,7 +9147,7 @@ arg0がtrueならば通常のチェックポイントであり、falseならば�
       <literal>multixact-checkpoint-start</literal>.</entry>
 -->
      <entry>
-マルチトランザクション部分のチェックポイントの正常終了を捕捉するプローブ。
+マルチトランザクション部分のチェックポイントの正常終了を捕捉するプローブです。
 arg0は<literal>multixact-checkpoint-start</literal>と同じ意味を持ちます。
      </entry>
     </row>
@@ -7878,7 +9161,7 @@ arg0は<literal>multixact-checkpoint-start</literal>と同じ意味を持ちま�
       types, such as shutdown, immediate or force.</entry>
 -->
      <entry>
-チェックポイントのバッファ書き込み部分の開始を捕捉するプローブ。
+チェックポイントのバッファ書き込み部分の開始を捕捉するプローブです。
 arg0はチェックポイントの種類の違い(shutdown、immediate、force)を区別するためのビットフラグを持っています。
      </entry>
     </row>
@@ -7892,7 +9175,7 @@ arg0はチェックポイントの種類の違い(shutdown、immediate、force)�
       arg1 is the number that are currently dirty and need to be written.</entry>
 -->
      <entry>
-チェックポイント中のダーティバッファの書き出し開始を捕捉するプローブ(どのバッファが書き出す必要があるのかを判定した後です)。
+チェックポイント中のダーティバッファの書き出し開始を捕捉するプローブです(どのバッファが書き出す必要があるのかを判定した後です)。
 arg0はバッファの総数で、arg1は現在ダーティであり、書き出す必要のあるバッファ数です。
      </entry>
     </row>
@@ -7904,7 +9187,7 @@ arg0はバッファの総数で、arg1は現在ダーティであり、書き出
       arg0 is the ID number of the buffer.</entry>
 -->
      <entry>
-チェックポイント中のそれぞれのバッファの書き出し後を捕捉するプローブ。
+チェックポイント中のそれぞれのバッファの書き出し後を捕捉するプローブです。
 arg0はバッファのIDを示します。
      </entry>
     </row>
@@ -7920,11 +9203,11 @@ arg0はバッファのIDを示します。
       buffers during the checkpoint.</entry>
 -->
      <entry>
-全てのダーティバッファの書き出し後を捕捉するプローブ。
+全てのダーティバッファの書き出し後を捕捉するプローブです。
 arg0はバッファの総数です。
 arg1はチェックポイント処理により実際に書き出されたバッファ数です。
 arg2は書き出されるであろうと見積もられたバッファ数(<literal>buffer-sync-start</literal>のarg1相当)です。
-この違いはチェックポイント中に他のプロセスにより書き出されたバッファ分です。
+違いはチェックポイント中に他のプロセスがバッファを書き出したことを反映しています。
      </entry>
     </row>
     <row>
@@ -7934,7 +9217,7 @@ arg2は書き出されるであろうと見積もられたバッファ数(<liter
      <entry>Probe that fires after dirty buffers have been written to the
       kernel, and before starting to issue fsync requests.</entry>
 -->
-     <entry>カーネルへのダーティバッファの書き出し処理発行の後、そして同期書き出し要求を開始する前を捕捉するプローブ。</entry>
+     <entry>カーネルへのダーティバッファの書き出し処理発行の後、そして同期書き出し要求を開始する前を捕捉するプローブです。</entry>
     </row>
     <row>
      <entry><literal>buffer-checkpoint-done</literal></entry>
@@ -7943,7 +9226,7 @@ arg2は書き出されるであろうと見積もられたバッファ数(<liter
      <entry>Probe that fires when syncing of buffers to disk is
       complete.</entry>
 -->
-     <entry>バッファからディスクへの同期書き出し処理の終了を捕捉するプローブ。</entry>
+     <entry>バッファからディスクへの同期書き出し処理の終了を捕捉するプローブです。</entry>
     </row>
     <row>
      <entry><literal>twophase-checkpoint-start</literal></entry>
@@ -7952,7 +9235,7 @@ arg2は書き出されるであろうと見積もられたバッファ数(<liter
      <entry>Probe that fires when the two-phase portion of a checkpoint is
       started.</entry>
 -->
-     <entry>二相コミット部分のチェックポイントの開始を捕捉するプローブ。</entry>
+     <entry>二相コミット部分のチェックポイントの開始を捕捉するプローブです。</entry>
     </row>
     <row>
      <entry><literal>twophase-checkpoint-done</literal></entry>
@@ -7961,7 +9244,7 @@ arg2は書き出されるであろうと見積もられたバッファ数(<liter
      <entry>Probe that fires when the two-phase portion of a checkpoint is
       complete.</entry>
 -->
-     <entry>二相コミット部分のチェックポイントの正常終了を捕捉するプローブ。</entry>
+     <entry>二相コミット部分のチェックポイントの正常終了を捕捉するプローブです。</entry>
     </row>
     <row>
      <entry><literal>buffer-read-start</literal></entry>
@@ -7978,7 +9261,8 @@ arg2は書き出されるであろうと見積もられたバッファ数(<liter
       read.</entry>
 -->
      <entry>
-バッファ読み込みの開始を捕捉するプローブ。arg0はとarg1は読み込みページのフォーク番号とブロック番号です(ただし、リレーションの拡張要求があった場合、arg1は-1になるでしょう)。
+バッファ読み込みの開始を捕捉するプローブです。
+arg0とarg1は読み込みページのフォーク番号とブロック番号です(ただし、リレーションの拡張要求であれば、arg1は-1になるでしょう)。
 arg2、arg3、arg4は対象のリレーションを識別するテーブル空間、データベース、そしてリレーションのOIDです。
 arg5は一時テーブルをローカルバッファに作成していればそのバックエンドのIDであり、<symbol>InvalidBackendId</symbol>(-1)であれは共有バッファを指します。
 arg6はtrueならばリレーションの拡張要求、falseは通常の読み込みを示します。</entry>
@@ -8000,10 +9284,12 @@ arg6はtrueならばリレーションの拡張要求、falseは通常の読み�
       arg7 is true if the buffer was found in the pool, false if not.</entry>
 -->
      <entry>
-バッファ読み込みの終了を捕捉するプローブ。
-arg0とarg1は読み込みページのフォーク番号とブロック番号です(もしリレーションの拡張要求があった場合、arg1は新たに追加されたブロックの番号を含みます)。
-arg2、arg3、arg4は対象のテーブルを識別するテーブル空間、データベース、そしてテーブルのOIDです。arg5は一時テーブルをローカルバッファに作成していればそのバックエンドのIDであり、<symbol>InvalidBackendId</symbol>(-1)であれは共有バッファを指します。
-arg6はtrueならばリレーションの拡張要求、falseは通常の読み込みを示します。arg7はtrueならばバッファがプール内にある、falseはプール内に無かったことを示します。
+バッファ読み込みの終了を捕捉するプローブです。
+arg0とarg1は読み込みページのフォーク番号とブロック番号です(もしリレーションの拡張要求であれば、arg1は新たに追加されたブロックの番号を含みます)。
+arg2、arg3、arg4は対象のテーブルを識別するテーブル空間、データベース、そしてテーブルのOIDです。
+arg5は一時テーブルをローカルバッファに作成していればそのバックエンドのIDであり、<symbol>InvalidBackendId</symbol>(-1)であれは共有バッファを指します。
+arg6はtrueならばリレーションの拡張要求、falseは通常の読み込みを示します。
+arg7はtrueならばバッファがプール内にある、falseはプール内に無かったことを示します。
      </entry>
     </row>
     <row>
@@ -8017,7 +9303,7 @@ arg6はtrueならばリレーションの拡張要求、falseは通常の読み�
       identifying the relation.</entry>
 -->
      <entry>
-共有バッファへの書き込み要求開始を捕捉するプローブ。
+共有バッファへの書き込み要求開始を捕捉するプローブです。
 arg0とarg1はそのページのフォーク番号とブロック番号です。
 arg2、arg3、arg4は対象のリレーションを識別するテーブル空間、データベース、そしてテーブルのOIDです。
      </entry>
@@ -8032,7 +9318,7 @@ arg2、arg3、arg4は対象のリレーションを識別するテーブル空�
       The arguments are the same as for <literal>buffer-flush-start</literal>.</entry>
 -->
      <entry>
-書き込み要求の終了を捕捉するプローブ。
+書き込み要求の終了を捕捉するプローブです。
 (これはカーネルへデータを渡したタイミングのみを反映していることに注意してください。大抵、この時点ではまだ実際にディスクへ書き込まれていません。)
 引数は<literal>buffer-flush-start</literal>と同じです。
      </entry>
@@ -8050,7 +9336,7 @@ arg2、arg3、arg4は対象のリレーションを識別するテーブル空�
       identifying the relation.</entry>
 -->
      <entry>
-サーバプロセスによるダーティバッファの書き出し開始を捕捉するプローブ。
+サーバプロセスによるダーティバッファの書き出し開始を捕捉するプローブです。
 (もしこれが頻発するようでしたら、<xref linkend="guc-shared-buffers"/>が少な過ぎるか、バックグラウンドライタ制御のパラメータの調節が必要なことを意味します。)
 arg0とarg1はそのページのフォーク番号とブロック番号です。
 arg2、arg3、arg4は対象のリレーションを識別するテーブル空間、データベース、そしてリレーションのOIDです。
@@ -8078,7 +9364,7 @@ arg2、arg3、arg4は対象のリレーションを識別するテーブル空�
       <xref linkend="guc-wal-buffers"/> is too small.)</entry>
 -->
      <entry>
-WALバッファ領域の不足によるサーバプロセスのダーティなWALバッファの書き出しを捕捉するプローブ。
+WALバッファ領域の不足によるサーバプロセスのダーティなWALバッファの書き出しを捕捉するプローブです。
 (もしこれが頻発するようでしたら、<xref linkend="guc-wal-buffers"/>が小さすぎることを意味します。)
      </entry>
     </row>
@@ -8088,7 +9374,7 @@ WALバッファ領域の不足によるサーバプロセスのダーティなWA
 <!--
      <entry>Probe that fires when a dirty WAL buffer write is complete.</entry>
 -->
-     <entry>ダーティなWALバッファの書き出し終了を捕捉するプローブ。</entry>
+     <entry>ダーティなWALバッファの書き出し終了を捕捉するプローブです。</entry>
     </row>
     <row>
      <entry><literal>wal-insert</literal></entry>
@@ -8099,8 +9385,9 @@ WALバッファ領域の不足によるサーバプロセスのダーティなWA
       arg1 contains the info flags.</entry>
 -->
      <entry>
-WALレコードの挿入を捕捉するプローブ。
-arg0はレコードのリソースマネージャ(rmid)です。arg1は情報フラグです。
+WALレコードの挿入を捕捉するプローブです。
+arg0はレコードのリソースマネージャ(rmid)です。
+arg1は情報フラグです。
      </entry>
     </row>
     <row>
@@ -8143,7 +9430,7 @@ arg5は一時テーブルをローカルバッファに作成していればそ�
       requested (if these are different it indicates trouble).</entry>
 -->
      <entry>
-ブロックの読み込み終了を捕捉するプローブ。
+ブロックの読み込み終了を捕捉するプローブです。
 arg0とarg1はそのページのフォーク番号とブロック番号です。
 arg2、arg3、arg4は対象のリレーションを識別するテーブル空間、データベース、そしてリレーションのOIDです。
 arg5は一時テーブルをローカルバッファに作成していればそのバックエンドのIDであり、<symbol>InvalidBackendId</symbol>(-1)であれは共有バッファを指します。
@@ -8162,7 +9449,7 @@ arg6は実際に読み込んだバイト数、arg7はリクエストされた読
       local buffer, or <symbol>InvalidBackendId</symbol> (-1) for a shared buffer.</entry>
 -->
      <entry>
-リレーションへのブロック書き出しの開始を捕捉するプローブ。
+リレーションへのブロック書き出しの開始を捕捉するプローブです。
 arg0とarg1はそのページのフォーク番号とブロック番号です。
 arg2、arg3、arg4は対象のリレーションを識別するテーブル空間、データベース、そしてリレーションのOIDです。
 arg5は一時テーブルをローカルバッファに作成していればそのバックエンドのIDであり、<symbol>InvalidBackendId</symbol>(-1)であれは共有バッファを指します。
@@ -8182,7 +9469,7 @@ arg5は一時テーブルをローカルバッファに作成していればそ�
       requested (if these are different it indicates trouble).</entry>
 -->
      <entry>
-ブロックの書き出し終了を捕捉するプローブ。
+ブロックの書き出し終了を捕捉するプローブです。
 arg0とarg1はそのページのフォーク番号とブロック番号です。
 arg2、arg3、arg4は対象のリレーションを識別するテーブル空間、データベース、そしてリレーションのOIDです。
 arg5は一時テーブルをローカルバッファに作成していればそのバックエンドのIDであり、<symbol>InvalidBackendId</symbol>(-1)であれは共有バッファを指します。
@@ -8203,13 +9490,13 @@ arg6は実際に書き出したバイト数、arg7はリクエストされた書
       <literal>1</literal>, or parallel leader when <literal>2</literal>.</entry>
 -->
      <entry>
-ソート処理の開始を捕捉するプローブ。
+ソート処理の開始を捕捉するプローブです。
 arg0は対象データがヒープ、インデックス、またはdatumのどれかを示します。
 arg1はtrueならば一意性を必要としていることを示します。
 arg2はカラムのキー数です。
 arg3は許容されている作業メモリ(work_mem)のキロバイト数です。
 arg4はtrueならばソート結果に対するランダムアクセスが要求されていることを示します。
-arg5は、<literal>0</literal>ならばシリアル、<literal>1</literal>ならばパラレルワーカー、<literal>2</literal>ならばパラレルリーダーであることを示します。
+arg5は、<literal>0</literal>ならばシリアル、<literal>1</literal>ならばパラレルワーカ、<literal>2</literal>ならばパラレルリーダーであることを示します。
      </entry>
     </row>
     <row>
@@ -8222,7 +9509,7 @@ arg5は、<literal>0</literal>ならばシリアル、<literal>1</literal>なら
       or kilobytes of memory used for an internal sort.</entry>
 -->
      <entry>
-ソート処理の終了を捕捉するプローブ。
+ソート処理の終了を捕捉するプローブです。
 arg0はtrueならば外部ソート、falseは内部ソートを示します。
 arg1は外部ソートで使用されたディスクブロック数、もしくは内部ソートで使用されたメモリーのキロバイト数を示します。
      </entry>
@@ -8236,7 +9523,7 @@ arg1は外部ソートで使用されたディスクブロック数、もしく�
       arg1 is the requested lock mode, either exclusive or shared.</entry>
 -->
      <entry>
-LWLockの獲得を捕捉するプローブ。
+LWLockの獲得を捕捉するプローブです。
 arg0はLWLockのトランシェを示します。
 arg1は要求されたロックモード（排他または共有）を示します。
      </entry>
@@ -8250,7 +9537,7 @@ arg1は要求されたロックモード（排他または共有）を示しま�
       arg0 is the LWLock's tranche.</entry>
 -->
      <entry>
-LWLockの解放を捕捉するプローブ（ただし、解放された待機状態のものにはまだ通知されていないことに注意してください）。
+LWLockの解放を捕捉するプローブです（ただし、解放された待機状態のものにはまだ通知されていないことに注意してください）。
 arg0はLWLockのトランシェを示します。
      </entry>
     </row>
@@ -8264,7 +9551,7 @@ arg0はLWLockのトランシェを示します。
       arg1 is the requested lock mode, either exclusive or shared.</entry>
 -->
      <entry>
-LWLockが即座には獲得できず、ロックが利用可能になるまでサーバプロセスが待機を開始したことを捕捉するプローブ。
+LWLockが即座には獲得できず、ロックが利用可能になるまでサーバプロセスが待機を開始したことを捕捉するプローブです。
 arg0はLWLockのトランシェを示します。
 arg1は要求されたロックモード（排他または共有）を示します。
      </entry>
@@ -8279,7 +9566,7 @@ arg1は要求されたロックモード（排他または共有）を示しま�
       arg1 is the requested lock mode, either exclusive or shared.</entry>
 -->
      <entry>
-サーバプロセスがLWLockの待機から解放されたことを捕捉するプローブ（まだ実際にはロックを取得していません）。
+サーバプロセスがLWLockの待機から解放されたことを捕捉するプローブです（まだ実際にはロックを取得していません）。
 arg0はLWLockのトランシェを示します。
 arg1は要求されたロックモード（排他または共有）を示します。
      </entry>
@@ -8294,7 +9581,7 @@ arg1は要求されたロックモード（排他または共有）を示しま�
       arg1 is the requested lock mode, either exclusive or shared.</entry>
 -->
      <entry>
-呼び出し元が待機しないことを指定した際の、LWLockの獲得成功を捕捉するプローブ。
+呼び出し元が待機しないことを指定した際の、LWLockの獲得成功を捕捉するプローブです。
 arg0はLWLockのトランシェを示します。
 arg1は要求されたロックモード（排他または共有）を示します。
      </entry>
@@ -8309,7 +9596,7 @@ arg1は要求されたロックモード（排他または共有）を示しま�
       arg1 is the requested lock mode, either exclusive or shared.</entry>
 -->
      <entry>
-呼び出し元が待機しないことを指定した際の、LWLockの獲得失敗を捕捉するプローブ。
+呼び出し元が待機しないことを指定した際の、LWLockの獲得失敗を捕捉するプローブです。
 arg0はLWLockのトランシェを示します。
 arg1は要求されたロックモード（排他または共有）を示します。
      </entry>
@@ -8325,7 +9612,7 @@ arg1は要求されたロックモード（排他または共有）を示しま�
       arg5 indicates the lock type being requested.</entry>
 -->
      <entry>
-通常のロック(lmgr lock)を即座に取得できなかったため、サーバプロセスがロックを利用できるまでロック待ち状態になった際の開始を捕捉するプローブ。
+重量ロック(lmgr lock)を即座に取得できなかったため、サーバプロセスがロックを利用できるまでロック待ち状態になった際の開始を捕捉するプローブです。
 arg0からarg3はロックされたオブジェクトの識別用タグ領域です。
 arg4はロックされたオブジェクトのタイプを示します。
 arg5は要求されたロックの種類を示します。
@@ -8340,7 +9627,7 @@ arg5は要求されたロックの種類を示します。
       The arguments are the same as for <literal>lock-wait-start</literal>.</entry>
 -->
      <entry>
-通常のロック(lmgr lock)要求の待機終了を捕捉するプローブ(つまりロックを取得した)。
+重量ロック(lmgr lock)要求の待機終了を捕捉するプローブです(つまりロックを取得した)。
 引数は<literal>lock-wait-start</literal>と同じです。
      </entry>
     </row>
@@ -8351,7 +9638,7 @@ arg5は要求されたロックの種類を示します。
      <entry>Probe that fires when a deadlock is found by the deadlock
       detector.</entry>
 -->
-     <entry>デッドロック検知器によるデッドロックの発見を捕捉するプローブ。</entry>
+     <entry>デッドロック検知器によるデッドロックの発見を捕捉するプローブです。</entry>
     </row>
 
    </tbody>
@@ -8425,7 +9712,7 @@ arg5は要求されたロックの種類を示します。
    counts in the system, as an alternative to snapshotting
    <structname>pg_stat_database</structname> before and after a performance test:
 -->
-以下の例では、システムにおけるトランザクション数を解析するDTraceスクリプトを示します。性能試験前後で<structname>pg_stat_database</structname>のスナップショットを取ることで代替可能です。
+以下の例では、性能試験前後で<structname>pg_stat_database</structname>のスナップショットを取る代わりに、システムにおけるトランザクション数を解析するDTraceスクリプトを示します。
 <programlisting>
 #!/usr/sbin/dtrace -qs
 
@@ -8486,7 +9773,9 @@ Total time (ns)                        2312105013
    discussing information found using dynamic tracing, be sure to enclose
    the script used to allow that too to be checked and discussed.
 -->
-DTraceスクリプトの作成には注意が必要であり、デバッグが必要であることは忘れないでください。さもないと、収集される追跡情報の意味がなくなるかもしれません。ほとんどの場合、見つかる問題はシステムではなく使用方法の間違いです。動的追跡を使用して見つかった情報に関して議論を行う際には、スクリプトの検査や議論もできるようにスクリプトも含めるようにしてください。
+DTraceスクリプトの作成には注意が必要であり、デバッグが必要であることは忘れないでください。さもないと、収集される追跡情報の意味がなくなるかもしれません。
+ほとんどの場合、見つかる問題はシステムではなく使用方法の間違いです。
+動的追跡を使用して見つかった情報に関して議論を行う際には、スクリプトの検査や議論もできるようにスクリプトも含めるようにしてください。
   </para>
   </sect2>
 
@@ -8502,7 +9791,8 @@ DTraceスクリプトの作成には注意が必要であり、デバッグが�
    desires, though this will require a recompilation. Below are the steps
    for inserting new probes:
 -->
-開発者が望めばコード内に新しくプローブを定義することができます。しかし、これには再コンパイルが必要です。下記は、新規プローブの定義の手順です。
+開発者が望めばコード内に新しくプローブを定義することができます。しかし、これには再コンパイルが必要です。
+下記は、新規プローブの定義の手順です。
   </para>
 
   <procedure>
@@ -8532,7 +9822,7 @@ DTraceスクリプトの作成には注意が必要であり、デバッグが�
      <literal>TRACE_POSTGRESQL</literal> probe macros at the desired locations
      in the source code
 -->
-もし、プローブポイントを含むモジュールが<filename>pg_trace.h</filename>をインクルードしてなければそれをインクルードし、ソースコード中のプローブを行いたい場所に<literal>TRACE_POSTGRESQL</literal>マクロを挿入します
+もし、プローブポイントを含むモジュールが<filename>pg_trace.h</filename>をインクルードしていなければそれをインクルードし、ソースコード中のプローブを行いたい場所に<literal>TRACE_POSTGRESQL</literal>マクロを挿入します
     </para>
    </step>
 
@@ -8567,7 +9857,7 @@ DTraceスクリプトの作成には注意が必要であり、デバッグが�
      Decide that the probe will be named <literal>transaction-start</literal> and
      requires a parameter of type <type>LocalTransactionId</type>
 -->
-プローブ名を<literal>transaction-start</literal>とし、パラメータとして<type>LocalTransactionId</type>型を必要とすることを決めます。
+プローブ名を<literal>transaction-start</literal>とし、<type>LocalTransactionId</type>型のパラメータを必要とすることを決めます。
     </para>
    </step>
 
@@ -8586,7 +9876,7 @@ probe transaction__start(LocalTransactionId);
      hyphen, so <literal>transaction-start</literal> is the name to document for
      users.
 -->
-プローブ名に二重のアンダースコアを使用する場合は注意して下さい。
+プローブ名に二重のアンダースコアを使用する場合は注意してください。
 DTraceスクリプトでプローブを用いる場合、二重のアンダースコアをハイフンに置き換える必要があります。そのため、<literal>transaction-start</literal>がユーザ向けの文書に記載される名前となります。
     </para>
    </step>
@@ -8617,7 +9907,8 @@ TRACE_POSTGRESQL_TRANSACTION_START(vxid.localTransactionId);
      probe is available by executing the following DTrace command.  You
      should see similar output:
 -->
-再コンパイル後に新しいバイナリでサーバを起動し、下記の様なDTraceコマンドの実行により新たに追加したプローブが利用可能なチェックします。下記の様な出力が確認できるはずです:
+再コンパイル後に新しいバイナリでサーバを起動し、下記の様なDTraceコマンドの実行により新たに追加したプローブが利用可能かチェックします。
+下記の様な出力が確認できるはずです:
 <screen>
 # dtrace -ln transaction-start
    ID    PROVIDER          MODULE           FUNCTION NAME
@@ -8646,7 +9937,8 @@ Cのソースコードに追跡用のマクロを追加する際、いくつか�
       parameters match the data types of the variables used in the macro.
       Otherwise, you will get compilation errors.
 -->
-プローブの引数に指定したデータ型がマクロで使用される変数のデータ型と一致するよう注意しなければなりません。でなければ、コンパイル時にエラーとなるでしょう。
+プローブの引数に指定したデータ型がマクロで使用される変数のデータ型と一致するよう注意しなければなりません。
+でなければ、コンパイル時にエラーとなるでしょう。
      </para>
     </listitem>
 
@@ -8664,9 +9956,9 @@ Cのソースコードに追跡用のマクロを追加する際、いくつか�
       consider protecting the macro with a check to see if the trace
       is actually enabled:
 -->
-ほとんどのプラットフォームでは、もし<productname>PostgreSQL</productname>が<option>--enable-dtrace</option>付きでビルドされた場合、<emphasis>何の追跡がされなかった</emphasis>としても、制御がマクロを通過する際はいつでも追跡用マクロの引数が評価されます。
+ほとんどのプラットフォームでは、もし<productname>PostgreSQL</productname>が<option>--enable-dtrace</option>付きでビルドされた場合、<emphasis>何の追跡もされなかった</emphasis>としても、制御がマクロを通過する際はいつでも追跡用マクロの引数が評価されます。
 ごく少数のローカルな変数を報告するような場合はそれほど心配はいりません。
-ただし、高価な関数呼び出しを引数にする場合は注意して下さい。
+ただし、高価な関数呼び出しを引数にする場合は注意してください。
 もしそのようにする必要がある場合、追跡が実際に有効かどうかをチェックしてマクロを保護することを考慮してください:
 
 <programlisting>

--- a/doc/src/sgml/monitoring.sgml
+++ b/doc/src/sgml/monitoring.sgml
@@ -1485,9 +1485,9 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
        identify the specific wait point;
        see <xref linkend="wait-event-ipc-table"/>.
 -->
+      <entry>
 サーバプロセスは、他のサーバプロセスとの相互作用を待機しています。
 <literal>wait_event</literal>によりその待機点が特定できます。<xref linkend="wait-event-ipc-table"/>を参照してください。
-      <entry>
       </entry>
      </row>
      <row>


### PR DESCRIPTION
monitoring.sgml の 13.1 対応です。

既存の訳を再利用できた部分も多かったのですが、そのためには結局全体を見ないといけないことになって、その時気になった統一感のなさにも同時に対応してます。 #1955 や #1957 もこの作業からの派生です。 