### PR TITLE
glossaryの見出しの形式を英語【日本語】（補足）に変更

### DIFF
--- a/doc/src/sgml/glossary.sgml
+++ b/doc/src/sgml/glossary.sgml
@@ -36,7 +36,7 @@
 <!--
    <glossterm>Aggregate function (routine)</glossterm>
 -->
-   <glossterm>集約関数（ルーチン）</glossterm>
+   <glossterm>Aggregate function【集約関数】（ルーチン）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -62,7 +62,7 @@
 <!--
    <glossterm>Analytic function</glossterm>
 -->
-   <glossterm>分析関数</glossterm>
+   <glossterm>Analytic function【分析関数】</glossterm>
    <glosssee otherterm="glossary-window-function" />
   </glossentry>
 
@@ -70,7 +70,7 @@
 <!--
    <glossterm>Analyze (operation)</glossterm>
 -->
-   <glossterm>アナライズ（操作）</glossterm>
+   <glossterm>Analyze【アナライズ】（操作）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -104,7 +104,7 @@
 <!--
    <glossterm>Atomic</glossterm>
 -->
-   <glossterm>原子的</glossterm>
+   <glossterm>Atomic【原子的】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -131,7 +131,7 @@
 <!--
    <glossterm>Atomicity</glossterm>
 -->
-   <glossterm>原子性</glossterm>
+   <glossterm>Atomicity【原子性】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -152,7 +152,7 @@
 <!--
    <glossterm>Attribute</glossterm>
 -->
-   <glossterm>属性</glossterm>
+   <glossterm>Attribute【属性】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -168,7 +168,7 @@
 <!--
    <glossterm>Autovacuum (process)</glossterm>
 -->
-   <glossterm>自動バキューム（プロセス）</glossterm>
+   <glossterm>Autovacuum【自動バキューム】（プロセス）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -193,7 +193,7 @@
 <!--
    <glossterm>Backend (process)</glossterm>
 -->
-   <glossterm>バックエンド（プロセス）</glossterm>
+   <glossterm>Backend【バックエンド】（プロセス）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -218,7 +218,7 @@
 <!--
    <glossterm>Background worker (process)</glossterm>
 -->
-   <glossterm>バックグラウンドワーカ（プロセス）</glossterm>
+   <glossterm>Background worker【バックグラウンドワーカ】（プロセス）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -249,7 +249,7 @@
 <!--
    <glossterm>Background writer (process)</glossterm>
 -->
-   <glossterm>バックグラウンドライタ（プロセス）</glossterm>
+   <glossterm>Background writer【バックグラウンドライタ】（プロセス）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -278,7 +278,7 @@
 <!--
    <glossterm>Bloat</glossterm>
 -->
-   <glossterm>ブロート</glossterm>
+   <glossterm>Bloat【ブロート】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -294,7 +294,7 @@
 <!--
    <glossterm>Cast</glossterm>
 -->
-   <glossterm>キャスト</glossterm>
+   <glossterm>Cast【キャスト】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -346,7 +346,7 @@
 <!--
    <glossterm>Check constraint</glossterm>
 -->
-   <glossterm>チェック制約</glossterm>
+   <glossterm>Check constraint【チェック制約】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -375,7 +375,7 @@
 <!--
    <glossterm>Checkpoint</glossterm>
 -->
-   <glossterm>チェックポイント</glossterm>
+   <glossterm>Checkpoint【チェックポイント】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -417,7 +417,7 @@
 <!--
    <glossterm>Checkpointer (process)</glossterm>
 -->
-   <glossterm>チェックポインター（プロセス）</glossterm>
+   <glossterm>Checkpointer【チェックポインター】（プロセス）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -432,7 +432,7 @@
 <!--
    <glossterm>Class (archaic)</glossterm>
 -->
-   <glossterm>クラス（旧用語）</glossterm>
+   <glossterm>Class【クラス】（旧用語）</glossterm>
    <glosssee otherterm="glossary-relation" />
   </glossentry>
 
@@ -440,7 +440,7 @@
 <!--
    <glossterm>Client (process)</glossterm>
 -->
-   <glossterm>クライアント（プロセス）</glossterm>
+   <glossterm>Client【クライアント】（プロセス）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -459,7 +459,7 @@
 <!--
    <glossterm>Column</glossterm>
 -->
