### PR TITLE
glossary.sgmlのPostgreSQL 13.1対応です。

### DIFF
--- a/doc/src/sgml/glossary.sgml
+++ b/doc/src/sgml/glossary.sgml
@@ -316,9 +316,13 @@
   </glossentry>
 
   <glossentry id="glossary-check-constraint">
+<!--
    <glossterm>Check constraint</glossterm>
+-->
+   <glossterm>チェック制約</glossterm>
    <glossdef>
     <para>
+<!--
      A type of <glossterm linkend="glossary-constraint">constraint</glossterm>
      defined on a <glossterm linkend="glossary-relation">relation</glossterm>
      which restricts the values allowed in one or more
@@ -326,6 +330,9 @@
      check constraint can make reference to any attribute of the same row in
      the relation, but cannot reference other rows of the same relation or
      other relations.
+-->
+一つ以上の<glossterm linkend="glossary-attribute">属性</glossterm>の取り得る値が制限される<glossterm linkend="glossary-relation">リレーション</glossterm>に定義される<glossterm linkend="glossary-constraint">制約</glossterm>の一形式。
+チェック制約は同じ行内のすべての属性を参照できますが、同じあるいは別のリレーションの別の行は参照できません。
     </para>
     <para>
 <!--
@@ -338,9 +345,13 @@
   </glossentry>
 
   <glossentry id="glossary-checkpoint">
+<!--
    <glossterm>Checkpoint</glossterm>
+-->
+   <glossterm>チェックポイント</glossterm>
    <glossdef>
     <para>
+<!--
      A point in the <glossterm linkend="glossary-wal">WAL</glossterm> sequence
      at which it is guaranteed that the heap and index data files have been
      updated with all information from
@@ -348,14 +359,22 @@
      modified before that checkpoint;
      a <firstterm>checkpoint record</firstterm> is written and flushed to WAL
      to mark that point.
+-->
+一連の<glossterm linkend="glossary-wal">WAL</glossterm>の中で、そのチェックポイント以前に更新された<glossterm linkend="glossary-shared-memory">共有メモリ</glossterm>のすべての情報がヒープとインデックスのデータファイルに反映されたことが保証されている点。
+その点を記録するために、<firstterm>チェックポイントレコード</firstterm>がWALに書き出されます。
     </para>
     <para>
+<!--
      A checkpoint is also the act of carrying out all the actions that
      are necessary to reach a checkpoint as defined above.
      This process is initiated when predefined conditions are met,
      such as a specified amount of time has passed, or a certain volume
      of records has been written; or it can be invoked by the user
      with the command <command>CHECKPOINT</command>.
+-->
+また、チェックポイントは、上で定義されているチェックポイントに到達するために必要なすべてのアクションを実行に移すことでもあります。
+このプロセスはあらかじめ決められた条件、たとえば一定の時間が経過した、またはある量のレコードが書き出されたなどの条件が整うことで開始されます。
+あるいは、<command>CHECKPOINT</command>コマンドでユーザが起動することもできます。
     </para>
     <para>
 <!--
@@ -368,28 +387,43 @@
   </glossentry>
 
   <glossentry id="glossary-checkpointer">
+<!--
    <glossterm>Checkpointer (process)</glossterm>
+-->
+   <glossterm>チェックポインター（プロセス）</glossterm>
    <glossdef>
     <para>
+<!--
      A specialized process responsible for executing checkpoints.
+-->
+チェックポイントを実行するための特別なプロセス。
     </para>
    </glossdef>
   </glossentry>
 
   <glossentry>
+<!--
    <glossterm>Class (archaic)</glossterm>
+-->
+   <glossterm>クラス（旧用語）</glossterm>
    <glosssee otherterm="glossary-relation" />
   </glossentry>
 
   <glossentry id="glossary-client">
+<!--
    <glossterm>Client (process)</glossterm>
+-->
+   <glossterm>クライアント（プロセス）</glossterm>
    <glossdef>
     <para>
+<!--
      Any process, possibly remote, that establishes a
      <glossterm linkend="glossary-session">session</glossterm>
      by <glossterm linkend="glossary-connection">connecting</glossterm> to an
      <glossterm linkend="glossary-instance">instance</glossterm>
      to interact with a <glossterm linkend="glossary-database">database</glossterm>.
