### PR TITLE
ACIDの文言の統一（調整）

### DIFF
--- a/doc/src/sgml/glossary.sgml
+++ b/doc/src/sgml/glossary.sgml
@@ -143,7 +143,7 @@
 -->
 すべての操作が不可分なものとして完了するか、あるいは何もなかったことになるかのどちらかで終わる<glossterm linkend="glossary-transaction">トランザクション</glossterm>の性質。
 加えて、トランザクションの実行中にシステム障害が起きても、リカバリ後には中途半端な結果が見えるようなことはないこと。
-これは<acronym>ACID</acronym>性質の一部です。
+これは<acronym>ACID</acronym>特性の一部です。
     </para>
    </glossdef>
   </glossentry>
@@ -566,7 +566,7 @@
 -->
 <glossterm linkend="glossary-database">データベース</glossterm>中のデータが常に<glossterm linkend="glossary-constraint">一貫性制約(integrity constraints)</glossterm>に従う性質。
 トランザクションは、コミット前には一時的に制約の一部に違反する可能性もありますが、コミット時点までにそうした違反が解決されなければ、トランザクションは自動的に<glossterm linkend="glossary-rollback">ロールバック</glossterm>されます。
-これは<acronym>ACID</acronym>性質の一部です。
+これは<acronym>ACID</acronym>特性の一部です。
     </para>
    </glossdef>
   </glossentry>
@@ -780,7 +780,7 @@
      This is one of the <acronym>ACID</acronym> properties.
 -->
 <glossterm linkend="glossary-transaction">トランザクション</glossterm>が一旦<glossterm linkend="glossary-commit">コミット</glossterm>されると、その変更がシステム故障あるいはクラッシュ後も維持されることの保証。
-これは<acronym>ACID</acronym>性質の一部です。
+これは<acronym>ACID</acronym>特性の一部です。
     </para>
    </glossdef>
   </glossentry>
@@ -1189,7 +1189,7 @@
      <glossterm linkend="glossary-client">client processes</glossterm>,
      privilege verification, crash recovery, replication, etc.
 -->
-インスタンスは、ファイルと共有メモリからの読み出しおよび書き込みアクセス、<acronym>ACID</acronym>性質の保障、<glossterm linkend="glossary-client">クライアントプロセス</glossterm>への<glossterm linkend="glossary-connection">接続</glossterm>、権限の検証、クラッシュからの回復、レプリケーションその他の<acronym>DBMS</acronym>のすべての重要な機能を管理します。
+インスタンスは、ファイルと共有メモリからの読み出しおよび書き込みアクセス、<acronym>ACID</acronym>特性の保障、<glossterm linkend="glossary-client">クライアントプロセス</glossterm>への<glossterm linkend="glossary-connection">接続</glossterm>、権限の検証、クラッシュからの回復、レプリケーションその他の<acronym>DBMS</acronym>のすべての重要な機能を管理します。
     </para>
    </glossdef>
   </glossentry>
@@ -1208,7 +1208,7 @@
      This is one of the <acronym>ACID</acronym> properties.
 -->
 コミット前にはトランザクションの効果が<glossterm linkend="glossary-concurrency">同時実行するトランザクション</glossterm>から見えない性質。
-これは<acronym>ACID</acronym>性質の一部です。
+これは<acronym>ACID</acronym>特性の一部です。
     </para>
     <para>
 <!--

--- a/doc/src/sgml/glossary.sgml
+++ b/doc/src/sgml/glossary.sgml
@@ -143,7 +143,7 @@
 -->
 すべての操作が不可分なものとして完了するか、あるいは何もなかったことになるかのどちらかで終わる<glossterm linkend="glossary-transaction">トランザクション</glossterm>の性質。
 加えて、トランザクションの実行中にシステム障害が起きても、リカバリ後には中途半端な結果が見えるようなことはないこと。
-これは<acronym>ACID</acronym>性の一部です。
+これは<acronym>ACID</acronym>性質の一部です。
     </para>
    </glossdef>
   </glossentry>
@@ -1189,7 +1189,7 @@
      <glossterm linkend="glossary-client">client processes</glossterm>,
      privilege verification, crash recovery, replication, etc.
 -->
-インスタンスは、ファイルと共有メモリからの読み出しおよび書き込みアクセス、<acronym>ACID</acronym>性の保障、<glossterm linkend="glossary-client">クライアントプロセス</glossterm>への<glossterm linkend="glossary-connection">接続</glossterm>、権限の検証、クラッシュからの回復、レプリケーションその他の<acronym>DBMS</acronym>のすべての重要な機能を管理します。
+インスタンスは、ファイルと共有メモリからの読み出しおよび書き込みアクセス、<acronym>ACID</acronym>性質の保障、<glossterm linkend="glossary-client">クライアントプロセス</glossterm>への<glossterm linkend="glossary-connection">接続</glossterm>、権限の検証、クラッシュからの回復、レプリケーションその他の<acronym>DBMS</acronym>のすべての重要な機能を管理します。
     </para>
    </glossdef>
   </glossentry>
@@ -1198,7 +1198,7 @@
 <!--
    <glossterm>Isolation</glossterm>
 -->
-   <glossterm>Isolation【隔離】</glossterm>
+   <glossterm>Isolation【独立性】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1208,7 +1208,7 @@
      This is one of the <acronym>ACID</acronym> properties.
 -->
 コミット前にはトランザクションの効果が<glossterm linkend="glossary-concurrency">同時実行するトランザクション</glossterm>から見えない性質。
-これは<acronym>ACID</acronym>性の一つです。
+これは<acronym>ACID</acronym>性質の一部です。
     </para>
     <para>
 <!--
@@ -2123,7 +2123,7 @@
 <!--
      This term is sometimes used to refer to an instance or to a host.
 -->
-この用語は時にはインスタンスあるいはホストに関連して用いられます
+この用語は時にはインスタンスあるいはホストに関連して用いられます。
     </para>
    </glossdef>
   </glossentry>
@@ -2740,7 +2740,7 @@
      For more information, see
      <xref linkend="routine-vacuuming"/> .
 -->
-詳細については<xref linkend="routine-vacuuming"/>を参照してください。.
+詳細については<xref linkend="routine-vacuuming"/>を参照してください。
     </para>
    </glossdef>
   </glossentry>


### PR DESCRIPTION
「 This is one of the <acronym>ACID</acronym> properties.」は同じ文言なので統一。
ACIDのIsolationの場合は「独立性」に変更。
末尾の「。」の抜け修正。
「.」が残っていたミスの修正。