-   <glossterm>列</glossterm>
+   <glossterm>Column【列】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -476,7 +476,7 @@
 <!--
    <glossterm>Commit</glossterm>
 -->
-   <glossterm>コミット</glossterm>
+   <glossterm>Commit【コミット】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -502,7 +502,7 @@
 <!--
    <glossterm>Concurrency</glossterm>
 -->
-   <glossterm>Concurrency（並行性）</glossterm>
+   <glossterm>Concurrency【並行性】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -522,7 +522,7 @@
 <!--
    <glossterm>Connection</glossterm>
 -->
-   <glossterm>接続</glossterm>
+   <glossterm>Connection【接続】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -550,7 +550,7 @@
 <!--
    <glossterm>Consistency</glossterm>
 -->
-   <glossterm>Consistency（一貫性）</glossterm>
+   <glossterm>Consistency【一貫性】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -575,7 +575,7 @@
 <!--
    <glossterm>Constraint</glossterm>
 -->
-   <glossterm>制約</glossterm>
+   <glossterm>Constraint【制約】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -603,7 +603,7 @@
 <!--
    <glossterm>Data area</glossterm>
 -->
-   <glossterm>データ領域</glossterm>
+   <glossterm>Data area【データ領域】</glossterm>
    <glosssee otherterm="glossary-data-directory" />
   </glossentry>
 
@@ -611,7 +611,7 @@
 <!--
    <glossterm>Database</glossterm>
 -->
-   <glossterm>データベース</glossterm>
+   <glossterm>Database【データベース】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -634,7 +634,7 @@
 <!--
    <glossterm>Database cluster</glossterm>
 -->
-   <glossterm>データベースクラスタ</glossterm>
+   <glossterm>Database cluster【データベースクラスタ】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -662,7 +662,7 @@
 <!--
    <glossterm>Database server</glossterm>
 -->
-   <glossterm>データベースサーバ</glossterm>
+   <glossterm>Database server【データベースサーバ】</glossterm>
    <glosssee otherterm="glossary-instance" />
   </glossentry>
 
@@ -670,7 +670,7 @@
 <!--
    <glossterm>Data directory</glossterm>
 -->
-   <glossterm>データディレクトリ</glossterm>
+   <glossterm>Data directory【データディレクトリ】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -708,7 +708,7 @@
 <!--
    <glossterm>Data page</glossterm>
 -->
-   <glossterm>データページ</glossterm>
+   <glossterm>Data page【データページ】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -769,7 +769,7 @@
 <!--
    <glossterm>Durability</glossterm>
 -->
-   <glossterm>永続性</glossterm>
+   <glossterm>Durability【永続性】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -789,7 +789,7 @@
 <!--
    <glossterm>Epoch</glossterm>
 -->
-   <glossterm>エポック</glossterm>
+   <glossterm>Epoch【エポック】</glossterm>
    <glosssee otherterm="glossary-xid" />
   </glossentry>
 
@@ -797,7 +797,7 @@
 <!--
    <glossterm>Extension</glossterm>
 -->
-   <glossterm>拡張</glossterm>
+   <glossterm>Extension【拡張】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -821,7 +821,7 @@
 <!--
    <glossterm>File segment</glossterm>
 -->
-   <glossterm>ファイルセグメント</glossterm>
+   <glossterm>File segment【ファイルセグメント】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -856,7 +856,7 @@
 <!--
    <glossterm>Foreign data wrapper</glossterm>
 -->
-   <glossterm>外部データラッパ</glossterm>
+   <glossterm>Foreign data wrapper【外部データラッパ】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -883,7 +883,7 @@
 <!--
    <glossterm>Foreign key</glossterm>
 -->
-   <glossterm>外部キー</glossterm>
+   <glossterm>Foreign key【外部キー】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -905,7 +905,7 @@
 <!--
    <glossterm>Foreign server</glossterm>
 -->
-   <glossterm>外部サーバ</glossterm>
+   <glossterm>Foreign server【外部サーバ】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -931,7 +931,7 @@
 <!--
    <glossterm>Foreign table (relation)</glossterm>
 -->
