### PR TITLE
config.sgmlの未翻訳箇所を見つけました。

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -10012,7 +10012,7 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
              <entry>Backend type</entry>
 -->
              <entry>バックエンドタイプ</entry>
-             <entry>no</entry>
+             <entry><!--no-->×</entry>
             </row>
             <row>
              <entry><literal>%p</literal></entry>

--- a/doc/src/sgml/config1.sgml
+++ b/doc/src/sgml/config1.sgml
@@ -1257,7 +1257,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When <varname>archive_mode</varname> is enabled, completed WAL segments
         are sent to archive storage by setting
         <xref linkend="guc-archive-command"/>. In addition to <literal>off</literal>,
@@ -1268,26 +1268,25 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
         mode. In <literal>always</literal> mode, all files restored from the archive
         or streamed with streaming replication will be archived (again). See
         <xref linkend="continuous-archiving-in-standby"/> for details.
-       </para>
-       <para>
-        <varname>archive_mode</varname> and <varname>archive_command</varname> are
-        separate variables so that <varname>archive_command</varname> can be
-        changed without leaving archiving mode.
-        This parameter can only be set at server start.
-        <varname>archive_mode</varname> cannot be enabled when
-        <varname>wal_level</varname> is set to <literal>minimal</literal>.
-       -->
-       <varname>archive_mode</varname>が有効な場合、<xref linkend="guc-archive-command"/>を設定することにより、完了したWALセグメントはアーカイブ格納領域に送信されます。
+-->
+<varname>archive_mode</varname>が有効な場合、<xref linkend="guc-archive-command"/>を設定することにより、完了したWALセグメントはアーカイブ格納領域に送信されます。
 無効にするための<literal>off</literal>に加え、2つのモードがあります。<literal>on</literal>と<literal>always</literal>です。
 通常の運用ではこの2つのモードには違いはありませんが、<literal>always</literal>に設定すると、アーカイブリカバリおよびスタンバイモードでWALアーカイバが有効になります。
 <literal>always</literal>モードでは、アーカイブからリストアされたファイルや、ストリーミングレプリケーションでストリームされたファイルもすべて(再び)アーカイブされます。
 詳細は<xref linkend="continuous-archiving-in-standby"/>を参照してください。
        </para>
        <para>
+<!--
+        <varname>archive_mode</varname> and <varname>archive_command</varname> are
+        separate variables so that <varname>archive_command</varname> can be
+        changed without leaving archiving mode.
+        This parameter can only be set at server start.
+        <varname>archive_mode</varname> cannot be enabled when
+        <varname>wal_level</varname> is set to <literal>minimal</literal>.
+-->
 アーカイブモードを抜けることなく<varname>archive_command</varname>を変更できるように、<varname>archive_mode</varname>と<varname>archive_command</varname>は分離されました。
 このパラメータはサーバ起動時のみ設定可能です。
-<varname>wal_level</varname> が
-<literal>minimal</literal>に設定されている場合、<varname>archive_mode</varname>は有効になりません。
+<varname>wal_level</varname>が<literal>minimal</literal>に設定されている場合、<varname>archive_mode</varname>は有効になりません。
        </para>
       </listitem>
      </varlistentry>
@@ -2328,8 +2327,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         <structname>pg_stat_replication</structname></link> view).
         Specifying more than one synchronous standby can allow for very high
         availability and protection against data loss.
-       </para>
-       -->
+-->
 <xref linkend="synchronous-replication"/>で説明されているように、<firstterm>同期レプリケーション</firstterm>をサポート可能なスタンバイサーバのリストを指定します。
 活動中の同期スタンバイサーバは1つまたはそれ以上です。
 コミットを待機しているトランザクションは、このスタンバイサーバがそのデータの受信を確認してから処理の継続が許可されます。

--- a/doc/src/sgml/config2.sgml
+++ b/doc/src/sgml/config2.sgml
@@ -1722,7 +1722,7 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
              <entry>Backend type</entry>
 -->
              <entry>バックエンドタイプ</entry>
-             <entry>no</entry>
+             <entry><!--no-->×</entry>
             </row>
             <row>
              <entry><literal>%p</literal></entry>


### PR DESCRIPTION
log_line_prefixの表です。
なお、config1.sgmlの差分は、今回の修正とは無関係で、前回config.sgmlの修正が反映されていなかったようです。