### PR TITLE
glossary.sgmlのPostgreSQL 13.1対応です。

### DIFF
--- a/doc/src/sgml/glossary.sgml
+++ b/doc/src/sgml/glossary.sgml
@@ -101,32 +101,49 @@
   </glossentry>
 
   <glossentry id="glossary-atomic">
+<!--
    <glossterm>Atomic</glossterm>
+-->
+   <glossterm>原子的</glossterm>
    <glossdef>
     <para>
+<!--
      In reference to a <glossterm linkend="glossary-datum">datum</glossterm>:
      the fact that its value cannot be broken down into smaller
      components.
+-->
+<glossterm linkend="glossary-datum">datum</glossterm>との関連においては、値がより小さな構成要素に分解できないこと。
     </para>
    </glossdef>
    <glossdef>
     <para>
+<!--
      In reference to a
      <glossterm linkend="glossary-transaction">database transaction</glossterm>:
      see <glossterm linkend="glossary-atomicity">atomicity</glossterm>.
+-->
+<glossterm linkend="glossary-transaction">データベーストランザクション</glossterm>との関連においては、<glossterm linkend="glossary-atomicity">原子性</glossterm>を参照のこと。
     </para>
    </glossdef>
   </glossentry>
 
   <glossentry id="glossary-atomicity">
+<!--
    <glossterm>Atomicity</glossterm>
+-->
+   <glossterm>原子性</glossterm>
    <glossdef>
     <para>
+<!--
      The property of a <glossterm linkend="glossary-transaction">transaction</glossterm>
      that either all its operations complete as a single unit or none do.
      In addition, if a system failure occurs during the execution of a
      transaction, no partial results are visible after recovery.
      This is one of the <acronym>ACID</acronym> properties.
+-->
+すべての操作が不可分なものとして完了するか、あるいは何もなかったことになるかのどちらかで終わる<glossterm linkend="glossary-transaction">トランザクション</glossterm>の性質。
+加えて、トランザクションの実行中にシステム障害が起きても、リカバリ後には中途半端な結果が見えるようなことはないこと。
+これは<acronym>ACID</acronym>性の一部です。
     </para>
    </glossdef>
   </glossentry>
@@ -148,13 +165,19 @@
   </glossentry>
 
   <glossentry id="glossary-autovacuum">
+<!--
    <glossterm>Autovacuum (process)</glossterm>
+-->
+   <glossterm>自動バキューム（プロセス）</glossterm>
    <glossdef>
     <para>
+<!--
      A set of background processes that routinely perform
      <glossterm linkend="glossary-vacuum">vacuum</glossterm>
      and <glossterm linkend="glossary-analyze">analyze</glossterm>
      operations.
+-->
+<glossterm linkend="glossary-vacuum">バキューム</glossterm>及び<glossterm linkend="glossary-analyze">アナライズ</glossterm>操作を定期的に実行する一連のバックグラウンドプロセス。
     </para>
     <para>
 <!--


### PR DESCRIPTION
Atomic, Atomicity, Autovacuumを訳しました。(Aの項完了）