-   <glossterm>外部テーブル（リレーション）</glossterm>
+   <glossterm>Foreign table【外部テーブル】（リレーション）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -961,7 +961,7 @@
 <!--
    <glossterm>Fork</glossterm>
 -->
-   <glossterm>フォーク</glossterm>
+   <glossterm>Fork【フォーク】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -986,7 +986,7 @@
 <!--
    <glossterm>Free space map (fork)</glossterm>
 -->
-   <glossterm>フリースペースマップ（フォーク）</glossterm>
+   <glossterm>Free space map【フリースペースマップ】（フォーク）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1013,7 +1013,7 @@
 <!--
    <glossterm>Function (routine)</glossterm>
 -->
-   <glossterm>関数（ルーチン）</glossterm>
+   <glossterm>Function【関数】（ルーチン）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1073,7 +1073,7 @@
 <!--
    <glossterm>Heap</glossterm>
 -->
-   <glossterm>ヒープ</glossterm>
+   <glossterm>Heap【ヒープ】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1094,7 +1094,7 @@
 <!--
    <glossterm>Host</glossterm>
 -->
-   <glossterm>ホスト</glossterm>
+   <glossterm>Host【ホスト】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1115,7 +1115,7 @@
 <!--
    <glossterm>Index (relation)</glossterm>
 -->
-   <glossterm>インデックス（リレーション）</glossterm>
+   <glossterm>Index【インデックス】（リレーション）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1162,7 +1162,7 @@
 <!--
    <glossterm>Instance</glossterm>
 -->
-   <glossterm>インスタンス</glossterm>
+   <glossterm>Instance【インスタンス】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1198,7 +1198,7 @@
 <!--
    <glossterm>Isolation</glossterm>
 -->
-   <glossterm>Isolation（隔離）</glossterm>
+   <glossterm>Isolation【隔離】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1223,7 +1223,7 @@
 <!--
    <glossterm>Join</glossterm>
 -->
-   <glossterm>結合</glossterm>
+   <glossterm>Join【結合】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1241,7 +1241,7 @@
 <!--
    <glossterm>Key</glossterm>
 -->
-   <glossterm>キー</glossterm>
+   <glossterm>Key【キー】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1261,7 +1261,7 @@
 <!--
    <glossterm>Lock</glossterm>
 -->
-   <glossterm>ロック</glossterm>
+   <glossterm>Lock【ロック】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1277,7 +1277,7 @@
 <!--
    <glossterm>Log file</glossterm>
 -->
-   <glossterm>ログファイル</glossterm>
+   <glossterm>Log file【ログファイル】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1301,7 +1301,7 @@
 <!--
    <glossterm>Logged</glossterm>
 -->
-   <glossterm>Logged（ログされる）</glossterm>
+   <glossterm>Logged【ログされる】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1323,7 +1323,7 @@
 <!--
    <glossterm>Logger (process)</glossterm>
 -->
-   <glossterm>ロガー（プロセス）</glossterm>
+   <glossterm>Logger【ロガー】（プロセス）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1352,7 +1352,7 @@
 <!--
    <glossterm>Log record</glossterm>
 -->
-   <glossterm>ログレコード</glossterm>
+   <glossterm>Log record【ログレコード】</glossterm>
     <glossdef>
      <para>
 <!--
@@ -1367,7 +1367,7 @@
 <!--
    <glossterm>Master (server)</glossterm>
 -->
-   <glossterm>マスタ（サーバ）</glossterm>
+   <glossterm>Master【マスタ】（サーバ）</glossterm>
    <glosssee otherterm="glossary-primary-server" />
   </glossentry>
 
@@ -1375,7 +1375,7 @@
 <!--
    <glossterm>Materialized</glossterm>
 -->
-   <glossterm>Materialized（マテリアライズド）</glossterm>
+   <glossterm>Materialized【マテリアライズド】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1409,7 +1409,7 @@
 <!--
    <glossterm>Materialized view (relation)</glossterm>
 -->
-   <glossterm>マテリアライズドビュー（リレーション）</glossterm>
+   <glossterm>Materialized view【マテリアライズドビュー】（リレーション）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1438,7 +1438,7 @@
 <!--
    <glossterm>Multi-version concurrency control (MVCC)</glossterm>
 -->