+-->
+<glossterm linkend="glossary-database">データベース</glossterm>と情報交換するために、遠隔の可能性があり、<glossterm linkend="glossary-instance">インスタンス</glossterm>に<glossterm linkend="glossary-connection">接続</glossterm>することによって<glossterm linkend="glossary-session">セッション</glossterm>を確立するすべてのプロセス。
     </para>
    </glossdef>
   </glossentry>
@@ -412,14 +446,20 @@
   </glossentry>
 
   <glossentry id="glossary-commit">
+<!--
    <glossterm>Commit</glossterm>
+-->
+   <glossterm>コミット</glossterm>
    <glossdef>
     <para>
+<!--
      The act of finalizing a
      <glossterm linkend="glossary-transaction">transaction</glossterm> within
      the <glossterm linkend="glossary-database">database</glossterm>, which
      makes it visible to other transactions and assures its
      <glossterm linkend="glossary-durability">durability</glossterm>.
+-->
+他のトランザクションに対してトランザクションを可視化し、その<glossterm linkend="glossary-durability">永続性</glossterm>を保証し、<glossterm linkend="glossary-database">データベース</glossterm>中の<glossterm linkend="glossary-transaction">トランザクション</glossterm>の終了を実行すること。
     </para>
     <para>
 <!--
@@ -432,27 +472,42 @@
   </glossentry>
 
   <glossentry id="glossary-concurrency">
+<!--
    <glossterm>Concurrency</glossterm>
+-->
+   <glossterm>Concurrency（並行性）</glossterm>
    <glossdef>
     <para>
+<!--
      The concept that multiple independent operations happen within the
      <glossterm linkend="glossary-database">database</glossterm> at the same time.
      In <productname>PostgreSQL</productname>, concurrency is controlled by
      the <glossterm linkend="glossary-mvcc">multiversion concurrency control</glossterm>
      mechanism.
+-->
+<glossterm linkend="glossary-database">データベース</glossterm>の中で複数の独立した操作が同時に行われる概念。
+<productname>PostgreSQL</productname>においては、並行性は<glossterm linkend="glossary-mvcc">複数バージョン並行性制御(multiversion concurrency control</glossterm>機構によって制御されます。
     </para>
    </glossdef>
   </glossentry>
 
   <glossentry id="glossary-connection">
+<!--
    <glossterm>Connection</glossterm>
+-->
+   <glossterm>接続</glossterm>
    <glossdef>
     <para>
+<!--
      An established line of communication between a client process and a
      <glossterm linkend="glossary-backend">backend</glossterm> process,
      usually over a network, supporting a
      <glossterm linkend="glossary-session">session</glossterm>.  This term is
      sometimes used as a synonym for session.
+-->
+通常ネットワーク越しにクライアントプロセスと<glossterm linkend="glossary-backend">バックエンド</glossterm>プロセスの間で確立された通信回線。
+<glossterm linkend="glossary-session">セッション</glossterm>をサポートします。
+この用語は時にセッションの同義語として使われることがあります。
     </para>
     <para>
 <!--
@@ -465,9 +520,13 @@
   </glossentry>
 
   <glossentry id="glossary-consistency">
+<!--
    <glossterm>Consistency</glossterm>
+-->
+   <glossterm>Consistency（一貫性）</glossterm>
    <glossdef>
     <para>
+<!--
      The property that the data in the
      <glossterm linkend="glossary-database">database</glossterm>
      is always in compliance with
@@ -477,6 +536,10 @@
      by the time it commits, such a transaction is automatically
      <glossterm linkend="glossary-rollback">rolled back</glossterm>.
      This is one of the <acronym>ACID</acronym> properties.
+-->
+<glossterm linkend="glossary-database">データベース</glossterm>中のデータがが常に<glossterm linkend="glossary-constraint">一貫性制約(integrity constraints)</glossterm>に従う性質。
+トランザクションは、コミット前には一時的に制約の一部に違反する可能性もありますが、コミット時点までにそうした違反が解決されなければ、トランザクションは自動的に<glossterm linkend="glossary-rollback">ロールバック</glossterm>されます。
+これは<acronym>ACID</acronym>性質の一部です。
     </para>
    </glossdef>
   </glossentry>


### PR DESCRIPTION
"C"の項目を翻訳しました。