### PR TITLE
translate grant in glossary

### DIFF
--- a/doc/src/sgml/glossary.sgml
+++ b/doc/src/sgml/glossary.sgml
@@ -216,7 +216,10 @@
   </glossentry>
 
   <glossentry id="glossary-cast">
+<!--
    <glossterm>Cast</glossterm>
+-->
+   <glossterm>キャスト</glossterm>
    <glossdef>
     <para>
 <!--
@@ -344,7 +347,10 @@
   </glossentry>
 
   <glossentry id="glossary-column">
+<!--
    <glossterm>Column</glossterm>
+-->
+   <glossterm>列</glossterm>
    <glossdef>
     <para>
      An <glossterm linkend="glossary-attribute">attribute</glossterm> found in
@@ -778,10 +784,13 @@
    <glossterm>Grant</glossterm>
    <glossdef>
     <para>
+<!--
      An <acronym>SQL</acronym> command that is used to allow a
      <glossterm linkend="glossary-user">user</glossterm> or
      <glossterm linkend="glossary-role">role</glossterm> to access
      specific objects within the <glossterm linkend="glossary-database">database</glossterm>.
+-->
+<glossterm linkend="glossary-user">ユーザ</glossterm>や<glossterm linkend="glossary-role">ロール</glossterm>が<glossterm linkend="glossary-database">データベース</glossterm>内の特定のオブジェクトにアクセスすることを許可するために使われる<acronym>SQL</acronym>コマンド。
     </para>
     <para>
 <!--
@@ -1413,7 +1422,10 @@
   </glossentry>
 
   <glossentry>
+<!--
    <glossterm>Row</glossterm>
+-->
+   <glossterm>行</glossterm>
    <glosssee otherterm="glossary-tuple" />
   </glossentry>
 


### PR DESCRIPTION
glossary の grant を訳しました。
あと、＜glossterm＞で訳すべきところもついでに訳しています。（grantは訳すべきではないと考えています。）