-   <glossterm>Multi-version concurrency control（多版型同時実行制御）(MVCC)</glossterm>
+   <glossterm>Multi-version concurrency control【多版型同時実行制御】(MVCC)</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1477,7 +1477,7 @@
 <!--
    <glossterm>Optimizer</glossterm>
 -->
-   <glossterm>Optimizer（オプティマイザ）</glossterm>
+   <glossterm>Optimizer【オプティマイザ】</glossterm>
    <glosssee otherterm="glossary-planner" />
   </glossentry>
 
@@ -1485,7 +1485,7 @@
 <!--
    <glossterm>Parallel query</glossterm>
 -->
-   <glossterm>Parallel query（パラレルクエリ）</glossterm>
+   <glossterm>Parallel query【パラレルクエリ】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1502,7 +1502,7 @@
 <!--
    <glossterm>Partition</glossterm>
 -->
-   <glossterm>パーティション</glossterm>
+   <glossterm>Partition【パーティション】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1546,7 +1546,7 @@
 <!--
    <glossterm>Partitioned table (relation)</glossterm>
 -->
-   <glossterm>パーティション化テーブル（リレーション）</glossterm>
+   <glossterm>Partitioned table【パーティション化テーブル】（リレーション）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1590,7 +1590,7 @@
 <!--
    <glossterm>Primary key</glossterm>
 -->
-   <glossterm>主キー</glossterm>
+   <glossterm>Primary key【主キー】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1618,7 +1618,7 @@
 <!--
    <glossterm>Primary (server)</glossterm>
 -->
-   <glossterm>Primary（プライマリ）（サーバ）</glossterm>
+   <glossterm>Primary【プライマリ】（サーバ）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1639,7 +1639,7 @@
 <!--
    <glossterm>Procedure (routine)</glossterm>
 -->
-   <glossterm>Procedure（プロシージャ）（ルーチン）</glossterm>
+   <glossterm>Procedure【プロシージャ】（ルーチン）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1667,7 +1667,7 @@
 <!--
    <glossterm>Query</glossterm>
 -->
-   <glossterm>Query（問い合わせ）</glossterm>
+   <glossterm>Query【問い合わせ】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1683,7 +1683,7 @@
 <!--
    <glossterm>Query planner</glossterm>
 -->
-   <glossterm>Query planner（問い合わせプランナ）</glossterm>
+   <glossterm>Query planner【問い合わせプランナ】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1713,7 +1713,7 @@
 <!--
    <glossterm>Referential integrity</glossterm>
 -->
-   <glossterm>Referential integrity（参照整合性）</glossterm>
+   <glossterm>Referential integrity【参照整合性】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1731,7 +1731,7 @@
 <!--
    <glossterm>Relation</glossterm>
 -->
-   <glossterm>リレーション</glossterm>
+   <glossterm>Relation【リレーション】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1774,7 +1774,7 @@
 <!--
    <glossterm>Replica (server)</glossterm>
 -->
-   <glossterm>レプリカ（サーバ）</glossterm>
+   <glossterm>Replica【レプリカ】（サーバ）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1796,7 +1796,7 @@
 <!--
    <glossterm>Replication</glossterm>
 -->
-   <glossterm>レプリケーション</glossterm>
+   <glossterm>Replication【レプリケーション】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1818,7 +1818,7 @@
 <!--
    <glossterm>Result set</glossterm>
 -->
-   <glossterm>Result set（結果集合）</glossterm>
+   <glossterm>Result set【結果集合】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1850,9 +1850,6 @@
   </glossentry>
 
   <glossentry id="glossary-revoke">
-<!--
-   <glossterm>Revoke</glossterm>
--->
    <glossterm>Revoke</glossterm>
    <glossdef>
     <para>
@@ -1877,7 +1874,7 @@
 <!--
    <glossterm>Role</glossterm>
 -->
-   <glossterm>ロール</glossterm>
+   <glossterm>Role【ロール】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1906,7 +1903,7 @@
 <!--
    <glossterm>Rollback</glossterm>
 -->
-   <glossterm>ロールバック</glossterm>
+   <glossterm>Rollback【ロールバック】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1929,7 +1926,7 @@
 <!--
    <glossterm>Routine</glossterm>
 -->
