### PR TITLE
fix comments in split shells

### DIFF
--- a/doc/src/sgml/split-catalogs.sh
+++ b/doc/src/sgml/split-catalogs.sh
@@ -7,7 +7,7 @@
 
 comment='
 <!-- 警告：このファイルは直接編集しないでください！
-1. catalogs.sgmlを編集したら、split.shを起動します。
+1. catalogs.sgmlを編集したら、split-catalogs.shを起動します。
 2. するとcatalogs[0-4].sgmlが生成されます。
 3. catalogs.sgmlとともにcatalogs[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
 4. レビューはcatalogs[0-4].sgmlに対して行います。

--- a/doc/src/sgml/split-libpq.sh
+++ b/doc/src/sgml/split-libpq.sh
@@ -7,7 +7,7 @@
 
 comment='
 <!-- 警告：このファイルは直接編集しないでください！
-1. libpq.sgmlを編集したら、split.shを起動します。
+1. libpq.sgmlを編集したら、split-libpq.shを起動します。
 2. するとlibpq[0-3].sgmlが生成されます。
 3. libpq.sgmlとともにlibpq[0-3].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
 4. レビューはlibpq[0-3].sgmlに対して行います。


### PR DESCRIPTION
翻訳には影響しないのですが、ファイル分割スクリプトのコメントに間違いを見つけたので。