### PR TITLE
glossary.sgmlのPostgreSQL 13.1対応です。(Transaction ID)

### DIFF
--- a/doc/src/sgml/glossary.sgml
+++ b/doc/src/sgml/glossary.sgml
@@ -1798,9 +1798,13 @@
   </glossentry>
 
   <glossentry id="glossary-xid">
+<!--
    <glossterm>Transaction ID</glossterm>
+-->
+   <glossterm>トランザクションID</glossterm>
    <glossdef>
     <para>
+<!--
      The numerical, unique, sequentially-assigned identifier that each
      transaction receives when it first causes a database modification.
      Frequently abbreviated as <firstterm>xid</firstterm>.
@@ -1813,6 +1817,13 @@
      epoch value is incremented by one.
      In some contexts, the epoch and xid values are
      considered together as a single 64-bit value.
+-->
+個々のトランザクションが最初にデータベースに変更を加える際に、数値としてユニークな順序数としてアサインされる識別子です。
+しばしば<firstterm>xid</firstterm>と略されます。
+ディスク上ではxidは32ビット幅しかないので、約4億の書き込みトランザクションIDしか生成できません。
+それよりも長くシステムが実行できるようにするために、これもまた32ビット幅である<firstterm>epoch</firstterm>が用いられます。
+カウンタがxidの最大値に到達すると、xidは<literal>3</literal>（これよりも小さな値は予約されています）から再開し、epochの値は1増えます。
+ときにはepochとxidの値を組み合わせて、単一の64ビット値として扱うこともあります。
     </para>
     <para>
 <!--


### PR DESCRIPTION
"epoch"はうまい訳語が思いつかず、原文のママにしてあります。