-   <glossterm>ルーチン</glossterm>
+   <glossterm>Routine【ルーチン】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1961,7 +1958,7 @@
 <!--
    <glossterm>Row</glossterm>
 -->
-   <glossterm>行</glossterm>
+   <glossterm>Row【行】</glossterm>
    <glosssee otherterm="glossary-tuple" />
   </glossentry>
 
@@ -1969,7 +1966,7 @@
 <!--
    <glossterm>Savepoint</glossterm>
 -->
-   <glossterm>Savepoint（セーブポイント）</glossterm>
+   <glossterm>Savepoint【セーブポイント】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1995,7 +1992,7 @@
 <!--
    <glossterm>Schema</glossterm>
 -->
-   <glossterm>Schema（スキーマ）</glossterm>
+   <glossterm>Schema【スキーマ】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2039,7 +2036,7 @@
 <!--
    <glossterm>Segment</glossterm>
 -->
-   <glossterm>Segment（セグメント）</glossterm>
+   <glossterm>Segment【セグメント】</glossterm>
    <glosssee otherterm="glossary-file-segment" />
   </glossentry>
 
@@ -2073,7 +2070,7 @@
 <!--
    <glossterm>Sequence (relation)</glossterm>
 -->
-   <glossterm>シーケンス（リレーション）</glossterm>
+   <glossterm>Sequence【シーケンス】（リレーション）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2109,7 +2106,7 @@
 <!--
    <glossterm>Server</glossterm>
 -->
-   <glossterm>サーバ</glossterm>
+   <glossterm>Server【サーバ】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2134,7 +2131,7 @@
 <!--
    <glossterm>Session</glossterm>
 -->
-   <glossterm>セッション</glossterm>
+   <glossterm>Session【セッション】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2150,7 +2147,7 @@
 <!--
    <glossterm>Shared memory</glossterm>
 -->
-   <glossterm>共有メモリ</glossterm>
+   <glossterm>Shared memory【共有メモリ】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2191,7 +2188,7 @@
 <!--
    <glossterm>SQL object</glossterm>
 -->
-   <glossterm>SQLオブジェクト</glossterm>
+   <glossterm>SQL object【SQLオブジェクト】</glossterm>
     <glossdef>
      <para>
 <!--
@@ -2259,7 +2256,7 @@
 <!--
    <glossterm>SQL standard</glossterm>
 -->
-   <glossterm>標準SQL</glossterm>
+   <glossterm>SQL standard【標準SQL】</glossterm>
    <glossdef>
     <para>
 <!-- 
@@ -2274,7 +2271,7 @@
 <!--
    <glossterm>Standby (server)</glossterm>
 -->
-   <glossterm>スタンバイ（サーバ)</glossterm>
+   <glossterm>Standby【スタンバイ】（サーバ）</glossterm>
    <glosssee otherterm="glossary-replica" />
   </glossentry>
 
@@ -2282,7 +2279,7 @@
 <!--
    <glossterm>Stats collector (process)</glossterm>
 -->
-   <glossterm>Stats collector（統計情報収集器）（プロセス）</glossterm>
+   <glossterm>Stats collector【統計情報収集器】（プロセス）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2305,7 +2302,7 @@
 <!--
    <glossterm>System catalog</glossterm>
 -->
-   <glossterm>システムカタログ</glossterm>
+   <glossterm>System catalog【システムカタログ】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2344,7 +2341,7 @@
 <!--
    <glossterm>Table</glossterm>
 -->
-   <glossterm>テーブル</glossterm>
+   <glossterm>Table【テーブル】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2373,7 +2370,7 @@
 <!--
    <glossterm>Tablespace</glossterm>
 -->
-   <glossterm>テーブルスペース</glossterm>
+   <glossterm>Tablespace【テーブルスペース】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2404,7 +2401,7 @@
 <!--
    <glossterm>Temporary table</glossterm>
 -->
-   <glossterm>一時テーブル</glossterm>
+   <glossterm>Temporary table【一時テーブル】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2459,7 +2456,7 @@
 <!--
    <glossterm>Transaction</glossterm>
 -->
-   <glossterm>トランザクション</glossterm>
+   <glossterm>Transaction【トランザクション】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2487,7 +2484,7 @@
 <!--
    <glossterm>Transaction ID</glossterm>
 -->
-   <glossterm>トランザクションID</glossterm>
+   <glossterm>Transaction ID【トランザクションID】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2542,7 +2539,7 @@
 <!--
    <glossterm>Trigger</glossterm>
 -->
-   <glossterm>トリガ</glossterm>
+   <glossterm>Trigger【トリガ】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2573,7 +2570,7 @@
 <!--
    <glossterm>Tuple</glossterm>
 -->
-   <glossterm>タプル</glossterm>
+   <glossterm>Tuple【タプル】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2596,7 +2593,7 @@
 <!--
    <glossterm>Unique constraint</glossterm>
 -->
-   <glossterm>一意性制約</glossterm>
+   <glossterm>Unique constraint【一意性制約】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2624,7 +2621,7 @@
 <!--
    <glossterm>Unlogged</glossterm>
 -->
-   <glossterm>Unlogged（ログを取らない）</glossterm>
+   <glossterm>Unlogged【ログを取らない】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2680,7 +2677,7 @@
 <!--
    <glossterm>User</glossterm>
 -->
-   <glossterm>ユーザ</glossterm>
+   <glossterm>User【ユーザ】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2696,7 +2693,7 @@
 <!--
    <glossterm>User mapping</glossterm>
 -->
-   <glossterm>ユーザマッピング</glossterm>
+   <glossterm>User mapping【ユーザマッピング】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2721,7 +2718,7 @@
 <!--
    <glossterm>Vacuum</glossterm>
 -->
-   <glossterm>バキューム</glossterm>
+   <glossterm>Vacuum【バキューム】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2751,7 +2748,7 @@
 <!--
    <glossterm>View</glossterm>
 -->
-   <glossterm>ビュー</glossterm>
+   <glossterm>View【ビュー】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2778,7 +2775,7 @@
 <!--
    <glossterm>Visibility map (fork)</glossterm>
 -->
-   <glossterm>可視性マップ（フォーク）</glossterm>
+   <glossterm>Visibility map【可視性マップ】（フォーク）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2807,7 +2804,7 @@
 <!--
    <glossterm>WAL archiver (process)</glossterm>
 -->
-   <glossterm>WALアーカイバ（プロセス）</glossterm>
+   <glossterm>WAL archiver【WALアーカイバ】（プロセス）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2831,7 +2828,7 @@
 <!--
    <glossterm>WAL file</glossterm>
 -->
-   <glossterm>WALファイル</glossterm>
+   <glossterm>WAL file【WALファイル】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2877,7 +2874,7 @@
 <!--
    <glossterm>WAL record</glossterm>
 -->
-   <glossterm>WALレコード</glossterm>
+   <glossterm>WAL record【WALレコード】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2905,7 +2902,7 @@ WALレコードは表示できないバイナリフォーマットを使用し�
 <!--
    <glossterm>WAL segment</glossterm>
 -->
-   <glossterm>WALセグメント</glossterm>
+   <glossterm>WAL segment【WALセグメント】</glossterm>
    <glosssee otherterm="glossary-wal-file" />
   </glossentry>
 
@@ -2913,7 +2910,7 @@ WALレコードは表示できないバイナリフォーマットを使用し�
 <!--
    <glossterm>WAL writer (process)</glossterm>
 -->
-   <glossterm>WALライタ（プロセス）</glossterm>
+   <glossterm>WAL writer【WALライタ】（プロセス）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2937,7 +2934,7 @@ WALレコードは表示できないバイナリフォーマットを使用し�
 <!--
    <glossterm>Window function (routine)</glossterm>
 -->
-   <glossterm>ウィンドウ関数（ルーチン）</glossterm>
+   <glossterm>Window function【ウィンドウ関数】（ルーチン）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -2975,7 +2972,7 @@ WALレコードは表示できないバイナリフォーマットを使用し�
 <!--
    <glossterm>Write-ahead log</glossterm>
 -->
-   <glossterm>Write-ahead log（ログ先行書き込み）</glossterm>
+   <glossterm>Write-ahead log【ログ先行書き込み】</glossterm>
    <glossdef>
     <para>
 <!--


### PR DESCRIPTION
日本語訳がついているところは「英語【日本語】」にするのを試しにやってみました。  #2021