### PR TITLE
indexterm内の英語をコメントアウトしないで追加する

### DIFF
--- a/doc/src/sgml/advanced.sgml
+++ b/doc/src/sgml/advanced.sgml
@@ -52,9 +52,9 @@
    <title>ビュー</title>
 
    <indexterm zone="tutorial-views">
-<!--
     <primary>view</primary>
--->
+   </indexterm>
+   <indexterm zone="tutorial-views">
     <primary>ビュー</primary>
    </indexterm>
 
@@ -110,16 +110,16 @@ SELECT * FROM myview;
    <title>外部キー</title>
 
    <indexterm zone="tutorial-fk">
-<!--
     <primary>foreign key</primary>
--->
+   </indexterm>
+   <indexterm zone="tutorial-fk">
     <primary>外部キー</primary>
    </indexterm>
 
    <indexterm zone="tutorial-fk">
-<!--
     <primary>referential integrity</primary>
--->
+   </indexterm>
+   <indexterm zone="tutorial-fk">
    <primary>参照整合性</primary>
    </indexterm>
 
@@ -207,9 +207,9 @@ DETAIL:  Key (city)=(Berkeley) is not present in table "cities".
    <title>トランザクション</title>
 
    <indexterm zone="tutorial-transactions">
-<!--
     <primary>transaction</primary>
--->
+   </indexterm>
+   <indexterm zone="tutorial-transactions">
     <primary>トランザクション</primary>
    </indexterm>
 
@@ -471,9 +471,9 @@ COMMIT;
    <title>ウィンドウ関数</title>
 
    <indexterm zone="tutorial-window">
-<!--
     <primary>window function</primary>
--->
+   </indexterm>
+   <indexterm zone="tutorial-window">
     <primary>ウィンドウ関数</primary>
    </indexterm>
 
@@ -806,9 +806,9 @@ SELECT sum(salary) OVER w, avg(salary) OVER w
    <title>継承</title>
 
    <indexterm zone="tutorial-inheritance">
-<!--
     <primary>inheritance</primary>
--->
+   </indexterm>
+   <indexterm zone="tutorial-inheritance">
     <primary>継承</primary>
    </indexterm>
 

--- a/doc/src/sgml/array.sgml
+++ b/doc/src/sgml/array.sgml
@@ -7,9 +7,9 @@
  <title>配列</title>
 
  <indexterm>
-<!--
   <primary>array</primary>
--->
+ </indexterm>
+ <indexterm>
   <primary>配列</primary>
  </indexterm>
 
@@ -31,10 +31,10 @@
   <title>配列型の宣言</title>
 
   <indexterm>
-<!--
    <primary>array</primary>
    <secondary>declaration</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>配列</primary>
    <secondary>宣言</secondary>
   </indexterm>
@@ -139,10 +139,10 @@ SQLに準拠し、<literal>ARRAY</literal>キーワードを使用したもう1�
 
   <title>配列の値の入力</title>
   <indexterm>
-<!--
    <primary>array</primary>
    <secondary>constant</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>配列</primary>
    <secondary>定数</secondary>
   </indexterm>
@@ -302,10 +302,10 @@ INSERT INTO sal_emp
   <title>配列へのアクセス</title>
 
   <indexterm>
-<!--
    <primary>array</primary>
    <secondary>accessing</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>配列</primary>
    <secondary>アクセス</secondary>
   </indexterm>
@@ -547,10 +547,10 @@ SELECT cardinality(schedule) FROM sal_emp WHERE name = 'Carol';
   <title>配列の変更</title>
 
   <indexterm>
-<!--
    <primary>array</primary>
    <secondary>modifying</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>配列</primary>
    <secondary>変更</secondary>
   </indexterm>
@@ -847,10 +847,10 @@ SELECT array_append(ARRAY[1, 2], NULL);    -- これがやりたかった事か�
   <title>配列内の検索</title>
 
   <indexterm>
-<!--
    <primary>array</primary>
    <secondary>searching</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>配列</primary>
    <secondary>検索</secondary>
   </indexterm>
@@ -993,9 +993,9 @@ SELECT array_positions(ARRAY[1, 4, 3, 1, 3, 4, 2, 1], 1);
   <title>配列の入出力構文</title>
 
   <indexterm>
-<!--
    <primary>array</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>配列</primary>
    <secondary>I/O</secondary>
   </indexterm>

--- a/doc/src/sgml/auth-delay.sgml
+++ b/doc/src/sgml/auth-delay.sgml
@@ -39,11 +39,10 @@
     <term>
      <varname>auth_delay.milliseconds</varname> (<type>int</type>)
      <indexterm>
-<!--
       <primary><varname>auth_delay.milliseconds</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>auth_delay.milliseconds</varname>設定パラメータ</primary>
-
      </indexterm>
     </term>
     <listitem>

--- a/doc/src/sgml/auto-explain.sgml
+++ b/doc/src/sgml/auto-explain.sgml
@@ -69,9 +69,9 @@ LOAD 'auto_explain';
     <term>
      <varname>auto_explain.log_min_duration</varname> (<type>integer</type>)
      <indexterm>
-<!--
       <primary><varname>auto_explain.log_min_duration</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>auto_explain.log_min_duration</varname>設定パラメータ</primary>
      </indexterm>
     </term>
@@ -99,9 +99,9 @@ LOAD 'auto_explain';
     <term>
      <varname>auto_explain.log_analyze</varname> (<type>boolean</type>)
      <indexterm>
-<!--
       <primary><varname>auto_explain.log_analyze</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>auto_explain.log_analyze</varname>設定パラメータ</primary>
      </indexterm>
     </term>
@@ -138,9 +138,9 @@ LOAD 'auto_explain';
     <term>
      <varname>auto_explain.log_buffers</varname> (<type>boolean</type>)
      <indexterm>
-<!--
       <primary><varname>auto_explain.log_buffers</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>auto_explain.log_buffers</varname>設定パラメータ</primary>
      </indexterm>
     </term>
@@ -168,9 +168,9 @@ LOAD 'auto_explain';
     <term>
      <varname>auto_explain.log_wal</varname> (<type>boolean</type>)
      <indexterm>
-<!--
       <primary><varname>auto_explain.log_wal</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>auto_explain.log_wal</varname>設定パラメータ</primary>
      </indexterm>
     </term>
@@ -198,9 +198,9 @@ LOAD 'auto_explain';
     <term>
      <varname>auto_explain.log_timing</varname> (<type>boolean</type>)
      <indexterm>
-<!--
       <primary><varname>auto_explain.log_timing</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>auto_explain.log_timing</varname>設定パラメータ</primary>
      </indexterm>
     </term>
@@ -233,9 +233,9 @@ LOAD 'auto_explain';
     <term>
      <varname>auto_explain.log_triggers</varname> (<type>boolean</type>)
      <indexterm>
-<!--
       <primary><varname>auto_explain.log_triggers</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>auto_explain.log_triggers</varname>設定パラメータ</primary>
      </indexterm>
     </term>
@@ -261,9 +261,9 @@ LOAD 'auto_explain';
     <term>
      <varname>auto_explain.log_verbose</varname> (<type>boolean</type>)
      <indexterm>
-<!--
       <primary><varname>auto_explain.log_verbose</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>auto_explain.log_verbose</varname>設定パラメータ</primary>
      </indexterm>
     </term>
@@ -288,9 +288,9 @@ LOAD 'auto_explain';
     <term>
      <varname>auto_explain.log_settings</varname> (<type>boolean</type>)
      <indexterm>
-<!--
       <primary><varname>auto_explain.log_settings</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>auto_explain.log_settings</varname>設定パラメータ</primary>
      </indexterm>
     </term>
@@ -315,9 +315,9 @@ LOAD 'auto_explain';
     <term>
      <varname>auto_explain.log_format</varname> (<type>enum</type>)
      <indexterm>
-<!--
       <primary><varname>auto_explain.log_format</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>auto_explain.log_format</varname>設定パラメータ</primary>
      </indexterm>
     </term>
@@ -342,9 +342,9 @@ LOAD 'auto_explain';
     <term>
      <varname>auto_explain.log_level</varname> (<type>enum</type>)
      <indexterm>
-<!--
       <primary><varname>auto_explain.log_level</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>auto_explain.log_level</varname>設定パラメータ</primary>
      </indexterm>
     </term>
@@ -372,9 +372,9 @@ LOAD 'auto_explain';
     <term>
      <varname>auto_explain.log_nested_statements</varname> (<type>boolean</type>)
      <indexterm>
-<!--
       <primary><varname>auto_explain.log_nested_statements</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>auto_explain.log_nested_statements</varname>設定パラメータ</primary>
      </indexterm>
     </term>
@@ -398,9 +398,9 @@ LOAD 'auto_explain';
     <term>
      <varname>auto_explain.sample_rate</varname> (<type>real</type>)
      <indexterm>
-<!--
       <primary><varname>auto_explain.sample_rate</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>auto_explain.sample_rate</varname>設定パラメータ</primary>
      </indexterm>
     </term>

--- a/doc/src/sgml/backup-manifest.sgml
+++ b/doc/src/sgml/backup-manifest.sgml
@@ -7,9 +7,9 @@
  <title>バックアップマニフェスト書式</title>
 
   <indexterm>
-<!--
    <primary>Backup Manifest</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>バックアップマニフェスト</primary>
   </indexterm>
 

--- a/doc/src/sgml/backup.sgml
+++ b/doc/src/sgml/backup.sgml
@@ -6,9 +6,7 @@
 -->
  <title>バックアップとリストア</title>
 
-<!--
  <indexterm zone="backup"><primary>backup</primary></indexterm>
--->
  <indexterm zone="backup"><primary>バックアップ</primary></indexterm>
 
  <para>
@@ -717,16 +715,16 @@ tar -cf backup.tar /usr/local/pgsql/data
   <title>継続的アーカイブとポイントインタイムリカバリ（PITR）</title>
 
   <indexterm zone="backup">
-<!--
    <primary>continuous archiving</primary>
--->
+  </indexterm>
+  <indexterm zone="backup">
    <primary>継続的アーカイブ</primary>
   </indexterm>
 
   <indexterm zone="backup">
-<!--
    <primary>point-in-time recovery</primary>
--->
+  </indexterm>
+  <indexterm zone="backup">
    <primary>ポイントインタイムリカバリ</primary>
   </indexterm>
 
@@ -2135,9 +2133,9 @@ restore_command = 'cp /mnt/server/archivedir/%f %p'
    <title>タイムライン</title>
 
   <indexterm zone="backup">
-<!--
    <primary>timelines</primary>
--->
+  </indexterm>
+  <indexterm zone="backup">
    <primary>タイムライン</primary>
   </indexterm>
 

--- a/doc/src/sgml/bgworker.sgml
+++ b/doc/src/sgml/bgworker.sgml
@@ -7,9 +7,9 @@
  <title>バックグラウンドワーカプロセス</title>
 
  <indexterm zone="bgworker">
-<!--
   <primary>Background workers</primary>
--->
+ </indexterm>
+ <indexterm zone="bgworker">
   <primary>バックグラウンドワーカ</primary>
  </indexterm>
 

--- a/doc/src/sgml/btree.sgml
+++ b/doc/src/sgml/btree.sgml
@@ -7,9 +7,9 @@
 <title>B-Treeインデックス</title>
 
    <indexterm>
-<!--
     <primary>index</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>インデックス</primary>
     <secondary>B-Tree</secondary>
    </indexterm>
@@ -378,16 +378,16 @@ NULLの結果は許されず、データ型の全ての値は比較可能でな�
    <term><function>in_range</function></term>
    <listitem>
     <indexterm>
-<!--
      <primary>in_range support functions</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>in_rangeサポート関数</primary>
     </indexterm>
 
     <indexterm>
-<!--
      <primary>support functions</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>サポート関数</primary>
      <secondary>in_range</secondary>
     </indexterm>

--- a/doc/src/sgml/catalogs.sgml
+++ b/doc/src/sgml/catalogs.sgml
@@ -14388,9 +14388,9 @@ SELECT * FROM pg_locks pl LEFT JOIN pg_prepared_xacts ppx
   </indexterm>
 
   <indexterm zone="view-pg-matviews">
-<!--
    <primary>materialized views</primary>
--->
+  </indexterm>
+  <indexterm zone="view-pg-matviews">
    <primary>マテリアライズドビュー</primary>
   </indexterm>
 

--- a/doc/src/sgml/catalogs3.sgml
+++ b/doc/src/sgml/catalogs3.sgml
@@ -3314,9 +3314,9 @@ SELECT * FROM pg_locks pl LEFT JOIN pg_prepared_xacts ppx
   </indexterm>
 
   <indexterm zone="view-pg-matviews">
-<!--
    <primary>materialized views</primary>
--->
+  </indexterm>
+  <indexterm zone="view-pg-matviews">
    <primary>マテリアライズドビュー</primary>
   </indexterm>
 

--- a/doc/src/sgml/charset.sgml
+++ b/doc/src/sgml/charset.sgml
@@ -53,9 +53,7 @@
 -->
 <title>ロケールのサポート</title>
 
-<!--
   <indexterm zone="locale"><primary>locale</primary></indexterm>
--->
   <indexterm zone="locale"><primary>ロケール</primary></indexterm>
 
   <para>
@@ -1470,9 +1468,7 @@ B-treeは非決定的照合順序を使用したインデックスでは重複�
 -->
 
   <title>文字セットサポート</title>
-<!--
   <indexterm zone="multibyte"><primary>character set</primary></indexterm>
--->
   <indexterm zone="multibyte"><primary>文字セット</primary></indexterm>
 
   <para>

--- a/doc/src/sgml/client-auth.sgml
+++ b/doc/src/sgml/client-auth.sgml
@@ -7,9 +7,9 @@
  <title>クライアント認証</title>
 
  <indexterm zone="client-authentication">
-<!--
   <primary>client authentication</primary>
--->
+ </indexterm>
+ <indexterm zone="client-authentication">
   <primary>クライアント認証</primary>
  </indexterm>
 
@@ -1165,9 +1165,9 @@ local   db1,db2,@demodbs  all                                   md5
   <title>ユーザ名マップ</title>
 
   <indexterm zone="auth-username-maps">
-<!--
    <primary>User name maps</primary>
--->
+  </indexterm>
+  <indexterm zone="auth-username-maps">
    <primary>ユーザ名マップ</primary>
   </indexterm>
 
@@ -1583,10 +1583,10 @@ TCP/IP接続における<literal>trust</literal>認証は、<literal>trust</lite
     <primary>SCRAM</primary>
    </indexterm>
    <indexterm>
-<!--
     <primary>password</primary>
     <secondary>authentication</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>パスワード</primary>
     <secondary>認証</secondary>
    </indexterm>
@@ -2959,9 +2959,9 @@ host ... radius radiusservers="server1,server2" radiussecrets="""secret one"",""
    <title>証明書認証</title>
 
    <indexterm zone="auth-cert">
-<!--
     <primary>Certificate</primary>
--->
+   </indexterm>
+   <indexterm zone="auth-cert">
     <primary>証明書</primary>
    </indexterm>
 

--- a/doc/src/sgml/color.sgml
+++ b/doc/src/sgml/color.sgml
@@ -7,9 +7,9 @@
  <title>色対応</title>
 
  <indexterm zone="color">
-<!--
   <primary>color</primary>
--->
+ </indexterm>
+ <indexterm zone="color">
   <primary>色</primary>
  </indexterm>
 

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -7,10 +7,10 @@
   <title>サーバの設定</title>
 
   <indexterm>
-  <!--
    <primary>configuration</primary>
    <secondary>of the server</secondary>
-   -->
+  </indexterm>
+  <indexterm>
    <primary>設定</primary>
    <secondary>サーバの</secondary>
   </indexterm>
@@ -566,9 +566,10 @@ env PGOPTIONS="-c geqo=off -c statement_timeout=5min" psql
      <para>
       <indexterm>
        <primary><literal>include</literal></primary>
-       <!--
        <secondary>in configuration file</secondary>
-       -->
+      </indexterm>
+      <indexterm>
+       <primary><literal>include</literal></primary>
        <secondary>設定ファイルの中</secondary>
       </indexterm>
       <!--
@@ -603,9 +604,10 @@ Includeコマンドは入れ子にすることができます。
      <para>
       <indexterm>
        <primary><literal>include_if_exists</literal></primary>
-       <!--
        <secondary>in configuration file</secondary>
-       -->
+      </indexterm>
+      <indexterm>
+       <primary><literal>include_if_exists</literal></primary>
        <secondary>設定ファイルにおける</secondary>
       </indexterm>
 <!--
@@ -624,9 +626,10 @@ Includeコマンドは入れ子にすることができます。
      <para>
       <indexterm>
        <primary><literal>include_dir</literal></primary>
-       <!--
        <secondary>in configuration file</secondary>
-       -->
+      </indexterm>
+      <indexterm>
+       <primary><literal>include_dir</literal></primary>
        <secondary>設定ファイルにおける</secondary>
       </indexterm>
 <!--
@@ -792,9 +795,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-data-directory" xreflabel="data_directory">
       <term><varname>data_directory</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>data_directory</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>data_directory</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -813,9 +816,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-config-file" xreflabel="config_file">
       <term><varname>config_file</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>config_file</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>config_file</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -835,9 +838,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-hba-file" xreflabel="hba_file">
       <term><varname>hba_file</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>hba_file</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>hba_file</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -857,9 +860,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-ident-file" xreflabel="ident_file">
       <term><varname>ident_file</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>ident_file</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ident_file</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -881,9 +884,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-external-pid-file" xreflabel="external_pid_file">
       <term><varname>external_pid_file</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>external_pid_file</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>external_pid_file</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -974,9 +977,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-listen-addresses" xreflabel="listen_addresses">
       <term><varname>listen_addresses</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>listen_addresses</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>listen_addresses</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1019,9 +1022,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-port" xreflabel="port">
       <term><varname>port</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>port</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>port</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1042,9 +1045,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-max-connections" xreflabel="max_connections">
       <term><varname>max_connections</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_connections</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_connections</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1078,9 +1081,9 @@ include_dir 'conf.d'
       <term><varname>superuser_reserved_connections</varname>
       (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>superuser_reserved_connections</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>superuser_reserved_connections</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1118,9 +1121,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-unix-socket-directories" xreflabel="unix_socket_directories">
       <term><varname>unix_socket_directories</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>unix_socket_directories</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>unix_socket_directories</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1171,9 +1174,9 @@ Windowsではデフォルトは空文字で、これはつまりUnixドメイン
      <varlistentry id="guc-unix-socket-group" xreflabel="unix_socket_group">
       <term><varname>unix_socket_group</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>unix_socket_group</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>unix_socket_group</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1209,9 +1212,9 @@ Unixドメインソケット（複数も）を所有するグループを設定�
      <varlistentry id="guc-unix-socket-permissions" xreflabel="unix_socket_permissions">
       <term><varname>unix_socket_permissions</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>unix_socket_permissions</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>unix_socket_permissions</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1278,9 +1281,9 @@ Unixドメインソケットは通常のUnixファイルシステムパーミッ
      <varlistentry id="guc-bonjour" xreflabel="bonjour">
       <term><varname>bonjour</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>bonjour</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>bonjour</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1299,9 +1302,9 @@ Unixドメインソケットは通常のUnixファイルシステムパーミッ
      <varlistentry id="guc-bonjour-name" xreflabel="bonjour_name">
       <term><varname>bonjour_name</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>bonjour_name</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>bonjour_name</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1326,9 +1329,9 @@ Unixドメインソケットは通常のUnixファイルシステムパーミッ
      <varlistentry id="guc-tcp-keepalives-idle" xreflabel="tcp_keepalives_idle">
       <term><varname>tcp_keepalives_idle</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>tcp_keepalives_idle</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>tcp_keepalives_idle</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1367,9 +1370,9 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
      <varlistentry id="guc-tcp-keepalives-interval" xreflabel="tcp_keepalives_interval">
       <term><varname>tcp_keepalives_interval</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>tcp_keepalives_interval</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>tcp_keepalives_interval</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1408,9 +1411,9 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
      <varlistentry id="guc-tcp-keepalives-count" xreflabel="tcp_keepalives_count">
       <term><varname>tcp_keepalives_count</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>tcp_keepalives_count</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>tcp_keepalives_count</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1446,9 +1449,9 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
      <varlistentry id="guc-tcp-user-timeout" xreflabel="tcp_user_timeout">
       <term><varname>tcp_user_timeout</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>tcp_user_timeout</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>tcp_user_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1493,18 +1496,14 @@ UNIXドメインソケットで接続しているセッションではこのパ�
      <variablelist>
      <varlistentry id="guc-authentication-timeout" xreflabel="authentication_timeout">
       <term><varname>authentication_timeout</varname> (<type>integer</type>)
-      <!--
       <indexterm><primary>timeout</primary><secondary>client authentication</secondary></indexterm>
-      -->
       <indexterm><primary>timeout</primary><secondary>クライアント認証</secondary></indexterm>
-      <!--
       <indexterm><primary>client authentication</primary><secondary>timeout during</secondary></indexterm>
-      -->
       <indexterm><primary>client authentication</primary><secondary>タイムアウト期間</secondary></indexterm>
       <indexterm>
-      <!--
        <primary><varname>authentication_timeout</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>authentication_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1534,9 +1533,9 @@ UNIXドメインソケットで接続しているセッションではこのパ�
      <varlistentry id="guc-password-encryption" xreflabel="password_encryption">
       <term><varname>password_encryption</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>password_encryption</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>password_encryption</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1569,9 +1568,9 @@ UNIXドメインソケットで接続しているセッションではこのパ�
      <varlistentry id="guc-krb-server-keyfile" xreflabel="krb_server_keyfile">
       <term><varname>krb_server_keyfile</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>krb_server_keyfile</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>krb_server_keyfile</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1593,9 +1592,9 @@ Kerberosサーバーキーファイルの場所を設定します。
      <varlistentry id="guc-krb-caseins-users" xreflabel="krb_caseins_users">
       <term><varname>krb_caseins_users</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>krb_caseins_users</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>krb_caseins_users</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1617,9 +1616,9 @@ GSSAPIユーザ名を大文字小文字の区別なく取り扱うかどうか�
      <varlistentry id="guc-db-user-namespace" xreflabel="db_user_namespace">
       <term><varname>db_user_namespace</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>db_user_namespace</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>db_user_namespace</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1709,9 +1708,9 @@ SSLの設定に関するさらなる情報については<xref linkend="ssl-tcp"
      <varlistentry id="guc-ssl" xreflabel="ssl">
       <term><varname>ssl</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>ssl</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1733,9 +1732,9 @@ SSLの設定に関するさらなる情報については<xref linkend="ssl-tcp"
      <varlistentry id="guc-ssl-ca-file" xreflabel="ssl_ca_file">
       <term><varname>ssl_ca_file</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>ssl_ca_file</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_ca_file</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1761,9 +1760,9 @@ SSLサーバ認証局（CA）が入っているファイル名を設定します
      <varlistentry id="guc-ssl-cert-file" xreflabel="ssl_cert_file">
       <term><varname>ssl_cert_file</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>ssl_cert_file</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_cert_file</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1787,9 +1786,9 @@ SSLサーバ証明書が入っているファイル名を設定します。
      <varlistentry id="guc-ssl-crl-file" xreflabel="ssl_crl_file">
       <term><varname>ssl_crl_file</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>ssl_crl_file</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_crl_file</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1814,9 +1813,9 @@ SSLサーバ証明書失効リスト（CRL）が入っているファイル名�
      <varlistentry id="guc-ssl-key-file" xreflabel="ssl_key_file">
       <term><varname>ssl_key_file</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>ssl_key_file</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_key_file</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1840,9 +1839,9 @@ SSLサーバの秘密鍵が入っているファイル名を設定します。
      <varlistentry id="guc-ssl-ciphers" xreflabel="ssl_ciphers">
       <term><varname>ssl_ciphers</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>ssl_ciphers</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_ciphers</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1966,9 +1965,9 @@ OpenSSLのバージョンにより、利用可能な暗号スイートの詳細�
      <varlistentry id="guc-ssl-prefer-server-ciphers" xreflabel="ssl_prefer_server_ciphers">
       <term><varname>ssl_prefer_server_ciphers</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>ssl_prefer_server_ciphers</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_prefer_server_ciphers</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2004,9 +2003,9 @@ OpenSSLのバージョンにより、利用可能な暗号スイートの詳細�
      <varlistentry id="guc-ssl-ecdh-curve" xreflabel="ssl_ecdh_curve">
       <term><varname>ssl_ecdh_curve</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>ssl_ecdh_curve</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_ecdh_curve</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2049,9 +2048,9 @@ OpenSSLのバージョンにより、利用可能な暗号スイートの詳細�
      <varlistentry id="guc-ssl-min-protocol-version" xreflabel="ssl_min_protocol_version">
       <term><varname>ssl_min_protocol_version</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>ssl_min_protocol_version</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_min_protocol_version</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2086,9 +2085,9 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
      <varlistentry id="guc-ssl-max-protocol-version" xreflabel="ssl_max_protocol_version">
       <term><varname>ssl_max_protocol_version</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>ssl_max_protocol_version</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_max_protocol_version</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2113,9 +2112,9 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
      <varlistentry id="guc-ssl-dh-params-file" xreflabel="ssl_dh_params_file">
       <term><varname>ssl_dh_params_file</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>ssl_dh_params_file</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_dh_params_file</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2149,9 +2148,9 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
      <varlistentry id="guc-ssl-passphrase-command" xreflabel="ssl_passphrase_command">
       <term><varname>ssl_passphrase_command</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>ssl_passphrase_command</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_passphrase_command</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2205,9 +2204,9 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
      <varlistentry id="guc-ssl-passphrase-command-supports-reload" xreflabel="ssl_passphrase_command_supports_reload">
       <term><varname>ssl_passphrase_command_supports_reload</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>ssl_passphrase_command_supports_reload</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_passphrase_command_supports_reload</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2260,9 +2259,9 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
      <varlistentry id="guc-shared-buffers" xreflabel="shared_buffers">
       <term><varname>shared_buffers</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>shared_buffers</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>shared_buffers</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2327,9 +2326,9 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
      <varlistentry id="guc-huge-pages" xreflabel="huge_pages">
       <term><varname>huge_pages</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>huge_pages</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>huge_pages</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2418,9 +2417,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-temp-buffers" xreflabel="temp_buffers">
       <term><varname>temp_buffers</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>temp_buffers</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>temp_buffers</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2468,9 +2467,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-max-prepared-transactions" xreflabel="max_prepared_transactions">
       <term><varname>max_prepared_transactions</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_prepared_transactions</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_prepared_transactions</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2516,9 +2515,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-work-mem" xreflabel="work_mem">
       <term><varname>work_mem</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>work_mem</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>work_mem</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2573,9 +2572,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-hash-mem-multiplier" xreflabel="hash_mem_multiplier">
       <term><varname>hash_mem_multiplier</varname> (<type>floating point</type>)
       <indexterm>
-<!--
        <primary><varname>hash_mem_multiplier</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>hash_mem_multiplier</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2617,9 +2616,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-maintenance-work-mem" xreflabel="maintenance_work_mem">
       <term><varname>maintenance_work_mem</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>maintenance_work_mem</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>maintenance_work_mem</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2661,9 +2660,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-autovacuum-work-mem" xreflabel="autovacuum_work_mem">
       <term><varname>autovacuum_work_mem</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>autovacuum_work_mem</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>autovacuum_work_mem</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2689,9 +2688,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-logical-decoding-work-mem" xreflabel="logical_decoding_work_mem">
       <term><varname>logical_decoding_work_mem</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>logical_decoding_work_mem</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>logical_decoding_work_mem</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2719,9 +2718,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-max-stack-depth" xreflabel="max_stack_depth">
       <term><varname>max_stack_depth</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_stack_depth</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_stack_depth</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2770,9 +2769,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-shared-memory-type" xreflabel="shared_memory_type">
       <term><varname>shared_memory_type</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>shared_memory_type</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>shared_memory_type</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2807,9 +2806,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-dynamic-shared-memory-type" xreflabel="dynamic_shared_memory_type">
       <term><varname>dynamic_shared_memory_type</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>dynamic_shared_memory_type</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>dynamic_shared_memory_type</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2854,9 +2853,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-temp-file-limit" xreflabel="temp_file_limit">
       <term><varname>temp_file_limit</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>temp_file_limit</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>temp_file_limit</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2905,9 +2904,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-max-files-per-process" xreflabel="max_files_per_process">
       <term><varname>max_files_per_process</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_files_per_process</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_files_per_process</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2991,9 +2990,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       <varlistentry id="guc-vacuum-cost-delay" xreflabel="vacuum_cost_delay">
        <term><varname>vacuum_cost_delay</varname> (<type>floating point</type>)
        <indexterm>
-       <!--
         <primary><varname>vacuum_cost_delay</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>vacuum_cost_delay</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3038,9 +3037,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       <varlistentry id="guc-vacuum-cost-page-hit" xreflabel="vacuum_cost_page_hit">
        <term><varname>vacuum_cost_page_hit</varname> (<type>integer</type>)
        <indexterm>
-       <!--
         <primary><varname>vacuum_cost_page_hit</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>vacuum_cost_page_hit</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3060,9 +3059,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       <varlistentry id="guc-vacuum-cost-page-miss" xreflabel="vacuum_cost_page_miss">
        <term><varname>vacuum_cost_page_miss</varname> (<type>integer</type>)
        <indexterm>
-       <!--
         <primary><varname>vacuum_cost_page_miss</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>vacuum_cost_page_miss</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3082,9 +3081,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       <varlistentry id="guc-vacuum-cost-page-dirty" xreflabel="vacuum_cost_page_dirty">
        <term><varname>vacuum_cost_page_dirty</varname> (<type>integer</type>)
        <indexterm>
-       <!--
         <primary><varname>vacuum_cost_page_dirty</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>vacuum_cost_page_dirty</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3105,9 +3104,9 @@ vacuumが、先だって掃除したブロックを変更するのに必要な�
       <varlistentry id="guc-vacuum-cost-limit" xreflabel="vacuum_cost_limit">
        <term><varname>vacuum_cost_limit</varname> (<type>integer</type>)
        <indexterm>
-       <!--
         <primary><varname>vacuum_cost_limit</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>vacuum_cost_limit</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3176,9 +3175,9 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
       <varlistentry id="guc-bgwriter-delay" xreflabel="bgwriter_delay">
        <term><varname>bgwriter_delay</varname> (<type>integer</type>)
        <indexterm>
-       <!--
         <primary><varname>bgwriter_delay</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>bgwriter_delay</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3218,9 +3217,9 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
       <varlistentry id="guc-bgwriter-lru-maxpages" xreflabel="bgwriter_lru_maxpages">
        <term><varname>bgwriter_lru_maxpages</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>bgwriter_lru_maxpages</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>bgwriter_lru_maxpages</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3247,9 +3246,9 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
       <varlistentry id="guc-bgwriter-lru-multiplier" xreflabel="bgwriter_lru_multiplier">
        <term><varname>bgwriter_lru_multiplier</varname> (<type>floating point</type>)
        <indexterm>
-       <!--
         <primary><varname>bgwriter_lru_multiplier</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>bgwriter_lru_multiplier</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3289,10 +3288,9 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
       <varlistentry id="guc-bgwriter-flush-after" xreflabel="bgwriter_flush_after">
        <term><varname>bgwriter_flush_after</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>bgwriter_flush_after</varname> configuration parameter</primary>
        </indexterm>
--->
+       <indexterm>
         <primary><varname>bgwriter_flush_after</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3356,9 +3354,9 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
       <varlistentry id="guc-effective-io-concurrency" xreflabel="effective_io_concurrency">
        <term><varname>effective_io_concurrency</varname> (<type>integer</type>)
        <indexterm>
-       <!--
         <primary><varname>effective_io_concurrency</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>effective_io_concurrency</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3429,9 +3427,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
       <varlistentry id="guc-maintenance-io-concurrency" xreflabel="maintenance_io_concurrency">
        <term><varname>maintenance_io_concurrency</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>maintenance_io_concurrency</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>maintenance_io_concurrency</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3459,9 +3457,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
       <varlistentry id="guc-max-worker-processes" xreflabel="max_worker_processes">
        <term><varname>max_worker_processes</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>max_worker_processes</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>max_worker_processes</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3502,9 +3500,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
       <varlistentry id="guc-max-parallel-workers-per-gather" xreflabel="max_parallel_workers_per_gather">
        <term><varname>max_parallel_workers_per_gather</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>max_parallel_workers_per_gather</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>max_parallel_workers_per_gather</varname> 設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3566,9 +3564,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
       <varlistentry id="guc-max-parallel-workers-maintenance" xreflabel="max_parallel_maintenance_workers">
        <term><varname>max_parallel_maintenance_workers</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>max_parallel_maintenance_workers</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>max_parallel_maintenance_workers</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3622,9 +3620,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
       <varlistentry id="guc-max-parallel-workers" xreflabel="max_parallel_workers">
        <term><varname>max_parallel_workers</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>max_parallel_workers</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>max_parallel_workers</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3653,9 +3651,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
       <varlistentry id="guc-backend-flush-after" xreflabel="backend_flush_after">
        <term><varname>backend_flush_after</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>backend_flush_after</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>backend_flush_after</varname> 設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3699,9 +3697,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
       <varlistentry id="guc-old-snapshot-threshold" xreflabel="old_snapshot_threshold">
        <term><varname>old_snapshot_threshold</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>old_snapshot_threshold</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>old_snapshot_threshold</varname> 設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3813,9 +3811,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
      <varlistentry id="guc-wal-level" xreflabel="wal_level">
       <term><varname>wal_level</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_level</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_level</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3897,9 +3895,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
      <varlistentry id="guc-fsync" xreflabel="fsync">
       <term><varname>fsync</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>fsync</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>fsync</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3986,9 +3984,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
      <varlistentry id="guc-synchronous-commit" xreflabel="synchronous_commit">
       <term><varname>synchronous_commit</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>synchronous_commit</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>synchronous_commit</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4194,9 +4192,9 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
      <varlistentry id="guc-wal-sync-method" xreflabel="wal_sync_method">
       <term><varname>wal_sync_method</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_sync_method</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_sync_method</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4281,9 +4279,9 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
      <varlistentry id="guc-full-page-writes" xreflabel="full_page_writes">
       <term><varname>full_page_writes</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>full_page_writes</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>full_page_writes</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4350,9 +4348,9 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
      <varlistentry id="guc-wal-log-hints" xreflabel="wal_log_hints">
       <term><varname>wal_log_hints</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>wal_log_hints</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_log_hints</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4391,9 +4389,9 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
      <varlistentry id="guc-wal-compression" xreflabel="wal_compression">
       <term><varname>wal_compression</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>wal_compression</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_compression</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4429,9 +4427,9 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
      <varlistentry id="guc-wal-init-zero" xreflabel="wal_init_zero">
       <term><varname>wal_init_zero</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>wal_init_zero</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_init_zero</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4457,9 +4455,9 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
      <varlistentry id="guc-wal-recycle" xreflabel="wal_recycle">
       <term><varname>wal_recycle</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>wal_recycle</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_recycle</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4480,9 +4478,9 @@ COWファイルシステムでは、新しいファイルを作るほうが速�
      <varlistentry id="guc-wal-buffers" xreflabel="wal_buffers">
       <term><varname>wal_buffers</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_buffers</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_buffers</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4532,9 +4530,9 @@ COWファイルシステムでは、新しいファイルを作るほうが速�
      <varlistentry id="guc-wal-writer-delay" xreflabel="wal_writer_delay">
       <term><varname>wal_writer_delay</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_writer_delay</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_writer_delay</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4572,9 +4570,9 @@ WALを吐き出したとあと、非同期コミットしているトランザ�
      <varlistentry id="guc-wal-writer-flush-after" xreflabel="wal_writer_flush_after">
       <term><varname>wal_writer_flush_after</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>wal_writer_flush_after</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_writer_flush_after</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4607,9 +4605,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
      <varlistentry id="guc-wal-skip-threshold" xreflabel="wal_skip_threshold">
       <term><varname>wal_skip_threshold</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>wal_skip_threshold</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_skip_threshold</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4638,9 +4636,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
      <varlistentry id="guc-commit-delay" xreflabel="commit_delay">
       <term><varname>commit_delay</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>commit_delay</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>commit_delay</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4693,9 +4691,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
      <varlistentry id="guc-commit-siblings" xreflabel="commit_siblings">
       <term><varname>commit_siblings</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>commit_siblings</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>commit_siblings</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4727,9 +4725,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
      <varlistentry id="guc-checkpoint-timeout" xreflabel="checkpoint_timeout">
       <term><varname>checkpoint_timeout</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>checkpoint_timeout</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>checkpoint_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4758,9 +4756,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
      <varlistentry id="guc-checkpoint-completion-target" xreflabel="checkpoint_completion_target">
       <term><varname>checkpoint_completion_target</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>checkpoint_completion_target</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>checkpoint_completion_target</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4782,9 +4780,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
      <varlistentry id="guc-checkpoint-flush-after" xreflabel="checkpoint_flush_after">
       <term><varname>checkpoint_flush_after</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>checkpoint_flush_after</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>checkpoint_flush_after</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4828,9 +4826,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
      <varlistentry id="guc-checkpoint-warning" xreflabel="checkpoint_warning">
       <term><varname>checkpoint_warning</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>checkpoint_warning</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>checkpoint_warning</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4863,9 +4861,9 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
      <varlistentry id="guc-max-wal-size" xreflabel="max_wal_size">
       <term><varname>max_wal_size</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>max_wal_size</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_wal_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4897,9 +4895,9 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
      <varlistentry id="guc-min-wal-size" xreflabel="min_wal_size">
       <term><varname>min_wal_size</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>min_wal_size</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>min_wal_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4937,9 +4935,9 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
      <varlistentry id="guc-archive-mode" xreflabel="archive_mode">
       <term><varname>archive_mode</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>archive_mode</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>archive_mode</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4982,9 +4980,9 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
      <varlistentry id="guc-archive-command" xreflabel="archive_command">
       <term><varname>archive_command</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>archive_command</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>archive_command</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -5035,9 +5033,9 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
      <varlistentry id="guc-archive-timeout" xreflabel="archive_timeout">
       <term><varname>archive_timeout</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>archive_timeout</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>archive_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -5161,9 +5159,9 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
      <varlistentry id="guc-restore-command" xreflabel="restore_command">
       <term><varname>restore_command</varname> (<type>string</type>)
       <indexterm>
-<!--
         <primary><varname>restore_command</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>restore_command</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -5234,9 +5232,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-archive-cleanup-command" xreflabel="archive_cleanup_command">
       <term><varname>archive_cleanup_command</varname> (<type>string</type>)
       <indexterm>
-<!--
         <primary><varname>archive_cleanup_command</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>archive_cleanup_command</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -5301,9 +5299,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-recovery-end-command" xreflabel="recovery_end_command">
       <term><varname>recovery_end_command</varname> (<type>string</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_end_command</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_end_command</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -5376,9 +5374,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-recovery-target" xreflabel="recovery_target">
       <term><varname>recovery_target</varname><literal> = 'immediate'</literal>
       <indexterm>
-<!--
         <primary><varname>recovery_target</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_target</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -5406,9 +5404,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-recovery-target-name" xreflabel="recovery_target_name">
       <term><varname>recovery_target_name</varname> (<type>string</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_target_name</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_target_name</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -5426,9 +5424,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-recovery-target-time" xreflabel="recovery_target_time">
       <term><varname>recovery_target_time</varname> (<type>timestamp</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_target_time</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_target_time</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -5463,9 +5461,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-recovery-target-xid" xreflabel="recovery_target_xid">
       <term><varname>recovery_target_xid</varname> (<type>string</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_target_xid</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_target_xid</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -5492,9 +5490,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-recovery-target-lsn" xreflabel="recovery_target_lsn">
       <term><varname>recovery_target_lsn</varname> (<type>pg_lsn</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_target_lsn</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_target_lsn</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -5528,9 +5526,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
                    xreflabel="recovery_target_inclusive">
       <term><varname>recovery_target_inclusive</varname> (<type>boolean</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_target_inclusive</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_target_inclusive</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -5559,9 +5557,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
                    xreflabel="recovery_target_timeline">
       <term><varname>recovery_target_timeline</varname> (<type>string</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_target_timeline</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_target_timeline</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -5600,9 +5598,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
                    xreflabel="recovery_target_action">
       <term><varname>recovery_target_action</varname> (<type>enum</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_target_action</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_target_action</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -5736,9 +5734,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
       <varlistentry id="guc-max-wal-senders" xreflabel="max_wal_senders">
        <term><varname>max_wal_senders</varname> (<type>integer</type>)
        <indexterm>
-       <!--
         <primary><varname>max_wal_senders</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>max_wal_senders</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -5782,9 +5780,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
       <varlistentry id="guc-max-replication-slots" xreflabel="max_replication_slots">
        <term><varname>max_replication_slots</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>max_replication_slots</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>max_replication_slots</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -5813,9 +5811,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
       <varlistentry id="guc-wal-keep-size" xreflabel="wal_keep_size">
        <term><varname>wal_keep_size</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>wal_keep_size</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>wal_keep_size</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -5866,9 +5864,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
       <varlistentry id="guc-max-slot-wal-keep-size" xreflabel="max_slot_wal_keep_size">
        <term><varname>max_slot_wal_keep_size</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>max_slot_wal_keep_size</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>max_slot_wal_keep_size</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -5899,9 +5897,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-wal-sender-timeout" xreflabel="wal_sender_timeout">
       <term><varname>wal_sender_timeout</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_sender_timeout</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_sender_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -5941,9 +5939,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-track-commit-timestamp" xreflabel="track_commit_timestamp">
       <term><varname>track_commit_timestamp</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>track_commit_timestamp</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>track_commit_timestamp</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -5992,9 +5990,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-synchronous-standby-names" xreflabel="synchronous_standby_names">
       <term><varname>synchronous_standby_names</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>synchronous_standby_names</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>synchronous_standby_names</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -6186,9 +6184,9 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
      <varlistentry id="guc-vacuum-defer-cleanup-age" xreflabel="vacuum_defer_cleanup_age">
       <term><varname>vacuum_defer_cleanup_age</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>vacuum_defer_cleanup_age</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>vacuum_defer_cleanup_age</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -6258,9 +6256,9 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
        <varlistentry id="guc-primary-conninfo" xreflabel="primary_conninfo">
         <term><varname>primary_conninfo</varname> (<type>string</type>)
         <indexterm>
-<!--
           <primary><varname>primary_conninfo</varname> configuration parameter</primary>
--->
+        </indexterm>
+        <indexterm>
           <primary><varname>primary_conninfo</varname>設定パラメータ</primary>
         </indexterm>
         </term>
@@ -6321,9 +6319,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
        <varlistentry id="guc-primary-slot-name" xreflabel="primary_slot_name">
         <term><varname>primary_slot_name</varname> (<type>string</type>)
         <indexterm>
-<!--
           <primary><varname>primary_slot_name</varname> configuration parameter</primary>
--->
+        </indexterm>
+        <indexterm>
           <primary><varname>primary_slot_name</varname>設定パラメータ</primary>
         </indexterm>
         </term>
@@ -6353,9 +6351,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
        <varlistentry id="guc-promote-trigger-file" xreflabel="promote_trigger_file">
         <term><varname>promote_trigger_file</varname> (<type>string</type>)
         <indexterm>
-<!--
           <primary><varname>promote_trigger_file</varname> configuration parameter</primary>
--->
+        </indexterm>
+        <indexterm>
           <primary><varname>promote_trigger_file</varname>設定パラメータ</primary>
         </indexterm>
         </term>
@@ -6379,9 +6377,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
      <varlistentry id="guc-hot-standby" xreflabel="hot_standby">
       <term><varname>hot_standby</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>hot_standby</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>hot_standby</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -6403,9 +6401,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
      <varlistentry id="guc-max-standby-archive-delay" xreflabel="max_standby_archive_delay">
       <term><varname>max_standby_archive_delay</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_standby_archive_delay</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_standby_archive_delay</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -6451,9 +6449,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
      <varlistentry id="guc-max-standby-streaming-delay" xreflabel="max_standby_streaming_delay">
       <term><varname>max_standby_streaming_delay</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_standby_streaming_delay</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_standby_streaming_delay</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -6500,9 +6498,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
      <varlistentry id="guc-wal-receiver-create-temp-slot" xreflabel="wal_receiver_create_temp_slot">
       <term><varname>wal_receiver_create_temp_slot</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>wal_receiver_create_temp_slot</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_receiver_create_temp_slot</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -6528,9 +6526,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
      <varlistentry id="guc-wal-receiver-status-interval" xreflabel="wal_receiver_status_interval">
       <term><varname>wal_receiver_status_interval</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_receiver_status_interval</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_receiver_status_interval</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -6574,9 +6572,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
      <varlistentry id="guc-hot-standby-feedback" xreflabel="hot_standby_feedback">
       <term><varname>hot_standby_feedback</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>hot_standby_feedback</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>hot_standby_feedback</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -6630,9 +6628,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
      <varlistentry id="guc-wal-receiver-timeout" xreflabel="wal_receiver_timeout">
       <term><varname>wal_receiver_timeout</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_receiver_timeout</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_receiver_timeout</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -6663,9 +6661,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
      <varlistentry id="guc-wal-retrieve-retry-interval" xreflabel="wal_retrieve_retry_interval">
       <term><varname>wal_retrieve_retry_interval</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>wal_retrieve_retry_interval</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_retrieve_retry_interval</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -6711,9 +6709,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-recovery-min-apply-delay" xreflabel="recovery_min_apply_delay">
       <term><varname>recovery_min_apply_delay</varname> (<type>integer</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_min_apply_delay</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_min_apply_delay</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -6843,9 +6841,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-max-logical-replication-workers" xreflabel="max_logical_replication_workers">
       <term><varname>max_logical_replication_workers</varname> (<type>int</type>)
       <indexterm>
-<!--
        <primary><varname>max_logical_replication_workers</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_logical_replication_workers</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -6877,9 +6875,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-max-sync-workers-per-subscription" xreflabel="max_sync_workers_per_subscription">
       <term><varname>max_sync_workers_per_subscription</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>max_sync_workers_per_subscription</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_sync_workers_per_subscription</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -6959,15 +6957,15 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-bitmapscan" xreflabel="enable_bitmapscan">
       <term><varname>enable_bitmapscan</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary>bitmap scan</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary>ビットマップ走査</primary>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>enable_bitmapscan</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_bitmapscan</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -6985,9 +6983,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-gathermerge" xreflabel="enable_gathermerge">
       <term><varname>enable_gathermerge</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_gathermerge</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_gathermerge</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7006,9 +7004,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-hashagg" xreflabel="enable_hashagg">
       <term><varname>enable_hashagg</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>enable_hashagg</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_hashagg</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7027,9 +7025,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-hashjoin" xreflabel="enable_hashjoin">
       <term><varname>enable_hashjoin</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>enable_hashjoin</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_hashjoin</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7047,9 +7045,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-incremental-sort" xreflabel="enable_incremental_sort">
       <term><varname>enable_incremental_sort</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_incremental_sort</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_incremental_sort</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7068,15 +7066,15 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-indexscan" xreflabel="enable_indexscan">
       <term><varname>enable_indexscan</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary>index scan</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary>インデックス走査</primary>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>enable_indexscan</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_indexscan</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7094,9 +7092,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-indexonlyscan" xreflabel="enable_indexonlyscan">
       <term><varname>enable_indexonlyscan</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_indexonlyscan</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_indexonlyscan</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7117,9 +7115,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-material" xreflabel="enable_material">
       <term><varname>enable_material</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>enable_material</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_material</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7141,9 +7139,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-mergejoin" xreflabel="enable_mergejoin">
       <term><varname>enable_mergejoin</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>enable_mergejoin</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_mergejoin</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7161,9 +7159,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-nestloop" xreflabel="enable_nestloop">
       <term><varname>enable_nestloop</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>enable_nestloop</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_nestloop</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7186,9 +7184,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-parallel-append" xreflabel="enable_parallel_append">
       <term><varname>enable_parallel_append</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_parallel_append</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_parallel_append</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7207,9 +7205,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-parallel-hash" xreflabel="enable_parallel_hash">
       <term><varname>enable_parallel_hash</varname> (<type>boolean</type>)
        <indexterm>
-<!--
         <primary><varname>enable_parallel_hash</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>enable_parallel_hash</varname>設定パラメータ</primary>
        </indexterm>
       </term>
@@ -7229,9 +7227,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-partition-pruning" xreflabel="enable_partition_pruning">
       <term><varname>enable_partition_pruning</varname> (<type>boolean</type>)
        <indexterm>
-<!--
         <primary><varname>enable_partition_pruning</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>enable_partition_pruning</varname>設定パラメータ</primary>
        </indexterm>
       </term>
@@ -7256,9 +7254,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-partitionwise-join" xreflabel="enable_partitionwise_join">
       <term><varname>enable_partitionwise_join</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_partitionwise_join</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_partitionwise_join</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7285,9 +7283,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-partitionwise-aggregate" xreflabel="enable_partitionwise_aggregate">
       <term><varname>enable_partitionwise_aggregate</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_partitionwise_aggregate</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_partitionwise_aggregate</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7314,15 +7312,15 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-seqscan" xreflabel="enable_seqscan">
       <term><varname>enable_seqscan</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary>sequential scan</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary>シーケンシャル走査</primary>
       </indexterm>
       <indexterm>
-<!--
        <primary><varname>enable_seqscan</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_seqscan</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7345,9 +7343,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-sort" xreflabel="enable_sort">
       <term><varname>enable_sort</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_sort</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_sort</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7370,9 +7368,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-tidscan" xreflabel="enable_tidscan">
       <term><varname>enable_tidscan</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_tidscan</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_tidscan</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7435,9 +7433,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-seq-page-cost" xreflabel="seq_page_cost">
       <term><varname>seq_page_cost</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>seq_page_cost</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>seq_page_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7460,9 +7458,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-random-page-cost" xreflabel="random_page_cost">
       <term><varname>random_page_cost</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>random_page_cost</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>random_page_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7551,9 +7549,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-cpu-tuple-cost" xreflabel="cpu_tuple_cost">
       <term><varname>cpu_tuple_cost</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>cpu_tuple_cost</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>cpu_tuple_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7573,9 +7571,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-cpu-index-tuple-cost" xreflabel="cpu_index_tuple_cost">
       <term><varname>cpu_index_tuple_cost</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>cpu_index_tuple_cost</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>cpu_index_tuple_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7595,9 +7593,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-cpu-operator-cost" xreflabel="cpu_operator_cost">
       <term><varname>cpu_operator_cost</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>cpu_operator_cost</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>cpu_operator_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7616,9 +7614,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-parallel-setup-cost" xreflabel="parallel_setup_cost">
       <term><varname>parallel_setup_cost</varname> (<type>floating point</type>)
       <indexterm>
-<!--
        <primary><varname>parallel_setup_cost</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>parallel_setup_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7638,9 +7636,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-parallel-tuple-cost" xreflabel="parallel_tuple_cost">
       <term><varname>parallel_tuple_cost</varname> (<type>floating point</type>)
       <indexterm>
-<!--
        <primary><varname>parallel_tuple_cost</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>parallel_tuple_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7660,9 +7658,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-min-parallel-table-scan-size" xreflabel="min_parallel_table_scan_size">
       <term><varname>min_parallel_table_scan_size</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>min_parallel_table_scan_size</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>min_parallel_relation_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7690,9 +7688,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-min-parallel-index-scan-size" xreflabel="min_parallel_index_scan_size">
       <term><varname>min_parallel_index_scan_size</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>min_parallel_index_scan_size</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>min_parallel_index_scan_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7724,9 +7722,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-effective-cache-size" xreflabel="effective_cache_size">
       <term><varname>effective_cache_size</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>effective_cache_size</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>effective_cache_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7774,9 +7772,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-jit-above-cost" xreflabel="jit_above_cost">
       <term><varname>jit_above_cost</varname> (<type>floating point</type>)
       <indexterm>
-<!--
        <primary><varname>jit_above_cost</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit_above_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7801,9 +7799,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-jit-inline-above-cost" xreflabel="jit_inline_above_cost">
       <term><varname>jit_inline_above_cost</varname> (<type>floating point</type>)
       <indexterm>
-<!--
        <primary><varname>jit_inline_above_cost</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit_inline_above_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7829,9 +7827,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-jit-optimize-above-cost" xreflabel="jit_optimize_above_cost">
       <term><varname>jit_optimize_above_cost</varname> (<type>floating point</type>)
       <indexterm>
-<!--
        <primary><varname>jit_optimize_above_cost</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit_optimize_above_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7884,9 +7882,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-geqo" xreflabel="geqo">
       <term><varname>geqo</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary>genetic query optimization</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary>遺伝的問い合わせ最適化</primary>
       </indexterm>
       <indexterm>
@@ -7897,9 +7895,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
        <see>遺伝的問い合わせ最適化</see>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>geqo</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>geqo</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7920,9 +7918,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-geqo-threshold" xreflabel="geqo_threshold">
       <term><varname>geqo_threshold</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>geqo_threshold</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>geqo_threshold</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7951,9 +7949,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-geqo-effort" xreflabel="geqo_effort">
       <term><varname>geqo_effort</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>geqo_effort</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>geqo_effort</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7987,9 +7985,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-geqo-pool-size" xreflabel="geqo_pool_size">
       <term><varname>geqo_pool_size</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>geqo_pool_size</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>geqo_pool_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8011,9 +8009,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-geqo-generations" xreflabel="geqo_generations">
       <term><varname>geqo_generations</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>geqo_generations</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>geqo_generations</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8035,9 +8033,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-geqo-selection-bias" xreflabel="geqo_selection_bias">
       <term><varname>geqo_selection_bias</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>geqo_selection_bias</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>geqo_selection_bias</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8056,9 +8054,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-geqo-seed" xreflabel="geqo_seed">
       <term><varname>geqo_seed</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>geqo_seed</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>geqo_seed</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8091,9 +8089,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-default-statistics-target" xreflabel="default_statistics_target">
       <term><varname>default_statistics_target</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>default_statistics_target</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>default_statistics_target</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8119,15 +8117,15 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-constraint-exclusion" xreflabel="constraint_exclusion">
       <term><varname>constraint_exclusion</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary>constraint exclusion</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary>制約除外</primary>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>constraint_exclusion</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>constraint_exclusion</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8208,9 +8206,9 @@ SELECT * FROM parent WHERE key = 2400;
      <varlistentry id="guc-cursor-tuple-fraction" xreflabel="cursor_tuple_fraction">
       <term><varname>cursor_tuple_fraction</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>cursor_tuple_fraction</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>cursor_tuple_fraction</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8241,9 +8239,9 @@ SELECT * FROM parent WHERE key = 2400;
      <varlistentry id="guc-from-collapse-limit" xreflabel="from_collapse_limit">
       <term><varname>from_collapse_limit</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>from_collapse_limit</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>from_collapse_limit</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8276,9 +8274,9 @@ SELECT * FROM parent WHERE key = 2400;
      <varlistentry id="guc-jit" xreflabel="jit">
       <term><varname>jit</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>jit</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8301,9 +8299,9 @@ SELECT * FROM parent WHERE key = 2400;
      <varlistentry id="guc-join-collapse-limit" xreflabel="join_collapse_limit">
       <term><varname>join_collapse_limit</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>join_collapse_limit</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>join_collapse_limit</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8390,9 +8388,9 @@ SELECT * FROM parent WHERE key = 2400;
      <varlistentry id="guc-force-parallel-mode" xreflabel="force_parallel_mode">
       <term><varname>force_parallel_mode</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>force_parallel_mode</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>force_parallel_mode</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8452,9 +8450,9 @@ SELECT * FROM parent WHERE key = 2400;
      <varlistentry id="guc-plan-cache_mode" xreflabel="plan_cache_mode">
       <term><varname>plan_cache_mode</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>plan_cache_mode</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>plan_cache_mode</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8522,9 +8520,10 @@ SELECT * FROM parent WHERE key = 2400;
 
      <indexterm>
        <primary>current_logfiles</primary>
-<!--
        <secondary>and the log_destination configuration parameter</secondary>
--->
+     </indexterm>
+     <indexterm>
+       <primary>current_logfiles</primary>
        <secondary>およびlog_destination設定パラメータ</secondary>
      </indexterm>
 
@@ -8533,9 +8532,9 @@ SELECT * FROM parent WHERE key = 2400;
      <varlistentry id="guc-log-destination" xreflabel="log_destination">
       <term><varname>log_destination</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>log_destination</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_destination</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8648,9 +8647,9 @@ local0.*    /var/log/postgresql
      <varlistentry id="guc-logging-collector" xreflabel="logging_collector">
       <term><varname>logging_collector</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>logging_collector</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>logging_collector</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8718,9 +8717,9 @@ local0.*    /var/log/postgresql
      <varlistentry id="guc-log-directory" xreflabel="log_directory">
       <term><varname>log_directory</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>log_directory</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_directory</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8746,9 +8745,9 @@ local0.*    /var/log/postgresql
      <varlistentry id="guc-log-filename" xreflabel="log_filename">
       <term><varname>log_filename</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>log_filename</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_filename</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8817,9 +8816,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-file-mode" xreflabel="log_file_mode">
       <term><varname>log_file_mode</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>log_file_mode</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_file_mode</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8868,9 +8867,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-rotation-age" xreflabel="log_rotation_age">
       <term><varname>log_rotation_age</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>log_rotation_age</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_rotation_age</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8899,9 +8898,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-rotation-size" xreflabel="log_rotation_size">
       <term><varname>log_rotation_size</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>log_rotation_size</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_rotation_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8931,9 +8930,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-truncate-on-rotation" xreflabel="log_truncate_on_rotation">
       <term><varname>log_truncate_on_rotation</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_truncate_on_rotation</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_truncate_on_rotation</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8992,9 +8991,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-syslog-facility" xreflabel="syslog_facility">
       <term><varname>syslog_facility</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>syslog_facility</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>syslog_facility</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9025,9 +9024,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-syslog-ident" xreflabel="syslog_ident">
       <term><varname>syslog_ident</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>syslog_ident</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>syslog_ident</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9051,9 +9050,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
       <varlistentry id="guc-syslog-sequence-numbers" xreflabel="syslog_sequence_numbers">
        <term><varname>syslog_sequence_numbers</varname> (<type>boolean</type>)
         <indexterm>
-<!--
          <primary><varname>syslog_sequence_numbers</varname> configuration parameter</primary>
--->
+        </indexterm>
+        <indexterm>
          <primary><varname>syslog_sequence_numbers</varname>設定パラメータ</primary>
         </indexterm>
        </term>
@@ -9091,9 +9090,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-syslog-split-messages" xreflabel="syslog_split_messages">
       <term><varname>syslog_split_messages</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>syslog_split_messages</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>syslog_split_messages</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9142,9 +9141,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-event-source" xreflabel="event_source">
       <term><varname>event_source</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>event_source</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>event_source</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9176,9 +9175,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-min-messages" xreflabel="log_min_messages">
       <term><varname>log_min_messages</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>log_min_messages</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_min_messages</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9211,9 +9210,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-min-error-statement" xreflabel="log_min_error_statement">
       <term><varname>log_min_error_statement</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>log_min_error_statement</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_min_error_statement</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9253,9 +9252,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-min-duration-statement" xreflabel="log_min_duration_statement">
       <term><varname>log_min_duration_statement</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>log_min_duration_statement</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_min_duration_statement</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9323,9 +9322,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-min-duration-sample" xreflabel="log_min_duration_sample">
       <term><varname>log_min_duration_sample</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>log_min_duration_sample</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_min_duration_sample</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9381,9 +9380,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-statement-sample-rate" xreflabel="log_statement_sample_rate">
       <term><varname>log_statement_sample_rate</varname> (<type>floating point</type>)
       <indexterm>
-<!--
        <primary><varname>log_statement_sample_rate</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_statement_sample_rate</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9415,9 +9414,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-transaction-sample-rate" xreflabel="log_transaction_sample_rate">
       <term><varname>log_transaction_sample_rate</varname> (<type>floating point</type>)
       <indexterm>
-<!--
        <primary><varname>log_transaction_sample_rate</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_transaction_sample_rate</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9603,9 +9602,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-application-name" xreflabel="application_name">
       <term><varname>application_name</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>application_name</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>application_name</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9634,25 +9633,25 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry>
       <term><varname>debug_print_parse</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>debug_print_parse</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>debug_print_parse</varname>設定パラメータ</primary>
       </indexterm>
       </term>
       <term><varname>debug_print_rewritten</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>debug_print_rewritten</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>debug_print_rewritten</varname>設定パラメータ</primary>
       </indexterm>
       </term>
       <term><varname>debug_print_plan</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>debug_print_plan</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>debug_print_plan</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9681,9 +9680,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry>
       <term><varname>debug_pretty_print</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>debug_pretty_print</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>debug_pretty_print</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9707,9 +9706,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-checkpoints" xreflabel="log_checkpoints">
       <term><varname>log_checkpoints</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_checkpoints</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_checkpoints</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9733,9 +9732,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-connections" xreflabel="log_connections">
       <term><varname>log_connections</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_connections</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_connections</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9770,9 +9769,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-disconnections" xreflabel="log_disconnections">
       <term><varname>log_disconnections</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_disconnections</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_disconnections</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9798,9 +9797,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-duration" xreflabel="log_duration">
       <term><varname>log_duration</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_duration</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_duration</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9848,9 +9847,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-error-verbosity" xreflabel="log_error_verbosity">
       <term><varname>log_error_verbosity</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>log_error_verbosity</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_error_verbosity</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9880,9 +9879,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-hostname" xreflabel="log_hostname">
       <term><varname>log_hostname</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_hostname</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_hostname</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -9907,9 +9906,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-line-prefix" xreflabel="log_line_prefix">
       <term><varname>log_line_prefix</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>log_line_prefix</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_line_prefix</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -10203,9 +10202,9 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      <varlistentry id="guc-log-lock-waits" xreflabel="log_lock_waits">
       <term><varname>log_lock_waits</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_lock_waits</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_lock_waits</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -10229,9 +10228,9 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      <varlistentry id="guc-log-parameter-max-length" xreflabel="log_parameter_max_length">
       <term><varname>log_parameter_max_length</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>log_parameter_max_length</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_parameter_max_length</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -10271,9 +10270,9 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      <varlistentry id="guc-log-parameter-max-length-on-error" xreflabel="log_parameter_max_length_on_error">
       <term><varname>log_parameter_max_length_on_error</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>log_parameter_max_length_on_error</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_parameter_max_length_on_error</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -10314,9 +10313,9 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      <varlistentry id="guc-log-statement" xreflabel="log_statement">
       <term><varname>log_statement</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>log_statement</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_statement</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -10378,9 +10377,9 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      <varlistentry id="guc-log-replication-commands" xreflabel="log_replication_commands">
       <term><varname>log_replication_commands</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>log_replication_commands</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_replication_commands</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -10403,9 +10402,9 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      <varlistentry id="guc-log-temp-files" xreflabel="log_temp_files">
       <term><varname>log_temp_files</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>log_temp_files</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_temp_files</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -10439,9 +10438,9 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      <varlistentry id="guc-log-timezone" xreflabel="log_timezone">
       <term><varname>log_timezone</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>log_timezone</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_timezone</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -10673,9 +10672,9 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
      <varlistentry id="guc-cluster-name" xreflabel="cluster_name">
       <term><varname>cluster_name</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>cluster_name</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>cluster_name</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -10716,9 +10715,9 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
      <varlistentry id="guc-update-process-title" xreflabel="update_process_title">
       <term><varname>update_process_title</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>update_process_title</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>update_process_title</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -10772,9 +10771,9 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
      <varlistentry id="guc-track-activities" xreflabel="track_activities">
       <term><varname>track_activities</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>track_activities</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>track_activities</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -10802,9 +10801,9 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
      <varlistentry id="guc-track-activity-query-size" xreflabel="track_activity_query_size">
       <term><varname>track_activity_query_size</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>track_activity_query_size</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>track_activity_query_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -10829,9 +10828,9 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
      <varlistentry id="guc-track-counts" xreflabel="track_counts">
       <term><varname>track_counts</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>track_counts</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>track_counts</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -10853,9 +10852,9 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
      <varlistentry id="guc-track-io-timing" xreflabel="track_io_timing">
       <term><varname>track_io_timing</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>track_io_timing</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>track_io_timing</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -10887,9 +10886,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-track-functions" xreflabel="track_functions">
       <term><varname>track_functions</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>track_functions</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>track_functions</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -10925,9 +10924,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-stats-temp-directory" xreflabel="stats_temp_directory">
       <term><varname>stats_temp_directory</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>stats_temp_directory</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>stats_temp_directory</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -10964,33 +10963,33 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry>
       <term><varname>log_statement_stats</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_statement_stats</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_statement_stats</varname>設定パラメータ</primary>
       </indexterm>
       </term>
       <term><varname>log_parser_stats</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>log_parser_stats</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_parser_stats</varname>設定パラメータ</primary>
       </indexterm>
       </term>
       <term><varname>log_planner_stats</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>log_planner_stats</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_planner_stats</varname>設定パラメータ</primary>
       </indexterm>
       </term>
       <term><varname>log_executor_stats</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>log_executor_stats</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
       <primary><varname>log_executor_stats</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -11053,9 +11052,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-autovacuum" xreflabel="autovacuum">
       <term><varname>autovacuum</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>autovacuum</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>autovacuum</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -11093,9 +11092,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>log_autovacuum_min_duration</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>log_autovacuum_min_duration</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>log_autovacuum_min_duration</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -11134,9 +11134,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-autovacuum-max-workers" xreflabel="autovacuum_max_workers">
       <term><varname>autovacuum_max_workers</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>autovacuum_max_workers</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>autovacuum_max_workers</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -11157,9 +11157,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-autovacuum-naptime" xreflabel="autovacuum_naptime">
       <term><varname>autovacuum_naptime</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>autovacuum_naptime</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>autovacuum_naptime</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -11188,9 +11188,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_vacuum_threshold</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>autovacuum_vacuum_threshold</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_vacuum_threshold</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -11217,9 +11218,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_vacuum_insert_threshold</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>autovacuum_vacuum_insert_threshold</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_vacuum_insert_threshold</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -11249,9 +11251,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_analyze_threshold</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>autovacuum_analyze_threshold</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_analyze_threshold</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -11278,9 +11281,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_vacuum_scale_factor</varname> (<type>floating point</type>)
       <indexterm>
        <primary><varname>autovacuum_vacuum_scale_factor</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_vacuum_scale_factor</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -11307,10 +11311,11 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_vacuum_insert_scale_factor</varname> (<type>floating point</type>)
       <indexterm>
        <primary><varname>autovacuum_vacuum_insert_scale_factor</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
-       <secondary>設定パラメータ</secondary>
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_vacuum_insert_scale_factor</varname></primary>
+       <secondary>>設定パラメータ</secondary>
       </indexterm>
       </term>
       <listitem>
@@ -11336,9 +11341,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_analyze_scale_factor</varname> (<type>floating point</type>)
       <indexterm>
        <primary><varname>autovacuum_analyze_scale_factor</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_analyze_scale_factor</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -11406,9 +11412,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_multixact_freeze_max_age</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>autovacuum_multixact_freeze_max_age</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_multixact_freeze_max_age</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -11449,9 +11456,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_vacuum_cost_delay</varname> (<type>floating point</type>)
       <indexterm>
        <primary><varname>autovacuum_vacuum_cost_delay</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_vacuum_cost_delay</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -11482,9 +11490,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_vacuum_cost_limit</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>autovacuum_vacuum_cost_limit</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_vacuum_cost_limit</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -11532,9 +11541,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-client-min-messages" xreflabel="client_min_messages">
       <term><varname>client_min_messages</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>client_min_messages</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>client_min_messages</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -11571,14 +11580,12 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-search-path" xreflabel="search_path">
       <term><varname>search_path</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>search_path</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>search_path</varname>設定パラメータ</primary>
       </indexterm>
-      <!--
       <indexterm><primary>path</primary><secondary>for schemas</secondary></indexterm>
-      -->
       <indexterm><primary>パス</primary><secondary>スキーマへの</secondary></indexterm>
       </term>
       <listitem>
@@ -11716,9 +11723,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-row-security" xreflabel="row_security">
       <term><varname>row_security</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>row_security</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>row_security</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -11758,9 +11765,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-default-table-access-method" xreflabel="default_table_access_method">
       <term><varname>default_table_access_method</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>default_table_access_method</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>default_table_access_method</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -11782,14 +11789,12 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-default-tablespace" xreflabel="default_tablespace">
       <term><varname>default_tablespace</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>default_tablespace</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>default_tablespace</varname>設定パラメータ</primary>
       </indexterm>
-      <!--
       <indexterm><primary>tablespace</primary><secondary>default</secondary></indexterm>
-      -->
       <indexterm><primary>テーブル空間</primary><secondary>デフォルト</secondary></indexterm>
       </term>
       <listitem>
@@ -11851,14 +11856,12 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-temp-tablespaces" xreflabel="temp_tablespaces">
       <term><varname>temp_tablespaces</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>temp_tablespaces</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>temp_tablespaces</varname>設定パラメータ</primary>
       </indexterm>
-      <!--
       <indexterm><primary>tablespace</primary><secondary>temporary</secondary></indexterm>
-      -->
       <indexterm><primary>テーブル空間</primary><secondary>一時的</secondary></indexterm>
       </term>
       <listitem>
@@ -11930,9 +11933,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-check-function-bodies" xreflabel="check_function_bodies">
       <term><varname>check_function_bodies</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>check_function_bodies</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>check_function_bodies</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -11969,9 +11972,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
        <secondary>デフォルト設定</secondary>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>default_transaction_isolation</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>default_transaction_isolation</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12017,9 +12020,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
        <secondary>デフォルト設定</secondary>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>default_transaction_read_only</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>default_transaction_read_only</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12055,9 +12058,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
        <secondary>デフォルト設定</secondary>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>default_transaction_deferrable</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>default_transaction_deferrable</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12101,9 +12104,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-session-replication-role" xreflabel="session_replication_role">
       <term><varname>session_replication_role</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>session_replication_role</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>session_replication_role</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12163,9 +12166,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-statement-timeout" xreflabel="statement_timeout">
       <term><varname>statement_timeout</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>statement_timeout</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>statement_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12217,9 +12220,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-lock-timeout" xreflabel="lock_timeout">
       <term><varname>lock_timeout</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>lock_timeout</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>lock_timeout</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12272,9 +12275,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-idle-in-transaction-session-timeout" xreflabel="idle_in_transaction_session_timeout">
       <term><varname>idle_in_transaction_session_timeout</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>idle_in_transaction_session_timeout</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>idle_in_transaction_session_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12306,9 +12309,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-vacuum-freeze-table-age" xreflabel="vacuum_freeze_table_age">
       <term><varname>vacuum_freeze_table_age</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>vacuum_freeze_table_age</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>vacuum_freeze_table_age</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12341,9 +12344,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-vacuum-freeze-min-age" xreflabel="vacuum_freeze_min_age">
       <term><varname>vacuum_freeze_min_age</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>vacuum_freeze_min_age</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>vacuum_freeze_min_age</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12373,9 +12376,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-vacuum-multixact-freeze-table-age" xreflabel="vacuum_multixact_freeze_table_age">
       <term><varname>vacuum_multixact_freeze_table_age</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>vacuum_multixact_freeze_table_age</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>vacuum_multixact_freeze_table_age</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12407,9 +12410,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-vacuum-multixact-freeze-min-age" xreflabel="vacuum_multixact_freeze_min_age">
       <term><varname>vacuum_multixact_freeze_min_age</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>vacuum_multixact_freeze_min_age</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>vacuum_multixact_freeze_min_age</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12439,9 +12442,10 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
       <term><varname>vacuum_cleanup_index_scale_factor</varname> (<type>floating point</type>)
       <indexterm>
        <primary><varname>vacuum_cleanup_index_scale_factor</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>vacuum_cleanup_index_scale_factor</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -12500,9 +12504,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-bytea-output" xreflabel="bytea_output">
       <term><varname>bytea_output</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>bytea_output</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>bytea_output</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12527,9 +12531,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-xmlbinary" xreflabel="xmlbinary">
       <term><varname>xmlbinary</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>xmlbinary</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>xmlbinary</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12570,18 +12574,18 @@ XMLに関連した関数については<xref linkend="functions-xml"/>を参照�
      <varlistentry id="guc-xmloption" xreflabel="xmloption">
       <term><varname>xmloption</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>xmloption</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>xmloption</varname>設定パラメータ</primary>
       </indexterm>
       <indexterm>
        <primary><varname>SET XML OPTION</varname></primary>
       </indexterm>
       <indexterm>
-      <!--
        <primary>XML option</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary>XMLオプション</primary>
       </indexterm>
       </term>
@@ -12622,9 +12626,10 @@ SET XML OPTION { DOCUMENT | CONTENT };
       <term><varname>gin_pending_list_limit</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>gin_pending_list_limit</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>gin_pending_list_limit</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -12665,9 +12670,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-datestyle" xreflabel="DateStyle">
       <term><varname>DateStyle</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>DateStyle</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>DateStyle</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12705,9 +12710,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-intervalstyle" xreflabel="IntervalStyle">
       <term><varname>IntervalStyle</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>IntervalStyle</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>IntervalStyle</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12749,15 +12754,13 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-timezone" xreflabel="TimeZone">
       <term><varname>TimeZone</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>TimeZone</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>TimeZone</varname>設定パラメータ</primary>
       </indexterm>
-      <!--
       <indexterm><primary>time zone</primary></indexterm>
-      -->
-      <indexterm><primary><!--time zone-->時間帯</primary></indexterm>
+      <indexterm><primary>時間帯</primary></indexterm>
       </term>
       <listitem>
        <para>
@@ -12778,14 +12781,12 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-timezone-abbreviations" xreflabel="timezone_abbreviations">
       <term><varname>timezone_abbreviations</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>timezone_abbreviations</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>timezone_abbreviations</varname>設定パラメータ</primary>
       </indexterm>
-      <!--
       <indexterm><primary>time zone names</primary></indexterm>
-      -->
       <indexterm><primary>時間帯名</primary></indexterm>
       </term>
       <listitem>
@@ -12810,9 +12811,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-extra-float-digits" xreflabel="extra_float_digits">
       <term><varname>extra_float_digits</varname> (<type>integer</type>)
       <indexterm>
-     <!--
        <primary>significant digits</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary>有効数字</primary>
       </indexterm>
       <indexterm>
@@ -12826,9 +12827,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
        <secondary>表示</secondary>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>extra_float_digits</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>extra_float_digits</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12893,14 +12894,12 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-client-encoding" xreflabel="client_encoding">
       <term><varname>client_encoding</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>client_encoding</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>client_encoding</varname>設定パラメータ</primary>
       </indexterm>
-      <!--
       <indexterm><primary>character set</primary></indexterm>
-      -->
       <indexterm><primary>文字セット</primary></indexterm>
       </term>
       <listitem>
@@ -12920,9 +12919,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-lc-messages" xreflabel="lc_messages">
       <term><varname>lc_messages</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>lc_messages</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>lc_messages</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12967,9 +12966,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-lc-monetary" xreflabel="lc_monetary">
       <term><varname>lc_monetary</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>lc_monetary</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>lc_monetary</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12996,9 +12995,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-lc-numeric" xreflabel="lc_numeric">
       <term><varname>lc_numeric</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>lc_numeric</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>lc_numeric</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13025,9 +13024,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-lc-time" xreflabel="lc_time">
       <term><varname>lc_time</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>lc_time</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>lc_time</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13053,9 +13052,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-default-text-search-config" xreflabel="default_text_search_config">
       <term><varname>default_text_search_config</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>default_text_search_config</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>default_text_search_config</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13144,9 +13143,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-local-preload-libraries" xreflabel="local_preload_libraries">
       <term><varname>local_preload_libraries</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>local_preload_libraries</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>local_preload_libraries</varname>設定パラメータ</primary>
       </indexterm>
       <indexterm>
@@ -13225,9 +13224,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-session-preload-libraries" xreflabel="session_preload_libraries">
       <term><varname>session_preload_libraries</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>session_preload_libraries</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>session_preload_libraries</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13289,9 +13288,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-shared-preload-libraries" xreflabel="shared_preload_libraries">
       <term><varname>shared_preload_libraries</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>shared_preload_libraries</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>shared_preload_libraries</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13368,9 +13367,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-jit-provider" xreflabel="jit_provider">
       <term><varname>jit_provider</varname> (<type>string</type>)
        <indexterm>
-<!--
         <primary><varname>jit_provider</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>jit_provider</varname>設定パラメータ</primary>
        </indexterm>
       </term>
@@ -13414,14 +13413,12 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-dynamic-library-path" xreflabel="dynamic_library_path">
       <term><varname>dynamic_library_path</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>dynamic_library_path</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>dynamic_library_path</varname>設定パラメータ</primary>
       </indexterm>
-      <!--
       <indexterm><primary>dynamic loading</primary></indexterm>
-      -->
       <indexterm><primary>動的ロード</primary></indexterm>
       </term>
       <listitem>
@@ -13496,9 +13493,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-gin-fuzzy-search-limit" xreflabel="gin_fuzzy_search_limit">
       <term><varname>gin_fuzzy_search_limit</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>gin_fuzzy_search_limit</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>gin_fuzzy_search_limit</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13529,29 +13526,25 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-deadlock-timeout" xreflabel="deadlock_timeout">
       <term><varname>deadlock_timeout</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary>deadlock</primary>
-       -->
-       <primary><!--deadlock-->デッドロック</primary>
-       <!--
        <secondary>timeout during</secondary>
-       -->
+      </indexterm>
+      <indexterm>
+       <primary>デッドロック</primary>
        <secondary>間のタイムアウト</secondary>
       </indexterm>
       <indexterm>
-      <!--
        <primary>timeout</primary>
-       -->
-       <primary>タイムアウト</primary>
-       <!--
        <secondary>deadlock</secondary>
-       -->
+      </indexterm>
+      <indexterm>
+       <primary>タイムアウト</primary>
        <secondary>デッドロック</secondary>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>deadlock_timeout</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>deadlock_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13605,9 +13598,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-max-locks-per-transaction" xreflabel="max_locks_per_transaction">
       <term><varname>max_locks_per_transaction</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_locks_per_transaction</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_locks_per_transaction</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13653,9 +13646,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-max-pred-locks-per-transaction" xreflabel="max_pred_locks_per_transaction">
       <term><varname>max_pred_locks_per_transaction</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_pred_locks_per_transaction</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_pred_locks_per_transaction</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13693,9 +13686,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-max-pred-locks-per-relation" xreflabel="max_pred_locks_per_relation">
       <term><varname>max_pred_locks_per_relation</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>max_pred_locks_per_relation</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_pred_locks_per_relation</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13723,9 +13716,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-max-pred-locks-per-page" xreflabel="max_pred_locks_per_page">
       <term><varname>max_pred_locks_per_page</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>max_pred_locks_per_page</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_pred_locks_per_page</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13764,9 +13757,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-array-nulls" xreflabel="array_nulls">
       <term><varname>array_nulls</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>array_nulls</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>array_nulls</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13801,14 +13794,12 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
 
      <varlistentry id="guc-backslash-quote" xreflabel="backslash_quote">
       <term><varname>backslash_quote</varname> (<type>enum</type>)
-      <!--
       <indexterm><primary>strings</primary><secondary>backslash quotes</secondary></indexterm>
-      -->
       <indexterm><primary>文字列</primary><secondary>バックスラッシュによる引用</secondary></indexterm>
       <indexterm>
-      <!--
        <primary><varname>backslash_quote</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>backslash_quote</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13859,14 +13850,12 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
 
      <varlistentry id="guc-escape-string-warning" xreflabel="escape_string_warning">
       <term><varname>escape_string_warning</varname> (<type>boolean</type>)
-      <!--
       <indexterm><primary>strings</primary><secondary>escape warning</secondary></indexterm>
-      -->
       <indexterm><primary>文字列</primary><secondary>エスケープに関する警告</secondary></indexterm>
       <indexterm>
-      <!--
        <primary><varname>escape_string_warning</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>escape_string_warning</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13898,9 +13887,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-lo-compat-privileges" xreflabel="lo_compat_privileges">
       <term><varname>lo_compat_privileges</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>lo_compat_privileges</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>lo-compat-privileges</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13934,9 +13923,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-operator-precedence-warning" xreflabel="operator_precedence_warning">
       <term><varname>operator_precedence_warning</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>operator_precedence_warning</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>operator_precedence_warning</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13970,9 +13959,9 @@ onの場合、演算子の優先順位の変更の結果、<productname>PostgreS
     <varlistentry id="guc-quote-all-identifiers" xreflabel="quote-all-identifiers">
       <term><varname>quote_all_identifiers</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>quote_all_identifiers</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>quote_all_identifiers</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13995,14 +13984,12 @@ onの場合、演算子の優先順位の変更の結果、<productname>PostgreS
 
      <varlistentry id="guc-standard-conforming-strings" xreflabel="standard_conforming_strings">
       <term><varname>standard_conforming_strings</varname> (<type>boolean</type>)
-      <!--
       <indexterm><primary>strings</primary><secondary>standard conforming</secondary></indexterm>
-      -->
       <indexterm><primary>文字列</primary><secondary>標準に従う</secondary></indexterm>
       <indexterm>
-      <!--
        <primary><varname>standard_conforming_strings</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>standard_conforming_strings</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14034,9 +14021,9 @@ onの場合、演算子の優先順位の変更の結果、<productname>PostgreS
      <varlistentry id="guc-synchronize-seqscans" xreflabel="synchronize_seqscans">
       <term><varname>synchronize_seqscans</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>synchronize_seqscans</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>synchronize_seqscans</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14078,9 +14065,9 @@ onの場合、演算子の優先順位の変更の結果、<productname>PostgreS
       <term><varname>transform_null_equals</varname> (<type>boolean</type>)
       <indexterm><primary>IS NULL</primary></indexterm>
       <indexterm>
-      <!--
        <primary><varname>transform_null_equals</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>transform_null_equals</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14159,9 +14146,9 @@ onの場合、演算子の優先順位の変更の結果、<productname>PostgreS
      <varlistentry id="guc-exit-on-error" xreflabel="exit_on_error">
       <term><varname>exit_on_error</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>exit_on_error</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>exit_on_error</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14181,9 +14168,9 @@ onなら、全てのエラーは現在のセッションを中止させます。
      <varlistentry id="guc-restart-after-crash" xreflabel="restart_after_crash">
       <term><varname>restart_after_crash</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>restart_after_crash</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>restart_after_crash</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14208,9 +14195,9 @@ onなら、全てのエラーは現在のセッションを中止させます。
      <varlistentry id="guc-data-sync-retry" xreflabel="data_sync_retry">
       <term><varname>data_sync_retry</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>data_sync_retry</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>data_sync_retry</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14284,9 +14271,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-block-size" xreflabel="block_size">
       <term><varname>block_size</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>block_size</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>block_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14312,9 +14299,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-data-checksums" xreflabel="data_checksums">
       <term><varname>data_checksums</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>data_checksums</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>data_checksums</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14333,9 +14320,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-data-directory-mode" xreflabel="data_directory_mode">
       <term><varname>data_directory_mode</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>data_directory_mode</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>data_directory_mode</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14358,9 +14345,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-debug-assertions" xreflabel="debug_assertions">
       <term><varname>debug_assertions</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>debug_assertions</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>debug_assertions</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14386,9 +14373,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-integer-datetimes" xreflabel="integer_datetimes">
       <term><varname>integer_datetimes</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>integer_datetimes</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>integer_datetimes</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14408,9 +14395,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-lc-collate" xreflabel="lc_collate">
       <term><varname>lc_collate</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>lc_collate</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>lc_collate</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14431,9 +14418,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-lc-ctype" xreflabel="lc_ctype">
       <term><varname>lc_ctype</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>lc_ctype</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>lc_ctype</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14457,9 +14444,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-max-function-args" xreflabel="max_function_args">
       <term><varname>max_function_args</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_function_args</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_function_args</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14480,9 +14467,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-max-identifier-length" xreflabel="max_identifier_length">
       <term><varname>max_identifier_length</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_identifier_length</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_identifier_length</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14506,9 +14493,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-max-index-keys" xreflabel="max_index_keys">
       <term><varname>max_index_keys</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_index_keys</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_index_keys</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14527,9 +14514,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-segment-size" xreflabel="segment_size">
       <term><varname>segment_size</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>segment_size</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>segment_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14552,14 +14539,12 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-server-encoding" xreflabel="server_encoding">
       <term><varname>server_encoding</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>server_encoding</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>server_encoding</varname>設定パラメータ</primary>
       </indexterm>
-      <!--
       <indexterm><primary>character set</primary></indexterm>
-      -->
       <indexterm><primary>文字セット</primary></indexterm>
       </term>
       <listitem>
@@ -14580,9 +14565,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-server-version" xreflabel="server_version">
       <term><varname>server_version</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>server_version</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>server_version</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14601,9 +14586,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-server-version-num" xreflabel="server_version_num">
       <term><varname>server_version_num</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>server_version_num</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>server_version_num</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14622,9 +14607,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-ssl-library" xreflabel="ssl_library">
       <term><varname>ssl_library</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>ssl_library</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_library</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14644,9 +14629,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-wal-block-size" xreflabel="wal_block_size">
       <term><varname>wal_block_size</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_block_size</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_block_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14666,9 +14651,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-wal-segment-size" xreflabel="wal_segment_size">
       <term><varname>wal_segment_size</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_segment_size</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_segment_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14757,9 +14742,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-allow-system-table-mods" xreflabel="allow_system_table_mods">
       <term><varname>allow_system_table_mods</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
         <primary><varname>allow_system_table_mods</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>allow_system_table_mods</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14783,9 +14768,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-backtrace-functions" xreflabel="backtrace_functions">
       <term><varname>backtrace_functions</varname> (<type>string</type>)
       <indexterm>
-<!--
         <primary><varname>backtrace_functions</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>backtrace_functions</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14823,9 +14808,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-ignore-system-indexes" xreflabel="ignore_system_indexes">
       <term><varname>ignore_system_indexes</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
         <primary><varname>ignore_system_indexes</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ignore_system_indexes</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14847,9 +14832,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-post-auth-delay" xreflabel="post_auth_delay">
       <term><varname>post_auth_delay</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>post_auth_delay</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>post_auth_delay</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14876,9 +14861,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-pre-auth-delay" xreflabel="pre_auth_delay">
       <term><varname>pre_auth_delay</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>pre_auth_delay</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>pre_auth_delay</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14907,9 +14892,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-trace-notify" xreflabel="trace_notify">
       <term><varname>trace_notify</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>trace_notify</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>trace_notify</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14932,9 +14917,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-trace-recovery-messages" xreflabel="trace_recovery_messages">
       <term><varname>trace_recovery_messages</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>trace_recovery_messages</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>trace_recovery_messages</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14973,9 +14958,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-trace-sort" xreflabel="trace_sort">
       <term><varname>trace_sort</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>trace_sort</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>trace_sort</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14997,9 +14982,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry>
       <term><varname>trace_locks</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>trace_locks</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>trace_locks</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15054,9 +15039,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry>
       <term><varname>trace_lwlocks</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>trace_lwlocks</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>trace_lwlocks</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15084,9 +15069,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry>
       <term><varname>trace_userlocks</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>trace_userlocks</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>trace_userlocks</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15113,9 +15098,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry>
       <term><varname>trace_lock_oidmin</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>trace_lock_oidmin</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>trace_lock_oidmin</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15142,9 +15127,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry>
       <term><varname>trace_lock_table</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>trace_lock_table</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>trace_lock_table</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15169,9 +15154,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry>
       <term><varname>debug_deadlocks</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>debug_deadlocks</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>debug_deadlocks</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15197,9 +15182,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry>
       <term><varname>log_btree_build_stats</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_btree_build_stats</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_btree_build_stats</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15225,9 +15210,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry id="guc-wal-consistency-checking" xreflabel="wal_consistency_checking">
       <term><varname>wal_consistency_checking</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>wal_consistency_checking</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_consistency_checking</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15274,9 +15259,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry id="guc-wal-debug" xreflabel="wal_debug">
       <term><varname>wal_debug</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_debug</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_debug</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15296,9 +15281,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
     <varlistentry id="guc-ignore-checksum-failure" xreflabel="ignore_checksum_failure">
       <term><varname>ignore_checksum_failure</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>ignore_checksum_failure</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ignore_checksum_failure</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15335,9 +15320,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
     <varlistentry id="guc-zero-damaged-pages" xreflabel="zero_damaged_pages">
       <term><varname>zero_damaged_pages</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>zero_damaged_pages</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>zero_damaged_pages</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15375,9 +15360,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry id="guc-ignore-invalid-pages" xreflabel="ignore_invalid_pages">
       <term><varname>ignore_invalid_pages</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>ignore_invalid_pages</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>ignore_invalid_pages</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15411,9 +15396,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry id="guc-jit-debugging-support" xreflabel="jit_debugging_support">
       <term><varname>jit_debugging_support</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>jit_debugging_support</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit_debugging_support</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15436,9 +15421,9 @@ LLVMに要求された機能がある場合は、生成した関数を<productna
      <varlistentry id="guc-jit-dump-bitcode" xreflabel="jit_dump_bitcode">
       <term><varname>jit_dump_bitcode</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>jit_dump_bitcode</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit_dump_bitcode</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15462,9 +15447,9 @@ LLVMに要求された機能がある場合は、生成した関数を<productna
      <varlistentry id="guc-jit-expressions" xreflabel="jit_expressions">
       <term><varname>jit_expressions</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>jit_expressions</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit_expressions</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15485,9 +15470,9 @@ JITコンパイルが有効な時に式がJITコンパイルされるかどう�
      <varlistentry id="guc-jit-profiling-support" xreflabel="jit_profiling_support">
       <term><varname>jit_profiling_support</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>jit_profiling_support</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit_profiling_support</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15512,9 +15497,9 @@ LLVMに要求された機能がある場合は、JITが生成した関数を<pro
      <varlistentry id="guc-jit-tuple-deforming" xreflabel="jit_tuple_deforming">
       <term><varname>jit_tuple_deforming</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>jit_tuple_deforming</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit_tuple_deforming</varname>設定パラメータ</primary>
       </indexterm>
       </term>

--- a/doc/src/sgml/config0.sgml
+++ b/doc/src/sgml/config0.sgml
@@ -15,10 +15,10 @@
   <title>サーバの設定</title>
 
   <indexterm>
-  <!--
    <primary>configuration</primary>
    <secondary>of the server</secondary>
-   -->
+  </indexterm>
+  <indexterm>
    <primary>設定</primary>
    <secondary>サーバの</secondary>
   </indexterm>
@@ -574,9 +574,10 @@ env PGOPTIONS="-c geqo=off -c statement_timeout=5min" psql
      <para>
       <indexterm>
        <primary><literal>include</literal></primary>
-       <!--
        <secondary>in configuration file</secondary>
-       -->
+      </indexterm>
+      <indexterm>
+       <primary><literal>include</literal></primary>
        <secondary>設定ファイルの中</secondary>
       </indexterm>
       <!--
@@ -611,9 +612,10 @@ Includeコマンドは入れ子にすることができます。
      <para>
       <indexterm>
        <primary><literal>include_if_exists</literal></primary>
-       <!--
        <secondary>in configuration file</secondary>
-       -->
+      </indexterm>
+      <indexterm>
+       <primary><literal>include_if_exists</literal></primary>
        <secondary>設定ファイルにおける</secondary>
       </indexterm>
 <!--
@@ -632,9 +634,10 @@ Includeコマンドは入れ子にすることができます。
      <para>
       <indexterm>
        <primary><literal>include_dir</literal></primary>
-       <!--
        <secondary>in configuration file</secondary>
-       -->
+      </indexterm>
+      <indexterm>
+       <primary><literal>include_dir</literal></primary>
        <secondary>設定ファイルにおける</secondary>
       </indexterm>
 <!--
@@ -800,9 +803,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-data-directory" xreflabel="data_directory">
       <term><varname>data_directory</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>data_directory</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>data_directory</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -821,9 +824,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-config-file" xreflabel="config_file">
       <term><varname>config_file</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>config_file</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>config_file</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -843,9 +846,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-hba-file" xreflabel="hba_file">
       <term><varname>hba_file</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>hba_file</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>hba_file</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -865,9 +868,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-ident-file" xreflabel="ident_file">
       <term><varname>ident_file</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>ident_file</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ident_file</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -889,9 +892,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-external-pid-file" xreflabel="external_pid_file">
       <term><varname>external_pid_file</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>external_pid_file</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>external_pid_file</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -982,9 +985,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-listen-addresses" xreflabel="listen_addresses">
       <term><varname>listen_addresses</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>listen_addresses</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>listen_addresses</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1027,9 +1030,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-port" xreflabel="port">
       <term><varname>port</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>port</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>port</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1050,9 +1053,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-max-connections" xreflabel="max_connections">
       <term><varname>max_connections</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_connections</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_connections</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1086,9 +1089,9 @@ include_dir 'conf.d'
       <term><varname>superuser_reserved_connections</varname>
       (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>superuser_reserved_connections</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>superuser_reserved_connections</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1126,9 +1129,9 @@ include_dir 'conf.d'
      <varlistentry id="guc-unix-socket-directories" xreflabel="unix_socket_directories">
       <term><varname>unix_socket_directories</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>unix_socket_directories</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>unix_socket_directories</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1179,9 +1182,9 @@ Windowsではデフォルトは空文字で、これはつまりUnixドメイン
      <varlistentry id="guc-unix-socket-group" xreflabel="unix_socket_group">
       <term><varname>unix_socket_group</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>unix_socket_group</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>unix_socket_group</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1217,9 +1220,9 @@ Unixドメインソケット（複数も）を所有するグループを設定�
      <varlistentry id="guc-unix-socket-permissions" xreflabel="unix_socket_permissions">
       <term><varname>unix_socket_permissions</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>unix_socket_permissions</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>unix_socket_permissions</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1286,9 +1289,9 @@ Unixドメインソケットは通常のUnixファイルシステムパーミッ
      <varlistentry id="guc-bonjour" xreflabel="bonjour">
       <term><varname>bonjour</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>bonjour</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>bonjour</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1307,9 +1310,9 @@ Unixドメインソケットは通常のUnixファイルシステムパーミッ
      <varlistentry id="guc-bonjour-name" xreflabel="bonjour_name">
       <term><varname>bonjour_name</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>bonjour_name</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>bonjour_name</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1334,9 +1337,9 @@ Unixドメインソケットは通常のUnixファイルシステムパーミッ
      <varlistentry id="guc-tcp-keepalives-idle" xreflabel="tcp_keepalives_idle">
       <term><varname>tcp_keepalives_idle</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>tcp_keepalives_idle</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>tcp_keepalives_idle</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1375,9 +1378,9 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
      <varlistentry id="guc-tcp-keepalives-interval" xreflabel="tcp_keepalives_interval">
       <term><varname>tcp_keepalives_interval</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>tcp_keepalives_interval</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>tcp_keepalives_interval</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1416,9 +1419,9 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
      <varlistentry id="guc-tcp-keepalives-count" xreflabel="tcp_keepalives_count">
       <term><varname>tcp_keepalives_count</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>tcp_keepalives_count</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>tcp_keepalives_count</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1454,9 +1457,9 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
      <varlistentry id="guc-tcp-user-timeout" xreflabel="tcp_user_timeout">
       <term><varname>tcp_user_timeout</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>tcp_user_timeout</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>tcp_user_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1501,18 +1504,14 @@ UNIXドメインソケットで接続しているセッションではこのパ�
      <variablelist>
      <varlistentry id="guc-authentication-timeout" xreflabel="authentication_timeout">
       <term><varname>authentication_timeout</varname> (<type>integer</type>)
-      <!--
       <indexterm><primary>timeout</primary><secondary>client authentication</secondary></indexterm>
-      -->
       <indexterm><primary>timeout</primary><secondary>クライアント認証</secondary></indexterm>
-      <!--
       <indexterm><primary>client authentication</primary><secondary>timeout during</secondary></indexterm>
-      -->
       <indexterm><primary>client authentication</primary><secondary>タイムアウト期間</secondary></indexterm>
       <indexterm>
-      <!--
        <primary><varname>authentication_timeout</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>authentication_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1542,9 +1541,9 @@ UNIXドメインソケットで接続しているセッションではこのパ�
      <varlistentry id="guc-password-encryption" xreflabel="password_encryption">
       <term><varname>password_encryption</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>password_encryption</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>password_encryption</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1577,9 +1576,9 @@ UNIXドメインソケットで接続しているセッションではこのパ�
      <varlistentry id="guc-krb-server-keyfile" xreflabel="krb_server_keyfile">
       <term><varname>krb_server_keyfile</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>krb_server_keyfile</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>krb_server_keyfile</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1601,9 +1600,9 @@ Kerberosサーバーキーファイルの場所を設定します。
      <varlistentry id="guc-krb-caseins-users" xreflabel="krb_caseins_users">
       <term><varname>krb_caseins_users</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>krb_caseins_users</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>krb_caseins_users</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1625,9 +1624,9 @@ GSSAPIユーザ名を大文字小文字の区別なく取り扱うかどうか�
      <varlistentry id="guc-db-user-namespace" xreflabel="db_user_namespace">
       <term><varname>db_user_namespace</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>db_user_namespace</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>db_user_namespace</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1717,9 +1716,9 @@ SSLの設定に関するさらなる情報については<xref linkend="ssl-tcp"
      <varlistentry id="guc-ssl" xreflabel="ssl">
       <term><varname>ssl</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>ssl</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1741,9 +1740,9 @@ SSLの設定に関するさらなる情報については<xref linkend="ssl-tcp"
      <varlistentry id="guc-ssl-ca-file" xreflabel="ssl_ca_file">
       <term><varname>ssl_ca_file</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>ssl_ca_file</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_ca_file</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1769,9 +1768,9 @@ SSLサーバ認証局（CA）が入っているファイル名を設定します
      <varlistentry id="guc-ssl-cert-file" xreflabel="ssl_cert_file">
       <term><varname>ssl_cert_file</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>ssl_cert_file</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_cert_file</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1795,9 +1794,9 @@ SSLサーバ証明書が入っているファイル名を設定します。
      <varlistentry id="guc-ssl-crl-file" xreflabel="ssl_crl_file">
       <term><varname>ssl_crl_file</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>ssl_crl_file</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_crl_file</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1822,9 +1821,9 @@ SSLサーバ証明書失効リスト（CRL）が入っているファイル名�
      <varlistentry id="guc-ssl-key-file" xreflabel="ssl_key_file">
       <term><varname>ssl_key_file</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>ssl_key_file</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_key_file</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1848,9 +1847,9 @@ SSLサーバの秘密鍵が入っているファイル名を設定します。
      <varlistentry id="guc-ssl-ciphers" xreflabel="ssl_ciphers">
       <term><varname>ssl_ciphers</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>ssl_ciphers</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_ciphers</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1974,9 +1973,9 @@ OpenSSLのバージョンにより、利用可能な暗号スイートの詳細�
      <varlistentry id="guc-ssl-prefer-server-ciphers" xreflabel="ssl_prefer_server_ciphers">
       <term><varname>ssl_prefer_server_ciphers</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>ssl_prefer_server_ciphers</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_prefer_server_ciphers</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2012,9 +2011,9 @@ OpenSSLのバージョンにより、利用可能な暗号スイートの詳細�
      <varlistentry id="guc-ssl-ecdh-curve" xreflabel="ssl_ecdh_curve">
       <term><varname>ssl_ecdh_curve</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>ssl_ecdh_curve</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_ecdh_curve</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2057,9 +2056,9 @@ OpenSSLのバージョンにより、利用可能な暗号スイートの詳細�
      <varlistentry id="guc-ssl-min-protocol-version" xreflabel="ssl_min_protocol_version">
       <term><varname>ssl_min_protocol_version</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>ssl_min_protocol_version</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_min_protocol_version</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2094,9 +2093,9 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
      <varlistentry id="guc-ssl-max-protocol-version" xreflabel="ssl_max_protocol_version">
       <term><varname>ssl_max_protocol_version</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>ssl_max_protocol_version</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_max_protocol_version</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2121,9 +2120,9 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
      <varlistentry id="guc-ssl-dh-params-file" xreflabel="ssl_dh_params_file">
       <term><varname>ssl_dh_params_file</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>ssl_dh_params_file</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_dh_params_file</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2157,9 +2156,9 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
      <varlistentry id="guc-ssl-passphrase-command" xreflabel="ssl_passphrase_command">
       <term><varname>ssl_passphrase_command</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>ssl_passphrase_command</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_passphrase_command</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2213,9 +2212,9 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
      <varlistentry id="guc-ssl-passphrase-command-supports-reload" xreflabel="ssl_passphrase_command_supports_reload">
       <term><varname>ssl_passphrase_command_supports_reload</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>ssl_passphrase_command_supports_reload</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_passphrase_command_supports_reload</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2268,9 +2267,9 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
      <varlistentry id="guc-shared-buffers" xreflabel="shared_buffers">
       <term><varname>shared_buffers</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>shared_buffers</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>shared_buffers</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2335,9 +2334,9 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
      <varlistentry id="guc-huge-pages" xreflabel="huge_pages">
       <term><varname>huge_pages</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>huge_pages</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>huge_pages</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2426,9 +2425,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-temp-buffers" xreflabel="temp_buffers">
       <term><varname>temp_buffers</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>temp_buffers</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>temp_buffers</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2476,9 +2475,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-max-prepared-transactions" xreflabel="max_prepared_transactions">
       <term><varname>max_prepared_transactions</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_prepared_transactions</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_prepared_transactions</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2524,9 +2523,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-work-mem" xreflabel="work_mem">
       <term><varname>work_mem</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>work_mem</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>work_mem</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2581,9 +2580,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-hash-mem-multiplier" xreflabel="hash_mem_multiplier">
       <term><varname>hash_mem_multiplier</varname> (<type>floating point</type>)
       <indexterm>
-<!--
        <primary><varname>hash_mem_multiplier</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>hash_mem_multiplier</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2625,9 +2624,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-maintenance-work-mem" xreflabel="maintenance_work_mem">
       <term><varname>maintenance_work_mem</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>maintenance_work_mem</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>maintenance_work_mem</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2669,9 +2668,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-autovacuum-work-mem" xreflabel="autovacuum_work_mem">
       <term><varname>autovacuum_work_mem</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>autovacuum_work_mem</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>autovacuum_work_mem</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2697,9 +2696,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-logical-decoding-work-mem" xreflabel="logical_decoding_work_mem">
       <term><varname>logical_decoding_work_mem</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>logical_decoding_work_mem</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>logical_decoding_work_mem</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2727,9 +2726,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-max-stack-depth" xreflabel="max_stack_depth">
       <term><varname>max_stack_depth</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_stack_depth</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_stack_depth</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2778,9 +2777,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-shared-memory-type" xreflabel="shared_memory_type">
       <term><varname>shared_memory_type</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>shared_memory_type</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>shared_memory_type</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2815,9 +2814,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-dynamic-shared-memory-type" xreflabel="dynamic_shared_memory_type">
       <term><varname>dynamic_shared_memory_type</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>dynamic_shared_memory_type</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>dynamic_shared_memory_type</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2862,9 +2861,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-temp-file-limit" xreflabel="temp_file_limit">
       <term><varname>temp_file_limit</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>temp_file_limit</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>temp_file_limit</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2913,9 +2912,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-max-files-per-process" xreflabel="max_files_per_process">
       <term><varname>max_files_per_process</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_files_per_process</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_files_per_process</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2999,9 +2998,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       <varlistentry id="guc-vacuum-cost-delay" xreflabel="vacuum_cost_delay">
        <term><varname>vacuum_cost_delay</varname> (<type>floating point</type>)
        <indexterm>
-       <!--
         <primary><varname>vacuum_cost_delay</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>vacuum_cost_delay</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3046,9 +3045,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       <varlistentry id="guc-vacuum-cost-page-hit" xreflabel="vacuum_cost_page_hit">
        <term><varname>vacuum_cost_page_hit</varname> (<type>integer</type>)
        <indexterm>
-       <!--
         <primary><varname>vacuum_cost_page_hit</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>vacuum_cost_page_hit</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3068,9 +3067,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       <varlistentry id="guc-vacuum-cost-page-miss" xreflabel="vacuum_cost_page_miss">
        <term><varname>vacuum_cost_page_miss</varname> (<type>integer</type>)
        <indexterm>
-       <!--
         <primary><varname>vacuum_cost_page_miss</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>vacuum_cost_page_miss</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3090,9 +3089,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       <varlistentry id="guc-vacuum-cost-page-dirty" xreflabel="vacuum_cost_page_dirty">
        <term><varname>vacuum_cost_page_dirty</varname> (<type>integer</type>)
        <indexterm>
-       <!--
         <primary><varname>vacuum_cost_page_dirty</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>vacuum_cost_page_dirty</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3113,9 +3112,9 @@ vacuumが、先だって掃除したブロックを変更するのに必要な�
       <varlistentry id="guc-vacuum-cost-limit" xreflabel="vacuum_cost_limit">
        <term><varname>vacuum_cost_limit</varname> (<type>integer</type>)
        <indexterm>
-       <!--
         <primary><varname>vacuum_cost_limit</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>vacuum_cost_limit</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3184,9 +3183,9 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
       <varlistentry id="guc-bgwriter-delay" xreflabel="bgwriter_delay">
        <term><varname>bgwriter_delay</varname> (<type>integer</type>)
        <indexterm>
-       <!--
         <primary><varname>bgwriter_delay</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>bgwriter_delay</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3226,9 +3225,9 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
       <varlistentry id="guc-bgwriter-lru-maxpages" xreflabel="bgwriter_lru_maxpages">
        <term><varname>bgwriter_lru_maxpages</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>bgwriter_lru_maxpages</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>bgwriter_lru_maxpages</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3255,9 +3254,9 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
       <varlistentry id="guc-bgwriter-lru-multiplier" xreflabel="bgwriter_lru_multiplier">
        <term><varname>bgwriter_lru_multiplier</varname> (<type>floating point</type>)
        <indexterm>
-       <!--
         <primary><varname>bgwriter_lru_multiplier</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>bgwriter_lru_multiplier</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3297,10 +3296,9 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
       <varlistentry id="guc-bgwriter-flush-after" xreflabel="bgwriter_flush_after">
        <term><varname>bgwriter_flush_after</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>bgwriter_flush_after</varname> configuration parameter</primary>
        </indexterm>
--->
+       <indexterm>
         <primary><varname>bgwriter_flush_after</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3364,9 +3362,9 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
       <varlistentry id="guc-effective-io-concurrency" xreflabel="effective_io_concurrency">
        <term><varname>effective_io_concurrency</varname> (<type>integer</type>)
        <indexterm>
-       <!--
         <primary><varname>effective_io_concurrency</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>effective_io_concurrency</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3437,9 +3435,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
       <varlistentry id="guc-maintenance-io-concurrency" xreflabel="maintenance_io_concurrency">
        <term><varname>maintenance_io_concurrency</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>maintenance_io_concurrency</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>maintenance_io_concurrency</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3467,9 +3465,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
       <varlistentry id="guc-max-worker-processes" xreflabel="max_worker_processes">
        <term><varname>max_worker_processes</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>max_worker_processes</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>max_worker_processes</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3510,9 +3508,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
       <varlistentry id="guc-max-parallel-workers-per-gather" xreflabel="max_parallel_workers_per_gather">
        <term><varname>max_parallel_workers_per_gather</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>max_parallel_workers_per_gather</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>max_parallel_workers_per_gather</varname> 設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3574,9 +3572,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
       <varlistentry id="guc-max-parallel-workers-maintenance" xreflabel="max_parallel_maintenance_workers">
        <term><varname>max_parallel_maintenance_workers</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>max_parallel_maintenance_workers</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>max_parallel_maintenance_workers</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3630,9 +3628,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
       <varlistentry id="guc-max-parallel-workers" xreflabel="max_parallel_workers">
        <term><varname>max_parallel_workers</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>max_parallel_workers</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>max_parallel_workers</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3661,9 +3659,9 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
       <varlistentry id="guc-backend-flush-after" xreflabel="backend_flush_after">
        <term><varname>backend_flush_after</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>backend_flush_after</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>backend_flush_after</varname> 設定パラメータ</primary>
        </indexterm>
        </term>

--- a/doc/src/sgml/config1.sgml
+++ b/doc/src/sgml/config1.sgml
@@ -11,9 +11,9 @@
       <varlistentry id="guc-old-snapshot-threshold" xreflabel="old_snapshot_threshold">
        <term><varname>old_snapshot_threshold</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>old_snapshot_threshold</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>old_snapshot_threshold</varname> 設定パラメータ</primary>
        </indexterm>
        </term>
@@ -125,9 +125,9 @@
      <varlistentry id="guc-wal-level" xreflabel="wal_level">
       <term><varname>wal_level</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_level</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_level</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -209,9 +209,9 @@
      <varlistentry id="guc-fsync" xreflabel="fsync">
       <term><varname>fsync</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>fsync</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>fsync</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -298,9 +298,9 @@
      <varlistentry id="guc-synchronous-commit" xreflabel="synchronous_commit">
       <term><varname>synchronous_commit</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>synchronous_commit</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>synchronous_commit</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -506,9 +506,9 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
      <varlistentry id="guc-wal-sync-method" xreflabel="wal_sync_method">
       <term><varname>wal_sync_method</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_sync_method</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_sync_method</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -593,9 +593,9 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
      <varlistentry id="guc-full-page-writes" xreflabel="full_page_writes">
       <term><varname>full_page_writes</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>full_page_writes</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>full_page_writes</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -662,9 +662,9 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
      <varlistentry id="guc-wal-log-hints" xreflabel="wal_log_hints">
       <term><varname>wal_log_hints</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>wal_log_hints</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_log_hints</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -703,9 +703,9 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
      <varlistentry id="guc-wal-compression" xreflabel="wal_compression">
       <term><varname>wal_compression</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>wal_compression</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_compression</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -741,9 +741,9 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
      <varlistentry id="guc-wal-init-zero" xreflabel="wal_init_zero">
       <term><varname>wal_init_zero</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>wal_init_zero</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_init_zero</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -769,9 +769,9 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
      <varlistentry id="guc-wal-recycle" xreflabel="wal_recycle">
       <term><varname>wal_recycle</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>wal_recycle</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_recycle</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -792,9 +792,9 @@ COWファイルシステムでは、新しいファイルを作るほうが速�
      <varlistentry id="guc-wal-buffers" xreflabel="wal_buffers">
       <term><varname>wal_buffers</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_buffers</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_buffers</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -844,9 +844,9 @@ COWファイルシステムでは、新しいファイルを作るほうが速�
      <varlistentry id="guc-wal-writer-delay" xreflabel="wal_writer_delay">
       <term><varname>wal_writer_delay</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_writer_delay</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_writer_delay</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -884,9 +884,9 @@ WALを吐き出したとあと、非同期コミットしているトランザ�
      <varlistentry id="guc-wal-writer-flush-after" xreflabel="wal_writer_flush_after">
       <term><varname>wal_writer_flush_after</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>wal_writer_flush_after</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_writer_flush_after</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -919,9 +919,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
      <varlistentry id="guc-wal-skip-threshold" xreflabel="wal_skip_threshold">
       <term><varname>wal_skip_threshold</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>wal_skip_threshold</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_skip_threshold</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -950,9 +950,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
      <varlistentry id="guc-commit-delay" xreflabel="commit_delay">
       <term><varname>commit_delay</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>commit_delay</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>commit_delay</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1005,9 +1005,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
      <varlistentry id="guc-commit-siblings" xreflabel="commit_siblings">
       <term><varname>commit_siblings</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>commit_siblings</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>commit_siblings</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1039,9 +1039,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
      <varlistentry id="guc-checkpoint-timeout" xreflabel="checkpoint_timeout">
       <term><varname>checkpoint_timeout</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>checkpoint_timeout</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>checkpoint_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1070,9 +1070,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
      <varlistentry id="guc-checkpoint-completion-target" xreflabel="checkpoint_completion_target">
       <term><varname>checkpoint_completion_target</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>checkpoint_completion_target</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>checkpoint_completion_target</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1094,9 +1094,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
      <varlistentry id="guc-checkpoint-flush-after" xreflabel="checkpoint_flush_after">
       <term><varname>checkpoint_flush_after</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>checkpoint_flush_after</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>checkpoint_flush_after</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1140,9 +1140,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
      <varlistentry id="guc-checkpoint-warning" xreflabel="checkpoint_warning">
       <term><varname>checkpoint_warning</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>checkpoint_warning</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>checkpoint_warning</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1175,9 +1175,9 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
      <varlistentry id="guc-max-wal-size" xreflabel="max_wal_size">
       <term><varname>max_wal_size</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>max_wal_size</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_wal_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1209,9 +1209,9 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
      <varlistentry id="guc-min-wal-size" xreflabel="min_wal_size">
       <term><varname>min_wal_size</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>min_wal_size</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>min_wal_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1249,9 +1249,9 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
      <varlistentry id="guc-archive-mode" xreflabel="archive_mode">
       <term><varname>archive_mode</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>archive_mode</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>archive_mode</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1294,9 +1294,9 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
      <varlistentry id="guc-archive-command" xreflabel="archive_command">
       <term><varname>archive_command</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>archive_command</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>archive_command</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1347,9 +1347,9 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
      <varlistentry id="guc-archive-timeout" xreflabel="archive_timeout">
       <term><varname>archive_timeout</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>archive_timeout</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>archive_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1473,9 +1473,9 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
      <varlistentry id="guc-restore-command" xreflabel="restore_command">
       <term><varname>restore_command</varname> (<type>string</type>)
       <indexterm>
-<!--
         <primary><varname>restore_command</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>restore_command</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1546,9 +1546,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-archive-cleanup-command" xreflabel="archive_cleanup_command">
       <term><varname>archive_cleanup_command</varname> (<type>string</type>)
       <indexterm>
-<!--
         <primary><varname>archive_cleanup_command</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>archive_cleanup_command</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1613,9 +1613,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-recovery-end-command" xreflabel="recovery_end_command">
       <term><varname>recovery_end_command</varname> (<type>string</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_end_command</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_end_command</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1688,9 +1688,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-recovery-target" xreflabel="recovery_target">
       <term><varname>recovery_target</varname><literal> = 'immediate'</literal>
       <indexterm>
-<!--
         <primary><varname>recovery_target</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_target</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1718,9 +1718,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-recovery-target-name" xreflabel="recovery_target_name">
       <term><varname>recovery_target_name</varname> (<type>string</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_target_name</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_target_name</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1738,9 +1738,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-recovery-target-time" xreflabel="recovery_target_time">
       <term><varname>recovery_target_time</varname> (<type>timestamp</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_target_time</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_target_time</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1775,9 +1775,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-recovery-target-xid" xreflabel="recovery_target_xid">
       <term><varname>recovery_target_xid</varname> (<type>string</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_target_xid</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_target_xid</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1804,9 +1804,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-recovery-target-lsn" xreflabel="recovery_target_lsn">
       <term><varname>recovery_target_lsn</varname> (<type>pg_lsn</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_target_lsn</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_target_lsn</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1840,9 +1840,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
                    xreflabel="recovery_target_inclusive">
       <term><varname>recovery_target_inclusive</varname> (<type>boolean</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_target_inclusive</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_target_inclusive</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1871,9 +1871,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
                    xreflabel="recovery_target_timeline">
       <term><varname>recovery_target_timeline</varname> (<type>string</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_target_timeline</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_target_timeline</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1912,9 +1912,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
                    xreflabel="recovery_target_action">
       <term><varname>recovery_target_action</varname> (<type>enum</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_target_action</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_target_action</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2048,9 +2048,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
       <varlistentry id="guc-max-wal-senders" xreflabel="max_wal_senders">
        <term><varname>max_wal_senders</varname> (<type>integer</type>)
        <indexterm>
-       <!--
         <primary><varname>max_wal_senders</varname> configuration parameter</primary>
-       -->
+       </indexterm>
+       <indexterm>
        <primary><varname>max_wal_senders</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -2094,9 +2094,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
       <varlistentry id="guc-max-replication-slots" xreflabel="max_replication_slots">
        <term><varname>max_replication_slots</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>max_replication_slots</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>max_replication_slots</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -2125,9 +2125,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
       <varlistentry id="guc-wal-keep-size" xreflabel="wal_keep_size">
        <term><varname>wal_keep_size</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>wal_keep_size</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>wal_keep_size</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -2178,9 +2178,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
       <varlistentry id="guc-max-slot-wal-keep-size" xreflabel="max_slot_wal_keep_size">
        <term><varname>max_slot_wal_keep_size</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>max_slot_wal_keep_size</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>max_slot_wal_keep_size</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -2211,9 +2211,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-wal-sender-timeout" xreflabel="wal_sender_timeout">
       <term><varname>wal_sender_timeout</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_sender_timeout</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_sender_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2253,9 +2253,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-track-commit-timestamp" xreflabel="track_commit_timestamp">
       <term><varname>track_commit_timestamp</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>track_commit_timestamp</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>track_commit_timestamp</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2304,9 +2304,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <varlistentry id="guc-synchronous-standby-names" xreflabel="synchronous_standby_names">
       <term><varname>synchronous_standby_names</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>synchronous_standby_names</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>synchronous_standby_names</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2498,9 +2498,9 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
      <varlistentry id="guc-vacuum-defer-cleanup-age" xreflabel="vacuum_defer_cleanup_age">
       <term><varname>vacuum_defer_cleanup_age</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>vacuum_defer_cleanup_age</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>vacuum_defer_cleanup_age</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2570,9 +2570,9 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
        <varlistentry id="guc-primary-conninfo" xreflabel="primary_conninfo">
         <term><varname>primary_conninfo</varname> (<type>string</type>)
         <indexterm>
-<!--
           <primary><varname>primary_conninfo</varname> configuration parameter</primary>
--->
+        </indexterm>
+        <indexterm>
           <primary><varname>primary_conninfo</varname>設定パラメータ</primary>
         </indexterm>
         </term>
@@ -2633,9 +2633,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
        <varlistentry id="guc-primary-slot-name" xreflabel="primary_slot_name">
         <term><varname>primary_slot_name</varname> (<type>string</type>)
         <indexterm>
-<!--
           <primary><varname>primary_slot_name</varname> configuration parameter</primary>
--->
+        </indexterm>
+        <indexterm>
           <primary><varname>primary_slot_name</varname>設定パラメータ</primary>
         </indexterm>
         </term>
@@ -2665,9 +2665,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
        <varlistentry id="guc-promote-trigger-file" xreflabel="promote_trigger_file">
         <term><varname>promote_trigger_file</varname> (<type>string</type>)
         <indexterm>
-<!--
           <primary><varname>promote_trigger_file</varname> configuration parameter</primary>
--->
+        </indexterm>
+        <indexterm>
           <primary><varname>promote_trigger_file</varname>設定パラメータ</primary>
         </indexterm>
         </term>
@@ -2691,9 +2691,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
      <varlistentry id="guc-hot-standby" xreflabel="hot_standby">
       <term><varname>hot_standby</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>hot_standby</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>hot_standby</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2715,9 +2715,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
      <varlistentry id="guc-max-standby-archive-delay" xreflabel="max_standby_archive_delay">
       <term><varname>max_standby_archive_delay</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_standby_archive_delay</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_standby_archive_delay</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2763,9 +2763,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
      <varlistentry id="guc-max-standby-streaming-delay" xreflabel="max_standby_streaming_delay">
       <term><varname>max_standby_streaming_delay</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_standby_streaming_delay</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_standby_streaming_delay</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2812,9 +2812,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
      <varlistentry id="guc-wal-receiver-create-temp-slot" xreflabel="wal_receiver_create_temp_slot">
       <term><varname>wal_receiver_create_temp_slot</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>wal_receiver_create_temp_slot</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_receiver_create_temp_slot</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2840,9 +2840,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
      <varlistentry id="guc-wal-receiver-status-interval" xreflabel="wal_receiver_status_interval">
       <term><varname>wal_receiver_status_interval</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_receiver_status_interval</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_receiver_status_interval</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2886,9 +2886,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
      <varlistentry id="guc-hot-standby-feedback" xreflabel="hot_standby_feedback">
       <term><varname>hot_standby_feedback</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>hot_standby_feedback</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>hot_standby_feedback</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2942,9 +2942,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
      <varlistentry id="guc-wal-receiver-timeout" xreflabel="wal_receiver_timeout">
       <term><varname>wal_receiver_timeout</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_receiver_timeout</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_receiver_timeout</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2975,9 +2975,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
      <varlistentry id="guc-wal-retrieve-retry-interval" xreflabel="wal_retrieve_retry_interval">
       <term><varname>wal_retrieve_retry_interval</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>wal_retrieve_retry_interval</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_retrieve_retry_interval</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3023,9 +3023,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-recovery-min-apply-delay" xreflabel="recovery_min_apply_delay">
       <term><varname>recovery_min_apply_delay</varname> (<type>integer</type>)
       <indexterm>
-<!--
         <primary><varname>recovery_min_apply_delay</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>recovery_min_apply_delay</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3155,9 +3155,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-max-logical-replication-workers" xreflabel="max_logical_replication_workers">
       <term><varname>max_logical_replication_workers</varname> (<type>int</type>)
       <indexterm>
-<!--
        <primary><varname>max_logical_replication_workers</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_logical_replication_workers</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3189,9 +3189,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-max-sync-workers-per-subscription" xreflabel="max_sync_workers_per_subscription">
       <term><varname>max_sync_workers_per_subscription</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>max_sync_workers_per_subscription</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_sync_workers_per_subscription</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3271,15 +3271,15 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-bitmapscan" xreflabel="enable_bitmapscan">
       <term><varname>enable_bitmapscan</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary>bitmap scan</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary>ビットマップ走査</primary>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>enable_bitmapscan</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_bitmapscan</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3297,9 +3297,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-gathermerge" xreflabel="enable_gathermerge">
       <term><varname>enable_gathermerge</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_gathermerge</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_gathermerge</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3318,9 +3318,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-hashagg" xreflabel="enable_hashagg">
       <term><varname>enable_hashagg</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>enable_hashagg</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_hashagg</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3339,9 +3339,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-hashjoin" xreflabel="enable_hashjoin">
       <term><varname>enable_hashjoin</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>enable_hashjoin</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_hashjoin</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3359,9 +3359,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-incremental-sort" xreflabel="enable_incremental_sort">
       <term><varname>enable_incremental_sort</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_incremental_sort</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_incremental_sort</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3380,15 +3380,15 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-indexscan" xreflabel="enable_indexscan">
       <term><varname>enable_indexscan</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary>index scan</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary>インデックス走査</primary>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>enable_indexscan</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_indexscan</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3406,9 +3406,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-indexonlyscan" xreflabel="enable_indexonlyscan">
       <term><varname>enable_indexonlyscan</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_indexonlyscan</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_indexonlyscan</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3429,9 +3429,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-material" xreflabel="enable_material">
       <term><varname>enable_material</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>enable_material</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_material</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3453,9 +3453,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-mergejoin" xreflabel="enable_mergejoin">
       <term><varname>enable_mergejoin</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>enable_mergejoin</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_mergejoin</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3473,9 +3473,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-nestloop" xreflabel="enable_nestloop">
       <term><varname>enable_nestloop</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>enable_nestloop</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_nestloop</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3498,9 +3498,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-parallel-append" xreflabel="enable_parallel_append">
       <term><varname>enable_parallel_append</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_parallel_append</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_parallel_append</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3519,9 +3519,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-parallel-hash" xreflabel="enable_parallel_hash">
       <term><varname>enable_parallel_hash</varname> (<type>boolean</type>)
        <indexterm>
-<!--
         <primary><varname>enable_parallel_hash</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>enable_parallel_hash</varname>設定パラメータ</primary>
        </indexterm>
       </term>
@@ -3541,9 +3541,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-partition-pruning" xreflabel="enable_partition_pruning">
       <term><varname>enable_partition_pruning</varname> (<type>boolean</type>)
        <indexterm>
-<!--
         <primary><varname>enable_partition_pruning</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>enable_partition_pruning</varname>設定パラメータ</primary>
        </indexterm>
       </term>
@@ -3568,9 +3568,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-partitionwise-join" xreflabel="enable_partitionwise_join">
       <term><varname>enable_partitionwise_join</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_partitionwise_join</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_partitionwise_join</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3597,9 +3597,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-partitionwise-aggregate" xreflabel="enable_partitionwise_aggregate">
       <term><varname>enable_partitionwise_aggregate</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_partitionwise_aggregate</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_partitionwise_aggregate</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3626,15 +3626,15 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-seqscan" xreflabel="enable_seqscan">
       <term><varname>enable_seqscan</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary>sequential scan</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary>シーケンシャル走査</primary>
       </indexterm>
       <indexterm>
-<!--
        <primary><varname>enable_seqscan</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_seqscan</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3657,9 +3657,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-sort" xreflabel="enable_sort">
       <term><varname>enable_sort</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_sort</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_sort</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3682,9 +3682,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-tidscan" xreflabel="enable_tidscan">
       <term><varname>enable_tidscan</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_tidscan</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_tidscan</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3747,9 +3747,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-seq-page-cost" xreflabel="seq_page_cost">
       <term><varname>seq_page_cost</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>seq_page_cost</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>seq_page_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3772,9 +3772,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-random-page-cost" xreflabel="random_page_cost">
       <term><varname>random_page_cost</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>random_page_cost</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>random_page_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3863,9 +3863,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-cpu-tuple-cost" xreflabel="cpu_tuple_cost">
       <term><varname>cpu_tuple_cost</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>cpu_tuple_cost</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>cpu_tuple_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3885,9 +3885,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-cpu-index-tuple-cost" xreflabel="cpu_index_tuple_cost">
       <term><varname>cpu_index_tuple_cost</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>cpu_index_tuple_cost</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>cpu_index_tuple_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3907,9 +3907,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-cpu-operator-cost" xreflabel="cpu_operator_cost">
       <term><varname>cpu_operator_cost</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>cpu_operator_cost</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>cpu_operator_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3928,9 +3928,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-parallel-setup-cost" xreflabel="parallel_setup_cost">
       <term><varname>parallel_setup_cost</varname> (<type>floating point</type>)
       <indexterm>
-<!--
        <primary><varname>parallel_setup_cost</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>parallel_setup_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3950,9 +3950,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-parallel-tuple-cost" xreflabel="parallel_tuple_cost">
       <term><varname>parallel_tuple_cost</varname> (<type>floating point</type>)
       <indexterm>
-<!--
        <primary><varname>parallel_tuple_cost</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>parallel_tuple_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3972,9 +3972,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-min-parallel-table-scan-size" xreflabel="min_parallel_table_scan_size">
       <term><varname>min_parallel_table_scan_size</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>min_parallel_table_scan_size</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>min_parallel_relation_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4002,9 +4002,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-min-parallel-index-scan-size" xreflabel="min_parallel_index_scan_size">
       <term><varname>min_parallel_index_scan_size</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>min_parallel_index_scan_size</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>min_parallel_index_scan_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4036,9 +4036,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-effective-cache-size" xreflabel="effective_cache_size">
       <term><varname>effective_cache_size</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>effective_cache_size</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>effective_cache_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4086,9 +4086,9 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
      <varlistentry id="guc-jit-above-cost" xreflabel="jit_above_cost">
       <term><varname>jit_above_cost</varname> (<type>floating point</type>)
       <indexterm>
-<!--
        <primary><varname>jit_above_cost</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit_above_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4113,9 +4113,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-jit-inline-above-cost" xreflabel="jit_inline_above_cost">
       <term><varname>jit_inline_above_cost</varname> (<type>floating point</type>)
       <indexterm>
-<!--
        <primary><varname>jit_inline_above_cost</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit_inline_above_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4141,9 +4141,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-jit-optimize-above-cost" xreflabel="jit_optimize_above_cost">
       <term><varname>jit_optimize_above_cost</varname> (<type>floating point</type>)
       <indexterm>
-<!--
        <primary><varname>jit_optimize_above_cost</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit_optimize_above_cost</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4196,9 +4196,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-geqo" xreflabel="geqo">
       <term><varname>geqo</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary>genetic query optimization</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary>遺伝的問い合わせ最適化</primary>
       </indexterm>
       <indexterm>
@@ -4209,9 +4209,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
        <see>遺伝的問い合わせ最適化</see>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>geqo</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>geqo</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4232,9 +4232,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-geqo-threshold" xreflabel="geqo_threshold">
       <term><varname>geqo_threshold</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>geqo_threshold</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>geqo_threshold</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4263,9 +4263,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-geqo-effort" xreflabel="geqo_effort">
       <term><varname>geqo_effort</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>geqo_effort</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>geqo_effort</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4299,9 +4299,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-geqo-pool-size" xreflabel="geqo_pool_size">
       <term><varname>geqo_pool_size</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>geqo_pool_size</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>geqo_pool_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4323,9 +4323,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-geqo-generations" xreflabel="geqo_generations">
       <term><varname>geqo_generations</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>geqo_generations</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>geqo_generations</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4347,9 +4347,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-geqo-selection-bias" xreflabel="geqo_selection_bias">
       <term><varname>geqo_selection_bias</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>geqo_selection_bias</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>geqo_selection_bias</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4368,9 +4368,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-geqo-seed" xreflabel="geqo_seed">
       <term><varname>geqo_seed</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>geqo_seed</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>geqo_seed</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4403,9 +4403,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-default-statistics-target" xreflabel="default_statistics_target">
       <term><varname>default_statistics_target</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>default_statistics_target</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>default_statistics_target</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4431,15 +4431,15 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      <varlistentry id="guc-constraint-exclusion" xreflabel="constraint_exclusion">
       <term><varname>constraint_exclusion</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary>constraint exclusion</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary>制約除外</primary>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>constraint_exclusion</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>constraint_exclusion</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4520,9 +4520,9 @@ SELECT * FROM parent WHERE key = 2400;
      <varlistentry id="guc-cursor-tuple-fraction" xreflabel="cursor_tuple_fraction">
       <term><varname>cursor_tuple_fraction</varname> (<type>floating point</type>)
       <indexterm>
-      <!--
        <primary><varname>cursor_tuple_fraction</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>cursor_tuple_fraction</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4553,9 +4553,9 @@ SELECT * FROM parent WHERE key = 2400;
      <varlistentry id="guc-from-collapse-limit" xreflabel="from_collapse_limit">
       <term><varname>from_collapse_limit</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>from_collapse_limit</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>from_collapse_limit</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -4588,9 +4588,9 @@ SELECT * FROM parent WHERE key = 2400;
      <varlistentry id="guc-jit" xreflabel="jit">
       <term><varname>jit</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>jit</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit</varname>設定パラメータ</primary>
       </indexterm>
       </term>

--- a/doc/src/sgml/config2.sgml
+++ b/doc/src/sgml/config2.sgml
@@ -11,9 +11,9 @@
      <varlistentry id="guc-join-collapse-limit" xreflabel="join_collapse_limit">
       <term><varname>join_collapse_limit</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>join_collapse_limit</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>join_collapse_limit</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -100,9 +100,9 @@
      <varlistentry id="guc-force-parallel-mode" xreflabel="force_parallel_mode">
       <term><varname>force_parallel_mode</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>force_parallel_mode</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>force_parallel_mode</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -162,9 +162,9 @@
      <varlistentry id="guc-plan-cache_mode" xreflabel="plan_cache_mode">
       <term><varname>plan_cache_mode</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>plan_cache_mode</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>plan_cache_mode</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -232,9 +232,10 @@
 
      <indexterm>
        <primary>current_logfiles</primary>
-<!--
        <secondary>and the log_destination configuration parameter</secondary>
--->
+     </indexterm>
+     <indexterm>
+       <primary>current_logfiles</primary>
        <secondary>およびlog_destination設定パラメータ</secondary>
      </indexterm>
 
@@ -243,9 +244,9 @@
      <varlistentry id="guc-log-destination" xreflabel="log_destination">
       <term><varname>log_destination</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>log_destination</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_destination</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -358,9 +359,9 @@ local0.*    /var/log/postgresql
      <varlistentry id="guc-logging-collector" xreflabel="logging_collector">
       <term><varname>logging_collector</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>logging_collector</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>logging_collector</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -428,9 +429,9 @@ local0.*    /var/log/postgresql
      <varlistentry id="guc-log-directory" xreflabel="log_directory">
       <term><varname>log_directory</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>log_directory</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_directory</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -456,9 +457,9 @@ local0.*    /var/log/postgresql
      <varlistentry id="guc-log-filename" xreflabel="log_filename">
       <term><varname>log_filename</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>log_filename</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_filename</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -527,9 +528,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-file-mode" xreflabel="log_file_mode">
       <term><varname>log_file_mode</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>log_file_mode</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_file_mode</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -578,9 +579,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-rotation-age" xreflabel="log_rotation_age">
       <term><varname>log_rotation_age</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>log_rotation_age</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_rotation_age</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -609,9 +610,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-rotation-size" xreflabel="log_rotation_size">
       <term><varname>log_rotation_size</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>log_rotation_size</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_rotation_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -641,9 +642,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-truncate-on-rotation" xreflabel="log_truncate_on_rotation">
       <term><varname>log_truncate_on_rotation</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_truncate_on_rotation</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_truncate_on_rotation</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -702,9 +703,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-syslog-facility" xreflabel="syslog_facility">
       <term><varname>syslog_facility</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>syslog_facility</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>syslog_facility</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -735,9 +736,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-syslog-ident" xreflabel="syslog_ident">
       <term><varname>syslog_ident</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>syslog_ident</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>syslog_ident</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -761,9 +762,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
       <varlistentry id="guc-syslog-sequence-numbers" xreflabel="syslog_sequence_numbers">
        <term><varname>syslog_sequence_numbers</varname> (<type>boolean</type>)
         <indexterm>
-<!--
          <primary><varname>syslog_sequence_numbers</varname> configuration parameter</primary>
--->
+        </indexterm>
+        <indexterm>
          <primary><varname>syslog_sequence_numbers</varname>設定パラメータ</primary>
         </indexterm>
        </term>
@@ -801,9 +802,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-syslog-split-messages" xreflabel="syslog_split_messages">
       <term><varname>syslog_split_messages</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>syslog_split_messages</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>syslog_split_messages</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -852,9 +853,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-event-source" xreflabel="event_source">
       <term><varname>event_source</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>event_source</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>event_source</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -886,9 +887,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-min-messages" xreflabel="log_min_messages">
       <term><varname>log_min_messages</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>log_min_messages</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_min_messages</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -921,9 +922,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-min-error-statement" xreflabel="log_min_error_statement">
       <term><varname>log_min_error_statement</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>log_min_error_statement</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_min_error_statement</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -963,9 +964,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-min-duration-statement" xreflabel="log_min_duration_statement">
       <term><varname>log_min_duration_statement</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>log_min_duration_statement</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_min_duration_statement</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1033,9 +1034,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-min-duration-sample" xreflabel="log_min_duration_sample">
       <term><varname>log_min_duration_sample</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>log_min_duration_sample</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_min_duration_sample</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1091,9 +1092,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-statement-sample-rate" xreflabel="log_statement_sample_rate">
       <term><varname>log_statement_sample_rate</varname> (<type>floating point</type>)
       <indexterm>
-<!--
        <primary><varname>log_statement_sample_rate</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_statement_sample_rate</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1125,9 +1126,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-transaction-sample-rate" xreflabel="log_transaction_sample_rate">
       <term><varname>log_transaction_sample_rate</varname> (<type>floating point</type>)
       <indexterm>
-<!--
        <primary><varname>log_transaction_sample_rate</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_transaction_sample_rate</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1313,9 +1314,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-application-name" xreflabel="application_name">
       <term><varname>application_name</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>application_name</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>application_name</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1344,25 +1345,25 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry>
       <term><varname>debug_print_parse</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>debug_print_parse</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>debug_print_parse</varname>設定パラメータ</primary>
       </indexterm>
       </term>
       <term><varname>debug_print_rewritten</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>debug_print_rewritten</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>debug_print_rewritten</varname>設定パラメータ</primary>
       </indexterm>
       </term>
       <term><varname>debug_print_plan</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>debug_print_plan</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>debug_print_plan</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1391,9 +1392,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry>
       <term><varname>debug_pretty_print</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>debug_pretty_print</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>debug_pretty_print</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1417,9 +1418,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-checkpoints" xreflabel="log_checkpoints">
       <term><varname>log_checkpoints</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_checkpoints</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_checkpoints</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1443,9 +1444,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-connections" xreflabel="log_connections">
       <term><varname>log_connections</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_connections</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_connections</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1480,9 +1481,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-disconnections" xreflabel="log_disconnections">
       <term><varname>log_disconnections</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_disconnections</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_disconnections</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1508,9 +1509,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-duration" xreflabel="log_duration">
       <term><varname>log_duration</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_duration</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_duration</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1558,9 +1559,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-error-verbosity" xreflabel="log_error_verbosity">
       <term><varname>log_error_verbosity</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>log_error_verbosity</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_error_verbosity</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1590,9 +1591,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-hostname" xreflabel="log_hostname">
       <term><varname>log_hostname</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_hostname</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_hostname</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1617,9 +1618,9 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
      <varlistentry id="guc-log-line-prefix" xreflabel="log_line_prefix">
       <term><varname>log_line_prefix</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>log_line_prefix</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_line_prefix</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1913,9 +1914,9 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      <varlistentry id="guc-log-lock-waits" xreflabel="log_lock_waits">
       <term><varname>log_lock_waits</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_lock_waits</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_lock_waits</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1939,9 +1940,9 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      <varlistentry id="guc-log-parameter-max-length" xreflabel="log_parameter_max_length">
       <term><varname>log_parameter_max_length</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>log_parameter_max_length</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_parameter_max_length</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1981,9 +1982,9 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      <varlistentry id="guc-log-parameter-max-length-on-error" xreflabel="log_parameter_max_length_on_error">
       <term><varname>log_parameter_max_length_on_error</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>log_parameter_max_length_on_error</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_parameter_max_length_on_error</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2024,9 +2025,9 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      <varlistentry id="guc-log-statement" xreflabel="log_statement">
       <term><varname>log_statement</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>log_statement</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_statement</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2088,9 +2089,9 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      <varlistentry id="guc-log-replication-commands" xreflabel="log_replication_commands">
       <term><varname>log_replication_commands</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>log_replication_commands</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_replication_commands</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2113,9 +2114,9 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      <varlistentry id="guc-log-temp-files" xreflabel="log_temp_files">
       <term><varname>log_temp_files</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>log_temp_files</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_temp_files</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2149,9 +2150,9 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      <varlistentry id="guc-log-timezone" xreflabel="log_timezone">
       <term><varname>log_timezone</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>log_timezone</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_timezone</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2383,9 +2384,9 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
      <varlistentry id="guc-cluster-name" xreflabel="cluster_name">
       <term><varname>cluster_name</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>cluster_name</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>cluster_name</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2426,9 +2427,9 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
      <varlistentry id="guc-update-process-title" xreflabel="update_process_title">
       <term><varname>update_process_title</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>update_process_title</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>update_process_title</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2482,9 +2483,9 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
      <varlistentry id="guc-track-activities" xreflabel="track_activities">
       <term><varname>track_activities</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>track_activities</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>track_activities</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2512,9 +2513,9 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
      <varlistentry id="guc-track-activity-query-size" xreflabel="track_activity_query_size">
       <term><varname>track_activity_query_size</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>track_activity_query_size</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>track_activity_query_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2539,9 +2540,9 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
      <varlistentry id="guc-track-counts" xreflabel="track_counts">
       <term><varname>track_counts</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>track_counts</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>track_counts</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2563,9 +2564,9 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
      <varlistentry id="guc-track-io-timing" xreflabel="track_io_timing">
       <term><varname>track_io_timing</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>track_io_timing</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>track_io_timing</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2597,9 +2598,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-track-functions" xreflabel="track_functions">
       <term><varname>track_functions</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>track_functions</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>track_functions</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2635,9 +2636,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-stats-temp-directory" xreflabel="stats_temp_directory">
       <term><varname>stats_temp_directory</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>stats_temp_directory</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>stats_temp_directory</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2674,33 +2675,33 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry>
       <term><varname>log_statement_stats</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_statement_stats</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_statement_stats</varname>設定パラメータ</primary>
       </indexterm>
       </term>
       <term><varname>log_parser_stats</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>log_parser_stats</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_parser_stats</varname>設定パラメータ</primary>
       </indexterm>
       </term>
       <term><varname>log_planner_stats</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>log_planner_stats</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_planner_stats</varname>設定パラメータ</primary>
       </indexterm>
       </term>
       <term><varname>log_executor_stats</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>log_executor_stats</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
       <primary><varname>log_executor_stats</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2763,9 +2764,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-autovacuum" xreflabel="autovacuum">
       <term><varname>autovacuum</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>autovacuum</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>autovacuum</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2803,9 +2804,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>log_autovacuum_min_duration</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>log_autovacuum_min_duration</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>log_autovacuum_min_duration</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -2844,9 +2846,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-autovacuum-max-workers" xreflabel="autovacuum_max_workers">
       <term><varname>autovacuum_max_workers</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>autovacuum_max_workers</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>autovacuum_max_workers</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2867,9 +2869,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-autovacuum-naptime" xreflabel="autovacuum_naptime">
       <term><varname>autovacuum_naptime</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>autovacuum_naptime</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>autovacuum_naptime</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2898,9 +2900,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_vacuum_threshold</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>autovacuum_vacuum_threshold</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_vacuum_threshold</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -2927,9 +2930,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_vacuum_insert_threshold</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>autovacuum_vacuum_insert_threshold</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_vacuum_insert_threshold</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -2959,9 +2963,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_analyze_threshold</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>autovacuum_analyze_threshold</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_analyze_threshold</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -2988,9 +2993,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_vacuum_scale_factor</varname> (<type>floating point</type>)
       <indexterm>
        <primary><varname>autovacuum_vacuum_scale_factor</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_vacuum_scale_factor</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -3017,10 +3023,11 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_vacuum_insert_scale_factor</varname> (<type>floating point</type>)
       <indexterm>
        <primary><varname>autovacuum_vacuum_insert_scale_factor</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
-       <secondary>設定パラメータ</secondary>
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_vacuum_insert_scale_factor</varname></primary>
+       <secondary>>設定パラメータ</secondary>
       </indexterm>
       </term>
       <listitem>
@@ -3046,9 +3053,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_analyze_scale_factor</varname> (<type>floating point</type>)
       <indexterm>
        <primary><varname>autovacuum_analyze_scale_factor</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_analyze_scale_factor</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -3116,9 +3124,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_multixact_freeze_max_age</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>autovacuum_multixact_freeze_max_age</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_multixact_freeze_max_age</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -3159,9 +3168,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_vacuum_cost_delay</varname> (<type>floating point</type>)
       <indexterm>
        <primary><varname>autovacuum_vacuum_cost_delay</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_vacuum_cost_delay</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -3192,9 +3202,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <term><varname>autovacuum_vacuum_cost_limit</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>autovacuum_vacuum_cost_limit</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_vacuum_cost_limit</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -3242,9 +3253,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-client-min-messages" xreflabel="client_min_messages">
       <term><varname>client_min_messages</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>client_min_messages</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>client_min_messages</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3281,14 +3292,12 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-search-path" xreflabel="search_path">
       <term><varname>search_path</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>search_path</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>search_path</varname>設定パラメータ</primary>
       </indexterm>
-      <!--
       <indexterm><primary>path</primary><secondary>for schemas</secondary></indexterm>
-      -->
       <indexterm><primary>パス</primary><secondary>スキーマへの</secondary></indexterm>
       </term>
       <listitem>
@@ -3426,9 +3435,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-row-security" xreflabel="row_security">
       <term><varname>row_security</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>row_security</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>row_security</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3468,9 +3477,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-default-table-access-method" xreflabel="default_table_access_method">
       <term><varname>default_table_access_method</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>default_table_access_method</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>default_table_access_method</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3492,14 +3501,12 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-default-tablespace" xreflabel="default_tablespace">
       <term><varname>default_tablespace</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>default_tablespace</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>default_tablespace</varname>設定パラメータ</primary>
       </indexterm>
-      <!--
       <indexterm><primary>tablespace</primary><secondary>default</secondary></indexterm>
-      -->
       <indexterm><primary>テーブル空間</primary><secondary>デフォルト</secondary></indexterm>
       </term>
       <listitem>
@@ -3561,14 +3568,12 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-temp-tablespaces" xreflabel="temp_tablespaces">
       <term><varname>temp_tablespaces</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>temp_tablespaces</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>temp_tablespaces</varname>設定パラメータ</primary>
       </indexterm>
-      <!--
       <indexterm><primary>tablespace</primary><secondary>temporary</secondary></indexterm>
-      -->
       <indexterm><primary>テーブル空間</primary><secondary>一時的</secondary></indexterm>
       </term>
       <listitem>
@@ -3640,9 +3645,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
      <varlistentry id="guc-check-function-bodies" xreflabel="check_function_bodies">
       <term><varname>check_function_bodies</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>check_function_bodies</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>check_function_bodies</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3679,9 +3684,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
        <secondary>デフォルト設定</secondary>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>default_transaction_isolation</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>default_transaction_isolation</varname>設定パラメータ</primary>
       </indexterm>
       </term>

--- a/doc/src/sgml/config3.sgml
+++ b/doc/src/sgml/config3.sgml
@@ -21,9 +21,9 @@
        <secondary>デフォルト設定</secondary>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>default_transaction_read_only</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>default_transaction_read_only</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -59,9 +59,9 @@
        <secondary>デフォルト設定</secondary>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>default_transaction_deferrable</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>default_transaction_deferrable</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -105,9 +105,9 @@
      <varlistentry id="guc-session-replication-role" xreflabel="session_replication_role">
       <term><varname>session_replication_role</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>session_replication_role</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>session_replication_role</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -167,9 +167,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-statement-timeout" xreflabel="statement_timeout">
       <term><varname>statement_timeout</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>statement_timeout</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>statement_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -221,9 +221,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-lock-timeout" xreflabel="lock_timeout">
       <term><varname>lock_timeout</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>lock_timeout</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>lock_timeout</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -276,9 +276,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-idle-in-transaction-session-timeout" xreflabel="idle_in_transaction_session_timeout">
       <term><varname>idle_in_transaction_session_timeout</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>idle_in_transaction_session_timeout</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>idle_in_transaction_session_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -310,9 +310,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-vacuum-freeze-table-age" xreflabel="vacuum_freeze_table_age">
       <term><varname>vacuum_freeze_table_age</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>vacuum_freeze_table_age</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>vacuum_freeze_table_age</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -345,9 +345,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-vacuum-freeze-min-age" xreflabel="vacuum_freeze_min_age">
       <term><varname>vacuum_freeze_min_age</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>vacuum_freeze_min_age</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>vacuum_freeze_min_age</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -377,9 +377,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-vacuum-multixact-freeze-table-age" xreflabel="vacuum_multixact_freeze_table_age">
       <term><varname>vacuum_multixact_freeze_table_age</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>vacuum_multixact_freeze_table_age</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>vacuum_multixact_freeze_table_age</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -411,9 +411,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-vacuum-multixact-freeze-min-age" xreflabel="vacuum_multixact_freeze_min_age">
       <term><varname>vacuum_multixact_freeze_min_age</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>vacuum_multixact_freeze_min_age</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>vacuum_multixact_freeze_min_age</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -443,9 +443,10 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
       <term><varname>vacuum_cleanup_index_scale_factor</varname> (<type>floating point</type>)
       <indexterm>
        <primary><varname>vacuum_cleanup_index_scale_factor</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>vacuum_cleanup_index_scale_factor</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -504,9 +505,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-bytea-output" xreflabel="bytea_output">
       <term><varname>bytea_output</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>bytea_output</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>bytea_output</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -531,9 +532,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-xmlbinary" xreflabel="xmlbinary">
       <term><varname>xmlbinary</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>xmlbinary</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>xmlbinary</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -574,18 +575,18 @@ XMLに関連した関数については<xref linkend="functions-xml"/>を参照�
      <varlistentry id="guc-xmloption" xreflabel="xmloption">
       <term><varname>xmloption</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>xmloption</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>xmloption</varname>設定パラメータ</primary>
       </indexterm>
       <indexterm>
        <primary><varname>SET XML OPTION</varname></primary>
       </indexterm>
       <indexterm>
-      <!--
        <primary>XML option</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary>XMLオプション</primary>
       </indexterm>
       </term>
@@ -626,9 +627,10 @@ SET XML OPTION { DOCUMENT | CONTENT };
       <term><varname>gin_pending_list_limit</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>gin_pending_list_limit</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>gin_pending_list_limit</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -669,9 +671,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-datestyle" xreflabel="DateStyle">
       <term><varname>DateStyle</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>DateStyle</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>DateStyle</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -709,9 +711,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-intervalstyle" xreflabel="IntervalStyle">
       <term><varname>IntervalStyle</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>IntervalStyle</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>IntervalStyle</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -753,15 +755,13 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-timezone" xreflabel="TimeZone">
       <term><varname>TimeZone</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>TimeZone</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>TimeZone</varname>設定パラメータ</primary>
       </indexterm>
-      <!--
       <indexterm><primary>time zone</primary></indexterm>
-      -->
-      <indexterm><primary><!--time zone-->時間帯</primary></indexterm>
+      <indexterm><primary>時間帯</primary></indexterm>
       </term>
       <listitem>
        <para>
@@ -782,14 +782,12 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-timezone-abbreviations" xreflabel="timezone_abbreviations">
       <term><varname>timezone_abbreviations</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>timezone_abbreviations</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>timezone_abbreviations</varname>設定パラメータ</primary>
       </indexterm>
-      <!--
       <indexterm><primary>time zone names</primary></indexterm>
-      -->
       <indexterm><primary>時間帯名</primary></indexterm>
       </term>
       <listitem>
@@ -814,9 +812,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-extra-float-digits" xreflabel="extra_float_digits">
       <term><varname>extra_float_digits</varname> (<type>integer</type>)
       <indexterm>
-     <!--
        <primary>significant digits</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary>有効数字</primary>
       </indexterm>
       <indexterm>
@@ -830,9 +828,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
        <secondary>表示</secondary>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>extra_float_digits</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>extra_float_digits</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -897,14 +895,12 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-client-encoding" xreflabel="client_encoding">
       <term><varname>client_encoding</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>client_encoding</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>client_encoding</varname>設定パラメータ</primary>
       </indexterm>
-      <!--
       <indexterm><primary>character set</primary></indexterm>
-      -->
       <indexterm><primary>文字セット</primary></indexterm>
       </term>
       <listitem>
@@ -924,9 +920,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-lc-messages" xreflabel="lc_messages">
       <term><varname>lc_messages</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>lc_messages</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>lc_messages</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -971,9 +967,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-lc-monetary" xreflabel="lc_monetary">
       <term><varname>lc_monetary</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>lc_monetary</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>lc_monetary</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1000,9 +996,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-lc-numeric" xreflabel="lc_numeric">
       <term><varname>lc_numeric</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>lc_numeric</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>lc_numeric</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1029,9 +1025,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-lc-time" xreflabel="lc_time">
       <term><varname>lc_time</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>lc_time</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>lc_time</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1057,9 +1053,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-default-text-search-config" xreflabel="default_text_search_config">
       <term><varname>default_text_search_config</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>default_text_search_config</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>default_text_search_config</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1148,9 +1144,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-local-preload-libraries" xreflabel="local_preload_libraries">
       <term><varname>local_preload_libraries</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>local_preload_libraries</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>local_preload_libraries</varname>設定パラメータ</primary>
       </indexterm>
       <indexterm>
@@ -1229,9 +1225,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-session-preload-libraries" xreflabel="session_preload_libraries">
       <term><varname>session_preload_libraries</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>session_preload_libraries</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>session_preload_libraries</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1293,9 +1289,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-shared-preload-libraries" xreflabel="shared_preload_libraries">
       <term><varname>shared_preload_libraries</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>shared_preload_libraries</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>shared_preload_libraries</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1372,9 +1368,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-jit-provider" xreflabel="jit_provider">
       <term><varname>jit_provider</varname> (<type>string</type>)
        <indexterm>
-<!--
         <primary><varname>jit_provider</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>jit_provider</varname>設定パラメータ</primary>
        </indexterm>
       </term>
@@ -1418,14 +1414,12 @@ SET XML OPTION { DOCUMENT | CONTENT };
      <varlistentry id="guc-dynamic-library-path" xreflabel="dynamic_library_path">
       <term><varname>dynamic_library_path</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>dynamic_library_path</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>dynamic_library_path</varname>設定パラメータ</primary>
       </indexterm>
-      <!--
       <indexterm><primary>dynamic loading</primary></indexterm>
-      -->
       <indexterm><primary>動的ロード</primary></indexterm>
       </term>
       <listitem>
@@ -1500,9 +1494,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-gin-fuzzy-search-limit" xreflabel="gin_fuzzy_search_limit">
       <term><varname>gin_fuzzy_search_limit</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>gin_fuzzy_search_limit</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>gin_fuzzy_search_limit</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1533,29 +1527,25 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-deadlock-timeout" xreflabel="deadlock_timeout">
       <term><varname>deadlock_timeout</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary>deadlock</primary>
-       -->
-       <primary><!--deadlock-->デッドロック</primary>
-       <!--
        <secondary>timeout during</secondary>
-       -->
+      </indexterm>
+      <indexterm>
+       <primary>デッドロック</primary>
        <secondary>間のタイムアウト</secondary>
       </indexterm>
       <indexterm>
-      <!--
        <primary>timeout</primary>
-       -->
-       <primary>タイムアウト</primary>
-       <!--
        <secondary>deadlock</secondary>
-       -->
+      </indexterm>
+      <indexterm>
+       <primary>タイムアウト</primary>
        <secondary>デッドロック</secondary>
       </indexterm>
       <indexterm>
-      <!--
        <primary><varname>deadlock_timeout</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>deadlock_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1609,9 +1599,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-max-locks-per-transaction" xreflabel="max_locks_per_transaction">
       <term><varname>max_locks_per_transaction</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_locks_per_transaction</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_locks_per_transaction</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1657,9 +1647,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-max-pred-locks-per-transaction" xreflabel="max_pred_locks_per_transaction">
       <term><varname>max_pred_locks_per_transaction</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_pred_locks_per_transaction</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_pred_locks_per_transaction</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1697,9 +1687,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-max-pred-locks-per-relation" xreflabel="max_pred_locks_per_relation">
       <term><varname>max_pred_locks_per_relation</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>max_pred_locks_per_relation</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_pred_locks_per_relation</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1727,9 +1717,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-max-pred-locks-per-page" xreflabel="max_pred_locks_per_page">
       <term><varname>max_pred_locks_per_page</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>max_pred_locks_per_page</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_pred_locks_per_page</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1768,9 +1758,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-array-nulls" xreflabel="array_nulls">
       <term><varname>array_nulls</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>array_nulls</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>array_nulls</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1805,14 +1795,12 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
 
      <varlistentry id="guc-backslash-quote" xreflabel="backslash_quote">
       <term><varname>backslash_quote</varname> (<type>enum</type>)
-      <!--
       <indexterm><primary>strings</primary><secondary>backslash quotes</secondary></indexterm>
-      -->
       <indexterm><primary>文字列</primary><secondary>バックスラッシュによる引用</secondary></indexterm>
       <indexterm>
-      <!--
        <primary><varname>backslash_quote</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>backslash_quote</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1863,14 +1851,12 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
 
      <varlistentry id="guc-escape-string-warning" xreflabel="escape_string_warning">
       <term><varname>escape_string_warning</varname> (<type>boolean</type>)
-      <!--
       <indexterm><primary>strings</primary><secondary>escape warning</secondary></indexterm>
-      -->
       <indexterm><primary>文字列</primary><secondary>エスケープに関する警告</secondary></indexterm>
       <indexterm>
-      <!--
        <primary><varname>escape_string_warning</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>escape_string_warning</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1902,9 +1888,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-lo-compat-privileges" xreflabel="lo_compat_privileges">
       <term><varname>lo_compat_privileges</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>lo_compat_privileges</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>lo-compat-privileges</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1938,9 +1924,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
      <varlistentry id="guc-operator-precedence-warning" xreflabel="operator_precedence_warning">
       <term><varname>operator_precedence_warning</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>operator_precedence_warning</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>operator_precedence_warning</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1974,9 +1960,9 @@ onの場合、演算子の優先順位の変更の結果、<productname>PostgreS
     <varlistentry id="guc-quote-all-identifiers" xreflabel="quote-all-identifiers">
       <term><varname>quote_all_identifiers</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>quote_all_identifiers</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>quote_all_identifiers</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1999,14 +1985,12 @@ onの場合、演算子の優先順位の変更の結果、<productname>PostgreS
 
      <varlistentry id="guc-standard-conforming-strings" xreflabel="standard_conforming_strings">
       <term><varname>standard_conforming_strings</varname> (<type>boolean</type>)
-      <!--
       <indexterm><primary>strings</primary><secondary>standard conforming</secondary></indexterm>
-      -->
       <indexterm><primary>文字列</primary><secondary>標準に従う</secondary></indexterm>
       <indexterm>
-      <!--
        <primary><varname>standard_conforming_strings</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>standard_conforming_strings</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2038,9 +2022,9 @@ onの場合、演算子の優先順位の変更の結果、<productname>PostgreS
      <varlistentry id="guc-synchronize-seqscans" xreflabel="synchronize_seqscans">
       <term><varname>synchronize_seqscans</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>synchronize_seqscans</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>synchronize_seqscans</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2082,9 +2066,9 @@ onの場合、演算子の優先順位の変更の結果、<productname>PostgreS
       <term><varname>transform_null_equals</varname> (<type>boolean</type>)
       <indexterm><primary>IS NULL</primary></indexterm>
       <indexterm>
-      <!--
        <primary><varname>transform_null_equals</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>transform_null_equals</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2163,9 +2147,9 @@ onの場合、演算子の優先順位の変更の結果、<productname>PostgreS
      <varlistentry id="guc-exit-on-error" xreflabel="exit_on_error">
       <term><varname>exit_on_error</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>exit_on_error</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>exit_on_error</varname> 設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2185,9 +2169,9 @@ onなら、全てのエラーは現在のセッションを中止させます。
      <varlistentry id="guc-restart-after-crash" xreflabel="restart_after_crash">
       <term><varname>restart_after_crash</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>restart_after_crash</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>restart_after_crash</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2212,9 +2196,9 @@ onなら、全てのエラーは現在のセッションを中止させます。
      <varlistentry id="guc-data-sync-retry" xreflabel="data_sync_retry">
       <term><varname>data_sync_retry</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>data_sync_retry</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>data_sync_retry</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2288,9 +2272,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-block-size" xreflabel="block_size">
       <term><varname>block_size</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>block_size</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>block_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2316,9 +2300,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-data-checksums" xreflabel="data_checksums">
       <term><varname>data_checksums</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>data_checksums</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>data_checksums</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2337,9 +2321,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-data-directory-mode" xreflabel="data_directory_mode">
       <term><varname>data_directory_mode</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>data_directory_mode</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>data_directory_mode</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2362,9 +2346,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-debug-assertions" xreflabel="debug_assertions">
       <term><varname>debug_assertions</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>debug_assertions</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>debug_assertions</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2390,9 +2374,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-integer-datetimes" xreflabel="integer_datetimes">
       <term><varname>integer_datetimes</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>integer_datetimes</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>integer_datetimes</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2412,9 +2396,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-lc-collate" xreflabel="lc_collate">
       <term><varname>lc_collate</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>lc_collate</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>lc_collate</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2435,9 +2419,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-lc-ctype" xreflabel="lc_ctype">
       <term><varname>lc_ctype</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>lc_ctype</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>lc_ctype</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2461,9 +2445,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-max-function-args" xreflabel="max_function_args">
       <term><varname>max_function_args</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_function_args</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_function_args</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2484,9 +2468,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-max-identifier-length" xreflabel="max_identifier_length">
       <term><varname>max_identifier_length</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_identifier_length</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_identifier_length</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2510,9 +2494,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-max-index-keys" xreflabel="max_index_keys">
       <term><varname>max_index_keys</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>max_index_keys</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>max_index_keys</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2531,9 +2515,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-segment-size" xreflabel="segment_size">
       <term><varname>segment_size</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>segment_size</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>segment_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2556,14 +2540,12 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-server-encoding" xreflabel="server_encoding">
       <term><varname>server_encoding</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>server_encoding</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>server_encoding</varname>設定パラメータ</primary>
       </indexterm>
-      <!--
       <indexterm><primary>character set</primary></indexterm>
-      -->
       <indexterm><primary>文字セット</primary></indexterm>
       </term>
       <listitem>
@@ -2584,9 +2566,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-server-version" xreflabel="server_version">
       <term><varname>server_version</varname> (<type>string</type>)
       <indexterm>
-      <!--
        <primary><varname>server_version</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>server_version</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2605,9 +2587,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-server-version-num" xreflabel="server_version_num">
       <term><varname>server_version_num</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>server_version_num</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>server_version_num</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2626,9 +2608,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-ssl-library" xreflabel="ssl_library">
       <term><varname>ssl_library</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>ssl_library</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_library</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2648,9 +2630,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-wal-block-size" xreflabel="wal_block_size">
       <term><varname>wal_block_size</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_block_size</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_block_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2670,9 +2652,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-wal-segment-size" xreflabel="wal_segment_size">
       <term><varname>wal_segment_size</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_segment_size</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_segment_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2761,9 +2743,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-allow-system-table-mods" xreflabel="allow_system_table_mods">
       <term><varname>allow_system_table_mods</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
         <primary><varname>allow_system_table_mods</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>allow_system_table_mods</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2787,9 +2769,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-backtrace-functions" xreflabel="backtrace_functions">
       <term><varname>backtrace_functions</varname> (<type>string</type>)
       <indexterm>
-<!--
         <primary><varname>backtrace_functions</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
         <primary><varname>backtrace_functions</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2827,9 +2809,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-ignore-system-indexes" xreflabel="ignore_system_indexes">
       <term><varname>ignore_system_indexes</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
         <primary><varname>ignore_system_indexes</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ignore_system_indexes</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2851,9 +2833,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-post-auth-delay" xreflabel="post_auth_delay">
       <term><varname>post_auth_delay</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>post_auth_delay</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>post_auth_delay</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2880,9 +2862,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-pre-auth-delay" xreflabel="pre_auth_delay">
       <term><varname>pre_auth_delay</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>pre_auth_delay</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>pre_auth_delay</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2911,9 +2893,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-trace-notify" xreflabel="trace_notify">
       <term><varname>trace_notify</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>trace_notify</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>trace_notify</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2936,9 +2918,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-trace-recovery-messages" xreflabel="trace_recovery_messages">
       <term><varname>trace_recovery_messages</varname> (<type>enum</type>)
       <indexterm>
-      <!--
        <primary><varname>trace_recovery_messages</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>trace_recovery_messages</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2977,9 +2959,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-trace-sort" xreflabel="trace_sort">
       <term><varname>trace_sort</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>trace_sort</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>trace_sort</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3001,9 +2983,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry>
       <term><varname>trace_locks</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>trace_locks</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>trace_locks</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3058,9 +3040,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry>
       <term><varname>trace_lwlocks</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>trace_lwlocks</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>trace_lwlocks</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3088,9 +3070,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry>
       <term><varname>trace_userlocks</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>trace_userlocks</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>trace_userlocks</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3117,9 +3099,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry>
       <term><varname>trace_lock_oidmin</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>trace_lock_oidmin</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>trace_lock_oidmin</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3146,9 +3128,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry>
       <term><varname>trace_lock_table</varname> (<type>integer</type>)
       <indexterm>
-      <!--
        <primary><varname>trace_lock_table</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>trace_lock_table</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3173,9 +3155,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry>
       <term><varname>debug_deadlocks</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>debug_deadlocks</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>debug_deadlocks</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3201,9 +3183,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry>
       <term><varname>log_btree_build_stats</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>log_btree_build_stats</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_btree_build_stats</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3229,9 +3211,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry id="guc-wal-consistency-checking" xreflabel="wal_consistency_checking">
       <term><varname>wal_consistency_checking</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>wal_consistency_checking</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_consistency_checking</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3278,9 +3260,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry id="guc-wal-debug" xreflabel="wal_debug">
       <term><varname>wal_debug</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>wal_debug</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>wal_debug</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3300,9 +3282,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
     <varlistentry id="guc-ignore-checksum-failure" xreflabel="ignore_checksum_failure">
       <term><varname>ignore_checksum_failure</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>ignore_checksum_failure</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>ignore_checksum_failure</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3339,9 +3321,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
     <varlistentry id="guc-zero-damaged-pages" xreflabel="zero_damaged_pages">
       <term><varname>zero_damaged_pages</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
        <primary><varname>zero_damaged_pages</varname> configuration parameter</primary>
-       -->
+      </indexterm>
+      <indexterm>
        <primary><varname>zero_damaged_pages</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3379,9 +3361,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry id="guc-ignore-invalid-pages" xreflabel="ignore_invalid_pages">
       <term><varname>ignore_invalid_pages</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>ignore_invalid_pages</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>ignore_invalid_pages</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3415,9 +3397,9 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
      <varlistentry id="guc-jit-debugging-support" xreflabel="jit_debugging_support">
       <term><varname>jit_debugging_support</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>jit_debugging_support</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit_debugging_support</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3440,9 +3422,9 @@ LLVMに要求された機能がある場合は、生成した関数を<productna
      <varlistentry id="guc-jit-dump-bitcode" xreflabel="jit_dump_bitcode">
       <term><varname>jit_dump_bitcode</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>jit_dump_bitcode</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit_dump_bitcode</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3466,9 +3448,9 @@ LLVMに要求された機能がある場合は、生成した関数を<productna
      <varlistentry id="guc-jit-expressions" xreflabel="jit_expressions">
       <term><varname>jit_expressions</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>jit_expressions</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit_expressions</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3489,9 +3471,9 @@ JITコンパイルが有効な時に式がJITコンパイルされるかどう�
      <varlistentry id="guc-jit-profiling-support" xreflabel="jit_profiling_support">
       <term><varname>jit_profiling_support</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>jit_profiling_support</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit_profiling_support</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3516,9 +3498,9 @@ LLVMに要求された機能がある場合は、JITが生成した関数を<pro
      <varlistentry id="guc-jit-tuple-deforming" xreflabel="jit_tuple_deforming">
       <term><varname>jit_tuple_deforming</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>jit_tuple_deforming</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>jit_tuple_deforming</varname>設定パラメータ</primary>
       </indexterm>
       </term>

--- a/doc/src/sgml/contrib-spi.sgml
+++ b/doc/src/sgml/contrib-spi.sgml
@@ -5,9 +5,10 @@
 
  <indexterm zone="contrib-spi">
   <primary>SPI</primary>
-<!--
   <secondary>examples</secondary>
--->
+ </indexterm>
+ <indexterm zone="contrib-spi">
+  <primary>SPI</primary>
   <secondary>例</secondary>
  </indexterm>
 

--- a/doc/src/sgml/cube.sgml
+++ b/doc/src/sgml/cube.sgml
@@ -4,9 +4,9 @@
  <title>cube</title>
 
  <indexterm zone="cube">
-<!--
   <primary>cube (extension)</primary>
--->
+ </indexterm>
+ <indexterm zone="cube">
   <primary>cube (拡張)</primary>
  </indexterm>
 

--- a/doc/src/sgml/custom-scan.sgml
+++ b/doc/src/sgml/custom-scan.sgml
@@ -7,10 +7,10 @@
  <title>カスタムスキャンプロバイダの作成</title>
 
  <indexterm zone="custom-scan">
-<!--
   <primary>custom scan provider</primary>
   <secondary>handler for</secondary>
--->
+ </indexterm>
+ <indexterm zone="custom-scan">
   <primary>カスタムスキャンプロバイダ</primary>
   <secondary>のハンドラ</secondary>
  </indexterm>

--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -7,17 +7,17 @@
   <title>データ型</title>
 
   <indexterm zone="datatype">
-<!--
    <primary>data type</primary>
--->
+  </indexterm>
+  <indexterm zone="datatype">
    <primary>データ型</primary>
   </indexterm>
 
   <indexterm>
-<!--
    <primary>type</primary>
    <see>data type</see>
--->
+  </indexterm>
+  <indexterm>
    <primary>型</primary>
    <see>データ型</see>
   </indexterm>
@@ -516,10 +516,10 @@
 <title>数値データ型</title>
 
    <indexterm zone="datatype-numeric">
-<!--
     <primary>data type</primary>
     <secondary>numeric</secondary>
--->
+   </indexterm>
+   <indexterm zone="datatype-numeric">
     <primary>データ型</primary>
     <secondary>数値</secondary>
    </indexterm>
@@ -773,23 +773,23 @@
 <title>任意の精度を持つ数</title>
 
     <indexterm>
-<!--
      <primary>numeric (data type)</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>numeric（データ型）</primary>
     </indexterm>
 
    <indexterm>
-<!--
     <primary>arbitrary precision numbers</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>任意精度の数</primary>
    </indexterm>
 
     <indexterm>
-<!--
      <primary>decimal</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>10進数</primary>
      <see>numeric</see>
     </indexterm>
@@ -921,17 +921,18 @@ NUMERIC
 
     <indexterm>
      <primary>NaN</primary>
-<!--
      <see>not a number</see>
--->
+    </indexterm>
+    <indexterm>
+     <primary>NaN</primary>
      <see>非数</see>
    </indexterm>
 
     <indexterm>
-<!--
      <primary>not a number</primary>
      <secondary>numeric (data type)</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>非数</primary>
      <secondary>数値（データ型）</secondary>
     </indexterm>
@@ -1034,9 +1035,9 @@ FROM generate_series(-3.5, 3.5, 1) as x;
     </indexterm>
 
     <indexterm zone="datatype-float">
-<!--
      <primary>floating point</primary>
--->
+    </indexterm>
+    <indexterm zone="datatype-float">
      <primary>浮動小数点</primary>
     </indexterm>
 
@@ -1185,10 +1186,10 @@ FROM generate_series(-3.5, 3.5, 1) as x;
     </note>
 
     <indexterm>
-<!--
      <primary>not a number</primary>
      <secondary>double precision</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>非数</primary>
      <secondary>倍精度</secondary>
     </indexterm>
@@ -1288,18 +1289,18 @@ IEEE754では、<literal>NaN</literal>は（<literal>NaN</literal>を含む）�
     </indexterm>
 
     <indexterm>
-<!--
      <primary>auto-increment</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>自動増分</primary>
      <see>serial</see>
     </indexterm>
 
     <indexterm>
-<!--
      <primary>sequence</primary>
      <secondary>and serial type</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>シーケンス</primary>
      <secondary>連番型</secondary>
     </indexterm>
@@ -1563,19 +1564,19 @@ SELECT '52093.89'::money::numeric::float8;
 <title>文字型</title>
 
    <indexterm zone="datatype-character">
-<!--
     <primary>character string</primary>
     <secondary>data types</secondary>
--->
+   </indexterm>
+   <indexterm zone="datatype-character">
     <primary>文字の並び</primary>
     <secondary>データ型</secondary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>string</primary>
     <see>character string</see>
--->
+   </indexterm>
+   <indexterm>
     <primary>文字列</primary>
     <see>文字の並び</see>
    </indexterm>
@@ -1933,9 +1934,9 @@ SELECT b, char_length(b) FROM test2;
 <title>バイナリ列データ型</title>
 
   <indexterm zone="datatype-binary">
-<!--
    <primary>binary data</primary>
--->
+  </indexterm>
+  <indexterm zone="datatype-binary">
    <primary>バイナリデータ</primary>
   </indexterm>
 
@@ -2429,9 +2430,9 @@ SELECT 'abc \153\154\155 \052\251\124'::bytea;
     <primary>interval</primary>
    </indexterm>
    <indexterm zone="datatype-datetime">
-<!--
     <primary>time span</primary>
--->
+   </indexterm>
+   <indexterm zone="datatype-datetime">
     <primary>時間間隔</primary>
    </indexterm>
 
@@ -3252,19 +3253,20 @@ TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54+02'
 <title>特別な値</title>
 
      <indexterm>
-<!--
       <primary>time</primary>
       <secondary>constants</secondary>
--->
+     </indexterm>
+     <indexterm>
       <primary>time</primary>
       <secondary>定数</secondary>
      </indexterm>
 
      <indexterm>
       <primary>date</primary>
-<!--
       <secondary>constants</secondary>
--->
+     </indexterm>
+     <indexterm>
+      <primary>date</primary>
       <secondary>定数</secondary>
      </indexterm>
 
@@ -3421,20 +3423,22 @@ TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54+02'
 
     <indexterm>
      <primary>date</primary>
-<!--
      <secondary>output format</secondary>
      <seealso>formatting</seealso>
--->
+    </indexterm>
+    <indexterm>
+     <primary>date</primary>
      <secondary>出力書式</secondary>
      <seealso>書式設定</seealso>
     </indexterm>
 
     <indexterm>
      <primary>time</primary>
-<!--
      <secondary>output format</secondary>
      <seealso>formatting</seealso>
--->
+    </indexterm>
+    <indexterm>
+     <primary>time</primary>
      <secondary>出力書式</secondary>
      <seealso>書式設定</seealso>
     </indexterm>
@@ -3637,10 +3641,10 @@ ISO 8601の仕様では日付と時刻を区切るために大文字の<literal>
 <title>時間帯</title>
 
     <indexterm zone="datatype-timezones">
-<!--
      <primary>time zone</primary>
--->
-<primary>時間帯</primary>
+    </indexterm>
+    <indexterm zone="datatype-timezones">
+     <primary>時間帯</primary>
     </indexterm>
 
    <para>
@@ -3900,9 +3904,9 @@ ISO 8601の仕様では日付と時刻を区切るために大文字の<literal>
     <title>時間間隔の入力</title>
 
     <indexterm>
-    <!--
      <primary>interval</primary>
-     -->
+    </indexterm>
+    <indexterm>    
      <primary>時間間隔</primary>
     </indexterm>
 
@@ -4252,11 +4256,11 @@ SELECT EXTRACT(days from '80 hours'::interval);
     <title>時間間隔の出力</title>
 
     <indexterm>
-    <!--
      <primary>interval</primary>
      <secondary>output format</secondary>
      <seealso>formatting</seealso>
-     -->
+    </indexterm>
+    <indexterm>    
      <primary>時間間隔</primary>
      <secondary>出力書式</secondary>
      <seealso>書式設定</seealso>
@@ -4379,23 +4383,24 @@ SELECT EXTRACT(days from '80 hours'::interval);
 
    <indexterm zone="datatype-boolean">
     <primary>Boolean</primary>
-<!--
     <secondary>data type</secondary>
--->
+   </indexterm>
+   <indexterm zone="datatype-boolean">
+    <primary>Boolean</primary>
     <secondary>データ型</secondary>
    </indexterm>
 
    <indexterm zone="datatype-boolean">
-<!--
     <primary>true</primary>
--->
+   </indexterm>
+   <indexterm zone="datatype-boolean">
     <primary>真</primary>
    </indexterm>
 
    <indexterm zone="datatype-boolean">
-<!--
     <primary>false</primary>
--->
+   </indexterm>
+   <indexterm zone="datatype-boolean">
     <primary>偽</primary>
    </indexterm>
 
@@ -4557,18 +4562,18 @@ SELECT * FROM test1 WHERE a;
    <title>列挙型</title>
 
    <indexterm zone="datatype-enum">
-<!--
     <primary>data type</primary>
     <secondary>enumerated (enum)</secondary>
--->
+   </indexterm>
+   <indexterm zone="datatype-enum">
     <primary>データ型</primary>
     <secondary>列挙（enum）</secondary>
    </indexterm>
 
-   <indexterm zone="datatype-enum">
-   <!--
+   <indexterm zone="datatype-enum">   
     <primary>enumerated types</primary>
-    -->
+   </indexterm>
+   <indexterm zone="datatype-enum">   
     <primary>列挙型</primary>
    </indexterm>
 
@@ -4958,9 +4963,9 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
     <title>直線</title>
 
     <indexterm>
-<!--
      <primary>line</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>直線</primary>
     </indexterm>
 
@@ -5011,9 +5016,9 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
     </indexterm>
 
     <indexterm>
-<!--
      <primary>line segment</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>線分</primary>
     </indexterm>
 
@@ -5058,16 +5063,16 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
 <title>矩形</title>
 
     <indexterm>
-<!--
      <primary>box (data type)</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>box（データ型）</primary>
     </indexterm>
 
     <indexterm>
-<!--
      <primary>rectangle</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>矩形</primary>
     </indexterm>
 
@@ -5122,9 +5127,9 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
     <title>経路</title>
 
     <indexterm>
-<!--
      <primary>path (data type)</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>path（データ型）</primary>
     </indexterm>
 
@@ -5276,10 +5281,10 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
 <title>ネットワークアドレス型</title>
 
    <indexterm zone="datatype-net-types">
-<!--
     <primary>network</primary>
     <secondary>data types</secondary>
--->
+   </indexterm>
+   <indexterm zone="datatype-net-types">
     <primary>ネットワーク</primary>
     <secondary>データ型</secondary>
    </indexterm>
@@ -5382,9 +5387,9 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
     <title><type>inet</type></title>
 
     <indexterm>
-<!--
      <primary>inet (data type)</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>inet（データ型）</primary>
     </indexterm>
 
@@ -5607,16 +5612,16 @@ IPv6ではアドレス長は128ビットですので、128ビットが一意な�
     <title><type>macaddr</type></title>
 
     <indexterm>
-<!--
      <primary>macaddr (data type)</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>macaddr (データ型)</primary>
     </indexterm>
 
     <indexterm>
-<!--
      <primary>MAC address</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>MACアドレス</primary>
      <see>macaddr</see>
     </indexterm>
@@ -5682,16 +5687,16 @@ PostgreSQLではビット反転に関する準備をしていません。
     <title><type>macaddr8</type></title>
 
     <indexterm>
-<!--
      <primary>macaddr8 (data type)</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>macaddr8 (データ型)</primary>
     </indexterm>
 
     <indexterm>
-<!--
      <primary>MAC address (EUI-64 format)</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>MACアドレス (EUI-64 形式)</primary>
      <see>macaddr</see>
     </indexterm>
@@ -5751,16 +5756,16 @@ IPv6はEUI-48から変換後に７番目のビットに1となるべき設定が
 これらの例は全て同じアドレスを指します。
 桁には大文字の<literal>A</literal> から<literal>F</literal>、小文字の<literal>a</literal> から<literal>f</literal>も受付けられます。
 出力は常に１番目の形式です。
-</para>
+    </para>
 
-<para>
+    <para>
 <!--
      The last six input formats shown above are not part of any standard.
 -->
 上記の最後の6つの形式は標準ではありません。
-</para>
+    </para>
 
-<para>
+    <para>
 <!--
      To convert a traditional 48 bit MAC address in EUI-48 format to
      modified EUI-64 format to be included as the host portion of an
@@ -5791,12 +5796,12 @@ SELECT macaddr8_set7bit('08:00:2b:01:02:03');
 <title>ビット列データ型</title>
 
    <indexterm zone="datatype-bit">
-<!--
     <primary>bit string</primary>
     <secondary>data type</secondary>
--->
-<primary>ビット列</primary>
-<secondary>データ型</secondary>
+   </indexterm>
+   <indexterm zone="datatype-bit">
+    <primary>ビット列</primary>
+    <secondary>データ型</secondary>
    </indexterm>
 
    <para>
@@ -5903,19 +5908,19 @@ SELECT * FROM test;
    <title>テキスト検索に関する型</title>
 
    <indexterm zone="datatype-textsearch">
-<!--
     <primary>full text search</primary>
     <secondary>data types</secondary>
--->
+   </indexterm>
+   <indexterm zone="datatype-textsearch">
     <primary>全文検索</primary>
     <secondary>データ型</secondary>
    </indexterm>
 
    <indexterm zone="datatype-textsearch">
-<!--
     <primary>text search</primary>
     <secondary>data types</secondary>
--->
+   </indexterm>
+   <indexterm zone="datatype-textsearch">
     <primary>テキスト検索</primary>
     <secondary>データ型</secondary>
    </indexterm>
@@ -5944,9 +5949,9 @@ SELECT * FROM test;
     <title><type>tsvector</type></title>
 
     <indexterm>
-<!--
      <primary>tsvector (data type)</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>tsvector（データ型）</primary>
     </indexterm>
 
@@ -6099,9 +6104,9 @@ SELECT to_tsvector('english', 'The Fat Rats');
     <title><type>tsquery</type></title>
 
     <indexterm>
-<!--
      <primary>tsquery (data type)</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>tsquery（データ型)</primary>
     </indexterm>
 
@@ -6648,17 +6653,17 @@ PostgreSQLのテキスト検索機能を使用して、XMLデータの全文検�
    <title>ドメイン型</title>
 
    <indexterm zone="domains">
-<!--
     <primary>domain</primary>
--->
+   </indexterm>
+   <indexterm zone="domains">
     <primary>ドメイン</primary>
    </indexterm>
 
    <indexterm zone="domains">
-<!--
     <primary>data type</primary>
     <secondary>domain</secondary>
--->
+   </indexterm>
+   <indexterm zone="domains">
     <primary>データ型</primary>
     <secondary>ドメイン</secondary>
    </indexterm>
@@ -6730,12 +6735,12 @@ INSERT INTO mytable VALUES(-1);  -- fails
    <title>オブジェクト識別子データ型</title>
 
    <indexterm zone="datatype-oid">
-<!--
     <primary>object identifier</primary>
     <secondary>data type</secondary>
--->
-<primary>オブジェクト識別子</primary>
-<secondary>データ型</secondary>
+   </indexterm>
+   <indexterm zone="datatype-oid">
+    <primary>オブジェクト識別子</primary>
+    <secondary>データ型</secondary>
    </indexterm>
 
    <indexterm zone="datatype-oid">

--- a/doc/src/sgml/datetime.sgml
+++ b/doc/src/sgml/datetime.sgml
@@ -605,10 +605,10 @@ BCが指定されず年フィールドの長さが2桁の場合、年は4桁に�
   <title>日付/時刻設定ファイル</title>
 
    <indexterm>
-<!--
     <primary>time zone</primary>
     <secondary>input abbreviations</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>時間帯</primary>
     <secondary>入力簡略形</secondary>
    </indexterm>
@@ -1115,15 +1115,15 @@ POSIX時間帯の指定には以下の形式があります。
   <title>単位の歴史</title>
 
   <indexterm zone="datetime-units-history">
-<!--
    <primary>Gregorian calendar</primary>
--->
+  </indexterm>
+  <indexterm zone="datetime-units-history">
    <primary>グレゴリオ暦</primary>
   </indexterm>
   <indexterm zone="datetime-units-history">
-<!--
    <primary>Julian date</primary>
--->
+  </indexterm>
+  <indexterm zone="datetime-units-history">
    <primary>ユリウス日</primary>
   </indexterm>
 

--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -33,23 +33,23 @@
   <title>テーブルの基本</title>
 
   <indexterm zone="ddl-basics">
-<!--
    <primary>table</primary>
--->
+  </indexterm>
+  <indexterm zone="ddl-basics">
    <primary>テーブル</primary>
   </indexterm>
 
   <indexterm>
-<!--
    <primary>row</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>行</primary>
   </indexterm>
 
   <indexterm>
-<!--
    <primary>column</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>列</primary>
   </indexterm>
 
@@ -123,10 +123,10 @@ SQLではテーブル内の行の順序は保証されません。
   </para>
 
   <indexterm>
-<!--
    <primary>table</primary>
    <secondary>creating</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>テーブル</primary>
    <secondary>の作成</secondary>
   </indexterm>
@@ -217,10 +217,10 @@ CREATE TABLE products (
   </para>
 
   <indexterm>
-<!--
    <primary>table</primary>
    <secondary>removing</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>テーブル</primary>
    <secondary>の削除</secondary>
   </indexterm>
@@ -281,9 +281,9 @@ DROP TABLE products;
   <title>デフォルト値</title>
 
   <indexterm zone="ddl-default">
-<!--
    <primary>default value</primary>
--->
+  </indexterm>
+  <indexterm zone="ddl-default">
    <primary>デフォルト値</primary>
   </indexterm>
 
@@ -599,9 +599,9 @@ CREATE TABLE people (
   <title>制約</title>
 
   <indexterm zone="ddl-constraints">
-<!--
    <primary>constraint</primary>
--->
+  </indexterm>
+  <indexterm zone="ddl-constraints">
    <primary>制約</primary>
   </indexterm>
 
@@ -645,17 +645,17 @@ CREATE TABLE people (
    <title>検査制約</title>
 
    <indexterm>
-<!--
     <primary>check constraint</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>検査制約</primary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>constraint</primary>
     <secondary>check</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>制約</primary>
     <secondary>検査</secondary>
    </indexterm>
@@ -697,10 +697,10 @@ CREATE TABLE products (
    </para>
 
    <indexterm>
-<!--
     <primary>constraint</primary>
     <secondary>name</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>制約</primary>
     <secondary>の名前</secondary>
    </indexterm>
@@ -830,10 +830,10 @@ CREATE TABLE products (
    </para>
 
    <indexterm>
-<!--
     <primary>null value</primary>
     <secondary sortas="check constraints">with check constraints</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>NULL値</primary>
     <secondary sortas="check constraints">検査制約</secondary>
    </indexterm>
@@ -936,17 +936,17 @@ CREATE TABLE products (
    <title>非NULL制約</title>
 
    <indexterm>
-<!--
     <primary>not-null constraint</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>非NULL制約</primary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>constraint</primary>
     <secondary>NOT NULL</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>制約</primary>
     <secondary>非NULL</secondary>
    </indexterm>
@@ -1057,17 +1057,17 @@ CREATE TABLE products (
    <title>一意性制約</title>
 
    <indexterm>
-<!--
     <primary>unique constraint</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>一意性制約</primary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>constraint</primary>
     <secondary>unique</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>制約</primary>
     <secondary>一意性</secondary>
    </indexterm>
@@ -1155,10 +1155,10 @@ CREATE TABLE products (
    </para>
 
    <indexterm>
-<!--
     <primary>null value</primary>
     <secondary sortas="unique constraints">with unique constraints</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>NULL値</primary>
     <secondary sortas="unique constraints">一意性制約</secondary>
    </indexterm>
@@ -1192,17 +1192,17 @@ CREATE TABLE products (
    <title>主キー</title>
 
    <indexterm>
-<!--
     <primary>primary key</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>主キー</primary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>constraint</primary>
     <secondary>primary key</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>制約</primary>
     <secondary>主キー</secondary>
    </indexterm>
@@ -1304,25 +1304,25 @@ CREATE TABLE example (
    <title>外部キー</title>
 
    <indexterm>
-<!--
     <primary>foreign key</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>外部キー</primary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>constraint</primary>
     <secondary>foreign key</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>制約</primary>
     <secondary>外部キー</secondary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>referential integrity</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>参照整合性</primary>
    </indexterm>
 
@@ -1479,17 +1479,19 @@ CREATE TABLE order_items (
 
    <indexterm>
     <primary>CASCADE</primary>
-<!--
     <secondary>foreign key action</secondary>
--->
+   </indexterm>
+   <indexterm>
+    <primary>CASCADE</primary>
     <secondary>外部キー動作</secondary>
    </indexterm>
 
    <indexterm>
     <primary>RESTRICT</primary>
-<!--
     <secondary>foreign key action</secondary>
--->
+   </indexterm>
+   <indexterm>
+    <primary>RESTRICT</primary>
     <secondary>外部キー動作</secondary>
    </indexterm>
 
@@ -1652,17 +1654,17 @@ CREATE TABLE order_items (
    <title>排他制約</title>
 
    <indexterm>
-<!--
     <primary>exclusion constraint</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>排他制約</primary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>constraint</primary>
     <secondary>exclusion</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>制約</primary>
     <secondary>排他</secondary>
    </indexterm>
@@ -1728,10 +1730,10 @@ TABLE ... CONSTRAINT ... EXCLUDE</command></link>を参照して下さい。
   </para>
 
   <indexterm>
-<!--
    <primary>column</primary>
    <secondary>system column</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>列</primary>
    <secondary>システム列</secondary>
   </indexterm>
@@ -1906,10 +1908,10 @@ TABLE ... CONSTRAINT ... EXCLUDE</command></link>を参照して下さい。
   <title>テーブルの変更</title>
 
   <indexterm zone="ddl-alter">
-<!--
    <primary>table</primary>
    <secondary>modifying</secondary>
--->
+  </indexterm>
+  <indexterm zone="ddl-alter">
    <primary>テーブル</primary>
    <secondary>の変更</secondary>
   </indexterm>
@@ -2005,10 +2007,10 @@ TABLE ... CONSTRAINT ... EXCLUDE</command></link>を参照して下さい。
    <title>列の追加</title>
 
    <indexterm>
-<!--
     <primary>column</primary>
     <secondary>adding</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>列</primary>
     <secondary>の追加</secondary>
    </indexterm>
@@ -2090,10 +2092,10 @@ ALTER TABLE products ADD COLUMN description text CHECK (description &lt;&gt; '')
    <title>列の削除</title>
 
    <indexterm>
-<!--
     <primary>column</primary>
     <secondary>removing</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>列</primary>
     <secondary>の削除</secondary>
    </indexterm>
@@ -2136,10 +2138,10 @@ ALTER TABLE products DROP COLUMN description CASCADE;
    <title>制約の追加</title>
 
    <indexterm>
-<!--
     <primary>constraint</primary>
     <secondary>adding</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>制約</primary>
     <secondary>の追加</secondary>
    </indexterm>
@@ -2180,10 +2182,10 @@ ALTER TABLE products ALTER COLUMN product_no SET NOT NULL;
    <title>制約の削除</title>
 
    <indexterm>
-<!--
     <primary>constraint</primary>
     <secondary>removing</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>制約</primary>
     <secondary>の削除</secondary>
    </indexterm>
@@ -2250,10 +2252,10 @@ ALTER TABLE products ALTER COLUMN product_no DROP NOT NULL;
    <title>列のデフォルト値の変更</title>
 
    <indexterm>
-<!--
     <primary>default value</primary>
     <secondary>changing</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>デフォルト値</primary>
     <secondary>の変更</secondary>
    </indexterm>
@@ -2300,10 +2302,10 @@ ALTER TABLE products ALTER COLUMN price DROP DEFAULT;
    <title>列のデータ型の変更</title>
 
    <indexterm>
-<!--
     <primary>column data type</primary>
     <secondary>changing</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>列のデータ型</primary>
     <secondary>の変更</secondary>
    </indexterm>
@@ -2348,10 +2350,10 @@ ALTER TABLE products ALTER COLUMN price TYPE numeric(10,2);
    <title>列名の変更</title>
 
    <indexterm>
-<!--
     <primary>column</primary>
     <secondary>renaming</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>列</primary>
     <secondary>の名称変更</secondary>
    </indexterm>
@@ -2374,10 +2376,10 @@ ALTER TABLE products RENAME COLUMN product_no TO product_number;
    <title>テーブル名の変更</title>
 
    <indexterm>
-<!--
     <primary>table</primary>
     <secondary>renaming</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>テーブル</primary>
     <secondary>の名称変更</secondary>
    </indexterm>
@@ -2401,25 +2403,25 @@ ALTER TABLE products RENAME TO items;
   <title>権限</title>
 
   <indexterm zone="ddl-priv">
-<!--
    <primary>privilege</primary>
--->
+  </indexterm>
+  <indexterm zone="ddl-priv">
    <primary>権限</primary>
   </indexterm>
 
   <indexterm>
-<!--
    <primary>permission</primary>
    <see>privilege</see>
--->
+  </indexterm>
+  <indexterm>
    <primary>権利</primary>
    <see>権限</see>
   </indexterm>
 
   <indexterm zone="ddl-priv">
-<!--
    <primary>owner</primary>
--->
+  </indexterm>
+  <indexterm zone="ddl-priv">
    <primary>所有者</primary>
   </indexterm>
 
@@ -3257,16 +3259,16 @@ GRANT SELECT (col1), UPDATE (col1) ON mytable TO miriam_rw;
   <title>行セキュリティポリシー</title>
 
   <indexterm zone="ddl-rowsecurity">
-<!--
    <primary>row-level security</primary>
--->
+  </indexterm>
+  <indexterm zone="ddl-rowsecurity">
    <primary>行単位セキュリティ</primary>
   </indexterm>
 
   <indexterm zone="ddl-rowsecurity">
-<!--
    <primary>policy</primary>
--->
+  </indexterm>
+  <indexterm zone="ddl-rowsecurity">
    <primary>ポリシー</primary>
   </indexterm>
 
@@ -3944,9 +3946,9 @@ SELECT * FROM information WHERE group_id = 2 FOR UPDATE;
   <title>スキーマ</title>
 
   <indexterm zone="ddl-schemas">
-<!--
    <primary>schema</primary>
--->
+  </indexterm>
+  <indexterm zone="ddl-schemas">
    <primary>スキーマ</primary>
   </indexterm>
 
@@ -4049,10 +4051,10 @@ SELECT * FROM information WHERE group_id = 2 FOR UPDATE;
    <title>スキーマの作成</title>
 
    <indexterm zone="ddl-schemas-create">
-<!--
     <primary>schema</primary>
     <secondary>creating</secondary>
--->
+   </indexterm>
+   <indexterm zone="ddl-schemas-create">
     <primary>スキーマ</primary>
     <secondary>の作成</secondary>
    </indexterm>
@@ -4072,17 +4074,17 @@ CREATE SCHEMA myschema;
    </para>
 
    <indexterm>
-<!--
     <primary>qualified name</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>修飾名</primary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>name</primary>
     <secondary>qualified</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>名前</primary>
     <secondary>修飾された</secondary>
    </indexterm>
@@ -4139,10 +4141,10 @@ CREATE TABLE myschema.mytable (
    </para>
 
    <indexterm>
-<!--
     <primary>schema</primary>
     <secondary>removing</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>スキーマ</primary>
     <secondary>の削除</secondary>
    </indexterm>
@@ -4206,10 +4208,10 @@ CREATE SCHEMA <replaceable>schema_name</replaceable> AUTHORIZATION <replaceable>
    <title>publicスキーマ</title>
 
    <indexterm zone="ddl-schemas-public">
-<!--
     <primary>schema</primary>
     <secondary>public</secondary>
--->
+   </indexterm>
+   <indexterm zone="ddl-schemas-public">
     <primary>スキーマ</primary>
     <secondary>public</secondary>
    </indexterm>
@@ -4245,24 +4247,24 @@ CREATE TABLE public.products ( ... );
    <title>スキーマ検索パス</title>
 
    <indexterm>
-<!--
     <primary>search path</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>検索パス</primary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>unqualified name</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>非修飾名</primary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>name</primary>
     <secondary>unqualified</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>名前</primary>
     <secondary>非修飾の</secondary>
    </indexterm>
@@ -4307,10 +4309,10 @@ CREATE TABLE public.products ( ... );
    </para>
 
    <indexterm>
-<!--
     <primary>schema</primary>
     <secondary>current</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>スキーマ</primary>
     <secondary>現在の</secondary>
    </indexterm>
@@ -4327,9 +4329,9 @@ CREATE TABLE public.products ( ... );
    </para>
 
    <indexterm>
-<!--
     <primary><varname>search_path</varname> configuration parameter</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary><varname>search_path</varname>設定パラメータ</primary>
    </indexterm>
 
@@ -4467,10 +4469,10 @@ SELECT 3 OPERATOR(pg_catalog.+) 4;
    <title>スキーマおよび権限</title>
 
    <indexterm zone="ddl-schemas-priv">
-<!--
     <primary>privilege</primary>
     <secondary sortas="schemas">for schemas</secondary>
--->
+   </indexterm>
+   <indexterm zone="ddl-schemas-priv">
     <primary>権限</primary>
     <secondary sortas="schemas">スキーマ用の</secondary>
    </indexterm>
@@ -4528,10 +4530,10 @@ REVOKE CREATE ON SCHEMA public FROM PUBLIC;
    <title>システムカタログスキーマ</title>
 
    <indexterm zone="ddl-schemas-catalog">
-<!--
     <primary>system catalog</primary>
     <secondary>schema</secondary>
--->
+   </indexterm>
+   <indexterm zone="ddl-schemas-catalog">
     <primary>システムカタログ</primary>
     <secondary>スキーマ</secondary>
    </indexterm>
@@ -4757,17 +4759,17 @@ REVOKE CREATE ON SCHEMA public FROM PUBLIC;
   <title>継承</title>
 
   <indexterm>
-<!--
    <primary>inheritance</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>継承</primary>
   </indexterm>
 
   <indexterm>
-<!--
    <primary>table</primary>
    <secondary>inheritance</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>テーブル</primary>
    <secondary>継承</secondary>
   </indexterm>
@@ -5276,25 +5278,25 @@ VALUES ('Albany', NULL, NULL, 'NY');
    <title>テーブルのパーティショニング</title>
 
    <indexterm>
-<!--
     <primary>partitioning</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>パーティショニング</primary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>table</primary>
     <secondary>partitioning</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>テーブル</primary>
     <secondary>パーティショニング</secondary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>partitioned table</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>パーティションテーブル</primary>
    </indexterm>
 
@@ -6698,9 +6700,9 @@ ANALYZE measurement;
    <title>パーティション除去</title>
 
    <indexterm>
-<!--
     <primary>partition pruning</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>パーティション除去</primary>
    </indexterm>
 
@@ -6900,9 +6902,9 @@ EXPLAIN SELECT count(*) FROM measurement WHERE logdate &gt;= DATE '2008-01-01';
    <title>パーティショニングと制約による除外</title>
 
    <indexterm>
-<!--
     <primary>constraint exclusion</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>制約による除外</primary>
    </indexterm>
 
@@ -7162,21 +7164,21 @@ EXPLAIN SELECT count(*) FROM measurement WHERE logdate &gt;= DATE '2008-01-01';
   <title>外部データ</title>
 
    <indexterm>
-<!--
     <primary>foreign data</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>外部データ</primary>
    </indexterm>
    <indexterm>
-<!--
     <primary>foreign table</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>外部テーブル</primary>
    </indexterm>
    <indexterm>
-<!--
     <primary>user mapping</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>ユーザマッピング</primary>
    </indexterm>
 
@@ -7324,17 +7326,19 @@ EXPLAIN SELECT count(*) FROM measurement WHERE logdate &gt;= DATE '2008-01-01';
 
   <indexterm zone="ddl-depend">
    <primary>CASCADE</primary>
-<!--
    <secondary sortas="DROP">with DROP</secondary>
--->
+  </indexterm>
+  <indexterm zone="ddl-depend">
+   <primary>CASCADE</primary>
    <secondary sortas="DROP">DROPの</secondary>
   </indexterm>
 
   <indexterm zone="ddl-depend">
    <primary>RESTRICT</primary>
-<!--
    <secondary sortas="DROP">with DROP</secondary>
--->
+  </indexterm>
+  <indexterm zone="ddl-depend">
+   <primary>RESTRICT</primary>
    <secondary sortas="DROP">DROPの</secondary>
   </indexterm>
 

--- a/doc/src/sgml/dfunc.sgml
+++ b/doc/src/sgml/dfunc.sgml
@@ -85,9 +85,7 @@ Cで書かれた<productname>PostgreSQL</productname>の拡張関数を使うた
    <varlistentry>
     <term>
      <systemitem class="osname">FreeBSD</systemitem>
-<!--
      <indexterm><primary>FreeBSD</primary><secondary>shared library</secondary></indexterm>
--->
      <indexterm><primary>FreeBSD</primary><secondary>共有ライブラリ</secondary></indexterm>
     </term>
     <listitem>
@@ -115,9 +113,7 @@ gcc -shared -o foo.so foo.o
    <varlistentry>
     <term>
      <systemitem class="osname">HP-UX</systemitem>
-<!--
      <indexterm><primary>HP-UX</primary><secondary>shared library</secondary></indexterm>
--->
      <indexterm><primary>HP-UX</primary><secondary>共有ライブラリ</secondary></indexterm>
     </term>
     <listitem>
@@ -162,9 +158,7 @@ ld -b -o foo.sl foo.o
    <varlistentry>
     <term>
      <systemitem class="osname">Linux</systemitem>
-<!--
      <indexterm><primary>Linux</primary><secondary>shared library</secondary></indexterm>
--->
      <indexterm><primary>Linux</primary><secondary>共有ライブラリ</secondary></indexterm>
     </term>
     <listitem>
@@ -189,9 +183,7 @@ cc -shared -o foo.so foo.o
    <varlistentry>
     <term>
      <systemitem class="osname">macOS</systemitem>
-<!--
      <indexterm><primary>macOS</primary><secondary>shared library</secondary></indexterm>
--->
      <indexterm><primary>macOS</primary><secondary>共有ライブラリ</secondary></indexterm>
     </term>
     <listitem>
@@ -212,9 +204,7 @@ cc -bundle -flat_namespace -undefined suppress -o foo.so foo.o
    <varlistentry>
     <term>
      <systemitem class="osname">NetBSD</systemitem>
-<!--
      <indexterm><primary>NetBSD</primary><secondary>shared library</secondary></indexterm>
--->
      <indexterm><primary>NetBSD</primary><secondary>共有ライブラリ</secondary></indexterm>
     </term>
     <listitem>
@@ -240,9 +230,7 @@ gcc -shared -o foo.so foo.o
    <varlistentry>
     <term>
      <systemitem class="osname">OpenBSD</systemitem>
-<!--
      <indexterm><primary>OpenBSD</primary><secondary>shared library</secondary></indexterm>
--->
      <indexterm><primary>OpenBSD</primary><secondary>共有ライブラリ</secondary></indexterm>
     </term>
     <listitem>
@@ -265,9 +253,7 @@ ld -Bshareable -o foo.so foo.o
    <varlistentry>
     <term>
      <systemitem class="osname">Solaris</systemitem>
-<!--
      <indexterm><primary>Solaris</primary><secondary>shared library</secondary></indexterm>
--->
      <indexterm><primary>Solaris</primary><secondary>共有ライブラリ</secondary></indexterm>
     </term>
     <listitem>

--- a/doc/src/sgml/diskusage.sgml
+++ b/doc/src/sgml/diskusage.sgml
@@ -21,9 +21,9 @@
   <title>ディスク使用量の決定</title>
 
   <indexterm zone="disk-usage">
-<!--
    <primary>disk usage</primary>
--->
+  </indexterm>
+  <indexterm zone="disk-usage">
    <primary>ディスク使用量</primary>
   </indexterm>
 

--- a/doc/src/sgml/dml.sgml
+++ b/doc/src/sgml/dml.sgml
@@ -28,9 +28,9 @@
   <title>データの挿入</title>
 
   <indexterm zone="dml-insert">
-<!--
    <primary>inserting</primary>
--->
+  </indexterm>
+  <indexterm zone="dml-insert">
    <primary>挿入</primary>
   </indexterm>
 
@@ -196,9 +196,9 @@ INSERT INTO products (product_no, name, price)
   <title>データの更新</title>
 
   <indexterm zone="dml-update">
-<!--
    <primary>updating</primary>
--->
+  </indexterm>
+  <indexterm zone="dml-update">
    <primary>更新</primary>
   </indexterm>
 
@@ -353,9 +353,9 @@ UPDATE mytable SET a = 5, b = 3, c = 1 WHERE a &gt; 0;
   <title>データの削除</title>
 
   <indexterm zone="dml-delete">
-<!--
    <primary>deleting</primary>
--->
+  </indexterm>
+  <indexterm zone="dml-delete">
    <primary>削除</primary>
   </indexterm>
 

--- a/doc/src/sgml/errcodes.sgml
+++ b/doc/src/sgml/errcodes.sgml
@@ -7,10 +7,10 @@
  <title><productname>PostgreSQL</productname>エラーコード</title>
 
  <indexterm zone="errcodes-appendix">
-<!--
   <primary>error codes</primary>
   <secondary>list of</secondary>
--->
+ </indexterm>
+ <indexterm zone="errcodes-appendix">
   <primary>エラーコード</primary>
   <secondary>の一覧</secondary>
  </indexterm>

--- a/doc/src/sgml/event-trigger.sgml
+++ b/doc/src/sgml/event-trigger.sgml
@@ -7,9 +7,9 @@
   <title>イベントトリガ</title>
 
   <indexterm zone="event-triggers">
-<!--
    <primary>event trigger</primary>
--->
+  </indexterm>
+  <indexterm zone="event-triggers">
    <primary>イベントトリガ</primary>
   </indexterm>
 
@@ -1121,10 +1121,10 @@
    <title>C言語によるイベントトリガ関数の書き方</title>
 
    <indexterm zone="event-trigger-interface">
-<!--
     <primary>event trigger</primary>
     <secondary>in C</secondary>
--->
+   </indexterm>
+   <indexterm zone="event-trigger-interface">
     <primary>イベントトリガ</primary>
     <secondary>C言語による</secondary>
    </indexterm>

--- a/doc/src/sgml/extend.sgml
+++ b/doc/src/sgml/extend.sgml
@@ -7,9 +7,9 @@
   <title><acronym>SQL</acronym>の拡張</title>
 
   <indexterm zone="extend">
-<!--
    <primary>extending SQL</primary>
--->
+  </indexterm>
+  <indexterm zone="extend">
    <primary>SQLの拡張</primary>
   </indexterm>
 
@@ -139,49 +139,49 @@
    <title><productname>PostgreSQL</productname>の型システム</title>
 
    <indexterm zone="extend-type-system">
-<!--
     <primary>base type</primary>
--->
+   </indexterm>
+   <indexterm zone="extend-type-system">
     <primary>基本型</primary>
    </indexterm>
 
    <indexterm zone="extend-type-system">
-<!--
     <primary>data type</primary>
     <secondary>base</secondary>
--->
+   </indexterm>
+   <indexterm zone="extend-type-system">
     <primary>データ型</primary>
     <secondary>基本</secondary>
    </indexterm>
 
    <indexterm zone="extend-type-system">
-<!--
     <primary>composite type</primary>
--->
+   </indexterm>
+   <indexterm zone="extend-type-system">
     <primary>複合型</primary>
    </indexterm>
 
    <indexterm zone="extend-type-system">
-<!--
     <primary>data type</primary>
     <secondary>composite</secondary>
--->
+   </indexterm>
+   <indexterm zone="extend-type-system">
     <primary>データ型</primary>
     <secondary>複合</secondary>
    </indexterm>
 
    <indexterm zone="extend-type-system">
-<!--
     <primary>container type</primary>
--->
+   </indexterm>
+   <indexterm zone="extend-type-system">
     <primary>コンテナ型</primary>
    </indexterm>
 
    <indexterm zone="extend-type-system">
-<!--
     <primary>data type</primary>
     <secondary>container</secondary>
--->
+   </indexterm>
+   <indexterm zone="extend-type-system">
     <primary>データ型</primary>
     <secondary>コンテナ</secondary>
    </indexterm>
@@ -348,33 +348,33 @@
     <title>多様型</title>
 
    <indexterm zone="extend-types-polymorphic">
-<!--
     <primary>polymorphic type</primary>
--->
+   </indexterm>
+   <indexterm zone="extend-types-polymorphic">
     <primary>多様型</primary>
    </indexterm>
 
    <indexterm zone="extend-types-polymorphic">
-<!--
     <primary>polymorphic function</primary>
--->
+   </indexterm>
+   <indexterm zone="extend-types-polymorphic">
     <primary>多様関数</primary>
    </indexterm>
 
    <indexterm zone="extend-types-polymorphic">
-<!--
     <primary>data type</primary>
     <secondary>polymorphic</secondary>
--->
+   </indexterm>
+   <indexterm zone="extend-types-polymorphic">
     <primary>データ型</primary>
     <secondary>多様</secondary>
    </indexterm>
 
    <indexterm zone="extend-types-polymorphic">
-<!--
     <primary>function</primary>
     <secondary>polymorphic</secondary>
--->
+   </indexterm>
+   <indexterm zone="extend-types-polymorphic">
     <primary>関数</primary>
     <secondary>多様</secondary>
    </indexterm>
@@ -754,9 +754,9 @@ RETURNS anycompatible AS ...
    <title>関連するオブジェクトを拡張としてパッケージ化</title>
 
    <indexterm zone="extend-extensions">
-<!--
     <primary>extension</primary>
--->
+   </indexterm>
+   <indexterm zone="extend-extensions">
     <primary>拡張</primary>
    </indexterm>
 
@@ -927,9 +927,9 @@ RETURNS anycompatible AS ...
     <title>拡張のファイル</title>
 
    <indexterm>
-<!--
     <primary>control file</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>制御ファイル</primary>
    </indexterm>
 

--- a/doc/src/sgml/external-projects.sgml
+++ b/doc/src/sgml/external-projects.sgml
@@ -24,10 +24,10 @@
   <title>クライアントインタフェース</title>
 
   <indexterm>
-<!--
    <primary>interfaces</primary>
    <secondary>externally maintained</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>インタフェース</primary>
    <secondary>外部管理の</secondary>
   </indexterm>
@@ -204,10 +204,10 @@
  <title>管理ツール</title>
 
   <indexterm>
-<!--
    <primary>administration tools</primary>
    <secondary>externally maintained</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>管理ツール</primary>
    <secondary>外部で保守される</secondary>
   </indexterm>
@@ -231,10 +231,10 @@
   <title>手続き言語</title>
 
   <indexterm>
-<!--
    <primary>procedural language</primary>
    <secondary>externally maintained</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>手続き言語</primary>
    <secondary>外部管理の</secondary>
   </indexterm>
@@ -332,10 +332,10 @@
  <title>拡張</title>
 
   <indexterm>
-<!--
    <primary>extension</primary>
    <secondary>externally maintained</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>拡張</primary>
    <secondary>外部で保守される</secondary>
   </indexterm>

--- a/doc/src/sgml/fdwhandler.sgml
+++ b/doc/src/sgml/fdwhandler.sgml
@@ -7,10 +7,10 @@
    <title>外部データラッパの作成</title>
 
    <indexterm zone="fdwhandler">
-<!--
     <primary>foreign data wrapper</primary>
     <secondary>handler for</secondary>
--->
+   </indexterm>
+   <indexterm zone="fdwhandler">
     <primary>外部データラッパ</primary>
     <secondary>のハンドラ</secondary>
    </indexterm>

--- a/doc/src/sgml/features.sgml
+++ b/doc/src/sgml/features.sgml
@@ -247,9 +247,10 @@ PostgreSQLはSQL:2016の主な機能のほとんどをサポートします。
 
    <indexterm>
     <primary>SQL/XML</primary>
-<!--
     <secondary>limits and conformance</secondary>
--->
+   </indexterm>
+   <indexterm>
+    <primary>SQL/XML</primary>
     <secondary>制限と適合性</secondary>
    </indexterm>
 

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -7,16 +7,16 @@
   <title>関数と演算子</title>
 
   <indexterm zone="functions">
-<!--
    <primary>function</primary>
--->
-  <primary>関数</primary>
+  </indexterm>
+  <indexterm zone="functions">
+   <primary>関数</primary>
   </indexterm>
 
   <indexterm zone="functions">
-<!--
    <primary>operator</primary>
--->
+  </indexterm>
+  <indexterm zone="functions">
    <primary>演算子</primary>
   </indexterm>
 
@@ -84,20 +84,20 @@ repeat('Pg', 4) <returnvalue>PgPgPgPg</returnvalue>
    <title>論理演算子</title>
 
    <indexterm zone="functions-logical">
-<!--
     <primary>operator</primary>
     <secondary>logical</secondary>
--->
+   </indexterm>
+   <indexterm zone="functions-logical">
     <primary>演算子</primary>
     <secondary>論理</secondary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>Boolean</primary>
     <secondary>operators</secondary>
     <see>operators, logical</see>
--->
+   </indexterm>
+   <indexterm>
     <primary>論理値</primary>
     <secondary>演算子</secondary>
     <see>演算子, 論理</see>
@@ -110,44 +110,44 @@ repeat('Pg', 4) <returnvalue>PgPgPgPg</returnvalue>
     通常の論理演算子が使用できます。
 
     <indexterm>
-<!--
      <primary>AND (operator)</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>AND（演算子）</primary>
     </indexterm>
 
     <indexterm>
-<!--
      <primary>OR (operator)</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>OR（演算子）</primary>
     </indexterm>
 
     <indexterm>
-<!--
      <primary>NOT (operator)</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>NOT（演算子）</primary>
     </indexterm>
 
     <indexterm>
-<!--
      <primary>conjunction</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>論理積</primary>
     </indexterm>
 
     <indexterm>
-<!--
      <primary>disjunction</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>論理和</primary>
     </indexterm>
 
     <indexterm>
-<!--
      <primary>negation</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>否定</primary>
     </indexterm>
 
@@ -273,10 +273,10 @@ repeat('Pg', 4) <returnvalue>PgPgPgPg</returnvalue>
    <title>比較関数および演算子</title>
 
    <indexterm zone="functions-comparison">
-<!--
     <primary>comparison</primary>
     <secondary>operators</secondary>
--->
+   </indexterm>
+   <indexterm zone="functions-comparison">
     <primary>比較</primary>
     <secondary>演算子</secondary>
    </indexterm>
@@ -942,9 +942,7 @@ NULLを比較可能な値とした上で、等しい。
 <replaceable>expression</replaceable> ISNULL
 <replaceable>expression</replaceable> NOTNULL
 </synopsis>
-<!--
     <indexterm><primary>null value</primary><secondary>comparing</secondary></indexterm>
--->
     <indexterm><primary>NULL値</primary><secondary>比較</secondary></indexterm>
    </para>
 
@@ -3063,10 +3061,10 @@ NULL引数の数を返す。
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>character string</primary>
          <secondary>concatenation</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>文字列</primary>
          <secondary>結合</secondary>
         </indexterm>
@@ -3171,19 +3169,19 @@ NULL引数の数を返す。
          <primary>char_length</primary>
         </indexterm>
         <indexterm>
-<!--
          <primary>character string</primary>
          <secondary>length</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>文字列</primary>
          <secondary>長さ</secondary>
         </indexterm>
         <indexterm>
-<!--
          <primary>length</primary>
          <secondary sortas="character string">of a character string</secondary>
          <see>character string, length</see>
--->
+        </indexterm>
+        <indexterm>
          <primary>長さ</primary>
          <secondary sortas="character string">文字列の</secondary>
          <see>文字列, 長さ</see>
@@ -4788,10 +4786,10 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
    <title>バイナリ文字列関数と演算子</title>
 
    <indexterm zone="functions-binarystring">
-<!--
     <primary>binary data</primary>
     <secondary>functions</secondary>
--->
+   </indexterm>
+   <indexterm zone="functions-binarystring">
     <primary>バイナリデータ</primary>
     <secondary>関数</secondary>
    </indexterm>
@@ -4855,10 +4853,10 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>binary string</primary>
          <secondary>concatenation</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>バイナリ文字列</primary>
          <secondary>結合</secondary>
         </indexterm>
@@ -5156,11 +5154,11 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
          <secondary>length</secondary>
         </indexterm>
         <indexterm>
-<!--
          <primary>length</primary>
          <secondary sortas="binary string">of a binary string</secondary>
          <see>binary strings, length</see>
--->
+        </indexterm>
+        <indexterm>
         <primary>長さ</primary>
         <secondary sortas="binary string">バイナリ文字列の</secondary>
         <see>バイナリ文字列, 長さ</see>
@@ -5413,18 +5411,18 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
 
   <para>
    <indexterm>
-<!--
     <primary>character string</primary>
     <secondary>converting to binary string</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>文字列</primary>
     <secondary>バイナリ文字列への変換</secondary>
    </indexterm>
    <indexterm>
-<!--
     <primary>binary string</primary>
     <secondary>converting to character string</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>バイナリ文字列</primary>
     <secondary>文字列への変換</secondary>
    </indexterm>
@@ -5707,10 +5705,10 @@ RFCに従い、符号化された行は76文字に分割されます。
    <title>ビット文字列関数と演算子</title>
 
    <indexterm zone="functions-bitstring">
-<!--
     <primary>bit strings</primary>
     <secondary>functions</secondary>
--->
+   </indexterm>
+   <indexterm zone="functions-bitstring">
     <primary>ビット文字列</primary>
     <secondary>関数</secondary>
    </indexterm>
@@ -6145,9 +6143,9 @@ cast(-44 as bit(12))           <lineannotation>111111010100</lineannotation>
   <title>パターンマッチ</title>
 
   <indexterm zone="functions-matching">
-<!--
    <primary>pattern matching</primary>
--->
+  </indexterm>
+  <indexterm zone="functions-matching">
    <primary>パターンマッチ</primary>
   </indexterm>
 
@@ -6400,11 +6398,11 @@ SQL標準によれば、<literal>ESCAPE</literal>を省略することは（デ�
    <title><function>SIMILAR TO</function>正規表現</title>
 
    <indexterm>
-<!--
     <primary>regular expression</primary>
--->
+    <!-- <seealso>pattern matching</seealso> breaks index build -->
+   </indexterm>
+   <indexterm>
     <primary>正規表現</primary>
-    <!-- 原文コメント <seealso>pattern matching</seealso> breaks index build -->
    </indexterm>
 
    <indexterm>
@@ -6685,10 +6683,10 @@ substring('foobar' from '#"o_b#"%' for '#')    <lineannotation>NULL</lineannotat
    <title><acronym>POSIX</acronym>正規表現</title>
 
    <indexterm zone="functions-posix-regexp">
-<!--
     <primary>regular expression</primary>
     <seealso>pattern matching</seealso>
--->
+   </indexterm>
+   <indexterm zone="functions-posix-regexp">
     <primary>正規表現</primary>
     <seealso>パターンマッチ</seealso>
    </indexterm>
@@ -9078,9 +9076,9 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
    </indexterm>
 
    <indexterm zone="posix-vs-xquery">
-<!--
     <primary>XQuery regular expressions</primary>
--->
+   </indexterm>
+   <indexterm zone="posix-vs-xquery">
     <primary>XQuery正規表現</primary>
    </indexterm>
 
@@ -9278,9 +9276,9 @@ POSIXはバックスラッシュ以降の空白文字を無視しません。
    <title>データ型書式設定関数</title>
 
    <indexterm>
-<!--
     <primary>formatting</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>書式設定</primary>
    </indexterm>
 
@@ -12950,10 +12948,10 @@ SELECT date_trunc('hour', INTERVAL '3 days 02:47:33');
    <title><literal>AT TIME ZONE</literal></title>
 
    <indexterm>
-<!--
     <primary>time zone</primary>
     <secondary>conversion</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>時間帯</primary>
     <secondary>変換</secondary>
    </indexterm>
@@ -13130,19 +13128,19 @@ SELECT TIMESTAMP '2001-02-16 20:38:40' AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'A
    <title>現在の日付/時刻</title>
 
    <indexterm>
-<!--
     <primary>date</primary>
     <secondary>current</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>日付</primary>
     <secondary>現在</secondary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>time</primary>
     <secondary>current</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>時刻</primary>
     <secondary>現在</secondary>
    </indexterm>
@@ -13343,15 +13341,15 @@ SELECT TIMESTAMP 'now';  -- but see tip below
     <primary>pg_sleep_until</primary>
    </indexterm>
    <indexterm>
-<!--
     <primary>sleep</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>休止</primary>
    </indexterm>
    <indexterm>
-<!--
     <primary>delay</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>遅延</primary>
    </indexterm>
 
@@ -15965,19 +15963,19 @@ MACアドレス型である<type>macaddr</type>と<type>macaddr8</type>は、<xr
   <title>テキスト検索関数と演算子</title>
 
    <indexterm zone="datatype-textsearch">
-<!--
     <primary>full text search</primary>
     <secondary>functions and operators</secondary>
--->
+   </indexterm>
+   <indexterm zone="datatype-textsearch">
     <primary>全文テキスト検索</primary>
     <secondary>関数と演算子</secondary>
    </indexterm>
 
    <indexterm zone="datatype-textsearch">
-<!--
     <primary>text search</primary>
     <secondary>functions and operators</secondary>
--->
+   </indexterm>
+   <indexterm zone="datatype-textsearch">
     <primary>テキスト検索</primary>
     <secondary>関数と演算子</secondary>
    </indexterm>
@@ -17258,9 +17256,10 @@ OIDで指定したパーサが認識できるトークンの型を記述する�
 
   <indexterm zone="datatype-uuid">
    <primary>UUID</primary>
-<!--
    <secondary>generating</secondary>
--->
+  </indexterm>
+  <indexterm zone="datatype-uuid">
+   <primary>UUID</primary>
    <secondary>生成</secondary>
   </indexterm>
 
@@ -18206,9 +18205,9 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
     </indexterm>
 
     <indexterm zone="functions-xml-processing-xmltable">
-<!--
      <primary>table function</primary>
--->
+    </indexterm>
+    <indexterm zone="functions-xml-processing-xmltable">
      <primary>テーブル関数</primary>
      <secondary>XMLTABLE</secondary>
     </indexterm>
@@ -18940,9 +18939,10 @@ table2-mapping
 
   <indexterm zone="functions-json">
    <primary>JSON</primary>
-<!--
    <secondary>functions and operators</secondary>
--->
+  </indexterm>
+  <indexterm zone="functions-json">
+   <primary>JSON</primary>
    <secondary>関数と演算子</secondary>
   </indexterm>
 
@@ -20762,9 +20762,9 @@ JSON値に対するJSONパスによって返される最初のJSON項目を返�
   <title>SQL/JSONパス言語</title>
 
   <indexterm zone="functions-sqljson-path">
-<!--
    <primary>SQL/JSON path language</primary>
--->
+  </indexterm>
+  <indexterm zone="functions-sqljson-path">
    <primary>SQL/JSONパス言語</primary>
   </indexterm>
 
@@ -21934,9 +21934,10 @@ JSON定数<literal>null</literal>（SQLとは違って<literal>null</literal>と
 
     <indexterm zone="jsonpath-regular-expressions">
      <primary><literal>LIKE_REGEX</literal></primary>
-<!--
      <secondary>in SQL/JSON</secondary>
--->
+    </indexterm>
+    <indexterm zone="jsonpath-regular-expressions">
+     <primary><literal>LIKE_REGEX</literal></primary>
      <secondary>SQL/JSONにおける</secondary>
     </indexterm>
 
@@ -22384,9 +22385,9 @@ nextval('foo'::text)      <lineannotation><literal>foo</literal>は実行時に�
   </indexterm>
 
   <indexterm>
-<!--
    <primary>conditional expression</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>条件式</primary>
   </indexterm>
 
@@ -23972,10 +23973,10 @@ nullあるいは空の配列の結合は無処理です。そうでない場合�
   <title>集約関数</title>
 
   <indexterm zone="functions-aggregate">
-<!--
    <primary>aggregate function</primary>
    <secondary>built-in</secondary>
--->
+  </indexterm>
+  <indexterm zone="functions-aggregate">
    <primary>順序集合集約</primary>
    <secondary>組み込み</secondary>
   </indexterm>
@@ -24627,9 +24628,9 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>correlation</primary>
--->
+        </indexterm>
+        <indexterm>
          <primary>相関</primary>
         </indexterm>
         <indexterm>
@@ -24653,12 +24654,12 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>covariance</primary>
          <secondary>population</secondary>
--->
-        <primary>共分散</primary>
-        <secondary>母集団</secondary>
+        </indexterm>
+        <indexterm>
+         <primary>共分散</primary>
+         <secondary>母集団</secondary>
         </indexterm>
         <indexterm>
          <primary>covar_pop</primary>
@@ -24680,10 +24681,10 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>covariance</primary>
          <secondary>sample</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>共分散</primary>
          <secondary>標本</secondary>
         </indexterm>
@@ -24768,9 +24769,9 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>regression intercept</primary>
--->
+        </indexterm>
+        <indexterm>
          <primary>回帰切片</primary>
         </indexterm>
         <indexterm>
@@ -24814,9 +24815,9 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>regression slope</primary>
--->
+        </indexterm>
+        <indexterm>
          <primary>回帰勾配</primary>
         </indexterm>
         <indexterm>
@@ -24904,9 +24905,9 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>standard deviation</primary>
--->
+        </indexterm>
+        <indexterm>
          <primary>標準偏差</primary>
         </indexterm>
         <indexterm>
@@ -24934,10 +24935,10 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>standard deviation</primary>
          <secondary>population</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>標準偏差</primary>
          <secondary>母集団</secondary>
         </indexterm>
@@ -24966,10 +24967,10 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>standard deviation</primary>
          <secondary>sample</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>標準偏差</primary>
          <secondary>標本</secondary>
         </indexterm>
@@ -25022,10 +25023,10 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>variance</primary>
          <secondary>population</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>分散</primary>
          <secondary>母集団</secondary>
         </indexterm>
@@ -25055,10 +25056,10 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>variance</primary>
          <secondary>sample</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>分散</primary>
          <secondary>標本</secondary>
         </indexterm>
@@ -25110,17 +25111,17 @@ SELECT count(*) FROM sometable;
   </para>
 
   <indexterm>
-<!--
    <primary>ordered-set aggregate</primary>
    <secondary>built-in</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>順序集合集約</primary>
    <secondary>組み込み</secondary>
   </indexterm>
   <indexterm>
-<!--
    <primary>inverse distribution</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>逆分散</primary>
   </indexterm>
 
@@ -25157,12 +25158,12 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>mode</primary>
          <secondary>statistical</secondary>
--->
-        <primary>最頻値(モード)</primary>
-        <secondary>統計</secondary>
+        </indexterm>
+        <indexterm>
+         <primary>最頻値(モード)</primary>
+         <secondary>統計</secondary>
         </indexterm>
         <function>mode</function> () <literal>WITHIN GROUP</literal> ( <literal>ORDER BY</literal> <type>anyelement</type> )
         <returnvalue>anyelement</returnvalue>
@@ -25185,12 +25186,12 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>percentile</primary>
          <secondary>continuous</secondary>
--->
-        <primary>百分位数</primary>
-        <secondary>連続</secondary>
+        </indexterm>
+        <indexterm>
+         <primary>百分位数</primary>
+         <secondary>連続</secondary>
         </indexterm>
         <function>percentile_cont</function> ( <parameter>fraction</parameter> <type>double precision</type> ) <literal>WITHIN GROUP</literal> ( <literal>ORDER BY</literal> <type>double precision</type> )
         <returnvalue>double precision</returnvalue>
@@ -25241,10 +25242,10 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>percentile</primary>
          <secondary>discrete</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>百分位数</primary>
          <secondary>離散</secondary>
         </indexterm>
@@ -25293,10 +25294,10 @@ SELECT count(*) FROM sometable;
    </table>
 
   <indexterm>
-<!--
    <primary>hypothetical-set aggregate</primary>
    <secondary>built-in</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>仮想集合集約</primary>
    <secondary>組み込み</secondary>
   </indexterm>
@@ -25359,9 +25360,10 @@ NULL値は<literal>ORDER BY</literal>節で指定されるルールに従って�
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
          <primary>rank</primary>
-<!--
          <secondary>hypothetical</secondary>
--->
+        </indexterm>
+        <indexterm>
+         <primary>rank</primary>
          <secondary>仮想の</secondary>
         </indexterm>
         <function>rank</function> ( <replaceable>args</replaceable> ) <literal>WITHIN GROUP</literal> ( <literal>ORDER BY</literal> <replaceable>sorted_args</replaceable> )
@@ -25383,9 +25385,10 @@ NULL値は<literal>ORDER BY</literal>節で指定されるルールに従って�
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
          <primary>dense_rank</primary>
- <!--
          <secondary>hypothetical</secondary>
--->
+        </indexterm>
+        <indexterm>
+         <primary>dense_rank</primary> 
          <secondary>仮想の</secondary>
         </indexterm>
         <function>dense_rank</function> ( <replaceable>args</replaceable> ) <literal>WITHIN GROUP</literal> ( <literal>ORDER BY</literal> <replaceable>sorted_args</replaceable> )
@@ -25407,9 +25410,10 @@ NULL値は<literal>ORDER BY</literal>節で指定されるルールに従って�
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
          <primary>percent_rank</primary>
-<!--
          <secondary>hypothetical</secondary>
--->
+        </indexterm>
+        <indexterm>
+         <primary>percent_rank</primary>
          <secondary>仮想の</secondary>
         </indexterm>
         <function>percent_rank</function> ( <replaceable>args</replaceable> ) <literal>WITHIN GROUP</literal> ( <literal>ORDER BY</literal> <replaceable>sorted_args</replaceable> )
@@ -25433,9 +25437,10 @@ NULL値は<literal>ORDER BY</literal>節で指定されるルールに従って�
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
          <primary>cume_dist</primary>
-<!--
          <secondary>hypothetical</secondary>
--->
+        </indexterm>
+        <indexterm>
+         <primary>cume_dist</primary>
          <secondary>仮想の</secondary>
         </indexterm>
         <function>cume_dist</function> ( <replaceable>args</replaceable> ) <literal>WITHIN GROUP</literal> ( <literal>ORDER BY</literal> <replaceable>sorted_args</replaceable> )
@@ -25566,10 +25571,10 @@ NULL値は<literal>ORDER BY</literal>節で指定されるルールに従って�
   <title>ウィンドウ関数</title>
 
   <indexterm zone="functions-window">
-<!--
    <primary>window function</primary>
    <secondary>built-in</secondary>
--->
+  </indexterm>
+  <indexterm zone="functions-window">
    <primary>ウィンドウ関数</primary>
    <secondary>組み込み</secondary>
   </indexterm>
@@ -26399,13 +26404,11 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
    <title>単独行に関する比較</title>
 
    <indexterm zone="functions-subquery">
-<!--
     <primary>comparison</primary>
--->
-    <primary>比較</primary>
-<!--
     <secondary>subquery result row</secondary>
--->
+   </indexterm>
+   <indexterm zone="functions-subquery">
+    <primary>比較</primary>
     <secondary>副問い合わせ結果行</secondary>
    </indexterm>
 
@@ -26467,35 +26470,35 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
   </indexterm>
 
   <indexterm>
-<!--
    <primary>composite type</primary>
    <secondary>comparison</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>複合型</primary>
    <secondary>比較</secondary>
   </indexterm>
 
   <indexterm>
-<!--
    <primary>row-wise comparison</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>行に関する比較</primary>
   </indexterm>
 
   <indexterm>
-<!--
    <primary>comparison</primary>
    <secondary>composite type</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>比較</primary>
    <secondary>複合型</secondary>
   </indexterm>
 
   <indexterm>
-<!--
    <primary>comparison</primary>
    <secondary>row constructor</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>比較</primary>
    <secondary>行コンストラクタ</secondary>
   </indexterm>
@@ -26940,10 +26943,10 @@ SQL仕様では、結果が2つのNULL値、またはNULLと非NULLの比較に�
   <title>集合を返す関数</title>
 
   <indexterm zone="functions-srf">
-<!--
    <primary>set returning functions</primary>
    <secondary>functions</secondary>
--->
+  </indexterm>
+  <indexterm zone="functions-srf">
    <primary>集合を返す関数</primary>
    <secondary>関数</secondary>
   </indexterm>
@@ -27243,9 +27246,9 @@ SELECT * FROM unnest2(ARRAY[[1,2],[3,4]]);
   </para>
 
   <indexterm>
-<!--
    <primary>ordinality</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>順序性</primary>
   </indexterm>
 
@@ -27961,10 +27964,10 @@ Unix用語で言うと、セッションユーザは<quote>実ユーザ</quote>�
    </para>
 
   <indexterm>
-<!--
    <primary>privilege</primary>
    <secondary>querying</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>権限</primary>
    <secondary>問い合わせ</secondary>
   </indexterm>
@@ -28652,10 +28655,10 @@ SELECT relname FROM pg_class WHERE pg_table_is_visible(oid);
   </para>
 
    <indexterm>
-<!--
     <primary>search path</primary>
     <secondary>object visibility</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>検索パス</primary>
     <secondary>オブジェクトの可視性</secondary>
    </indexterm>
@@ -30156,10 +30159,10 @@ SELECT collation for ('foo' COLLATE "de_DE");
    </table>
 
    <indexterm>
-<!--
     <primary>comment</primary>
     <secondary sortas="database objects">about database objects</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>コメント</primary>
     <secondary sortas="database objects">データベースオブジェクトについて</secondary>
    </indexterm>
@@ -31346,10 +31349,10 @@ OIDとそれを含むシステム型で指定されるデータベース共有�
    <title>サーバシグナル送信関数</title>
 
    <indexterm>
-<!--
     <primary>signal</primary>
     <secondary sortas="backend">backend processes</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>シグナル</primary>
     <secondary sortas="backend">バックエンドプロセス</secondary>
    </indexterm>
@@ -31514,9 +31517,9 @@ OIDとそれを含むシステム型で指定されるデータベース共有�
    <title>バックアップ制御関数</title>
 
    <indexterm>
-<!--
     <primary>backup</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>バックアップ</primary>
    </indexterm>
 
@@ -35074,10 +35077,10 @@ CREATE EVENT TRIGGER test_table_rewrite_oid
    <title>統計情報関数</title>
 
    <indexterm zone="functions-statistics">
-<!--
     <primary>function</primary>
     <secondary>statistics</secondary>
--->
+   </indexterm>
+   <indexterm zone="functions-statistics">
     <primary>関数</primary>
     <secondary>統計</secondary>
    </indexterm>

--- a/doc/src/sgml/func0.sgml
+++ b/doc/src/sgml/func0.sgml
@@ -15,16 +15,16 @@
   <title>関数と演算子</title>
 
   <indexterm zone="functions">
-<!--
    <primary>function</primary>
--->
-  <primary>関数</primary>
+  </indexterm>
+  <indexterm zone="functions">
+   <primary>関数</primary>
   </indexterm>
 
   <indexterm zone="functions">
-<!--
    <primary>operator</primary>
--->
+  </indexterm>
+  <indexterm zone="functions">
    <primary>演算子</primary>
   </indexterm>
 

--- a/doc/src/sgml/func1.sgml
+++ b/doc/src/sgml/func1.sgml
@@ -15,20 +15,20 @@
    <title>論理演算子</title>
 
    <indexterm zone="functions-logical">
-<!--
     <primary>operator</primary>
     <secondary>logical</secondary>
--->
+   </indexterm>
+   <indexterm zone="functions-logical">
     <primary>演算子</primary>
     <secondary>論理</secondary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>Boolean</primary>
     <secondary>operators</secondary>
     <see>operators, logical</see>
--->
+   </indexterm>
+   <indexterm>
     <primary>論理値</primary>
     <secondary>演算子</secondary>
     <see>演算子, 論理</see>
@@ -41,44 +41,44 @@
     通常の論理演算子が使用できます。
 
     <indexterm>
-<!--
      <primary>AND (operator)</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>AND（演算子）</primary>
     </indexterm>
 
     <indexterm>
-<!--
      <primary>OR (operator)</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>OR（演算子）</primary>
     </indexterm>
 
     <indexterm>
-<!--
      <primary>NOT (operator)</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>NOT（演算子）</primary>
     </indexterm>
 
     <indexterm>
-<!--
      <primary>conjunction</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>論理積</primary>
     </indexterm>
 
     <indexterm>
-<!--
      <primary>disjunction</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>論理和</primary>
     </indexterm>
 
     <indexterm>
-<!--
      <primary>negation</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>否定</primary>
     </indexterm>
 
@@ -204,10 +204,10 @@
    <title>比較関数および演算子</title>
 
    <indexterm zone="functions-comparison">
-<!--
     <primary>comparison</primary>
     <secondary>operators</secondary>
--->
+   </indexterm>
+   <indexterm zone="functions-comparison">
     <primary>比較</primary>
     <secondary>演算子</secondary>
    </indexterm>
@@ -873,9 +873,7 @@ NULLを比較可能な値とした上で、等しい。
 <replaceable>expression</replaceable> ISNULL
 <replaceable>expression</replaceable> NOTNULL
 </synopsis>
-<!--
     <indexterm><primary>null value</primary><secondary>comparing</secondary></indexterm>
--->
     <indexterm><primary>NULL値</primary><secondary>比較</secondary></indexterm>
    </para>
 
@@ -2994,10 +2992,10 @@ NULL引数の数を返す。
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>character string</primary>
          <secondary>concatenation</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>文字列</primary>
          <secondary>結合</secondary>
         </indexterm>
@@ -3102,19 +3100,19 @@ NULL引数の数を返す。
          <primary>char_length</primary>
         </indexterm>
         <indexterm>
-<!--
          <primary>character string</primary>
          <secondary>length</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>文字列</primary>
          <secondary>長さ</secondary>
         </indexterm>
         <indexterm>
-<!--
          <primary>length</primary>
          <secondary sortas="character string">of a character string</secondary>
          <see>character string, length</see>
--->
+        </indexterm>
+        <indexterm>
          <primary>長さ</primary>
          <secondary sortas="character string">文字列の</secondary>
          <see>文字列, 長さ</see>
@@ -4719,10 +4717,10 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
    <title>バイナリ文字列関数と演算子</title>
 
    <indexterm zone="functions-binarystring">
-<!--
     <primary>binary data</primary>
     <secondary>functions</secondary>
--->
+   </indexterm>
+   <indexterm zone="functions-binarystring">
     <primary>バイナリデータ</primary>
     <secondary>関数</secondary>
    </indexterm>
@@ -4786,10 +4784,10 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>binary string</primary>
          <secondary>concatenation</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>バイナリ文字列</primary>
          <secondary>結合</secondary>
         </indexterm>
@@ -5087,11 +5085,11 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
          <secondary>length</secondary>
         </indexterm>
         <indexterm>
-<!--
          <primary>length</primary>
          <secondary sortas="binary string">of a binary string</secondary>
          <see>binary strings, length</see>
--->
+        </indexterm>
+        <indexterm>
         <primary>長さ</primary>
         <secondary sortas="binary string">バイナリ文字列の</secondary>
         <see>バイナリ文字列, 長さ</see>
@@ -5344,18 +5342,18 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
 
   <para>
    <indexterm>
-<!--
     <primary>character string</primary>
     <secondary>converting to binary string</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>文字列</primary>
     <secondary>バイナリ文字列への変換</secondary>
    </indexterm>
    <indexterm>
-<!--
     <primary>binary string</primary>
     <secondary>converting to character string</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>バイナリ文字列</primary>
     <secondary>文字列への変換</secondary>
    </indexterm>
@@ -5638,10 +5636,10 @@ RFCに従い、符号化された行は76文字に分割されます。
    <title>ビット文字列関数と演算子</title>
 
    <indexterm zone="functions-bitstring">
-<!--
     <primary>bit strings</primary>
     <secondary>functions</secondary>
--->
+   </indexterm>
+   <indexterm zone="functions-bitstring">
     <primary>ビット文字列</primary>
     <secondary>関数</secondary>
    </indexterm>
@@ -6076,9 +6074,9 @@ cast(-44 as bit(12))           <lineannotation>111111010100</lineannotation>
   <title>パターンマッチ</title>
 
   <indexterm zone="functions-matching">
-<!--
    <primary>pattern matching</primary>
--->
+  </indexterm>
+  <indexterm zone="functions-matching">
    <primary>パターンマッチ</primary>
   </indexterm>
 
@@ -6331,11 +6329,11 @@ SQL標準によれば、<literal>ESCAPE</literal>を省略することは（デ�
    <title><function>SIMILAR TO</function>正規表現</title>
 
    <indexterm>
-<!--
     <primary>regular expression</primary>
--->
+    <!-- <seealso>pattern matching</seealso> breaks index build -->
+   </indexterm>
+   <indexterm>
     <primary>正規表現</primary>
-    <!-- 原文コメント <seealso>pattern matching</seealso> breaks index build -->
    </indexterm>
 
    <indexterm>
@@ -6616,10 +6614,10 @@ substring('foobar' from '#"o_b#"%' for '#')    <lineannotation>NULL</lineannotat
    <title><acronym>POSIX</acronym>正規表現</title>
 
    <indexterm zone="functions-posix-regexp">
-<!--
     <primary>regular expression</primary>
     <seealso>pattern matching</seealso>
--->
+   </indexterm>
+   <indexterm zone="functions-posix-regexp">
     <primary>正規表現</primary>
     <seealso>パターンマッチ</seealso>
    </indexterm>
@@ -9009,9 +9007,9 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
    </indexterm>
 
    <indexterm zone="posix-vs-xquery">
-<!--
     <primary>XQuery regular expressions</primary>
--->
+   </indexterm>
+   <indexterm zone="posix-vs-xquery">
     <primary>XQuery正規表現</primary>
    </indexterm>
 

--- a/doc/src/sgml/func2.sgml
+++ b/doc/src/sgml/func2.sgml
@@ -14,9 +14,9 @@
    <title>データ型書式設定関数</title>
 
    <indexterm>
-<!--
     <primary>formatting</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>書式設定</primary>
    </indexterm>
 
@@ -3686,10 +3686,10 @@ SELECT date_trunc('hour', INTERVAL '3 days 02:47:33');
    <title><literal>AT TIME ZONE</literal></title>
 
    <indexterm>
-<!--
     <primary>time zone</primary>
     <secondary>conversion</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>時間帯</primary>
     <secondary>変換</secondary>
    </indexterm>
@@ -3866,19 +3866,19 @@ SELECT TIMESTAMP '2001-02-16 20:38:40' AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'A
    <title>現在の日付/時刻</title>
 
    <indexterm>
-<!--
     <primary>date</primary>
     <secondary>current</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>日付</primary>
     <secondary>現在</secondary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>time</primary>
     <secondary>current</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>時刻</primary>
     <secondary>現在</secondary>
    </indexterm>
@@ -4079,15 +4079,15 @@ SELECT TIMESTAMP 'now';  -- but see tip below
     <primary>pg_sleep_until</primary>
    </indexterm>
    <indexterm>
-<!--
     <primary>sleep</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>休止</primary>
    </indexterm>
    <indexterm>
-<!--
     <primary>delay</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>遅延</primary>
    </indexterm>
 
@@ -6701,19 +6701,19 @@ MACアドレス型である<type>macaddr</type>と<type>macaddr8</type>は、<xr
   <title>テキスト検索関数と演算子</title>
 
    <indexterm zone="datatype-textsearch">
-<!--
     <primary>full text search</primary>
     <secondary>functions and operators</secondary>
--->
+   </indexterm>
+   <indexterm zone="datatype-textsearch">
     <primary>全文テキスト検索</primary>
     <secondary>関数と演算子</secondary>
    </indexterm>
 
    <indexterm zone="datatype-textsearch">
-<!--
     <primary>text search</primary>
     <secondary>functions and operators</secondary>
--->
+   </indexterm>
+   <indexterm zone="datatype-textsearch">
     <primary>テキスト検索</primary>
     <secondary>関数と演算子</secondary>
    </indexterm>
@@ -7994,9 +7994,10 @@ OIDで指定したパーサが認識できるトークンの型を記述する�
 
   <indexterm zone="datatype-uuid">
    <primary>UUID</primary>
-<!--
    <secondary>generating</secondary>
--->
+  </indexterm>
+  <indexterm zone="datatype-uuid">
+   <primary>UUID</primary>
    <secondary>生成</secondary>
   </indexterm>
 
@@ -8942,9 +8943,9 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
     </indexterm>
 
     <indexterm zone="functions-xml-processing-xmltable">
-<!--
      <primary>table function</primary>
--->
+    </indexterm>
+    <indexterm zone="functions-xml-processing-xmltable">
      <primary>テーブル関数</primary>
      <secondary>XMLTABLE</secondary>
     </indexterm>

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -15,9 +15,10 @@
 
   <indexterm zone="functions-json">
    <primary>JSON</primary>
-<!--
    <secondary>functions and operators</secondary>
--->
+  </indexterm>
+  <indexterm zone="functions-json">
+   <primary>JSON</primary>
    <secondary>関数と演算子</secondary>
   </indexterm>
 
@@ -1837,9 +1838,9 @@ JSON値に対するJSONパスによって返される最初のJSON項目を返�
   <title>SQL/JSONパス言語</title>
 
   <indexterm zone="functions-sqljson-path">
-<!--
    <primary>SQL/JSON path language</primary>
--->
+  </indexterm>
+  <indexterm zone="functions-sqljson-path">
    <primary>SQL/JSONパス言語</primary>
   </indexterm>
 
@@ -3009,9 +3010,10 @@ JSON定数<literal>null</literal>（SQLとは違って<literal>null</literal>と
 
     <indexterm zone="jsonpath-regular-expressions">
      <primary><literal>LIKE_REGEX</literal></primary>
-<!--
      <secondary>in SQL/JSON</secondary>
--->
+    </indexterm>
+    <indexterm zone="jsonpath-regular-expressions">
+     <primary><literal>LIKE_REGEX</literal></primary>
      <secondary>SQL/JSONにおける</secondary>
     </indexterm>
 
@@ -3459,9 +3461,9 @@ nextval('foo'::text)      <lineannotation><literal>foo</literal>は実行時に�
   </indexterm>
 
   <indexterm>
-<!--
    <primary>conditional expression</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>条件式</primary>
   </indexterm>
 
@@ -5047,10 +5049,10 @@ nullあるいは空の配列の結合は無処理です。そうでない場合�
   <title>集約関数</title>
 
   <indexterm zone="functions-aggregate">
-<!--
    <primary>aggregate function</primary>
    <secondary>built-in</secondary>
--->
+  </indexterm>
+  <indexterm zone="functions-aggregate">
    <primary>順序集合集約</primary>
    <secondary>組み込み</secondary>
   </indexterm>
@@ -5702,9 +5704,9 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>correlation</primary>
--->
+        </indexterm>
+        <indexterm>
          <primary>相関</primary>
         </indexterm>
         <indexterm>
@@ -5728,12 +5730,12 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>covariance</primary>
          <secondary>population</secondary>
--->
-        <primary>共分散</primary>
-        <secondary>母集団</secondary>
+        </indexterm>
+        <indexterm>
+         <primary>共分散</primary>
+         <secondary>母集団</secondary>
         </indexterm>
         <indexterm>
          <primary>covar_pop</primary>
@@ -5755,10 +5757,10 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>covariance</primary>
          <secondary>sample</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>共分散</primary>
          <secondary>標本</secondary>
         </indexterm>
@@ -5843,9 +5845,9 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>regression intercept</primary>
--->
+        </indexterm>
+        <indexterm>
          <primary>回帰切片</primary>
         </indexterm>
         <indexterm>
@@ -5889,9 +5891,9 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>regression slope</primary>
--->
+        </indexterm>
+        <indexterm>
          <primary>回帰勾配</primary>
         </indexterm>
         <indexterm>
@@ -5979,9 +5981,9 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>standard deviation</primary>
--->
+        </indexterm>
+        <indexterm>
          <primary>標準偏差</primary>
         </indexterm>
         <indexterm>
@@ -6009,10 +6011,10 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>standard deviation</primary>
          <secondary>population</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>標準偏差</primary>
          <secondary>母集団</secondary>
         </indexterm>
@@ -6041,10 +6043,10 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>standard deviation</primary>
          <secondary>sample</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>標準偏差</primary>
          <secondary>標本</secondary>
         </indexterm>
@@ -6097,10 +6099,10 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>variance</primary>
          <secondary>population</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>分散</primary>
          <secondary>母集団</secondary>
         </indexterm>
@@ -6130,10 +6132,10 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>variance</primary>
          <secondary>sample</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>分散</primary>
          <secondary>標本</secondary>
         </indexterm>
@@ -6185,17 +6187,17 @@ SELECT count(*) FROM sometable;
   </para>
 
   <indexterm>
-<!--
    <primary>ordered-set aggregate</primary>
    <secondary>built-in</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>順序集合集約</primary>
    <secondary>組み込み</secondary>
   </indexterm>
   <indexterm>
-<!--
    <primary>inverse distribution</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>逆分散</primary>
   </indexterm>
 
@@ -6232,12 +6234,12 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>mode</primary>
          <secondary>statistical</secondary>
--->
-        <primary>最頻値(モード)</primary>
-        <secondary>統計</secondary>
+        </indexterm>
+        <indexterm>
+         <primary>最頻値(モード)</primary>
+         <secondary>統計</secondary>
         </indexterm>
         <function>mode</function> () <literal>WITHIN GROUP</literal> ( <literal>ORDER BY</literal> <type>anyelement</type> )
         <returnvalue>anyelement</returnvalue>
@@ -6260,12 +6262,12 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>percentile</primary>
          <secondary>continuous</secondary>
--->
-        <primary>百分位数</primary>
-        <secondary>連続</secondary>
+        </indexterm>
+        <indexterm>
+         <primary>百分位数</primary>
+         <secondary>連続</secondary>
         </indexterm>
         <function>percentile_cont</function> ( <parameter>fraction</parameter> <type>double precision</type> ) <literal>WITHIN GROUP</literal> ( <literal>ORDER BY</literal> <type>double precision</type> )
         <returnvalue>double precision</returnvalue>
@@ -6316,10 +6318,10 @@ SELECT count(*) FROM sometable;
       <row>
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
-<!--
          <primary>percentile</primary>
          <secondary>discrete</secondary>
--->
+        </indexterm>
+        <indexterm>
          <primary>百分位数</primary>
          <secondary>離散</secondary>
         </indexterm>
@@ -6368,10 +6370,10 @@ SELECT count(*) FROM sometable;
    </table>
 
   <indexterm>
-<!--
    <primary>hypothetical-set aggregate</primary>
    <secondary>built-in</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>仮想集合集約</primary>
    <secondary>組み込み</secondary>
   </indexterm>
@@ -6434,9 +6436,10 @@ NULL値は<literal>ORDER BY</literal>節で指定されるルールに従って�
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
          <primary>rank</primary>
-<!--
          <secondary>hypothetical</secondary>
--->
+        </indexterm>
+        <indexterm>
+         <primary>rank</primary>
          <secondary>仮想の</secondary>
         </indexterm>
         <function>rank</function> ( <replaceable>args</replaceable> ) <literal>WITHIN GROUP</literal> ( <literal>ORDER BY</literal> <replaceable>sorted_args</replaceable> )
@@ -6458,9 +6461,10 @@ NULL値は<literal>ORDER BY</literal>節で指定されるルールに従って�
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
          <primary>dense_rank</primary>
- <!--
          <secondary>hypothetical</secondary>
--->
+        </indexterm>
+        <indexterm>
+         <primary>dense_rank</primary> 
          <secondary>仮想の</secondary>
         </indexterm>
         <function>dense_rank</function> ( <replaceable>args</replaceable> ) <literal>WITHIN GROUP</literal> ( <literal>ORDER BY</literal> <replaceable>sorted_args</replaceable> )
@@ -6482,9 +6486,10 @@ NULL値は<literal>ORDER BY</literal>節で指定されるルールに従って�
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
          <primary>percent_rank</primary>
-<!--
          <secondary>hypothetical</secondary>
--->
+        </indexterm>
+        <indexterm>
+         <primary>percent_rank</primary>
          <secondary>仮想の</secondary>
         </indexterm>
         <function>percent_rank</function> ( <replaceable>args</replaceable> ) <literal>WITHIN GROUP</literal> ( <literal>ORDER BY</literal> <replaceable>sorted_args</replaceable> )
@@ -6508,9 +6513,10 @@ NULL値は<literal>ORDER BY</literal>節で指定されるルールに従って�
        <entry role="func_table_entry"><para role="func_signature">
         <indexterm>
          <primary>cume_dist</primary>
-<!--
          <secondary>hypothetical</secondary>
--->
+        </indexterm>
+        <indexterm>
+         <primary>cume_dist</primary>
          <secondary>仮想の</secondary>
         </indexterm>
         <function>cume_dist</function> ( <replaceable>args</replaceable> ) <literal>WITHIN GROUP</literal> ( <literal>ORDER BY</literal> <replaceable>sorted_args</replaceable> )
@@ -6641,10 +6647,10 @@ NULL値は<literal>ORDER BY</literal>節で指定されるルールに従って�
   <title>ウィンドウ関数</title>
 
   <indexterm zone="functions-window">
-<!--
    <primary>window function</primary>
    <secondary>built-in</secondary>
--->
+  </indexterm>
+  <indexterm zone="functions-window">
    <primary>ウィンドウ関数</primary>
    <secondary>組み込み</secondary>
   </indexterm>

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -468,13 +468,11 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
    <title>単独行に関する比較</title>
 
    <indexterm zone="functions-subquery">
-<!--
     <primary>comparison</primary>
--->
-    <primary>比較</primary>
-<!--
     <secondary>subquery result row</secondary>
--->
+   </indexterm>
+   <indexterm zone="functions-subquery">
+    <primary>比較</primary>
     <secondary>副問い合わせ結果行</secondary>
    </indexterm>
 
@@ -536,35 +534,35 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
   </indexterm>
 
   <indexterm>
-<!--
    <primary>composite type</primary>
    <secondary>comparison</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>複合型</primary>
    <secondary>比較</secondary>
   </indexterm>
 
   <indexterm>
-<!--
    <primary>row-wise comparison</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>行に関する比較</primary>
   </indexterm>
 
   <indexterm>
-<!--
    <primary>comparison</primary>
    <secondary>composite type</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>比較</primary>
    <secondary>複合型</secondary>
   </indexterm>
 
   <indexterm>
-<!--
    <primary>comparison</primary>
    <secondary>row constructor</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>比較</primary>
    <secondary>行コンストラクタ</secondary>
   </indexterm>
@@ -1009,10 +1007,10 @@ SQL仕様では、結果が2つのNULL値、またはNULLと非NULLの比較に�
   <title>集合を返す関数</title>
 
   <indexterm zone="functions-srf">
-<!--
    <primary>set returning functions</primary>
    <secondary>functions</secondary>
--->
+  </indexterm>
+  <indexterm zone="functions-srf">
    <primary>集合を返す関数</primary>
    <secondary>関数</secondary>
   </indexterm>
@@ -1312,9 +1310,9 @@ SELECT * FROM unnest2(ARRAY[[1,2],[3,4]]);
   </para>
 
   <indexterm>
-<!--
    <primary>ordinality</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>順序性</primary>
   </indexterm>
 
@@ -2030,10 +2028,10 @@ Unix用語で言うと、セッションユーザは<quote>実ユーザ</quote>�
    </para>
 
   <indexterm>
-<!--
    <primary>privilege</primary>
    <secondary>querying</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>権限</primary>
    <secondary>問い合わせ</secondary>
   </indexterm>
@@ -2721,10 +2719,10 @@ SELECT relname FROM pg_class WHERE pg_table_is_visible(oid);
   </para>
 
    <indexterm>
-<!--
     <primary>search path</primary>
     <secondary>object visibility</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>検索パス</primary>
     <secondary>オブジェクトの可視性</secondary>
    </indexterm>
@@ -4225,10 +4223,10 @@ SELECT collation for ('foo' COLLATE "de_DE");
    </table>
 
    <indexterm>
-<!--
     <primary>comment</primary>
     <secondary sortas="database objects">about database objects</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>コメント</primary>
     <secondary sortas="database objects">データベースオブジェクトについて</secondary>
    </indexterm>
@@ -5415,10 +5413,10 @@ OIDとそれを含むシステム型で指定されるデータベース共有�
    <title>サーバシグナル送信関数</title>
 
    <indexterm>
-<!--
     <primary>signal</primary>
     <secondary sortas="backend">backend processes</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>シグナル</primary>
     <secondary sortas="backend">バックエンドプロセス</secondary>
    </indexterm>
@@ -5583,9 +5581,9 @@ OIDとそれを含むシステム型で指定されるデータベース共有�
    <title>バックアップ制御関数</title>
 
    <indexterm>
-<!--
     <primary>backup</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>バックアップ</primary>
    </indexterm>
 
@@ -9143,10 +9141,10 @@ CREATE EVENT TRIGGER test_table_rewrite_oid
    <title>統計情報関数</title>
 
    <indexterm zone="functions-statistics">
-<!--
     <primary>function</primary>
     <secondary>statistics</secondary>
--->
+   </indexterm>
+   <indexterm zone="functions-statistics">
     <primary>関数</primary>
     <secondary>統計</secondary>
    </indexterm>

--- a/doc/src/sgml/gin.sgml
+++ b/doc/src/sgml/gin.sgml
@@ -7,9 +7,9 @@
 <title>GINインデックス</title>
 
    <indexterm>
-<!--
     <primary>index</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>インデックス</primary>
     <secondary>GIN</secondary>
    </indexterm>

--- a/doc/src/sgml/gist.sgml
+++ b/doc/src/sgml/gist.sgml
@@ -7,9 +7,9 @@
 <title>GiSTインデックス</title>
 
    <indexterm>
-<!--
     <primary>index</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>インデックス</primary>
     <secondary>GiST</secondary>
    </indexterm>

--- a/doc/src/sgml/high-availability.sgml
+++ b/doc/src/sgml/high-availability.sgml
@@ -6,14 +6,12 @@
 -->
  <title>高可用性、負荷分散およびレプリケーション</title>
 
-<!--
  <indexterm><primary>high availability</primary></indexterm>
  <indexterm><primary>failover</primary></indexterm>
  <indexterm><primary>replication</primary></indexterm>
  <indexterm><primary>load balancing</primary></indexterm>
  <indexterm><primary>clustering</primary></indexterm>
  <indexterm><primary>data partitioning</primary></indexterm>
--->
  <indexterm><primary>高可用性</primary></indexterm>
  <indexterm><primary>フェイルオーバー</primary></indexterm>
  <indexterm><primary>レプリケーション</primary></indexterm>
@@ -912,37 +910,37 @@ WALファイル(16MB)は隣り合うシステム、同じサイトの別シス�
   </para>
 
   <indexterm zone="high-availability">
-<!--
    <primary>warm standby</primary>
--->
+  </indexterm>
+  <indexterm zone="high-availability">
    <primary>ウォームスタンバイ</primary>
   </indexterm>
 
   <indexterm zone="high-availability">
-<!--
    <primary>PITR standby</primary>
--->
+  </indexterm>
+  <indexterm zone="high-availability">
    <primary>PITRスタンバイ</primary>
   </indexterm>
 
   <indexterm zone="high-availability">
-<!--
    <primary>standby server</primary>
--->
+  </indexterm>
+  <indexterm zone="high-availability">
    <primary>スタンバイサーバ</primary>
   </indexterm>
 
   <indexterm zone="high-availability">
-<!--
    <primary>log shipping</primary>
--->
+  </indexterm>
+  <indexterm zone="high-availability">
    <primary>ログシッピング</primary>
   </indexterm>
 
   <indexterm zone="high-availability">
-<!--
    <primary>witness server</primary>
--->
+  </indexterm>
+  <indexterm zone="high-availability">
    <primary>証明サーバ</primary>
   </indexterm>
 
@@ -1224,9 +1222,9 @@ archive_cleanup_command = 'pg_archivecleanup /path/to/archive %r'
    <title>ストリーミングレプリケーション</title>
 
    <indexterm zone="high-availability">
-<!--
     <primary>Streaming Replication</primary>
--->
+   </indexterm>
+   <indexterm zone="high-availability">
     <primary>ストリーミングレプリケーション</primary>
    </indexterm>
 
@@ -1463,10 +1461,10 @@ primary_conninfo = 'host=192.168.1.50 port=5432 user=foo password=foopass'
 -->
    <title>レプリケーションスロット</title>
    <indexterm>
-<!--
     <primary>replication slot</primary>
     <secondary>streaming replication</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>レプリケーションスロット</primary>
     <secondary>ストリーミングレプリケーション</secondary>
    </indexterm>
@@ -1585,9 +1583,9 @@ primary_slot_name = 'node_a_slot'
    <title>カスケードレプリケーション</title>
 
    <indexterm zone="high-availability">
-<!--
     <primary>Cascading Replication</primary>
--->
+   </indexterm>
+   <indexterm zone="high-availability">
     <primary>カスケードレプリケーション</primary>
    </indexterm>
 
@@ -1676,9 +1674,9 @@ primary_slot_name = 'node_a_slot'
    <title>同期レプリケーション</title>
 
    <indexterm zone="high-availability">
-<!--
     <primary>Synchronous Replication</primary>
--->
+   </indexterm>
+   <indexterm zone="high-availability">
     <primary>同期レプリケーション</primary>
    </indexterm>
 
@@ -2172,10 +2170,10 @@ PostgreSQLは、WALデータをすべてのスタンバイが安全に受信し�
    <title>スタンバイにおける継続的アーカイビング</title>
 
    <indexterm>
-<!--
      <primary>continuous archiving</primary>
      <secondary>in standby</secondary>
--->
+   </indexterm>
+   <indexterm>
      <primary>継続的アーカイビング</primary>
      <secondary>スタンバイにおける</secondary>
    </indexterm>
@@ -2653,9 +2651,9 @@ if (!triggered)
   <title>ホットスタンバイ</title>
 
   <indexterm zone="high-availability">
-<!--
    <primary>Hot Standby</primary>
--->
+  </indexterm>
+  <indexterm zone="high-availability">
    <primary>ホットスタンバイ</primary>
   </indexterm>
 

--- a/doc/src/sgml/history.sgml
+++ b/doc/src/sgml/history.sgml
@@ -7,10 +7,10 @@
  <title><productname>PostgreSQL</productname>小史</title>
 
  <indexterm zone="history">
-<!--
   <primary>history</primary>
   <secondary>of PostgreSQL</secondary>
--->
+ </indexterm>
+ <indexterm zone="history">
   <primary>歴史</primary>
   <secondary>PostgreSQLの</secondary>
  </indexterm>

--- a/doc/src/sgml/indexam.sgml
+++ b/doc/src/sgml/indexam.sgml
@@ -7,16 +7,17 @@
  <title>インデックスアクセスメソッドのインタフェース定義</title>
 
  <indexterm>
-<!--
   <primary>Index Access Method</primary>
--->
+ </indexterm>
+ <indexterm>
   <primary>インデックスアクセスメソッド</primary>
  </indexterm>
  <indexterm>
   <primary>indexam</primary>
-<!--
   <secondary>Index Access Method</secondary>
--->
+ </indexterm>
+ <indexterm>
+  <primary>indexam</primary>
   <secondary>インデックスアクセスメソッド</secondary>
  </indexterm>
 

--- a/doc/src/sgml/indices.sgml
+++ b/doc/src/sgml/indices.sgml
@@ -7,9 +7,9 @@
  <title>インデックス</title>
 
  <indexterm zone="indexes">
-<!--
   <primary>index</primary>
--->
+ </indexterm>
+ <indexterm zone="indexes">
   <primary>インデックス</primary>
  </indexterm>
 
@@ -197,17 +197,18 @@ CREATE INDEX test1_id_index ON test1 (id);
 
   <para>
    <indexterm>
-<!--
     <primary>index</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>インデックス</primary>
     <secondary>B-tree</secondary>
    </indexterm>
    <indexterm>
     <primary>B-tree</primary>
-<!--
     <see>index</see>
--->
+   </indexterm>
+   <indexterm>
+    <primary>B-tree</primary>
     <see>インデックス</see>
    </indexterm>
 <!--
@@ -273,18 +274,18 @@ B-treeインデックスをソートされた順序でデータを受けとる�
 
   <para>
    <indexterm>
-<!--
     <primary>index</primary>
     <secondary>hash</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>インデックス</primary>
     <secondary>ハッシュ</secondary>
    </indexterm>
    <indexterm>
-<!--
     <primary>hash</primary>
     <see>index</see>
--->
+   </indexterm>
+   <indexterm>
     <primary>ハッシュ</primary>
     <see>インデックス</see>
    </indexterm>
@@ -305,17 +306,18 @@ CREATE INDEX <replaceable>name</replaceable> ON <replaceable>table</replaceable>
 
   <para>
    <indexterm>
-<!--
     <primary>index</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>インデックス</primary>
     <secondary>GiST</secondary>
    </indexterm>
    <indexterm>
     <primary>GiST</primary>
-<!--
     <see>index</see>
--->
+   </indexterm>
+   <indexterm>
+    <primary>GiST</primary>
     <see>インデックス</see>
    </indexterm>
 <!--
@@ -385,17 +387,18 @@ SELECT * FROM places ORDER BY location <-> point '(101,456)' LIMIT 10;
 
   <para>
    <indexterm>
-<!--
     <primary>index</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>インデックス</primary>
     <secondary>SP-GiST</secondary>
    </indexterm>
    <indexterm>
     <primary>SP-GiST</primary>
-<!--
     <see>index</see>
--->
+   </indexterm>
+   <indexterm>
+    <primary>SP-GiST</primary>
     <see>インデックス</see>
    </indexterm>
 <!--
@@ -445,17 +448,18 @@ GiSTと同様に、SP-GiSTは<quote>最近傍</quote>検索をサポートしま
 
   <para>
    <indexterm>
-<!--
     <primary>index</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>インデックス</primary>
     <secondary>GIN</secondary>
    </indexterm>
    <indexterm>
     <primary>GIN</primary>
-<!--
     <see>index</see>
--->
+   </indexterm>
+   <indexterm>
+    <primary>GIN</primary>
     <see>インデックス</see>
    </indexterm>
 <!--
@@ -506,17 +510,18 @@ GiSTやSP-GiST同様、GINも多くの異なるユーザ定義のインデック
 
   <para>
    <indexterm>
-<!--
     <primary>index</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>インデックス</primary>
     <secondary>BRIN</secondary>
    </indexterm>
    <indexterm>
     <primary>BRIN</primary>
-<!--
     <see>index</see>
--->
+   </indexterm>
+   <indexterm>
+    <primary>BRIN</primary>
     <see>インデックス</see>
    </indexterm>
 <!--
@@ -562,10 +567,10 @@ GiST、SP-GiST、GINと同じように、BRINは多くの異なるインデッ�
   <title>複数列インデックス</title>
 
   <indexterm zone="indexes-multicolumn">
-<!--
    <primary>index</primary>
    <secondary>multicolumn</secondary>
--->
+  </indexterm>
+  <indexterm zone="indexes-multicolumn">
    <primary>インデックス</primary>
    <secondary>複数列</secondary>
   </indexterm>
@@ -726,10 +731,10 @@ GINと同様に、またB-treeやGiSTとは異なり、インデックス検索�
   <title>インデックスと<literal>ORDER BY</literal></title>
 
   <indexterm zone="indexes-ordering">
-<!--
    <primary>index</primary>
    <secondary>and <literal>ORDER BY</literal></secondary>
--->
+  </indexterm>
+  <indexterm zone="indexes-ordering">
    <primary>インデックス</primary>
    <secondary>と<literal>ORDER BY</literal></secondary>
   </indexterm>
@@ -857,18 +862,18 @@ CREATE INDEX test3_desc_index ON test3 (id DESC NULLS LAST);
   <title>複数のインデックスの組み合わせ</title>
 
   <indexterm zone="indexes-bitmap-scans">
-<!--
    <primary>index</primary>
    <secondary>combining multiple indexes</secondary>
--->
+  </indexterm>
+  <indexterm zone="indexes-bitmap-scans">
    <primary>インデックス</primary>
    <secondary>複数のインデックスの組み合わせ</secondary>
   </indexterm>
 
   <indexterm zone="indexes-bitmap-scans">
-<!--
    <primary>bitmap scan</primary>
--->
+  </indexterm>
+  <indexterm zone="indexes-bitmap-scans">
    <primary>ビットマップスキャン</primary>
   </indexterm>
 
@@ -989,10 +994,10 @@ CREATE INDEX test3_desc_index ON test3 (id DESC NULLS LAST);
   <title>一意インデックス</title>
 
   <indexterm zone="indexes-unique">
-<!--
    <primary>index</primary>
    <secondary>unique</secondary>
--->
+  </indexterm>
+  <indexterm zone="indexes-unique">
    <primary>インデックス</primary>
    <secondary>一意</secondary>
   </indexterm>
@@ -1057,10 +1062,10 @@ NULL 値は同じ値とはみなされません。
   <title>式に対するインデックス</title>
 
   <indexterm zone="indexes-expressional">
-<!--
    <primary>index</primary>
    <secondary sortas="expressions">on expressions</secondary>
--->
+  </indexterm>
+  <indexterm zone="indexes-expressional">
    <primary>インデックス</primary>
    <secondary sortas="expressions">式に対する</secondary>
   </indexterm>
@@ -1163,10 +1168,10 @@ CREATE INDEX people_names ON people ((first_name || ' ' || last_name));
   <title>部分インデックス</title>
 
   <indexterm zone="indexes-partial">
-<!--
    <primary>index</primary>
    <secondary>partial</secondary>
--->
+  </indexterm>
+  <indexterm zone="indexes-partial">
    <primary>インデックス</primary>
    <secondary>部分</secondary>
   </indexterm>
@@ -1591,31 +1596,31 @@ CREATE INDEX mytable_cat_data ON mytable (category, data);
   <title>インデックスオンリースキャンとカバリングインデックス</title>
 
   <indexterm zone="indexes-index-only-scans">
-<!--
    <primary>index</primary>
    <secondary>index-only scans</secondary>
--->
+  </indexterm>
+  <indexterm zone="indexes-index-only-scans">
    <primary>インデックス</primary>
    <secondary>インデックスオンリースキャン</secondary>
   </indexterm>
   <indexterm zone="indexes-index-only-scans">
-<!--
    <primary>index-only scan</primary>
--->
+  </indexterm>
+  <indexterm zone="indexes-index-only-scans">
    <primary>インデックスオンリースキャン</primary>
   </indexterm>
   <indexterm zone="indexes-index-only-scans">
-<!--
    <primary>index</primary>
    <secondary>covering</secondary>
--->
+  </indexterm>
+  <indexterm zone="indexes-index-only-scans">
    <primary>インデックス</primary>
    <secondary>カバリング</secondary>
   </indexterm>
   <indexterm zone="indexes-index-only-scans">
-<!--
    <primary>covering index</primary>
--->
+  </indexterm>
+  <indexterm zone="indexes-index-only-scans">
    <primary>カバリングインデックス</primary>
   </indexterm>
 
@@ -1771,9 +1776,10 @@ SELECT x FROM tab WHERE x = 'key' AND z &lt; 42;
   <para>
    <indexterm>
     <primary><literal>INCLUDE</literal></primary>
-<!--
     <secondary>in index definitions</secondary>
--->
+   </indexterm>
+   <indexterm>
+    <primary><literal>INCLUDE</literal></primary>
     <secondary>インデックス定義内</secondary>
    </indexterm>
 <!--
@@ -2001,16 +2007,16 @@ SELECT target FROM tests WHERE subject = 'some-subject' AND success;
   <title>演算子クラスと演算子族</title>
 
   <indexterm zone="indexes-opclass">
-<!--
    <primary>operator class</primary>
--->
+  </indexterm>
+  <indexterm zone="indexes-opclass">
    <primary>演算子クラス</primary>
   </indexterm>
 
   <indexterm zone="indexes-opclass">
-<!--
    <primary>operator family</primary>
--->
+  </indexterm>
+  <indexterm zone="indexes-opclass">
    <primary>演算子族</primary>
   </indexterm>
 
@@ -2255,10 +2261,10 @@ CREATE INDEX test1c_content_y_index ON test1c (content COLLATE "y");
   <title>インデックス使用状況の検証</title>
 
   <indexterm zone="indexes-examine">
-<!--
    <primary>index</primary>
    <secondary>examining usage</secondary>
--->
+  </indexterm>
+  <indexterm zone="indexes-examine">
    <primary>インデックス</primary>
    <secondary>の使用状況の検証</secondary>
   </indexterm>

--- a/doc/src/sgml/information_schema.sgml
+++ b/doc/src/sgml/information_schema.sgml
@@ -7,9 +7,9 @@
  <title>情報スキーマ</title>
 
  <indexterm zone="information-schema">
-<!--
   <primary>information schema</primary>
--->
+ </indexterm>
+ <indexterm zone="information-schema">
   <primary>情報スキーマ</primary>
  </indexterm>
 

--- a/doc/src/sgml/install-windows.sgml
+++ b/doc/src/sgml/install-windows.sgml
@@ -7,10 +7,10 @@
  <title><productname>Windows</productname>におけるソースコードからのインストール</title>
 
  <indexterm>
-<!--
   <primary>installation</primary>
   <secondary>on Windows</secondary>
--->
+ </indexterm>
+ <indexterm>
   <primary>インストール</primary>
   <secondary>Windowsにおける</secondary>
  </indexterm>

--- a/doc/src/sgml/installation.sgml
+++ b/doc/src/sgml/installation.sgml
@@ -15,9 +15,9 @@ documentation.  See standalone-profile.xsl for details.
  <title>ソースコードからインストール</title>
 
  <indexterm zone="installation">
-<!--
   <primary>installation</primary>
--->
+ </indexterm>
+ <indexterm zone="installation">
   <primary>インストール</primary>
  </indexterm>
 
@@ -694,9 +694,9 @@ build-postgresql:
    <title>リグレッションテスト</title>
 
    <indexterm>
-<!--
     <primary>regression test</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>リグレッションテスト</primary>
    </indexterm>
 
@@ -914,9 +914,9 @@ build-postgresql:
    <title><filename>configure</filename>オプション</title>
 
    <indexterm zone="configure-options">
-<!--
     <primary>configure options</primary>
--->
+   </indexterm>
+   <indexterm zone="configure-options">
     <primary>configureオプション</primary>
    </indexterm>
 
@@ -1853,9 +1853,9 @@ CPU不可分操作の使用を無効にします。
       <varlistentry>
        <term><option>--with-system-tzdata=<replaceable>DIRECTORY</replaceable></option>
        <indexterm>
-<!--
         <primary>time zone data</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary>時間帯データ</primary>
        </indexterm>
        </term>
@@ -1888,9 +1888,7 @@ CPU不可分操作の使用を無効にします。
 このオプションを使用する場合、指定した時間帯データが<productname>PostgreSQL</productname>で正しく動作するかどうかを検証するためにリグレッションテストを実行することが推奨されています。
         </para>
 
-<!--
         <indexterm><primary>cross compilation</primary></indexterm>
--->
         <indexterm><primary>クロスコンパイル</primary></indexterm>
 
         <para>
@@ -2331,9 +2329,9 @@ Sunのコンパイラを使用する場合は以下のようにします。
    <title><filename>configure</filename>環境変数</title>
 
    <indexterm zone="configure-envvars">
-<!--
     <primary>configure environment variables</primary>
--->
+   </indexterm>
+   <indexterm zone="configure-envvars">
     <primary>configure環境変数</primary>
    </indexterm>
 
@@ -2738,9 +2736,9 @@ GCCを使う場合、少なくとも<option>-O1</option>レベルの最適化で
    <title>共有ライブラリ</title>
 
    <indexterm>
-<!--
     <primary>shared library</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>共有ライブラリ</primary>
    </indexterm>
 
@@ -3054,9 +3052,10 @@ Linux (最近のディストリビューションすべて), Windows (XP以降),
 
    <indexterm zone="installation-notes-aix">
     <primary>AIX</primary>
-<!--
     <secondary>installation on</secondary>
--->
+   </indexterm>
+   <indexterm zone="installation-notes-aix">
+    <primary>AIX</primary>
     <secondary>上へのインストール</secondary>
    </indexterm>
 
@@ -3221,9 +3220,10 @@ ERROR:  could not load library "/opt/dbs/pgsql/lib/plperl.so": Bad address
 
    <indexterm zone="installation-notes-cygwin">
     <primary>Cygwin</primary>
-<!--
     <secondary>installation on</secondary>
--->
+   </indexterm>
+   <indexterm zone="installation-notes-cygwin">
+    <primary>Cygwin</primary>
     <secondary>上へのインストール</secondary>
    </indexterm>
 
@@ -3371,9 +3371,10 @@ Windows NTサービスとして<command>cygserver</command>とPostgreSQLサー�
 
    <indexterm zone="installation-notes-macos">
     <primary>macOS</primary>
-<!--
     <secondary>installation on</secondary>
--->
+   </indexterm>
+   <indexterm zone="installation-notes-macos">
+    <primary>macOS</primary>
     <secondary>上へのインストール</secondary>
    </indexterm>
 
@@ -3448,9 +3449,10 @@ xcodebuild -version -sdk macosx Path
 
    <indexterm zone="installation-notes-mingw">
     <primary>MinGW</primary>
-<!--
     <secondary>installation on</secondary>
--->
+   </indexterm>
+   <indexterm zone="installation-notes-mingw">
+    <primary>MinGW</primary>
     <secondary>上へのインストール</secondary>
    </indexterm>
 
@@ -3536,9 +3538,10 @@ MSYSコンソールはバッファリングに問題があるので、すべて�
 
    <indexterm zone="installation-notes-solaris">
     <primary>Solaris</primary>
-<!--
     <secondary>installation on</secondary>
--->
+   </indexterm>
+   <indexterm zone="installation-notes-solaris">
+    <primary>Solaris</primary>
     <secondary>上へのインストール</secondary>
    </indexterm>
 

--- a/doc/src/sgml/jit.sgml
+++ b/doc/src/sgml/jit.sgml
@@ -11,9 +11,9 @@
  </indexterm>
 
  <indexterm>
-<!--
   <primary>Just-In-Time compilation</primary>
--->
+ </indexterm>
+ <indexterm>
   <primary>実行時コンパイル</primary>
   <see><acronym>JIT</acronym></see>
  </indexterm>

--- a/doc/src/sgml/json.sgml
+++ b/doc/src/sgml/json.sgml
@@ -400,16 +400,18 @@ JSONデータはテーブルに格納するとき、他のデータ型と同一�
   <title><type>jsonb</type>型用包含演算子と存在演算子</title>
   <indexterm>
     <primary>jsonb</primary>
-<!--
     <secondary>containment</secondary>
--->
+  </indexterm>
+  <indexterm>
+    <primary>jsonb</primary>
     <secondary>包含</secondary>
   </indexterm>
   <indexterm>
     <primary>jsonb</primary>
-<!--
     <secondary>existence</secondary>
--->
+  </indexterm>
+  <indexterm>
+    <primary>jsonb</primary>
     <secondary>存在</secondary>
   </indexterm>
   <para>
@@ -649,9 +651,10 @@ JSONの様々な包含演算子や存在演算子、他のすべてのJSON演算
   <title><type>jsonb</type> インデックス</title>
   <indexterm>
     <primary>jsonb</primary>
-<!--
     <secondary>indexes on</secondary>
--->
+  </indexterm>
+  <indexterm>
+    <primary>jsonb</primary>
     <secondary>上のインデックス</secondary>
   </indexterm>
 

--- a/doc/src/sgml/keywords.sgml
+++ b/doc/src/sgml/keywords.sgml
@@ -7,10 +7,10 @@
  <title><acronym>SQL</acronym>キーワード</title>
 
  <indexterm zone="sql-keywords-appendix">
-<!--
   <primary>key word</primary>
   <secondary>list of</secondary>
--->
+ </indexterm>
+ <indexterm zone="sql-keywords-appendix">
   <primary>キーワード</primary>
   <secondary>の一覧</secondary>
  </indexterm>

--- a/doc/src/sgml/libpq.sgml
+++ b/doc/src/sgml/libpq.sgml
@@ -350,9 +350,7 @@ PGconn *PQsetdb(char *pghost,
      <term><function>PQconnectPoll</function><indexterm><primary>PQconnectPoll</primary></indexterm></term>
      <listitem>
       <para>
-<!--
        <indexterm><primary>nonblocking connection</primary></indexterm>
--->
        <indexterm><primary>非ブロック接続</primary></indexterm>
 <!--
        Make a connection to the database server in a nonblocking manner.
@@ -5689,10 +5687,10 @@ char *PQoidStatus(const PGresult *res);
   <title>SQLコマンドに含めるための文字列のエスケープ処理</title>
 
    <indexterm zone="libpq-exec-escape-string">
-<!--
     <primary>escaping strings</primary>
     <secondary>in libpq</secondary>
--->
+   </indexterm>
+   <indexterm zone="libpq-exec-escape-string">
     <primary>文字列のエスケープ</primary>
     <secondary>libpqにおける</secondary>
    </indexterm>
@@ -6163,9 +6161,9 @@ unsigned char *PQunescapeBytea(const unsigned char *from, size_t *to_length);
 <title>非同期コマンドの処理</title>
 
   <indexterm zone="libpq-async">
-<!--
    <primary>nonblocking connection</primary>
--->
+  </indexterm>
+  <indexterm zone="libpq-async">
   <primary>非ブロッキング接続</primary>
   </indexterm>
 
@@ -6843,9 +6841,10 @@ int PQflush(PGconn *conn);
 
   <indexterm zone="libpq-single-row-mode">
    <primary>libpq</primary>
-<!--
    <secondary>single-row mode</secondary>
--->
+  </indexterm>
+  <indexterm zone="libpq-single-row-mode">
+   <primary>libpq</primary>
    <secondary>単一行モード</secondary>
   </indexterm>
 
@@ -6968,10 +6967,10 @@ int PQsetSingleRowMode(PGconn *conn);
   <title>処理中の問い合わせのキャンセル</title>
 
   <indexterm zone="libpq-cancel">
-<!--
    <primary>canceling</primary>
    <secondary>SQL command</secondary>
--->
+  </indexterm>
+  <indexterm zone="libpq-cancel">
    <primary>キャンセル</primary>
    <secondary>SQLコマンドの</secondary>
   </indexterm>
@@ -7150,9 +7149,9 @@ int PQrequestCancel(PGconn *conn);
   <title>近道インタフェース</title>
 
   <indexterm zone="libpq-fastpath">
-<!--
    <primary>fast path</primary>
--->
+  </indexterm>
+  <indexterm zone="libpq-fastpath">
    <primary>近道</primary>
   </indexterm>
 
@@ -7290,9 +7289,10 @@ typedef struct
 
   <indexterm zone="libpq-notify">
    <primary>NOTIFY</primary>
-<!--
    <secondary>in libpq</secondary>
--->
+  </indexterm>
+  <indexterm zone="libpq-notify">
+   <primary>NOTIFY</primary>
    <secondary>libpqにおける</secondary>
   </indexterm>
 
@@ -7431,9 +7431,10 @@ typedef struct pgNotify
 
   <indexterm zone="libpq-copy">
    <primary>COPY</primary>
-<!--
    <secondary>with libpq</secondary>
--->
+  </indexterm>
+  <indexterm zone="libpq-copy">
+   <primary>COPY</primary>
    <secondary>libpqを使用した</secondary>
   </indexterm>
 
@@ -8927,10 +8928,10 @@ int PQlibVersion(void);
   <title>警告処理</title>
 
   <indexterm zone="libpq-notice-processing">
-<!--
    <primary>notice processing</primary>
    <secondary>in libpq</secondary>
--->
+  </indexterm>
+  <indexterm zone="libpq-notice-processing">
    <primary>警告処理</primary>
    <secondary>libpqでの</secondary>
   </indexterm>
@@ -9868,9 +9869,9 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
 <title>環境変数</title>
 
   <indexterm zone="libpq-envars">
-<!--
    <primary>environment variable</primary>
--->
+  </indexterm>
+  <indexterm zone="libpq-envars">
    <primary>環境変数</primary>
   </indexterm>
 
@@ -10389,9 +10390,9 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
   <title>パスワードファイル</title>
 
   <indexterm zone="libpq-pgpass">
-<!--
    <primary>password file</primary>
--->
+  </indexterm>
+  <indexterm zone="libpq-pgpass">
    <primary>パスワードファイル</primary>
   </indexterm>
   <indexterm zone="libpq-pgpass">
@@ -10482,9 +10483,9 @@ Microsoft Windowsにおいては、このファイルが安全なディレクト
   <title>接続サービスファイル</title>
 
   <indexterm zone="libpq-pgservice">
-<!--
    <primary>connection service file</primary>
--->
+  </indexterm>
+  <indexterm zone="libpq-pgservice">
    <primary>接続サービスファイル</primary>
   </indexterm>
   <indexterm zone="libpq-pgservice">
@@ -10560,9 +10561,9 @@ user=admin
   <title>接続パラメータのLDAP検索</title>
 
   <indexterm zone="libpq-ldap">
-<!--
    <primary>LDAP connection parameter lookup</primary>
--->
+  </indexterm>
+  <indexterm zone="libpq-ldap">
    <primary>LDAPによる接続パラメータ検索</primary>
   </indexterm>
 
@@ -11401,10 +11402,10 @@ void PQinitSSL(int do_ssl);
   <title>スレッド化プログラムの振舞い</title>
 
   <indexterm zone="libpq-threading">
-<!--
    <primary>threads</primary>
    <secondary>with libpq</secondary>
--->
+  </indexterm>
+  <indexterm zone="libpq-threading">
    <primary>スレッド</primary>
    <secondary>libpqにおける</secondary>
   </indexterm>
@@ -11515,10 +11516,10 @@ int PQisthreadsafe();
   <title><application>libpq</application>プログラムの構築</title>
 
   <indexterm zone="libpq-build">
-<!--
    <primary>compiling</primary>
    <secondary>libpq applications</secondary>
--->
+  </indexterm>
+  <indexterm zone="libpq-build">
    <primary>コンパイル</primary>
    <secondary>libpq アプリケーション</secondary>
   </indexterm>

--- a/doc/src/sgml/libpq0.sgml
+++ b/doc/src/sgml/libpq0.sgml
@@ -358,9 +358,7 @@ PGconn *PQsetdb(char *pghost,
      <term><function>PQconnectPoll</function><indexterm><primary>PQconnectPoll</primary></indexterm></term>
      <listitem>
       <para>
-<!--
        <indexterm><primary>nonblocking connection</primary></indexterm>
--->
        <indexterm><primary>非ブロック接続</primary></indexterm>
 <!--
        Make a connection to the database server in a nonblocking manner.

--- a/doc/src/sgml/libpq1.sgml
+++ b/doc/src/sgml/libpq1.sgml
@@ -2125,10 +2125,10 @@ char *PQoidStatus(const PGresult *res);
   <title>SQLコマンドに含めるための文字列のエスケープ処理</title>
 
    <indexterm zone="libpq-exec-escape-string">
-<!--
     <primary>escaping strings</primary>
     <secondary>in libpq</secondary>
--->
+   </indexterm>
+   <indexterm zone="libpq-exec-escape-string">
     <primary>文字列のエスケープ</primary>
     <secondary>libpqにおける</secondary>
    </indexterm>
@@ -2599,9 +2599,9 @@ unsigned char *PQunescapeBytea(const unsigned char *from, size_t *to_length);
 <title>非同期コマンドの処理</title>
 
   <indexterm zone="libpq-async">
-<!--
    <primary>nonblocking connection</primary>
--->
+  </indexterm>
+  <indexterm zone="libpq-async">
   <primary>非ブロッキング接続</primary>
   </indexterm>
 

--- a/doc/src/sgml/libpq2.sgml
+++ b/doc/src/sgml/libpq2.sgml
@@ -16,9 +16,10 @@
 
   <indexterm zone="libpq-single-row-mode">
    <primary>libpq</primary>
-<!--
    <secondary>single-row mode</secondary>
--->
+  </indexterm>
+  <indexterm zone="libpq-single-row-mode">
+   <primary>libpq</primary>
    <secondary>単一行モード</secondary>
   </indexterm>
 
@@ -141,10 +142,10 @@ int PQsetSingleRowMode(PGconn *conn);
   <title>処理中の問い合わせのキャンセル</title>
 
   <indexterm zone="libpq-cancel">
-<!--
    <primary>canceling</primary>
    <secondary>SQL command</secondary>
--->
+  </indexterm>
+  <indexterm zone="libpq-cancel">
    <primary>キャンセル</primary>
    <secondary>SQLコマンドの</secondary>
   </indexterm>
@@ -323,9 +324,9 @@ int PQrequestCancel(PGconn *conn);
   <title>近道インタフェース</title>
 
   <indexterm zone="libpq-fastpath">
-<!--
    <primary>fast path</primary>
--->
+  </indexterm>
+  <indexterm zone="libpq-fastpath">
    <primary>近道</primary>
   </indexterm>
 
@@ -463,9 +464,10 @@ typedef struct
 
   <indexterm zone="libpq-notify">
    <primary>NOTIFY</primary>
-<!--
    <secondary>in libpq</secondary>
--->
+  </indexterm>
+  <indexterm zone="libpq-notify">
+   <primary>NOTIFY</primary>
    <secondary>libpqにおける</secondary>
   </indexterm>
 
@@ -604,9 +606,10 @@ typedef struct pgNotify
 
   <indexterm zone="libpq-copy">
    <primary>COPY</primary>
-<!--
    <secondary>with libpq</secondary>
--->
+  </indexterm>
+  <indexterm zone="libpq-copy">
+   <primary>COPY</primary>
    <secondary>libpqを使用した</secondary>
   </indexterm>
 
@@ -2100,10 +2103,10 @@ int PQlibVersion(void);
   <title>警告処理</title>
 
   <indexterm zone="libpq-notice-processing">
-<!--
    <primary>notice processing</primary>
    <secondary>in libpq</secondary>
--->
+  </indexterm>
+  <indexterm zone="libpq-notice-processing">
    <primary>警告処理</primary>
    <secondary>libpqでの</secondary>
   </indexterm>
@@ -2968,7 +2971,7 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
 ]]><!--
             /* free instance data because the conn is being destroyed */
 --><![CDATA[
-            /* connが破棄されたのでインスタンスデータを開放 */
+            /* connが破棄されたのでインスタンスデータを解放 */
             if (data)
               free_mydata(data);
             break;
@@ -3010,7 +3013,7 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
 ]]><!--
             /* free instance data because the result is being destroyed */
 --><![CDATA[
-            /* 結果が破棄されたためインスタンスデータを開放 */
+            /* 結果が破棄されたためインスタンスデータを解放 */
             if (data)
               free_mydata(data);
             break;
@@ -3041,9 +3044,9 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
 <title>環境変数</title>
 
   <indexterm zone="libpq-envars">
-<!--
    <primary>environment variable</primary>
--->
+  </indexterm>
+  <indexterm zone="libpq-envars">
    <primary>環境変数</primary>
   </indexterm>
 

--- a/doc/src/sgml/libpq3.sgml
+++ b/doc/src/sgml/libpq3.sgml
@@ -15,9 +15,9 @@
   <title>パスワードファイル</title>
 
   <indexterm zone="libpq-pgpass">
-<!--
    <primary>password file</primary>
--->
+  </indexterm>
+  <indexterm zone="libpq-pgpass">
    <primary>パスワードファイル</primary>
   </indexterm>
   <indexterm zone="libpq-pgpass">
@@ -108,9 +108,9 @@ Microsoft Windowsにおいては、このファイルが安全なディレクト
   <title>接続サービスファイル</title>
 
   <indexterm zone="libpq-pgservice">
-<!--
    <primary>connection service file</primary>
--->
+  </indexterm>
+  <indexterm zone="libpq-pgservice">
    <primary>接続サービスファイル</primary>
   </indexterm>
   <indexterm zone="libpq-pgservice">
@@ -186,9 +186,9 @@ user=admin
   <title>接続パラメータのLDAP検索</title>
 
   <indexterm zone="libpq-ldap">
-<!--
    <primary>LDAP connection parameter lookup</primary>
--->
+  </indexterm>
+  <indexterm zone="libpq-ldap">
    <primary>LDAPによる接続パラメータ検索</primary>
   </indexterm>
 
@@ -1027,10 +1027,10 @@ void PQinitSSL(int do_ssl);
   <title>スレッド化プログラムの振舞い</title>
 
   <indexterm zone="libpq-threading">
-<!--
    <primary>threads</primary>
    <secondary>with libpq</secondary>
--->
+  </indexterm>
+  <indexterm zone="libpq-threading">
    <primary>スレッド</primary>
    <secondary>libpqにおける</secondary>
   </indexterm>
@@ -1141,10 +1141,10 @@ int PQisthreadsafe();
   <title><application>libpq</application>プログラムの構築</title>
 
   <indexterm zone="libpq-build">
-<!--
    <primary>compiling</primary>
    <secondary>libpq applications</secondary>
--->
+  </indexterm>
+  <indexterm zone="libpq-build">
    <primary>コンパイル</primary>
    <secondary>libpq アプリケーション</secondary>
   </indexterm>

--- a/doc/src/sgml/lobj.sgml
+++ b/doc/src/sgml/lobj.sgml
@@ -6,10 +6,8 @@
 -->
   <title>ラージオブジェクト</title>
 
-<!--
   <indexterm zone="largeobjects"><primary>large object</primary></indexterm>
   <indexterm><primary>BLOB</primary><see>large object</see></indexterm>
--->
   <indexterm zone="largeobjects"><primary>ラージオブジェクト</primary></indexterm>
   <indexterm><primary>BLOB</primary><see>ラージオブジェクト</see></indexterm>
 
@@ -50,10 +48,10 @@
    <title>はじめに</title>
 
    <indexterm>
-<!--
     <primary>TOAST</primary>
     <secondary>versus large objects</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>TOAST</primary>
     <secondary>対ラージオブジェクト</secondary>
    </indexterm>

--- a/doc/src/sgml/logicaldecoding.sgml
+++ b/doc/src/sgml/logicaldecoding.sgml
@@ -5,9 +5,9 @@
 -->
   <title>ロジカルデコーディング</title>
   <indexterm zone="logicaldecoding">
-<!--
    <primary>Logical Decoding</primary>
--->
+  </indexterm>
+  <indexterm zone="logicaldecoding">
    <primary>ロジカルデコーディング</primary>
   </indexterm>
   <para>
@@ -221,9 +221,9 @@ $ pg_recvlogical -d postgres --slot=test --drop-slot
     <title>ロジカルデコーディング</title>
 
     <indexterm>
-<!--
      <primary>Logical Decoding</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>ロジカルデコーディング</primary>
     </indexterm>
 
@@ -257,10 +257,10 @@ $ pg_recvlogical -d postgres --slot=test --drop-slot
     <title>レプリケーションスロット</title>
 
     <indexterm>
-<!--
      <primary>replication slot</primary>
      <secondary>logical replication</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>レプリケーションスロット</primary>
      <secondary>ロジカルレプリケーション</secondary>
     </indexterm>

--- a/doc/src/sgml/maintenance.sgml
+++ b/doc/src/sgml/maintenance.sgml
@@ -7,16 +7,16 @@
  <title>定常的なデータベース保守作業</title>
 
  <indexterm zone="maintenance">
-<!--
   <primary>maintenance</primary>
--->
+ </indexterm>
+ <indexterm zone="maintenance">
   <primary>保守</primary>
  </indexterm>
 
  <indexterm zone="maintenance">
-<!--
   <primary>routine maintenance</primary>
--->
+ </indexterm>
+ <indexterm zone="maintenance">
   <primary>定常的な保守</primary>
  </indexterm>
 
@@ -103,9 +103,9 @@
   <title>定常的なバキューム作業</title>
 
   <indexterm zone="routine-vacuuming">
-<!--
    <primary>vacuum</primary>
--->
+  </indexterm>
+  <indexterm zone="routine-vacuuming">
    <primary>バキューム</primary>
   </indexterm>
 
@@ -247,10 +247,10 @@
    <title>ディスク容量の復旧</title>
 
    <indexterm zone="vacuum-for-space-recovery">
-<!--
     <primary>disk space</primary>
--->
-<primary>ディスク容量</primary>
+   </indexterm>
+   <indexterm zone="vacuum-for-space-recovery">
+    <primary>ディスク容量</primary>
    </indexterm>
 
    <para>
@@ -416,10 +416,10 @@
 <title>プランナ用の統計情報の更新</title>
 
    <indexterm zone="vacuum-for-statistics">
-<!--
     <primary>statistics</primary>
     <secondary>of the planner</secondary>
--->
+   </indexterm>
+   <indexterm zone="vacuum-for-statistics">
     <primary>統計情報</primary>
     <secondary>プランナの</secondary>
    </indexterm>
@@ -603,19 +603,19 @@
    <title>トランザクションIDの周回エラーの防止</title>
 
    <indexterm zone="vacuum-for-wraparound">
-<!--
     <primary>transaction ID</primary>
     <secondary>wraparound</secondary>
--->
+   </indexterm>
+   <indexterm zone="vacuum-for-wraparound">
     <primary>トランザクションID</primary>
     <secondary>周回</secondary>
    </indexterm>
 
     <indexterm>
-<!--
      <primary>wraparound</primary>
      <secondary>of transaction IDs</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>周回</primary>
      <secondary>トランザクションIDの</secondary>
     </indexterm>
@@ -992,10 +992,10 @@ HINT:  Stop the postmaster and vacuum that database in single-user mode.
     </indexterm>
 
     <indexterm>
-<!--
      <primary>wraparound</primary>
      <secondary>of multixact IDs</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>周回</primary>
      <secondary>マルチトランザクションIDの</secondary>
     </indexterm>
@@ -1087,9 +1087,10 @@ HINT:  Stop the postmaster and vacuum that database in single-user mode.
 
    <indexterm>
     <primary>autovacuum</primary>
-<!--
     <secondary>general information</secondary>
--->
+   </indexterm>
+   <indexterm>
+    <primary>autovacuum</primary>
     <secondary>一般情報</secondary>
    </indexterm>
    <para>
@@ -1339,9 +1340,9 @@ analyze threshold = analyze base threshold + analyze scale factor * number of tu
 <title>定常的なインデックスの再作成</title>
 
   <indexterm zone="routine-reindex">
-<!--
    <primary>reindex</primary>
--->
+  </indexterm>
+  <indexterm zone="routine-reindex">
    <primary>インデックス再作成</primary>
   </indexterm>
 
@@ -1417,10 +1418,10 @@ B-tree以外の任意の種類のインデックスを使用する際には、�
 <title>ログファイルの保守</title>
 
   <indexterm zone="logfile-maintenance">
-<!--
    <primary>server log</primary>
    <secondary>log file maintenance</secondary>
--->
+  </indexterm>
+  <indexterm zone="logfile-maintenance">
    <primary>サーバログ</primary>
    <secondary>ログファイルの保守</secondary>
   </indexterm>

--- a/doc/src/sgml/manage-ag.sgml
+++ b/doc/src/sgml/manage-ag.sgml
@@ -6,9 +6,7 @@
 -->
  <title>データベース管理</title>
 
-<!--
  <indexterm zone="managing-databases"><primary>database</primary></indexterm>
--->
  <indexterm zone="managing-databases"><primary>データベース</primary></indexterm>
 
  <para>
@@ -32,9 +30,9 @@
   <title>概要</title>
 
   <indexterm zone="manage-ag-overview">
-<!--
    <primary>schema</primary>
--->
+  </indexterm>
+  <indexterm zone="manage-ag-overview">
    <primary>スキーマ</primary>
   </indexterm>
 
@@ -590,9 +588,9 @@ dropdb <replaceable class="parameter">dbname</replaceable>
   <title>テーブル空間</title>
 
   <indexterm zone="manage-ag-tablespaces">
-<!--
    <primary>tablespace</primary>
--->
+  </indexterm>
+  <indexterm zone="manage-ag-tablespaces">
    <primary>テーブル空間</primary>
   </indexterm>
 

--- a/doc/src/sgml/monitoring.sgml
+++ b/doc/src/sgml/monitoring.sgml
@@ -7,19 +7,19 @@
  <title>データベース活動状況の監視</title>
 
  <indexterm zone="monitoring">
-<!--
   <primary>monitoring</primary>
   <secondary>database activity</secondary>
--->
+ </indexterm>
+ <indexterm zone="monitoring">
   <primary>監視</primary>
   <secondary>データベース活動状況</secondary>
  </indexterm>
 
  <indexterm zone="monitoring">
-<!--
   <primary>database activity</primary>
   <secondary>monitoring</secondary>
--->
+ </indexterm>
+ <indexterm zone="monitoring">
   <primary>データベース活動状況</primary>
   <secondary>監視</secondary>
  </indexterm>
@@ -62,9 +62,10 @@
 
   <indexterm zone="monitoring-ps">
    <primary>ps</primary>
-<!--
    <secondary>to monitor activity</secondary>
--->
+  </indexterm>
+  <indexterm zone="monitoring-ps">
+   <primary>ps</primary>
    <secondary>活動状況監視のための</secondary>
   </indexterm>
 
@@ -201,9 +202,9 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
   <title>統計情報コレクタ</title>
 
   <indexterm zone="monitoring-stats">
-<!--
    <primary>statistics</primary>
--->
+  </indexterm>
+  <indexterm zone="monitoring-stats">
    <primary>統計情報</primary>
   </indexterm>
 
@@ -7120,10 +7121,10 @@ SELECT pg_stat_get_backend_pid(s.backendid) AS pid,
   <title>ロックの表示</title>
 
   <indexterm zone="monitoring-locks">
-<!--
    <primary>lock</primary>
    <secondary>monitoring</secondary>
--->
+  </indexterm>
+  <indexterm zone="monitoring-locks">
    <primary>ロック</primary>
    <secondary>監視</secondary>
   </indexterm>

--- a/doc/src/sgml/mvcc.sgml
+++ b/doc/src/sgml/mvcc.sgml
@@ -7,9 +7,9 @@
   <title>同時実行制御</title>
 
   <indexterm>
-<!--
    <primary>concurrency</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>同時実行制御</primary>
   </indexterm>
 
@@ -35,9 +35,9 @@
    <title>序文</title>
 
    <indexterm>
-<!--
     <primary>Multiversion Concurrency Control</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>多版型同時実行制御</primary>
    </indexterm>
 
@@ -46,9 +46,9 @@
    </indexterm>
 
    <indexterm>
-<!--
     <primary>Serializable Snapshot Isolation</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>シリアライザブルスナップショット分離</primary>
    </indexterm>
 
@@ -122,9 +122,9 @@
    <title>トランザクションの分離</title>
 
    <indexterm>
-<!--
     <primary>transaction isolation</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>トランザクションの分離</primary>
    </indexterm>
 
@@ -244,9 +244,9 @@
 
    <para>
     <indexterm>
-<!--
      <primary>transaction isolation level</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>トランザクション分離レベル</primary>
     </indexterm>
 <!--
@@ -494,18 +494,18 @@
    <title>リードコミッティド分離レベル</title>
 
    <indexterm>
-<!--
     <primary>transaction isolation level</primary>
     <secondary>read committed</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>トランザクション分離レベル</primary>
     <secondary>リードコミッティド</secondary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>read committed</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>リードコミッティド</primary>
    </indexterm>
 
@@ -704,18 +704,18 @@ COMMIT;
    <title>リピータブルリード分離レベル</title>
 
    <indexterm>
-<!--
     <primary>transaction isolation level</primary>
     <secondary>repeatable read</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>トランザクション分離レベル</primary>
     <secondary>リピータブルリード</secondary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>repeatable read</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>リピータブルリード</primary>
    </indexterm>
 
@@ -884,32 +884,32 @@ ERROR:  could not serialize access due to concurrent update
    <title>シリアライザブル分離レベル</title>
 
    <indexterm>
-<!--
     <primary>transaction isolation level</primary>
     <secondary>serializable</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>トランザクション分離レベル</primary>
     <secondary>シリアライザブル</secondary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>serializable</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>シリアライザブル</primary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>predicate locking</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>述語ロック</primary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>serialization anomaly</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>直列化異常</primary>
    </indexterm>
 
@@ -1250,9 +1250,9 @@ ERROR:  could not serialize access due to read/write dependencies among transact
    <title>明示的ロック</title>
 
    <indexterm>
-<!--
     <primary>lock</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>ロック</primary>
    </indexterm>
 
@@ -2001,9 +2001,9 @@ ERROR:  could not serialize access due to read/write dependencies among transact
     <title>デッドロック</title>
 
     <indexterm zone="locking-deadlocks">
-<!--
      <primary>deadlock</primary>
--->
+    </indexterm>
+    <indexterm zone="locking-deadlocks">
      <primary>デッドロック</primary>
     </indexterm>
 
@@ -2131,17 +2131,17 @@ UPDATE accounts SET balance = balance - 100.00 WHERE acctnum = 22222;
     <title>勧告的ロック</title>
 
     <indexterm zone="advisory-locks">
-<!--
      <primary>advisory lock</primary>
--->
+    </indexterm>
+    <indexterm zone="advisory-locks">
      <primary>勧告的ロック</primary>
     </indexterm>
 
     <indexterm zone="advisory-locks">
-<!--
      <primary>lock</primary>
      <secondary>advisory</secondary>
--->
+    </indexterm>
+    <indexterm zone="advisory-locks">
      <primary>ロック</primary>
      <secondary>勧告的</secondary>
     </indexterm>
@@ -2576,10 +2576,10 @@ DDLコマンドの中には、現在は<xref linkend="sql-truncate"/>とテー�
    <title>ロックとインデックス</title>
 
    <indexterm zone="locking-indexes">
-<!--
     <primary>index</primary>
     <secondary>locks</secondary>
--->
+   </indexterm>
+   <indexterm zone="locking-indexes">
     <primary>インデックス</primary>
     <secondary>ロック</secondary>
    </indexterm>

--- a/doc/src/sgml/parallel.sgml
+++ b/doc/src/sgml/parallel.sgml
@@ -7,9 +7,9 @@
   <title>パラレルクエリ</title>
 
   <indexterm zone="parallel-query">
-<!--
    <primary>parallel query</primary>
--->
+  </indexterm>
+  <indexterm zone="parallel-query">
    <primary>パラレルクエリ</primary>
   </indexterm>
 

--- a/doc/src/sgml/perform.sgml
+++ b/doc/src/sgml/perform.sgml
@@ -7,9 +7,9 @@
 <title>性能に関するヒント</title>
 
   <indexterm zone="performance-tips">
-<!--
    <primary>performance</primary>
--->
+  </indexterm>
+  <indexterm zone="performance-tips">
    <primary>性能</primary>
   </indexterm>
 
@@ -36,9 +36,9 @@
    </indexterm>
 
    <indexterm zone="using-explain">
-<!--
     <primary>query plan</primary>
--->
+   </indexterm>
+   <indexterm zone="using-explain">
     <primary>問い合わせ計画</primary>
    </indexterm>
 
@@ -1340,10 +1340,10 @@ EXPLAIN ANALYZE SELECT * FROM tenk1 WHERE unique1 &lt; 100 AND unique2 &gt; 9000
   <title>プランナで使用される統計情報</title>
 
   <indexterm zone="planner-stats">
-<!--
    <primary>statistics</primary>
    <secondary>of the planner</secondary>
--->
+  </indexterm>
+  <indexterm zone="planner-stats">
    <primary>統計情報</primary>
    <secondary>プランナの</secondary>
   </indexterm>
@@ -1544,19 +1544,19 @@ WHERE tablename = 'road';
    <title>拡張統計情報</title>
 
    <indexterm zone="planner-stats-extended">
-<!--
     <primary>statistics</primary>
     <secondary>of the planner</secondary>
--->
+   </indexterm>
+   <indexterm zone="planner-stats-extended">
     <primary>統計情報</primary>
     <secondary>プランナの</secondary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>correlation</primary>
     <secondary>in the query planner</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>相関関係</primary>
     <secondary>クエリプランナにおける</secondary>
    </indexterm>
@@ -1985,10 +1985,10 @@ SELECT m.* FROM pg_statistic_ext join pg_statistic_ext_data on (oid = stxoid),
   <title>明示的な<literal>JOIN</literal>句でプランナを制御する</title>
 
   <indexterm zone="explicit-joins">
-<!--
    <primary>join</primary>
    <secondary>controlling the order</secondary>
--->
+  </indexterm>
+  <indexterm zone="explicit-joins">
    <primary>結合</primary>
    <secondary>順番を制御する</secondary>
   </indexterm>
@@ -2282,10 +2282,10 @@ SELECT * FROM x, y, a, b, c WHERE something AND somethingelse;
 <title>自動コミットをオフにする</title>
 
    <indexterm>
-<!--
     <primary>autocommit</primary>
     <secondary>bulk-loading data</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>自動コミット</primary>
     <secondary>大量のデータロード</secondary>
    </indexterm>
@@ -2747,9 +2747,9 @@ WALアーカイブ処理またはストリーミングレプリケーション�
    <title>永続性がない設定</title>
 
    <indexterm zone="non-durability">
-<!--
     <primary>non-durable</primary>
--->
+   </indexterm>
+   <indexterm zone="non-durability">
     <primary>非永続性</primary>
    </indexterm>
 

--- a/doc/src/sgml/pgcrypto.sgml
+++ b/doc/src/sgml/pgcrypto.sgml
@@ -8,10 +8,10 @@
  </indexterm>
 
  <indexterm zone="pgcrypto">
-<!--
   <primary>encryption</primary>
   <secondary>for specific columns</secondary>
--->
+ </indexterm>
+ <indexterm zone="pgcrypto">
   <primary>暗号化</primary>
   <secondary>特定の列の</secondary>
  </indexterm>

--- a/doc/src/sgml/pgprewarm.sgml
+++ b/doc/src/sgml/pgprewarm.sgml
@@ -130,9 +130,9 @@ autoprewarm_dump_now() RETURNS int8
     <term>
      <varname>pg_prewarm.autoprewarm</varname> (<type>boolean</type>)
      <indexterm>
-<!--
       <primary><varname>pg_prewarm.autoprewarm</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>pg_prewarm.autoprewarm</varname>設定パラメータ</primary>
      </indexterm>
     </term>
@@ -155,9 +155,9 @@ autoprewarm_dump_now() RETURNS int8
    <term>
      <varname>pg_prewarm.autoprewarm_interval</varname> (<type>int</type>)
      <indexterm>
-<!--
       <primary><varname>pg_prewarm.autoprewarm_interval</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>pg_prewarm.autoprewarm_interval</varname>設定パラメータ</primary>
      </indexterm>
     </term>

--- a/doc/src/sgml/pgstatstatements.sgml
+++ b/doc/src/sgml/pgstatstatements.sgml
@@ -715,9 +715,10 @@ SQL文により生成されたWALバイトの総量
      <function>pg_stat_statements(showtext boolean) returns setof record</function>
      <indexterm>
       <primary>pg_stat_statements</primary>
-<!--
       <secondary>function</secondary>
--->
+     </indexterm>
+     <indexterm>
+      <primary>pg_stat_statements</primary>
       <secondary>関数</secondary>
      </indexterm>
     </term>

--- a/doc/src/sgml/pgtrgm.sgml
+++ b/doc/src/sgml/pgtrgm.sgml
@@ -481,9 +481,9 @@
     <term>
      <varname>pg_trgm.similarity_threshold</varname> (<type>real</type>)
      <indexterm>
-<!--
       <primary><varname>pg_trgm.similarity_threshold</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>pg_trgm.similarity_threshold</varname>設定パラメータ</primary>
      </indexterm>
     </term>
@@ -503,9 +503,11 @@
      <varname>pg_trgm.word_similarity_threshold</varname> (<type>real</type>)
      <indexterm>
       <primary>
-<!--
        <varname>pg_trgm.word_similarity_threshold</varname> configuration parameter
--->
+      </primary>
+     </indexterm>
+     <indexterm>
+      <primary>
        <varname>pg_trgm.word_similarity_threshold</varname>設定パラメータ
       </primary>
      </indexterm>
@@ -527,9 +529,11 @@
      <varname>pg_trgm.strict_word_similarity_threshold</varname> (<type>real</type>)
      <indexterm>
       <primary>
-<!--
        <varname>pg_trgm.strict_word_similarity_threshold</varname> configuration parameter
--->
+      </primary>
+     </indexterm>
+     <indexterm>
+       <primary>
        <varname>pg_trgm.strict_word_similarity_threshold</varname>設定パラメータ
       </primary>
      </indexterm>

--- a/doc/src/sgml/planstats.sgml
+++ b/doc/src/sgml/planstats.sgml
@@ -38,10 +38,10 @@
   <title>行数推定の例</title>
 
   <indexterm zone="row-estimation-examples">
-<!--
    <primary>row estimation</primary>
    <secondary>planner</secondary>
--->
+  </indexterm>
+  <indexterm zone="row-estimation-examples">
    <primary>行数推定</primary>
    <secondary>プランナ</secondary>
   </indexterm>
@@ -642,10 +642,10 @@ rows = (outer_cardinality * inner_cardinality) * selectivity
 <title>多変量統計の例</title>
 
   <indexterm>
-<!--
    <primary>row estimation</primary>
    <secondary>multivariate</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>行数推定</primary>
    <secondary>多変量</secondary>
   </indexterm>

--- a/doc/src/sgml/plhandler.sgml
+++ b/doc/src/sgml/plhandler.sgml
@@ -7,10 +7,10 @@
    <title>手続き言語ハンドラの作成</title>
 
    <indexterm zone="plhandler">
-<!--
     <primary>procedural language</primary>
     <secondary>handler for</secondary>
--->
+   </indexterm>
+   <indexterm zone="plhandler">
     <primary>手続き言語</primary>
     <secondary>の作成</secondary>
    </indexterm>

--- a/doc/src/sgml/plperl.sgml
+++ b/doc/src/sgml/plperl.sgml
@@ -635,9 +635,10 @@ Perl関数からデータベースそのものにアクセスするには以下�
       <literal><function>spi_exec_query</function>(<replaceable>query</replaceable> [, <replaceable>max-rows</replaceable>])</literal>
       <indexterm>
        <primary>spi_exec_query</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>spi_exec_query</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -745,9 +746,10 @@ SELECT * FROM test_munge();
       <literal><function>spi_query(<replaceable>command</replaceable>)</function></literal>
       <indexterm>
        <primary>spi_query</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>spi_query</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -755,9 +757,10 @@ SELECT * FROM test_munge();
       <literal><function>spi_fetchrow(<replaceable>cursor</replaceable>)</function></literal>
       <indexterm>
        <primary>spi_fetchrow</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>spi_fetchrow</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -765,9 +768,10 @@ SELECT * FROM test_munge();
       <literal><function>spi_cursor_close(<replaceable>cursor</replaceable>)</function></literal>
       <indexterm>
        <primary>spi_cursor_close</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>spi_cursor_close</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -841,9 +845,10 @@ SELECT * from lotsa_md5(500);
       <literal><function>spi_prepare(<replaceable>command</replaceable>, <replaceable>argument types</replaceable>)</function></literal>
       <indexterm>
        <primary>spi_prepare</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>spi_prepare</primary>
        <secondary>PL/Perlにおける</secondary>
      </indexterm>
      </term>
@@ -851,9 +856,10 @@ SELECT * from lotsa_md5(500);
       <literal><function>spi_query_prepared(<replaceable>plan</replaceable>, <replaceable>arguments</replaceable>)</function></literal>
       <indexterm>
        <primary>spi_query_prepared</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>spi_query_prepared</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -861,9 +867,10 @@ SELECT * from lotsa_md5(500);
       <literal><function>spi_exec_prepared(<replaceable>plan</replaceable> [, <replaceable>attributes</replaceable>], <replaceable>arguments</replaceable>)</function></literal>
       <indexterm>
        <primary>spi_exec_prepared</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>spi_exec_prepared</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -871,9 +878,10 @@ SELECT * from lotsa_md5(500);
       <literal><function>spi_freeplan(<replaceable>plan</replaceable>)</function></literal>
       <indexterm>
        <primary>spi_freeplan</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>spi_freeplan</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -1061,9 +1069,10 @@ CALL transaction_test1();
       <literal><function>elog(<replaceable>level</replaceable>, <replaceable>msg</replaceable>)</function></literal>
       <indexterm>
        <primary>elog</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>elog</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -1104,9 +1113,10 @@ CALL transaction_test1();
       <literal><function>quote_literal(<replaceable>string</replaceable>)</function></literal>
       <indexterm>
        <primary>quote_literal</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>quote_literal</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -1131,9 +1141,10 @@ CALL transaction_test1();
       <literal><function>quote_nullable(<replaceable>string</replaceable>)</function></literal>
       <indexterm>
        <primary>quote_nullable</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>quote_nullable</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -1156,9 +1167,10 @@ CALL transaction_test1();
       <literal><function>quote_ident(<replaceable>string</replaceable>)</function></literal>
       <indexterm>
        <primary>quote_ident</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>quote_ident</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -1182,9 +1194,10 @@ CALL transaction_test1();
       <literal><function>decode_bytea(<replaceable>string</replaceable>)</function></literal>
       <indexterm>
        <primary>decode_bytea</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>decode_bytea</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -1205,9 +1218,10 @@ CALL transaction_test1();
       <literal><function>encode_bytea(<replaceable>string</replaceable>)</function></literal>
       <indexterm>
        <primary>encode_bytea</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>encode_bytea</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -1226,9 +1240,10 @@ CALL transaction_test1();
       <literal><function>encode_array_literal(<replaceable>array</replaceable>)</function></literal>
       <indexterm>
        <primary>encode_array_literal</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>encode_array_literal</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -1256,9 +1271,10 @@ CALL transaction_test1();
       <literal><function>encode_typed_literal(<replaceable>value</replaceable>, <replaceable>typename</replaceable>)</function></literal>
       <indexterm>
        <primary>encode_typed_literal</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>encode_typed_literal</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -1280,9 +1296,10 @@ Perl変数を2番目の引数として渡されたデータ型の値に変換し
       <literal><function>encode_array_constructor(<replaceable>array</replaceable>)</function></literal>
       <indexterm>
        <primary>encode_array_constructor</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>encode_array_constructor</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -1307,9 +1324,10 @@ Perl変数を2番目の引数として渡されたデータ型の値に変換し
       <literal><function>looks_like_number(<replaceable>string</replaceable>)</function></literal>
       <indexterm>
        <primary>looks_like_number</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>looks_like_number</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -1334,9 +1352,10 @@ Perl変数を2番目の引数として渡されたデータ型の値に変換し
       <literal><function>is_array_ref(<replaceable>argument</replaceable>)</function></literal>
       <indexterm>
        <primary>is_array_ref</primary>
-<!--
        <secondary>in PL/Perl</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>is_array_ref</primary>
        <secondary>PL/Perlにおける</secondary>
       </indexterm>
      </term>
@@ -1469,10 +1488,10 @@ $$ LANGUAGE plperl;
   <title>信頼されたPL/Perlおよび信頼されないPL/Perl</title>
 
   <indexterm zone="plperl-trusted">
-<!--
    <primary>trusted</primary>
    <secondary>PL/Perl</secondary>
--->
+  </indexterm>
+  <indexterm zone="plperl-trusted">
    <primary>信頼</primary>
    <secondary>PL/Perl</secondary>
   </indexterm>
@@ -1973,9 +1992,9 @@ CREATE EVENT TRIGGER perl_a_snitch
       <term>
        <varname>plperl.on_init</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>plperl.on_init</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>plperl.on_init</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2060,18 +2079,18 @@ DO 'elog(WARNING, join ", ", sort keys %INC)' LANGUAGE plperl;
       <term>
        <varname>plperl.on_plperl_init</varname> (<type>string</type>)
        <indexterm>
-<!--
         <primary><varname>plperl.on_plperl_init</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>plperl.on_plperl_init</varname>設定パラメータ</primary>
        </indexterm>
       </term>
       <term>
        <varname>plperl.on_plperlu_init</varname> (<type>string</type>)
        <indexterm>
-<!--
         <primary><varname>plperl.on_plperlu_init</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>plperl.on_plperlu_init</varname>設定パラメータ</primary>
        </indexterm>
       </term>
@@ -2127,9 +2146,9 @@ Perl内ですでに行われた処理は取り消されません。
       <term>
        <varname>plperl.use_strict</varname> (<type>boolean</type>)
        <indexterm>
-<!--
         <primary><varname>plperl.use_strict</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>plperl.use_strict</varname>設定パラメータ</primary>
        </indexterm>
       </term>

--- a/doc/src/sgml/plpgsql.sgml
+++ b/doc/src/sgml/plpgsql.sgml
@@ -1108,10 +1108,10 @@ SELECT merge_fields(t.*) FROM table1 t WHERE ... ;
 <title><application>PL/pgSQL</application>変数の照合</title>
 
    <indexterm>
-<!--
     <primary>collation</primary>
     <secondary>in PL/pgSQL</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>照合</primary>
     <secondary>PL/pgSQLにおける</secondary>
    </indexterm>
@@ -1498,18 +1498,20 @@ PERFORM create_mv('cs_session_page_requests_mv', my_query);
 
     <indexterm zone="plpgsql-statements-sql-onerow">
      <primary>SELECT INTO</primary>
-<!--
      <secondary>in PL/pgSQL</secondary>
--->
-<secondary>PL/pgSQLにおける</secondary>
+    </indexterm>
+    <indexterm zone="plpgsql-statements-sql-onerow">
+     <primary>SELECT INTO</primary>
+     <secondary>PL/pgSQLにおける</secondary>
     </indexterm>
 
     <indexterm zone="plpgsql-statements-sql-onerow">
      <primary>RETURNING INTO</primary>
-<!--
      <secondary>in PL/pgSQL</secondary>
--->
-<secondary>PL/pgSQLにおける</secondary>
+    </indexterm>
+    <indexterm zone="plpgsql-statements-sql-onerow">
+     <primary>RETURNING INTO</primary>
+     <secondary>PL/pgSQLにおける</secondary>
     </indexterm>
 
     <para>
@@ -1937,34 +1939,38 @@ EXECUTE format('SELECT count(*) FROM %I '
 
     <indexterm>
      <primary>quote_ident</primary>
-<!--
      <secondary>use in PL/pgSQL</secondary>
--->
-<secondary>PL/pgSQLでの使用</secondary>
+    </indexterm>
+    <indexterm>
+     <primary>quote_ident</primary>
+     <secondary>PL/pgSQLでの使用</secondary>
     </indexterm>
 
     <indexterm>
      <primary>quote_literal</primary>
-<!--
      <secondary>use in PL/pgSQL</secondary>
--->
-<secondary>PL/pgSQLでの使用</secondary>
+    </indexterm>
+    <indexterm>
+     <primary>quote_literal</primary>
+     <secondary>PL/pgSQLでの使用</secondary>
     </indexterm>
 
     <indexterm>
      <primary>quote_nullable</primary>
-<!--
      <secondary>use in PL/pgSQL</secondary>
--->
-<secondary>PL/pgSQLでの使用</secondary>
+    </indexterm>
+    <indexterm>
+     <primary>quote_nullable</primary>
+     <secondary>PL/pgSQLでの使用</secondary>
     </indexterm>
 
     <indexterm>
      <primary>format</primary>
-<!--
      <secondary>use in PL/pgSQL</secondary>
--->
-<secondary>PL/pgSQLでの使用</secondary>
+    </indexterm>
+    <indexterm>
+     <primary>format</primary>
+     <secondary>PL/pgSQLでの使用</secondary>
     </indexterm>
 
     <para>
@@ -2573,17 +2579,19 @@ RETURN (1, 2, 'three'::text);  -- 正しい型の列にキャストしなけれ�
 <title><command>RETURN NEXT</command>および<command>RETURN QUERY</command></title>
     <indexterm>
      <primary>RETURN NEXT</primary>
-<!--
      <secondary>in PL/pgSQL</secondary>
--->
-<secondary>PL/pgSQLにおける</secondary>
+    </indexterm>
+    <indexterm>
+     <primary>RETURN NEXT</primary>
+     <secondary>PL/pgSQLにおける</secondary>
     </indexterm>
     <indexterm>
      <primary>RETURN QUERY</primary>
-<!--
      <secondary>in PL/pgSQL</secondary>
--->
-<secondary>PL/pgSQLにおける</secondary>
+    </indexterm>
+    <indexterm>
+     <primary>RETURN QUERY</primary>
+     <secondary>PL/pgSQLにおける</secondary>
     </indexterm>
 
 <synopsis>
@@ -3200,10 +3208,10 @@ END CASE;
 <title>単純なループ</title>
 
     <indexterm zone="plpgsql-control-structures-loops">
-<!--
      <primary>loop</primary>
      <secondary>in PL/pgSQL</secondary>
--->
+    </indexterm>
+    <indexterm zone="plpgsql-control-structures-loops">
      <primary>ループ</primary>
      <secondary>PL/pgSQLにおける</secondary>
     </indexterm>
@@ -3247,10 +3255,11 @@ END LOOP <optional> <replaceable>label</replaceable> </optional>;
 
      <indexterm>
       <primary>EXIT</primary>
-<!--
       <secondary>in PL/pgSQL</secondary>
--->
-<secondary>PL/pgSQLにおける</secondary>
+     </indexterm>
+     <indexterm>
+      <primary>EXIT</primary>
+      <secondary>PL/pgSQLにおける</secondary>
      </indexterm>
 
 <synopsis>
@@ -3363,9 +3372,10 @@ END;
 
      <indexterm>
       <primary>CONTINUE</primary>
-<!--
       <secondary>in PL/pgSQL</secondary>
--->
+     </indexterm>
+     <indexterm>
+      <primary>CONTINUE</primary>
       <secondary>PL/pgSQLにおける</secondary>
      </indexterm>
 
@@ -3437,10 +3447,11 @@ END LOOP;
 
      <indexterm>
       <primary>WHILE</primary>
-<!--
       <secondary>in PL/pgSQL</secondary>
--->
-<secondary>PL/pgSQLにおける</secondary>
+     </indexterm>
+     <indexterm>
+      <primary>WHILE</primary>
+      <secondary>PL/pgSQLにおける</secondary>
      </indexterm>
 
 <synopsis>
@@ -3825,10 +3836,10 @@ NOTICE:  row = {10,11,12}
 <title>エラーの捕捉</title>
 
     <indexterm>
-<!--
      <primary>exceptions</primary>
      <secondary>in PL/pgSQL</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>例外</primary>
      <secondary>PL/pgSQLにおける</secondary>
     </indexterm>
@@ -4325,12 +4336,12 @@ CONTEXT:  PL/pgSQL function outer_func() line 3 at RETURN
 <title>カーソル</title>
 
    <indexterm zone="plpgsql-cursors">
-<!--
     <primary>cursor</primary>
     <secondary>in PL/pgSQL</secondary>
--->
-<primary>カーソル</primary>
-<secondary>PL/pgSQLにおける</secondary>
+   </indexterm>
+   <indexterm zone="plpgsql-cursors">
+    <primary>カーソル</primary>
+    <secondary>PL/pgSQLにおける</secondary>
    </indexterm>
 
    <para>
@@ -5119,10 +5130,10 @@ CALL transaction_test1();
    </para>
 
    <indexterm zone="plpgsql-transaction-chain">
-<!--
     <primary>chained transactions</primary>
     <secondary>in PL/pgSQL</secondary>
--->
+   </indexterm>
+   <indexterm zone="plpgsql-transaction-chain">
     <primary>連鎖トランザクション</primary>
     <secondary>PL/pgSQLでの</secondary>
    </indexterm>
@@ -5229,19 +5240,20 @@ CALL transaction_test2();
 
    <indexterm>
     <primary>RAISE</primary>
-<!--
     <secondary>in PL/pgSQL</secondary>
--->
+   </indexterm>
+   <indexterm>
+    <primary>RAISE</primary>
     <secondary>PL/pgSQLにおける</secondary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>reporting errors</primary>
     <secondary>in PL/pgSQL</secondary>
--->
-<primary>エラー報告</primary>
-<secondary>PL/pgSQLにおける</secondary>
+   </indexterm>
+   <indexterm>
+    <primary>エラー報告</primary>
+    <secondary>PL/pgSQLにおける</secondary>
    </indexterm>
 
    <para>
@@ -5518,25 +5530,26 @@ SQLSTATEコードでエラーコードを指定する場合、事前に定義さ
 
    <indexterm>
     <primary>ASSERT</primary>
-<!--
     <secondary>in PL/pgSQL</secondary>
--->
+   </indexterm>
+   <indexterm>
+    <primary>ASSERT</primary>
     <secondary>PL/pgSQLにおける</secondary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>assertions</primary>
     <secondary>in PL/pgSQL</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>アサート</primary>
     <secondary>PL/pgSQLにおける</secondary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary><varname>plpgsql.check_asserts</varname> configuration parameter</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary><varname>plpgsql.check_asserts</varname> 設定パラメータ</primary>
    </indexterm>
 
@@ -5611,12 +5624,12 @@ ASSERT <replaceable class="parameter">condition</replaceable> <optional> , <repl
 <title>トリガ関数</title>
 
   <indexterm zone="plpgsql-trigger">
-<!--
    <primary>trigger</primary>
    <secondary>in PL/pgSQL</secondary>
--->
-<primary>トリガ</primary>
-<secondary>PL/pgSQLにおける</secondary>
+  </indexterm>
+  <indexterm zone="plpgsql-trigger">
+   <primary>トリガ</primary>
+   <secondary>PL/pgSQLにおける</secondary>
   </indexterm>
 
   <para>
@@ -6718,10 +6731,10 @@ BEGIN
    </para>
 
    <indexterm>
-<!--
      <primary><varname>plpgsql.variable_conflict</varname> configuration parameter</primary>
--->
-<primary><varname>plpgsql.variable_conflict</varname>設定パラメータ</primary>
+   </indexterm>
+   <indexterm>
+     <primary><varname>plpgsql.variable_conflict</varname>設定パラメータ</primary>
    </indexterm>
 
    <para>
@@ -6851,12 +6864,12 @@ $$ LANGUAGE plpgsql;
 
    <para>
     <indexterm>
-<!--
      <primary>preparing a query</primary>
      <secondary>in PL/pgSQL</secondary>
--->
-<primary>問い合わせの準備</primary>
-<secondary>PL/pgSQLにおける</secondary>
+    </indexterm>
+    <indexterm>
+     <primary>問い合わせの準備</primary>
+     <secondary>PL/pgSQLにおける</secondary>
     </indexterm>
 <!--
     As each expression and <acronym>SQL</acronym> command is first
@@ -7524,18 +7537,20 @@ HINT:  Make sure the query returns the exact list of columns.
 
   <indexterm zone="plpgsql-porting">
    <primary>Oracle</primary>
-<!--
    <secondary>porting from PL/SQL to PL/pgSQL</secondary>
--->
-<secondary>PL/SQLからPL/pgSQLへの移植</secondary>
+  </indexterm>
+  <indexterm zone="plpgsql-porting">
+   <primary>Oracle</primary>
+   <secondary>PL/SQLからPL/pgSQLへの移植</secondary>
   </indexterm>
 
   <indexterm zone="plpgsql-porting">
    <primary>PL/SQL (Oracle)</primary>
-<!--
    <secondary>porting to PL/pgSQL</secondary>
--->
-<secondary>PL/pgSQLへの移植</secondary>
+  </indexterm>
+  <indexterm zone="plpgsql-porting">
+    <primary>PL/SQL (Oracle)</primary>
+    <secondary>PL/pgSQLへの移植</secondary>
   </indexterm>
 
   <para>
@@ -8337,9 +8352,9 @@ $$ LANGUAGE plpgsql STRICT IMMUTABLE;
    </para>
 
    <indexterm>
-<!--
     <primary><function>instr</function> function</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary><function>instr</function>関数</primary>
    </indexterm>
 

--- a/doc/src/sgml/plpython.sgml
+++ b/doc/src/sgml/plpython.sgml
@@ -1155,10 +1155,10 @@ $$ LANGUAGE plpythonu;
   <title>トリガ関数</title>
 
   <indexterm zone="plpython-trigger">
-<!--
    <primary>trigger</primary>
    <secondary>in PL/Python</secondary>
--->
+  </indexterm>
+  <indexterm zone="plpython-trigger">
    <primary>トリガ</primary>
    <secondary>PL/Pythonにおける</secondary>
   </indexterm>
@@ -2020,9 +2020,7 @@ CALL transaction_test1();
     <member><literal>plpy.error(<replaceable>msg, **kwargs</replaceable>)</literal></member>
     <member><literal>plpy.fatal(<replaceable>msg, **kwargs</replaceable>)</literal></member>
    </simplelist>
-<!--
    <indexterm><primary>elog</primary><secondary>in PL/Python</secondary></indexterm>
--->
    <indexterm><primary>elog</primary><secondary>PL/Pythonにおける</secondary></indexterm>
 <!--
    <function>plpy.error</function> and <function>plpy.fatal</function>

--- a/doc/src/sgml/pltcl.sgml
+++ b/doc/src/sgml/pltcl.sgml
@@ -366,10 +366,10 @@ PL/Tcl関数コードに与えられる引数の値は、単に、テキスト�
 <title>PL/Tclにおけるグローバルデータ</title>
 
     <indexterm zone="pltcl-global">
-<!--
      <primary>global data</primary>
      <secondary>in PL/Tcl</secondary>
--->
+    </indexterm>
+    <indexterm zone="pltcl-global">
      <primary>グローバルデータ</primary>
      <secondary>PL/Tclにおける</secondary>
     </indexterm>
@@ -793,9 +793,10 @@ SELECT 'doesn''t' AS ret
        <function>elog</function> <replaceable>level</replaceable> <replaceable>msg</replaceable>
        <indexterm>
         <primary>elog</primary>
-<!--
         <secondary>in PL/Tcl</secondary>
--->
+       </indexterm>
+       <indexterm>
+        <primary>elog</primary>
         <secondary>PL/Tclにおける</secondary>
        </indexterm>
       </term>
@@ -849,10 +850,10 @@ SELECT 'doesn''t' AS ret
 <title>PL/Tclのトリガ関数</title>
 
     <indexterm>
-<!--
      <primary>trigger</primary>
      <secondary>in PL/Tcl</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>トリガ</primary>
      <secondary>PL/Tclにおける</secondary>
     </indexterm>
@@ -1140,10 +1141,10 @@ CREATE TRIGGER trig_mytab_modcount BEFORE INSERT OR UPDATE ON mytab
     <title>PL/Tclにおけるイベントトリガ関数</title>
 
     <indexterm>
-<!--
      <primary>event trigger</primary>
      <secondary>in PL/Tcl</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>イベントトリガ</primary>
      <secondary>PL/Tclにおける</secondary>
     </indexterm>
@@ -1328,10 +1329,10 @@ if {[catch { spi_exec $sql_command }]} {
     <title>PL/Tclにおける明示的サブトランザクション</title>
 
     <indexterm>
-<!--
      <primary>subtransactions</primary>
      <secondary>in PL/Tcl</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>サブトランザクション</primary>
      <secondary>PL/Tclにおける</secondary>
     </indexterm>
@@ -1514,9 +1515,9 @@ CALL transaction_test1();
       <term>
        <varname>pltcl.start_proc</varname> (<type>string</type>)
        <indexterm>
-<!--
         <primary><varname>pltcl.start_proc</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>pltcl.start_proc</varname>設定パラメータ</primary>
        </indexterm>
       </term>
@@ -1582,9 +1583,9 @@ Tcl内でそれまでに行われた操作は取り消されません。
       <term>
        <varname>pltclu.start_proc</varname> (<type>string</type>)
        <indexterm>
-<!--
         <primary><varname>pltclu.start_proc</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>pltclu.start_proc</varname>設定パラメータ</primary>
        </indexterm>
       </term>

--- a/doc/src/sgml/protocol.sgml
+++ b/doc/src/sgml/protocol.sgml
@@ -7,12 +7,12 @@
 <title>フロントエンド/バックエンドプロトコル</title>
 
  <indexterm zone="protocol">
-<!--
   <primary>protocol</primary>
   <secondary>frontend-backend</secondary>
--->
-<primary>プロトコル</primary>
-<secondary>フロントエンド/バックエンド</secondary>
+ </indexterm>
+ <indexterm zone="protocol">
+  <primary>プロトコル</primary>
+  <secondary>フロントエンド/バックエンド</secondary>
  </indexterm>
 
  <para>

--- a/doc/src/sgml/queries.sgml
+++ b/doc/src/sgml/queries.sgml
@@ -7,9 +7,9 @@
  <title>問い合わせ</title>
 
  <indexterm zone="queries">
-<!--
   <primary>query</primary>
--->
+ </indexterm>
+ <indexterm zone="queries">
   <primary>問い合わせ</primary>
  </indexterm>
 
@@ -133,9 +133,9 @@ SELECT random();
   <title>テーブル式</title>
 
   <indexterm zone="queries-table-expressions">
-<!--
    <primary>table expression</primary>
--->
+  </indexterm>
+  <indexterm zone="queries-table-expressions">
    <primary>テーブル式</primary>
   </indexterm>
 
@@ -240,9 +240,9 @@ FROM <replaceable>table_reference</replaceable> <optional>, <replaceable>table_r
     <title>結合テーブル</title>
 
     <indexterm zone="queries-join">
-<!--
      <primary>join</primary>
--->
+    </indexterm>
+    <indexterm zone="queries-join">
      <primary>結合</primary>
     </indexterm>
 
@@ -285,18 +285,18 @@ FROM <replaceable>table_reference</replaceable> <optional>, <replaceable>table_r
 -->
       <term>クロス結合
       <indexterm>
-<!--
        <primary>join</primary>
        <secondary>cross</secondary>
--->
+      </indexterm>
+      <indexterm>
        <primary>結合</primary>
        <secondary>クロス</secondary>
       </indexterm>
 
       <indexterm>
-<!--
        <primary>cross join</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary>クロス結合</primary>
       </indexterm>
       </term>
@@ -374,18 +374,18 @@ ON <replaceable>condition</replaceable></literal>
 -->
       <term>限定的な結合
       <indexterm>
-<!--
        <primary>join</primary>
        <secondary>outer</secondary>
--->
+      </indexterm>
+      <indexterm>
        <primary>結合</primary>
        <secondary>外部</secondary>
       </indexterm>
 
       <indexterm>
-<!--
        <primary>outer join</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary>外部結合</primary>
       </indexterm>
       </term>
@@ -452,18 +452,18 @@ T1の各行R1に対して、T2において行R1との結合条件を満たして
 -->
          <term><literal>LEFT OUTER JOIN</literal>（左外部結合）
          <indexterm>
-<!--
           <primary>join</primary>
           <secondary>left</secondary>
--->
+         </indexterm>
+         <indexterm>
           <primary>結合</primary>
           <secondary>左</secondary>
          </indexterm>
 
          <indexterm>
-<!--
           <primary>left join</primary>
--->
+         </indexterm>
+         <indexterm>
           <primary>左結合</primary>
          </indexterm>
          </term>
@@ -490,18 +490,18 @@ T1の各行R1に対して、T2において行R1との結合条件を満たして
 -->
          <term><literal>RIGHT OUTER JOIN</literal>（右外部結合）
          <indexterm>
-<!--
           <primary>join</primary>
           <secondary>right</secondary>
--->
+         </indexterm>
+         <indexterm>
           <primary>結合</primary>
           <secondary>右</secondary>
          </indexterm>
 
          <indexterm>
-<!--
           <primary>right join</primary>
--->
+         </indexterm>
+         <indexterm>
           <primary>右結合</primary>
          </indexterm>
          </term>
@@ -596,17 +596,17 @@ T1の各行R1に対して、T2において行R1との結合条件を満たして
 
        <para>
         <indexterm>
-<!--
          <primary>join</primary>
          <secondary>natural</secondary>
--->
+        </indexterm>
+       <indexterm>
          <primary>結合</primary>
          <secondary>自然</secondary>
         </indexterm>
         <indexterm>
-<!--
          <primary>natural join</primary>
--->
+        </indexterm>
+        <indexterm>
          <primary>自然結合</primary>
         </indexterm>
 <!--
@@ -791,19 +791,19 @@ T1の各行R1に対して、T2において行R1との結合条件を満たして
     <title>テーブルと列の別名</title>
 
     <indexterm zone="queries-table-aliases">
-<!--
      <primary>alias</primary>
      <secondary>in the FROM clause</secondary>
--->
+    </indexterm>
+    <indexterm zone="queries-table-aliases">
      <primary>別名</primary>
      <secondary>FROM句内の</secondary>
     </indexterm>
 
     <indexterm>
-<!--
      <primary>label</primary>
      <see>alias</see>
--->
+    </indexterm>
+    <indexterm>
      <primary>ラベル</primary>
      <see>別名</see>
     </indexterm>
@@ -957,9 +957,9 @@ SELECT a.* FROM (my_table AS a JOIN your_table AS b ON ...) AS c
     <title>副問い合わせ</title>
 
     <indexterm zone="queries-subqueries">
-<!--
      <primary>subquery</primary>
--->
+    </indexterm>
+    <indexterm zone="queries-subqueries">
      <primary>副問い合わせ</primary>
     </indexterm>
 
@@ -1015,16 +1015,14 @@ FROM (VALUES ('anne', 'smith'), ('bob', 'jones'), ('joe', 'blow'))
 -->
     <title>テーブル関数</title>
 
-<!--
     <indexterm zone="queries-tablefunctions"><primary>table function</primary></indexterm>
--->
     <indexterm zone="queries-tablefunctions"><primary>テーブル関数</primary></indexterm>
 
     <indexterm zone="queries-tablefunctions">
-<!--
      <primary>function</primary>
      <secondary>in the FROM clause</secondary>
--->
+    </indexterm>
+    <indexterm zone="queries-tablefunctions">
      <primary>関数</primary>
      <secondary>FROM句内の</secondary>
     </indexterm>
@@ -1254,9 +1252,10 @@ ORDER BY p;
 
     <indexterm zone="queries-lateral">
      <primary>LATERAL</primary>
-<!--
      <secondary>in the FROM clause</secondary>
--->
+    </indexterm>
+    <indexterm zone="queries-lateral">
+     <primary>LATERAL</primary>
      <secondary>FROM句内の</secondary>
     </indexterm>
 
@@ -1534,9 +1533,9 @@ SELECT ... FROM fdt WHERE EXISTS (SELECT c1 FROM t2 WHERE c2 &gt; fdt.c1)
    </indexterm>
 
    <indexterm zone="queries-group">
-<!--
     <primary>grouping</primary>
--->
+   </indexterm>
+   <indexterm zone="queries-group">
     <primary>グループ化</primary>
    </indexterm>
 
@@ -1677,9 +1676,7 @@ SELECT product_id, p.name, (sum(s.units) * p.price) AS sales
 この問い合わせは、各製品に対して製品の全販売に関する合計行が返されます。
    </para>
 
-<!--
    <indexterm><primary>functional dependency</primary></indexterm>
--->
    <indexterm><primary>関数依存</primary></indexterm>
 
    <para>
@@ -2042,10 +2039,10 @@ GROUP BY GROUPING SETS (
    <title>ウィンドウ関数処理</title>
 
    <indexterm zone="queries-window">
-<!--
     <primary>window function</primary>
     <secondary>order of execution</secondary>
--->
+   </indexterm>
+   <indexterm zone="queries-window">
     <primary>ウィンドウ関数</primary>
     <secondary>実行順</secondary>
    </indexterm>
@@ -2110,9 +2107,10 @@ GROUP BY GROUPING SETS (
 
   <indexterm>
    <primary>SELECT</primary>
-<!--
    <secondary>select list</secondary>
--->
+  </indexterm>
+  <indexterm>
+   <primary>SELECT</primary>
    <secondary>選択リスト</secondary>
   </indexterm>
 
@@ -2216,10 +2214,10 @@ SELECT tbl1.*, tbl2.a FROM ...
    <title>列ラベル</title>
 
    <indexterm zone="queries-column-labels">
-<!--
     <primary>alias</primary>
     <secondary>in the select list</secondary>
--->
+   </indexterm>
+   <indexterm zone="queries-column-labels">
     <primary>別名</primary>
     <secondary>選択リスト内の</secondary>
    </indexterm>
@@ -2304,9 +2302,9 @@ SELECT a "value", b + c AS sum FROM ...
    </indexterm>
 
    <indexterm zone="queries-distinct">
-<!--
     <primary>duplicates</primary>
--->
+   </indexterm>
+   <indexterm zone="queries-distinct">
     <primary>重複</primary>
    </indexterm>
 
@@ -2330,10 +2328,10 @@ SELECT DISTINCT <replaceable>select_list</replaceable> ...
    </para>
 
    <indexterm>
-<!--
     <primary>null value</primary>
     <secondary sortas="DISTINCT">in DISTINCT</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>NULL値</primary>
     <secondary sortas="DISTINCT">DISTINCT内の</secondary>
    </indexterm>
@@ -2407,27 +2405,27 @@ SELECT DISTINCT ON (<replaceable>expression</replaceable> <optional>, <replaceab
    <primary>EXCEPT</primary>
   </indexterm>
   <indexterm zone="queries-union">
-<!--
    <primary>set union</primary>
--->
-   <primary>集合和</primary>
   </indexterm>
   <indexterm zone="queries-union">
-<!--
+    <primary>集合和</primary>
+  </indexterm>
+  <indexterm zone="queries-union">
    <primary>set intersection</primary>
--->
+  </indexterm>
+  <indexterm zone="queries-union">
    <primary>集合積</primary>
   </indexterm>
   <indexterm zone="queries-union">
-<!--
    <primary>set difference</primary>
--->
+  </indexterm>
+  <indexterm zone="queries-union">
    <primary>集合差</primary>
   </indexterm>
   <indexterm zone="queries-union">
-<!--
    <primary>set operation</primary>
--->
+  </indexterm>
+  <indexterm zone="queries-union">
    <primary>集合操作</primary>
   </indexterm>
 
@@ -2522,9 +2520,9 @@ SELECT DISTINCT ON (<replaceable>expression</replaceable> <optional>, <replaceab
   <title>行の並べ替え</title>
 
   <indexterm zone="queries-order">
-<!--
    <primary>sorting</primary>
--->
+  </indexterm>
+  <indexterm zone="queries-order">
    <primary>並べ替え</primary>
   </indexterm>
 
@@ -2909,16 +2907,17 @@ SELECT <replaceable>select_list</replaceable> FROM <replaceable>table_expression
 
   <indexterm zone="queries-with">
    <primary>WITH</primary>
-<!--
    <secondary>in SELECT</secondary>
--->
+  </indexterm>
+  <indexterm zone="queries-with">
+   <primary>WITH</primary>
    <secondary>SELECTにおける</secondary>
   </indexterm>
 
   <indexterm>
-<!--
    <primary>common table expression</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>共通テーブル式</primary>
    <see>WITH</see>
   </indexterm>
@@ -2994,9 +2993,10 @@ GROUP BY region, product;
   <para>
    <indexterm>
     <primary>RECURSIVE</primary>
-<!--
     <secondary>in common table expressions</secondary>
--->
+   </indexterm>
+   <indexterm>
+    <primary>RECURSIVE</primary>
     <secondary>共通テーブル式内の</secondary>
    </indexterm>
 <!--

--- a/doc/src/sgml/query.sgml
+++ b/doc/src/sgml/query.sgml
@@ -94,13 +94,11 @@
    <title>概念</title>
 
    <para>
-<!--
     <indexterm><primary>relational database</primary></indexterm>
     <indexterm><primary>hierarchical database</primary></indexterm>
     <indexterm><primary>object-oriented database</primary></indexterm>
     <indexterm><primary>relation</primary></indexterm>
     <indexterm><primary>table</primary></indexterm>
--->
     <indexterm><primary>リレーショナルデータベース</primary></indexterm>
     <indexterm><primary>階層型データベース</primary></indexterm>
     <indexterm><primary>オブジェクト指向データベース</primary></indexterm>
@@ -128,10 +126,8 @@ Unix互換のオペレーティングシステムのファイルとディレク�
    </para>
 
    <para>
-<!--
     <indexterm><primary>row</primary></indexterm>
     <indexterm><primary>column</primary></indexterm>
--->
     <indexterm><primary>行</primary></indexterm>
     <indexterm><primary>列</primary></indexterm>
 
@@ -152,10 +148,8 @@ Unix互換のオペレーティングシステムのファイルとディレク�
    </para>
 
    <para>
-<!--
     <indexterm><primary>database cluster</primary></indexterm>
     <indexterm><primary>cluster</primary><secondary>of databases</secondary><see>database cluster</see></indexterm>
--->
     <indexterm><primary>データベースクラスタ</primary></indexterm>
     <indexterm><primary>クラスタ</primary><secondary>データベースの</secondary><see>データベースクラスタ</see></indexterm>
 
@@ -432,9 +426,7 @@ COPY weather FROM '/home/user/weather.txt';
    <title>テーブルへの問い合わせ</title>
 
    <para>
-<!--
     <indexterm><primary>query</primary></indexterm>
--->
     <indexterm><primary>問い合わせ</primary></indexterm>
     <indexterm><primary>SELECT</primary></indexterm>
 
@@ -594,9 +586,7 @@ SELECT * FROM weather
 
    <para>
     <indexterm><primary>DISTINCT</primary></indexterm>
-<!--
     <indexterm><primary>duplicate</primary></indexterm>
--->
     <indexterm><primary>重複</primary></indexterm>
 
 <!--
@@ -657,9 +647,9 @@ SELECT DISTINCT city
    <title>テーブル間を結合</title>
 
    <indexterm zone="tutorial-join">
-<!--
     <primary>join</primary>
--->
+   </indexterm>
+   <indexterm zone="tutorial-join">
     <primary>結合</primary>
    </indexterm>
 
@@ -822,9 +812,7 @@ SELECT *
    </para>
 
    <para>
-<!--
     <indexterm><primary>join</primary><secondary>outer</secondary></indexterm>
--->
     <indexterm><primary>結合</primary><secondary>外部</secondary></indexterm>
 
 <!--
@@ -888,10 +876,8 @@ SELECT *
    </formalpara>
 
    <para>
-<!--
     <indexterm><primary>join</primary><secondary>self</secondary></indexterm>
     <indexterm><primary>alias</primary><secondary>for table name in query</secondary></indexterm>
--->
     <indexterm><primary>結合</primary><secondary>自己</secondary></indexterm>
     <indexterm><primary>別名</primary><secondary>問い合わせ内のテーブル名用の</secondary></indexterm>
 
@@ -956,9 +942,9 @@ SELECT *
    <title>集約関数</title>
 
    <indexterm zone="tutorial-agg">
-<!--
     <primary>aggregate function</primary>
--->
+   </indexterm>
+   <indexterm zone="tutorial-agg">
     <primary>集約関数</primary>
    </indexterm>
 
@@ -998,9 +984,7 @@ SELECT max(temp_lo) FROM weather;
    </para>
 
    <para>
-<!--
     <indexterm><primary>subquery</primary></indexterm>
--->
     <indexterm><primary>副問い合わせ</primary></indexterm>
 
 <!--

--- a/doc/src/sgml/rangetypes.sgml
+++ b/doc/src/sgml/rangetypes.sgml
@@ -7,9 +7,9 @@
  <title>範囲型</title>
 
  <indexterm>
-<!--
   <primary>range type</primary>
--->
+ </indexterm>
+ <indexterm>
   <primary>範囲型</primary>
  </indexterm>
 
@@ -643,10 +643,10 @@ SELECT '[11:10, 23:00]'::timerange;
   <title>インデックス</title>
 
   <indexterm>
-<!--
     <primary>range type</primary>
     <secondary>indexes on</secondary>
--->
+  </indexterm>
+  <indexterm>
     <primary>範囲型</primary>
     <secondary>のインデックス</secondary>
   </indexterm>
@@ -704,10 +704,10 @@ GiSTあるいはSP-GiSTインデックスがあると、以下の範囲演算子
   <title>範囲の制約</title>
 
   <indexterm>
-<!--
     <primary>range type</primary>
     <secondary>exclude</secondary>
--->
+  </indexterm>
+  <indexterm>
     <primary>範囲型</primary>
     <secondary>排他</secondary>
   </indexterm>

--- a/doc/src/sgml/ref/alter_table.sgml
+++ b/doc/src/sgml/ref/alter_table.sgml
@@ -480,9 +480,10 @@ WITH ( MODULUS <replaceable class="parameter">numeric_literal</replaceable>, REM
      <literal>SET STORAGE</literal>
      <indexterm>
       <primary>TOAST</primary>
-<!--
       <secondary>per-column storage settings</secondary>
--->
+     </indexterm>
+     <indexterm>
+      <primary>TOAST</primary>
       <secondary>列ごとの保管設定</secondary>
      </indexterm>
     </term>

--- a/doc/src/sgml/ref/close.sgml
+++ b/doc/src/sgml/ref/close.sgml
@@ -9,9 +9,9 @@ PostgreSQL documentation
  </indexterm>
 
  <indexterm zone="sql-close">
-<!--
   <primary>cursor</primary>
--->
+ </indexterm>
+ <indexterm zone="sql-close">
   <primary>カーソル</primary>
   <secondary>CLOSE</secondary>
  </indexterm>

--- a/doc/src/sgml/ref/commit.sgml
+++ b/doc/src/sgml/ref/commit.sgml
@@ -55,9 +55,9 @@ COMMIT [ WORK | TRANSACTION ] [ AND [ NO ] CHAIN ]
   <title>パラメータ</title>
 
   <indexterm zone="sql-commit-chain">
-<!--
    <primary>chained transactions</primary>
--->
+  </indexterm>
+  <indexterm zone="sql-commit-chain">
    <primary>連鎖トランザクション</primary>
   </indexterm>
 

--- a/doc/src/sgml/ref/create_cast.sgml
+++ b/doc/src/sgml/ref/create_cast.sgml
@@ -461,10 +461,10 @@ SELECT CAST ( 2 AS numeric ) + 4.0;
   </para>
 
  <indexterm zone="sql-createcast">
-<!--
   <primary>cast</primary>
   <secondary>I/O conversion</secondary>
--->
+ </indexterm>
+ <indexterm zone="sql-createcast">
   <primary>キャスト</primary>
   <secondary>入出力変換</secondary>
  </indexterm>

--- a/doc/src/sgml/ref/create_function.sgml
+++ b/doc/src/sgml/ref/create_function.sgml
@@ -1034,10 +1034,10 @@ SELECT * FROM dup(42);
   <title><literal>SECURITY DEFINER</literal>関数の安全な作成</title>
 
   <indexterm>
-<!--
    <primary><varname>search_path</varname> configuration parameter</primary>
    <secondary>use in securing functions</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary><varname>search_path</varname>設定パラメータ</primary>
    <secondary>関数の安全化における使用</secondary>
   </indexterm>

--- a/doc/src/sgml/ref/create_index.sgml
+++ b/doc/src/sgml/ref/create_index.sgml
@@ -547,9 +547,9 @@ B-tree、ハッシュ、GiSTおよびSP-GiSTといったインデックスはす
    <varlistentry id="index-reloption-fillfactor" xreflabel="fillfactor">
     <term><literal>fillfactor</literal> (<type>integer</type>)
      <indexterm>
-<!--
       <primary><varname>fillfactor</varname> storage parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>fillfactor</varname>格納パラメータ</primary>
      </indexterm>
     </term>
@@ -594,9 +594,9 @@ B-treeインデックスは以下パラメータも受け付けます。
    <varlistentry id="index-reloption-deduplicate-items" xreflabel="deduplicate_items">
     <term><literal>deduplicate_items</literal> (<type>boolean</type>)
      <indexterm>
-<!--
       <primary><varname>deduplicate_items</varname> storage parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>deduplicate_items</varname>格納パラメータ</primary>
      </indexterm>
     </term>
@@ -635,9 +635,10 @@ B-treeインデックスは以下パラメータも受け付けます。
     <term><literal>vacuum_cleanup_index_scale_factor</literal> (<type>floating point</type>)
      <indexterm>
       <primary><varname>vacuum_cleanup_index_scale_factor</varname></primary>
-<!--
       <secondary>storage parameter</secondary>
--->
+     </indexterm>
+     <indexterm>
+      <primary><varname>vacuum_cleanup_index_scale_factor</varname></primary>
       <secondary>格納パラメータ</secondary>
      </indexterm>
     </term>
@@ -663,9 +664,9 @@ GiSTインデックスではさらに以下のパラメータを受け付けま�
    <varlistentry id="index-reloption-buffering" xreflabel="buffering">
     <term><literal>buffering</literal> (<type>enum</type>)
      <indexterm>
-<!--
       <primary><varname>buffering</varname> storage parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>buffering</varname>格納パラメータ</primary>
      </indexterm>
     </term>
@@ -699,9 +700,9 @@ GINインデックスでは以下の異なるパラメータを受け付けま�
    <varlistentry id="index-reloption-fastupdate" xreflabel="fastupdate">
     <term><literal>fastupdate</literal> (<type>boolean</type>)
      <indexterm>
-<!--
       <primary><varname>fastupdate</varname> storage parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>fastupdate</varname>格納パラメータ</primary>
      </indexterm>
     </term>
@@ -741,9 +742,10 @@ GINインデックスでは以下の異なるパラメータを受け付けま�
     <term><literal>gin_pending_list_limit</literal> (<type>integer</type>)
      <indexterm>
       <primary><varname>gin_pending_list_limit</varname></primary>
-<!--
       <secondary>storage parameter</secondary>
--->
+     </indexterm>
+     <indexterm>
+      <primary><varname>gin_pending_list_limit</varname></primary>
       <secondary>格納パラメータ</secondary>
      </indexterm>
     </term>
@@ -771,9 +773,9 @@ GINインデックスでは以下の異なるパラメータを受け付けま�
    <varlistentry id="index-reloption-pages-per-range" xreflabel="pages_per_range">
     <term><literal>pages_per_range</literal> (<type>integer</type>)
      <indexterm>
-<!--
       <primary><varname>pages_per_range</varname> storage parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>pages_per_range</varname>格納パラメータ</primary>
      </indexterm>
     </term>
@@ -793,9 +795,9 @@ GINインデックスでは以下の異なるパラメータを受け付けま�
    <varlistentry id="index-reloption-autosummarize" xreflabel="autosummarize">
     <term><literal>autosummarize</literal> (<type>boolean</type>)
      <indexterm>
-<!--
       <primary><varname>autosummarize</varname> storage parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>autosummarize</varname>格納パラメータ</primary>
      </indexterm>
     </term>
@@ -819,10 +821,10 @@ GINインデックスでは以下の異なるパラメータを受け付けま�
    <title>インデックスの同時作成</title>
 
    <indexterm zone="sql-createindex-concurrently">
-<!--
    <primary>index</primary>
    <secondary>building concurrently</secondary>
--->
+   </indexterm>
+   <indexterm zone="sql-createindex-concurrently">
    <primary>インデックス</primary>
    <secondary>同時作成</secondary>
    </indexterm>

--- a/doc/src/sgml/ref/create_table.sgml
+++ b/doc/src/sgml/ref/create_table.sgml
@@ -1895,9 +1895,9 @@ predicateの前後に括弧が必要であることに注意して下さい。
    <title>格納パラメータ</title>
 
  <indexterm zone="sql-createtable-storage-parameters">
-<!--
   <primary>storage parameters</primary>
--->
+ </indexterm>
+ <indexterm zone="sql-createtable-storage-parameters">
   <primary>格納パラメータ</primary>
  </indexterm>
 
@@ -1935,9 +1935,9 @@ predicateの前後に括弧が必要であることに注意して下さい。
     <varlistentry id="reloption-fillfactor" xreflabel="fillfactor">
     <term><varname>fillfactor</varname> (<type>integer</type>)
     <indexterm>
-<!--
      <primary><varname>fillfactor</varname> storage parameter</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary><varname>fillfactor</varname>格納パラメータ</primary>
     </indexterm>
     </term>
@@ -1970,9 +1970,9 @@ TOASTテーブルではこのパラメータを設定できません。
    <varlistentry id="reloption-toast-tuple-target" xreflabel="toast_tuple_target">
     <term><literal>toast_tuple_target</literal> (<type>integer</type>)
     <indexterm>
-<!--
      <primary><varname>toast_tuple_target</varname> storage parameter</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary><varname>toast_tuple_target</varname>格納パラメータ</primary>
     </indexterm>
     </term>
@@ -2008,9 +2008,9 @@ toast_tuple_targetは、長い列値を圧縮したりTOASTテーブルに移動
    <varlistentry id="reloption-parallel-workers" xreflabel="parallel_workers">
     <term><literal>parallel_workers</literal> (<type>integer</type>)
      <indexterm>
-<!--
      <primary><varname>parallel_workers</varname> storage parameter</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary><varname>parallel_workers</varname>格納パラメータ</primary>
     </indexterm>
     </term>
@@ -2033,9 +2033,9 @@ toast_tuple_targetは、長い列値を圧縮したりTOASTテーブルに移動
    <varlistentry id="reloption-autovacuum-enabled" xreflabel="autovacuum_enabled">
     <term><literal>autovacuum_enabled</literal>, <literal>toast.autovacuum_enabled</literal> (<type>boolean</type>)
     <indexterm>
-<!--
      <primary><varname>autovacuum_enabled</varname> storage parameter</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary><varname>autovacuum_enabled</varname>格納パラメータ</primary>
     </indexterm>
     </term>
@@ -2070,9 +2070,9 @@ falseの場合、トランザクションIDの周回問題を回避するため�
    <varlistentry id="reloption-vacuum-index-cleanup" xreflabel="vacuum_index_cleanup">
     <term><literal>vacuum_index_cleanup</literal>, <literal>toast.vacuum_index_cleanup</literal> (<type>boolean</type>)
     <indexterm>
-<!--
      <primary><varname>vacuum_index_cleanup</varname> storage parameter</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary><varname>vacuum_index_cleanup</varname>格納パラメータ</primary>
     </indexterm>
     </term>
@@ -2098,9 +2098,9 @@ falseの場合、トランザクションIDの周回問題を回避するため�
    <varlistentry id="reloption-vacuum-truncate" xreflabel="vacuum_truncate">
     <term><literal>vacuum_truncate</literal>, <literal>toast.vacuum_truncate</literal> (<type>boolean</type>)
     <indexterm>
-<!--
      <primary><varname>vacuum_truncate</varname> storage parameter</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary><varname>vacuum_truncate</varname>格納パラメータ</primary>
     </indexterm>
     </term>
@@ -2130,9 +2130,10 @@ falseの場合、トランザクションIDの周回問題を回避するため�
     <term><literal>autovacuum_vacuum_threshold</literal>, <literal>toast.autovacuum_vacuum_threshold</literal> (<type>integer</type>)
     <indexterm>
      <primary><varname>autovacuum_vacuum_threshold</varname></primary>
-<!--
      <secondary>storage parameter</secondary>
--->
+    </indexterm>
+    <indexterm>
+     <primary><varname>autovacuum_vacuum_threshold</varname></primary>
      <secondary>格納パラメータ</secondary>
     </indexterm>
     </term>
@@ -2151,9 +2152,10 @@ falseの場合、トランザクションIDの周回問題を回避するため�
     <term><literal>autovacuum_vacuum_scale_factor</literal>, <literal>toast.autovacuum_vacuum_scale_factor</literal> (<type>floating point</type>)
     <indexterm>
      <primary><varname>autovacuum_vacuum_scale_factor</varname> </primary>
-<!--
      <secondary>storage parameter</secondary>
--->
+    </indexterm>
+    <indexterm>
+     <primary><varname>autovacuum_vacuum_scale_factor</varname> </primary>
      <secondary>格納パラメータ</secondary>
     </indexterm>
     </term>
@@ -2172,9 +2174,10 @@ falseの場合、トランザクションIDの周回問題を回避するため�
     <term><literal>autovacuum_vacuum_insert_threshold</literal>, <literal>toast.autovacuum_vacuum_insert_threshold</literal> (<type>integer</type>)
     <indexterm>
      <primary><varname>autovacuum_vacuum_insert_threshold</varname></primary>
-<!--
      <secondary>storage parameter</secondary>
--->
+    </indexterm>
+    <indexterm>
+     <primary><varname>autovacuum_vacuum_insert_threshold</varname></primary>
      <secondary>格納パラメータ</secondary>
     </indexterm>
     </term>
@@ -2194,9 +2197,10 @@ falseの場合、トランザクションIDの周回問題を回避するため�
     <term><literal>autovacuum_vacuum_insert_scale_factor</literal>, <literal>toast.autovacuum_vacuum_insert_scale_factor</literal> (<type>float4</type>)
     <indexterm>
      <primary><varname>autovacuum_vacuum_insert_scale_factor</varname> </primary>
-<!--
      <secondary>storage parameter</secondary>
--->
+    </indexterm>
+    <indexterm>
+     <primary><varname>autovacuum_vacuum_insert_scale_factor</varname> </primary>
      <secondary>格納パラメータ</secondary>
     </indexterm>
     </term>
@@ -2215,9 +2219,10 @@ falseの場合、トランザクションIDの周回問題を回避するため�
     <term><literal>autovacuum_analyze_threshold</literal> (<type>integer</type>)
     <indexterm>
      <primary><varname>autovacuum_analyze_threshold</varname></primary>
-<!--
      <secondary>storage parameter</secondary>
--->
+    </indexterm>
+    <indexterm>
+     <primary><varname>autovacuum_analyze_threshold</varname></primary>
      <secondary>格納パラメータ</secondary>
     </indexterm>
     </term>
@@ -2236,9 +2241,10 @@ falseの場合、トランザクションIDの周回問題を回避するため�
     <term><literal>autovacuum_analyze_scale_factor</literal> (<type>floating point</type>)
     <indexterm>
      <primary><varname>autovacuum_analyze_scale_factor</varname></primary>
-<!--
      <secondary>storage parameter</secondary>
--->
+    </indexterm>
+    <indexterm>
+     <primary><varname>autovacuum_analyze_scale_factor</varname></primary>
      <secondary>格納パラメータ</secondary>
     </indexterm>
     </term>
@@ -2257,9 +2263,10 @@ falseの場合、トランザクションIDの周回問題を回避するため�
     <term><literal>autovacuum_vacuum_cost_delay</literal>, <literal>toast.autovacuum_vacuum_cost_delay</literal> (<type>floating point</type>)
     <indexterm>
      <primary><varname>autovacuum_vacuum_cost_delay</varname></primary>
-<!--
      <secondary>storage parameter</secondary>
--->
+    </indexterm>
+    <indexterm>
+     <primary><varname>autovacuum_vacuum_cost_delay</varname></primary>
      <secondary>格納パラメータ</secondary>
     </indexterm>
     </term>
@@ -2278,9 +2285,10 @@ falseの場合、トランザクションIDの周回問題を回避するため�
     <term><literal>autovacuum_vacuum_cost_limit</literal>, <literal>toast.autovacuum_vacuum_cost_limit</literal> (<type>integer</type>)
     <indexterm>
      <primary><varname>autovacuum_vacuum_cost_limit</varname></primary>
-<!--
      <secondary>storage parameter</secondary>
--->
+    </indexterm>
+    <indexterm>
+     <primary><varname>autovacuum_vacuum_cost_limit</varname></primary>
      <secondary>格納パラメータ</secondary>
     </indexterm>
     </term>
@@ -2298,9 +2306,9 @@ falseの場合、トランザクションIDの周回問題を回避するため�
    <varlistentry id="reloption-autovacuum-freeze-min-age" xreflabel="autovacuum_freeze_min_age">
     <term><literal>autovacuum_freeze_min_age</literal>, <literal>toast.autovacuum_freeze_min_age</literal> (<type>integer</type>)
     <indexterm>
-<!--
      <primary><varname>autovacuum_freeze_min_age</varname> storage parameter</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary><varname>autovacuum_freeze_min_age</varname>格納パラメータ</primary>
     </indexterm>
     </term>
@@ -2323,9 +2331,10 @@ falseの場合、トランザクションIDの周回問題を回避するため�
     <term><literal>autovacuum_freeze_max_age</literal>, <literal>toast.autovacuum_freeze_max_age</literal> (<type>integer</type>)
     <indexterm>
      <primary><varname>autovacuum_freeze_max_age</varname></primary>
-<!--
      <secondary>storage parameter</secondary>
--->
+    </indexterm>
+    <indexterm>
+     <primary><varname>autovacuum_freeze_max_age</varname></primary>
      <secondary>格納パラメータ</secondary>
     </indexterm>
     </term>
@@ -2346,9 +2355,9 @@ falseの場合、トランザクションIDの周回問題を回避するため�
    <varlistentry id="reloption-autovacuum-freeze-table-age" xreflabel="autovacuum_freeze_table_age">
     <term><literal>autovacuum_freeze_table_age</literal>, <literal>toast.autovacuum_freeze_table_age</literal> (<type>integer</type>)
     <indexterm>
-<!--
      <primary><varname>autovacuum_freeze_table_age</varname> storage parameter</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary><varname>autovacuum_freeze_table_age</varname>格納パラメータ</primary>
     </indexterm>
     </term>
@@ -2367,9 +2376,9 @@ falseの場合、トランザクションIDの周回問題を回避するため�
    <varlistentry id="reloption-autovacuum-multixact-freeze-min-age" xreflabel="autovacuum_multixact_freeze_min_age">
     <term><literal>autovacuum_multixact_freeze_min_age</literal>, <literal>toast.autovacuum_multixact_freeze_min_age</literal> (<type>integer</type>)
     <indexterm>
-<!--
      <primary><varname>autovacuum_multixact_freeze_min_age</varname> storage parameter</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary><varname>autovacuum_multixact_freeze_min_age</varname>格納パラメータ</primary>
     </indexterm>
     </term>
@@ -2393,9 +2402,10 @@ falseの場合、トランザクションIDの周回問題を回避するため�
     <term><literal>autovacuum_multixact_freeze_max_age</literal>, <literal>toast.autovacuum_multixact_freeze_max_age</literal> (<type>integer</type>)
     <indexterm>
      <primary><varname>autovacuum_multixact_freeze_max_age</varname></primary>
-<!--
      <secondary>storage parameter</secondary>
--->
+    </indexterm>
+    <indexterm>
+     <primary><varname>autovacuum_multixact_freeze_max_age</varname></primary>
      <secondary>格納パラメータ</secondary>
     </indexterm>
     </term>
@@ -2418,9 +2428,9 @@ falseの場合、トランザクションIDの周回問題を回避するため�
    <varlistentry id="reloption-autovacuum-multixact-freeze-table-age" xreflabel="autovacuum_multixact_freeze_table_age">
     <term><literal>autovacuum_multixact_freeze_table_age</literal>, <literal>toast.autovacuum_multixact_freeze_table_age</literal> (<type>integer</type>)
     <indexterm>
-<!--
      <primary><varname>autovacuum_multixact_freeze_table_age</varname> storage parameter</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary><varname>autovacuum_multixact_freeze_table_age</varname>格納パラメータ</primary>
     </indexterm>
     </term>
@@ -2439,9 +2449,10 @@ falseの場合、トランザクションIDの周回問題を回避するため�
     <term><literal>log_autovacuum_min_duration</literal>, <literal>toast.log_autovacuum_min_duration</literal> (<type>integer</type>)
     <indexterm>
      <primary><varname>log_autovacuum_min_duration</varname></primary>
-<!--
      <secondary>storage parameter</secondary>
--->
+    </indexterm>
+    <indexterm>
+     <primary><varname>log_autovacuum_min_duration</varname></primary>
      <secondary>格納パラメータ</secondary>
     </indexterm>
     </term>
@@ -2459,9 +2470,9 @@ falseの場合、トランザクションIDの周回問題を回避するため�
    <varlistentry id="reloption-user-catalog-table" xreflabel="user_catalog_table">
     <term><literal>user_catalog_table</literal> (<type>boolean</type>)
     <indexterm>
-<!--
      <primary><varname>user_catalog_table</varname> storage parameter</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary><varname>user_catalog_table</varname>格納パラメータ</primary>
     </indexterm>
     </term>

--- a/doc/src/sgml/ref/create_trigger.sgml
+++ b/doc/src/sgml/ref/create_trigger.sgml
@@ -9,10 +9,10 @@ PostgreSQL documentation
  </indexterm>
 
  <indexterm>
-<!--
   <primary>transition tables</primary>
   <seealso>ephemeral named relation</seealso>
--->
+ </indexterm>
+ <indexterm>
   <primary>遷移テーブル</primary>
   <seealso>短命の名前付きリレーション</seealso>
  </indexterm>

--- a/doc/src/sgml/ref/create_view.sgml
+++ b/doc/src/sgml/ref/create_view.sgml
@@ -127,9 +127,10 @@ CREATE [ OR REPLACE ] [ TEMP | TEMPORARY ] [ RECURSIVE ] VIEW <replaceable class
     <term><literal>RECURSIVE</literal>
       <indexterm zone="sql-createview">
        <primary>RECURSIVE</primary>
-<!--
        <secondary>in views</secondary>
--->
+      </indexterm>
+      <indexterm zone="sql-createview">
+       <primary>RECURSIVE</primary>
        <secondary>ビューにおける</secondary>
       </indexterm>
     </term>
@@ -418,9 +419,9 @@ CREATE VIEW vista AS SELECT text 'Hello World' AS hello;
    <title>更新可能ビュー</title>
 
    <indexterm zone="sql-createview-updatable-views">
-<!--
     <primary>updatable views</primary>
--->
+   </indexterm>
+   <indexterm zone="sql-createview-updatable-views">
     <primary>更新可能ビュー</primary>
    </indexterm>
 

--- a/doc/src/sgml/ref/deallocate.sgml
+++ b/doc/src/sgml/ref/deallocate.sgml
@@ -9,10 +9,10 @@ PostgreSQL documentation
  </indexterm>
 
  <indexterm zone="sql-deallocate">
-<!--
   <primary>prepared statements</primary>
   <secondary>removing</secondary>
--->
+ </indexterm>
+ <indexterm zone="sql-deallocate">
   <primary>プリペアド文</primary>
   <secondary>の削除</secondary>
  </indexterm>

--- a/doc/src/sgml/ref/declare.sgml
+++ b/doc/src/sgml/ref/declare.sgml
@@ -9,9 +9,9 @@ PostgreSQL documentation
  </indexterm>
 
  <indexterm zone="sql-declare">
-<!--
   <primary>cursor</primary>
--->
+ </indexterm>
+ <indexterm zone="sql-declare">
   <primary>カーソル</primary>
   <secondary>DECLARE</secondary>
  </indexterm>

--- a/doc/src/sgml/ref/do.sgml
+++ b/doc/src/sgml/ref/do.sgml
@@ -9,9 +9,9 @@ PostgreSQL documentation
  </indexterm>
 
  <indexterm zone="sql-do">
-<!--
   <primary>anonymous code blocks</primary>
--->
+ </indexterm>
+ <indexterm zone="sql-do">
   <primary>無名コードブロック</primary>
  </indexterm>
 

--- a/doc/src/sgml/ref/execute.sgml
+++ b/doc/src/sgml/ref/execute.sgml
@@ -9,10 +9,10 @@ PostgreSQL documentation
  </indexterm>
 
  <indexterm zone="sql-execute">
-<!--
   <primary>prepared statements</primary>
   <secondary>executing</secondary>
--->
+ </indexterm>
+ <indexterm zone="sql-execute">
   <primary>プリペアド文</primary>
   <secondary>の実行</secondary>
  </indexterm>

--- a/doc/src/sgml/ref/explain.sgml
+++ b/doc/src/sgml/ref/explain.sgml
@@ -9,19 +9,19 @@ PostgreSQL documentation
  </indexterm>
 
  <indexterm zone="sql-explain">
-<!--
   <primary>prepared statements</primary>
   <secondary>showing the query plan</secondary>
--->
+ </indexterm>
+ <indexterm zone="sql-explain">
   <primary>プリペアド文</primary>
   <secondary>の問い合わせ計画の表示</secondary>
  </indexterm>
 
  <indexterm zone="sql-explain">
-<!--
   <primary>cursor</primary>
   <secondary>showing the query plan</secondary>
--->
+ </indexterm>
+ <indexterm zone="sql-explain">
   <primary>カーソル</primary>
   <secondary>の問い合わせ計画の表示</secondary>
  </indexterm>

--- a/doc/src/sgml/ref/fetch.sgml
+++ b/doc/src/sgml/ref/fetch.sgml
@@ -10,9 +10,9 @@ PostgreSQL documentation
  </indexterm>
 
  <indexterm zone="sql-fetch">
-<!--
   <primary>cursor</primary>
--->
+ </indexterm>
+ <indexterm zone="sql-fetch">
   <primary>カーソル</primary>
   <secondary>FETCH</secondary>
  </indexterm>

--- a/doc/src/sgml/ref/move.sgml
+++ b/doc/src/sgml/ref/move.sgml
@@ -9,9 +9,9 @@ PostgreSQL documentation
  </indexterm>
 
  <indexterm zone="sql-move">
-<!--
   <primary>cursor</primary>
--->
+ </indexterm>
+ <indexterm zone="sql-move">
   <primary>カーソル</primary>
   <secondary>MOVE</secondary>
  </indexterm>

--- a/doc/src/sgml/ref/postgres-ref.sgml
+++ b/doc/src/sgml/ref/postgres-ref.sgml
@@ -755,9 +755,9 @@ PostgreSQL documentation
     <title>シングルユーザモード用のオプション</title>
 
     <indexterm>
-<!--
      <primary>single-user mode</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>シングルユーザモード</primary>
     </indexterm>
 

--- a/doc/src/sgml/ref/prepare.sgml
+++ b/doc/src/sgml/ref/prepare.sgml
@@ -9,10 +9,10 @@ PostgreSQL documentation
  </indexterm>
 
  <indexterm zone="sql-prepare">
-<!--
   <primary>prepared statements</primary>
   <secondary>creating</secondary>
--->
+ </indexterm>
+ <indexterm zone="sql-prepare">
   <primary>プリペアド文</primary>
   <secondary>の作成</secondary>
  </indexterm>

--- a/doc/src/sgml/ref/psql-ref.sgml
+++ b/doc/src/sgml/ref/psql-ref.sgml
@@ -3975,10 +3975,10 @@ lo_import 152801
           <para>
 <literal>csv</literal>書式は
           <indexterm>
-<!--
            <primary>CSV (Comma-Separated Values) format</primary>
            <secondary>in psql</secondary>
--->
+          </indexterm>
+          <indexterm>
            <primary>CSV(コンマ区切り値)書式</primary>
            <secondary>psqlでの</secondary>
           </indexterm>
@@ -4949,10 +4949,10 @@ select 1\; select 2\; select 3;
    <title>パターン</title>
 
    <indexterm>
-<!--
     <primary>patterns</primary>
     <secondary>in psql and pg_dump</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>パターン</primary>
     <secondary>psqlおよびpg_dumpにおける</secondary>
    </indexterm>
@@ -5621,9 +5621,9 @@ SQLキーワードを補完する時に大文字小文字のどちらを使用�
       <term>
        <varname>ON_ERROR_ROLLBACK</varname>
        <indexterm>
-<!--
         <primary>rollback</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary>ロールバック</primary>
         <secondary>psql</secondary>
        </indexterm>

--- a/doc/src/sgml/ref/reindex.sgml
+++ b/doc/src/sgml/ref/reindex.sgml
@@ -394,10 +394,10 @@ REINDEX [ ( <replaceable class="parameter">option</replaceable> [, ...] ) ] { IN
    <title>インデックスを同時に再構築</title>
 
    <indexterm zone="sql-reindex-concurrently">
-<!--
     <primary>index</primary>
     <secondary>rebuilding concurrently</secondary>
--->
+   </indexterm>
+   <indexterm zone="sql-reindex-concurrently">
     <primary>インデックス</primary>
     <secondary>同時に再構築</secondary>
    </indexterm>

--- a/doc/src/sgml/ref/release_savepoint.sgml
+++ b/doc/src/sgml/ref/release_savepoint.sgml
@@ -9,10 +9,10 @@ PostgreSQL documentation
  </indexterm>
 
  <indexterm zone="sql-release-savepoint">
-<!--
   <primary>savepoints</primary>
   <secondary>releasing</secondary>
--->
+ </indexterm>
+ <indexterm zone="sql-release-savepoint">
   <primary>セーブポイント</primary>
   <secondary>の解放</secondary>
  </indexterm>

--- a/doc/src/sgml/ref/rollback.sgml
+++ b/doc/src/sgml/ref/rollback.sgml
@@ -53,9 +53,9 @@ ROLLBACK [ WORK | TRANSACTION ] [ AND [ NO ] CHAIN ]
   <title>パラメータ</title>
 
   <indexterm zone="sql-rollback-chain">
-<!--
    <primary>chained transactions</primary>
--->
+  </indexterm>
+  <indexterm zone="sql-rollback-chain">
    <primary>連鎖トランザクション</primary>
   </indexterm>
 

--- a/doc/src/sgml/ref/rollback_to.sgml
+++ b/doc/src/sgml/ref/rollback_to.sgml
@@ -9,10 +9,10 @@ PostgreSQL documentation
  </indexterm>
 
  <indexterm zone="sql-rollback-to">
-<!--
   <primary>savepoints</primary>
   <secondary>rolling back</secondary>
--->
+ </indexterm>
+ <indexterm zone="sql-rollback-to">
   <primary>セーブポイント</primary>
   <secondary>ロールバック</secondary>
  </indexterm>

--- a/doc/src/sgml/ref/savepoint.sgml
+++ b/doc/src/sgml/ref/savepoint.sgml
@@ -9,10 +9,10 @@ PostgreSQL documentation
  </indexterm>
 
  <indexterm zone="sql-savepoint">
-<!--
   <primary>savepoints</primary>
   <secondary>defining</secondary>
--->
+ </indexterm>
+ <indexterm zone="sql-savepoint">
   <primary>セーブポイント</primary>
   <secondary>の定義</secondary>
  </indexterm>

--- a/doc/src/sgml/ref/select.sgml
+++ b/doc/src/sgml/ref/select.sgml
@@ -9,17 +9,18 @@ PostgreSQL documentation
  </indexterm>
 
  <indexterm zone="sql-select">
-<!--
   <primary>TABLE command</primary>
--->
+ </indexterm>
+ <indexterm zone="sql-select">
   <primary>TABLEコマンド</primary>
  </indexterm>
 
  <indexterm zone="sql-select">
   <primary>WITH</primary>
-<!--
   <secondary>in SELECT</secondary>
--->
+ </indexterm>
+ <indexterm zone="sql-select">
+  <primary>WITH</primary>
   <secondary>SELECTにおける</secondary>
  </indexterm>
 

--- a/doc/src/sgml/ref/set_transaction.sgml
+++ b/doc/src/sgml/ref/set_transaction.sgml
@@ -9,28 +9,28 @@ PostgreSQL documentation
  </indexterm>
 
  <indexterm>
-<!--
   <primary>transaction isolation level</primary>
   <secondary>setting</secondary>
--->
+ </indexterm>
+ <indexterm>
   <primary>トランザクション隔離レベル</primary>
   <secondary>の設定</secondary>
  </indexterm>
 
  <indexterm>
-<!--
   <primary>read-only transaction</primary>
   <secondary>setting</secondary>
--->
+ </indexterm>
+ <indexterm>
   <primary>読み取りのみトランザクション</primary>
   <secondary>の設定</secondary>
  </indexterm>
 
  <indexterm>
-<!--
   <primary>deferrable transaction</primary>
   <secondary>setting</secondary>
--->
+ </indexterm>
+ <indexterm>
   <primary>遅延トランザクション</primary>
   <secondary>の設定</secondary>
  </indexterm>

--- a/doc/src/sgml/regress.sgml
+++ b/doc/src/sgml/regress.sgml
@@ -7,16 +7,16 @@
   <title>リグレッションテスト</title>
 
   <indexterm zone="regress">
-<!--
    <primary>regression tests</primary>
--->
+  </indexterm>
+  <indexterm zone="regress">
    <primary>リグレッションテスト</primary>
   </indexterm>
 
   <indexterm zone="regress">
-<!--
    <primary>test</primary>
--->
+  </indexterm>
+  <indexterm zone="regress">
    <primary>テスト</primary>
   </indexterm>
 

--- a/doc/src/sgml/replication-origins.sgml
+++ b/doc/src/sgml/replication-origins.sgml
@@ -6,15 +6,15 @@
  <title>レプリケーション進捗の追跡</title>
 
  <indexterm zone="replication-origins">
-<!--
   <primary>Replication Progress Tracking</primary>
--->
+ </indexterm>
+ <indexterm zone="replication-origins">
   <primary>レプリケーション進捗の追跡</primary>
  </indexterm>
  <indexterm zone="replication-origins">
-<!--
   <primary>Replication Origins</primary>
--->
+ </indexterm>
+ <indexterm zone="replication-origins">
   <primary>レプリケーション起点</primary>
  </indexterm>
 

--- a/doc/src/sgml/rowtypes.sgml
+++ b/doc/src/sgml/rowtypes.sgml
@@ -7,16 +7,16 @@
  <title>複合型</title>
 
  <indexterm>
-<!--
   <primary>composite type</primary>
--->
+ </indexterm>
+ <indexterm>
   <primary>複合型</primary>
  </indexterm>
 
  <indexterm>
-<!--
   <primary>row type</primary>
--->
+ </indexterm>
+ <indexterm>
   <primary>行型</primary>
  </indexterm>
 
@@ -140,10 +140,10 @@ CREATE TABLE inventory_item (
   <title>複合型の値の構成</title>
 
   <indexterm>
-<!--
    <primary>composite type</primary>
    <secondary>constant</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>複合型</primary>
    <secondary>の定数</secondary>
   </indexterm>
@@ -642,16 +642,16 @@ SELECT c.somefunc FROM inventory_item c;
 -->
 この関数的記法とフィールド記法の同等性により、複合型に対する関数を使用して<quote>計算されたフィールド</quote>を実装することができます。
    <indexterm>
-<!--
     <primary>computed field</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>計算されたフィールド</primary>
    </indexterm>
    <indexterm>
-<!--
     <primary>field</primary>
     <secondary>computed</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>フィールド</primary>
     <secondary>計算された</secondary>
    </indexterm>

--- a/doc/src/sgml/rules.sgml
+++ b/doc/src/sgml/rules.sgml
@@ -7,9 +7,9 @@
 <title>ルールシステム</title>
 
  <indexterm zone="rules">
-<!--
   <primary>rule</primary>
--->
+ </indexterm>
+ <indexterm zone="rules">
   <primary>ルール</primary>
  </indexterm>
 
@@ -60,9 +60,9 @@
 <title>問い合わせツリーとは</title>
 
 <indexterm zone="querytree">
-<!--
  <primary>query tree</primary>
--->
+ </indexterm>
+<indexterm zone="querytree">
  <primary>問い合わせツリー</primary>
 </indexterm>
 
@@ -414,19 +414,19 @@
 <title>ビューとルールシステム</title>
 
 <indexterm zone="rules-views">
-<!--
  <primary>rule</primary>
  <secondary>and views</secondary>
--->
+ </indexterm>
+<indexterm zone="rules-views">
  <primary>ルール</primary>
  <secondary>とビュー</secondary>
 </indexterm>
 
 <indexterm zone="rules-views">
-<!--
  <primary>view</primary>
  <secondary>implementation through rules</secondary>
--->
+ </indexterm>
+<indexterm zone="rules-views">
  <primary>ビュー</primary>
  <secondary>ルールを使用した実装</secondary>
 </indexterm>
@@ -479,10 +479,10 @@ CREATE RULE "_RETURN" AS ON SELECT TO myview DO INSTEAD
 <title><command>SELECT</command>ルールの動き</title>
 
 <indexterm zone="rules-select">
-<!--
  <primary>rule</primary>
  <secondary sortas="SELECT">for SELECT</secondary>
--->
+ </indexterm>
+<indexterm zone="rules-select">
  <primary>ルール</primary>
  <secondary sortas="SELECT">SELECT用</secondary>
 </indexterm>
@@ -1281,28 +1281,28 @@ SELECT t1.a, t2.b, t1.ctid FROM t1, t2 WHERE t1.a = t2.a;
 <title>マテリアライズドビュー</title>
 
 <indexterm zone="rules-materializedviews">
-<!--
  <primary>rule</primary>
  <secondary>and materialized views</secondary>
--->
+ </indexterm>
+<indexterm zone="rules-materializedviews">
  <primary>ルール</primary>
  <secondary>とマテリアライズドビュー</secondary>
 </indexterm>
 
 <indexterm zone="rules-materializedviews">
-<!--
  <primary>materialized view</primary>
  <secondary>implementation through rules</secondary>
--->
+ </indexterm>
+<indexterm zone="rules-materializedviews">
  <primary>マテリアライズドビュー</primary>
  <secondary>ルールによる実装</secondary>
 </indexterm>
 
 <indexterm zone="rules-materializedviews">
-<!--
  <primary>view</primary>
  <secondary>materialized</secondary>
--->
+ </indexterm>
+<indexterm zone="rules-materializedviews">
  <primary>ビュー</primary>
  <secondary>マテリアライズド</secondary>
 </indexterm>
@@ -1568,28 +1568,28 @@ SELECT word FROM words ORDER BY word &lt;-&gt; 'caterpiler' LIMIT 10;
 <title><command>INSERT</command>、<command>UPDATE</command>、<command>DELETE</command>についてのルール</title>
 
 <indexterm zone="rules-update">
-<!--
  <primary>rule</primary>
  <secondary sortas="INSERT">for INSERT</secondary>
--->
+ </indexterm>
+<indexterm zone="rules-update">
  <primary>ルール</primary>
  <secondary sortas="INSERT">INSERT用</secondary>
 </indexterm>
 
 <indexterm zone="rules-update">
-<!--
  <primary>rule</primary>
  <secondary sortas="UPDATE">for UPDATE</secondary>
--->
+ </indexterm>
+<indexterm zone="rules-update">
  <primary>ルール</primary>
  <secondary sortas="UPDATE">UPDATE用</secondary>
 </indexterm>
 
 <indexterm zone="rules-update">
-<!--
  <primary>rule</primary>
  <secondary sortas="DELETE">for DELETE</secondary>
--->
+ </indexterm>
+<indexterm zone="rules-update">
  <primary>ルール</primary>
  <secondary sortas="DELETE">DELETE用</secondary>
 </indexterm>
@@ -2236,9 +2236,7 @@ SELECT shoelace_data.sl_name, 0,
 -->
 <title>ビューとの協調</title>
 
-<!--
 <indexterm zone="rules-update-views"><primary>view</primary><secondary>updating</secondary></indexterm>
--->
 <indexterm zone="rules-update-views"><primary>ビュー</primary><secondary>更新</secondary></indexterm>
 
 <para>
@@ -2793,19 +2791,19 @@ SELECT * FROM shoelace;
 <title>ルールと権限</title>
 
 <indexterm zone="rules-privileges">
-<!--
  <primary>privilege</primary>
  <secondary sortas="Regeln">with rules</secondary>
--->
+ </indexterm>
+<indexterm zone="rules-privileges">
  <primary>権限</primary>
  <secondary sortas="Regeln">ルールでの</secondary>
 </indexterm>
 
 <indexterm zone="rules-privileges">
-<!--
  <primary>privilege</primary>
  <secondary sortas="Sichten">with views</secondary>
--->
+ </indexterm>
+<indexterm zone="rules-privileges">
  <primary>権限</primary>
  <secondary sortas="Sichten">ビューでの</secondary>
 </indexterm>
@@ -3153,19 +3151,19 @@ CREATE VIEW phone_number WITH (security_barrier) AS
 <title>ルール対トリガ</title>
 
 <indexterm zone="rules-triggers">
-<!--
  <primary>rule</primary>
  <secondary sortas="Trigger">compared with triggers</secondary>
--->
+ </indexterm>
+<indexterm zone="rules-triggers">
  <primary>ルール</primary>
  <secondary sortas="Trigger">とトリガとの比較</secondary>
 </indexterm>
 
 <indexterm zone="rules-triggers">
-<!--
  <primary>trigger</primary>
  <secondary sortas="Regeln">compared with rules</secondary>
--->
+ </indexterm>
+<indexterm zone="rules-triggers">
  <primary>トリガ</primary>
  <secondary sortas="Regeln">とルールとの比較</secondary>
 </indexterm>

--- a/doc/src/sgml/runtime.sgml
+++ b/doc/src/sgml/runtime.sgml
@@ -38,10 +38,10 @@
   <title><productname>PostgreSQL</productname>ユーザアカウント</title>
 
   <indexterm>
-<!--
    <primary>postgres user</primary>
--->
-<primary>postgresユーザ</primary>
+  </indexterm>
+  <indexterm>
+   <primary>postgresユーザ</primary>
   </indexterm>
 
   <para>
@@ -91,19 +91,19 @@
   <title>データベースクラスタの作成</title>
 
   <indexterm>
-<!--
    <primary>database cluster</primary>
--->
-<primary>データベースクラスタ</primary>
+  </indexterm>
+  <indexterm>
+   <primary>データベースクラスタ</primary>
   </indexterm>
 
   <indexterm>
-<!--
    <primary>data area</primary>
    <see>database cluster</see>
--->
-<primary>データ領域</primary>
-<see>データベースクラスタ</see>
+  </indexterm>
+  <indexterm>
+   <primary>データ領域</primary>
+   <see>データベースクラスタ</see>
   </indexterm>
 
   <para>
@@ -386,9 +386,9 @@ postgres$ <userinput>initdb -D /usr/local/pgsql/data</userinput>
    <title>セカンダリファイルシステムの使用</title>
 
    <indexterm zone="creating-cluster-mount-points">
-<!--
     <primary>file system mount points</primary>
--->
+   </indexterm>
+   <indexterm zone="creating-cluster-mount-points">
     <primary>ファイルシステムマウントポイント</primary>
    </indexterm>
 
@@ -1048,16 +1048,16 @@ psql: could not connect to server: No such file or directory
    <title>共有メモリとセマフォ</title>
 
    <indexterm zone="sysvipc">
-<!--
     <primary>shared memory</primary>
--->
+   </indexterm>
+   <indexterm zone="sysvipc">
     <primary>共有メモリ</primary>
    </indexterm>
 
    <indexterm zone="sysvipc">
-<!--
     <primary>semaphores</primary>
--->
+   </indexterm>
+   <indexterm zone="sysvipc">
     <primary>セマフォ</primary>
    </indexterm>
 
@@ -1362,9 +1362,7 @@ POSIXセマフォを使用している場合、System Vと同じ数のセマフ�
     <variablelist>
      <varlistentry>
       <term><systemitem class="osname">AIX</systemitem>
-<!--
       <indexterm><primary>AIX</primary><secondary>IPC configuration</secondary></indexterm>
--->
       <indexterm><primary>AIX</primary><secondary>IPCの設定</secondary></indexterm>
       </term>
       <listitem>
@@ -1398,9 +1396,7 @@ POSIXセマフォを使用している場合、System Vと同じ数のセマフ�
 
      <varlistentry>
       <term><systemitem class="osname">FreeBSD</systemitem>
-<!--
       <indexterm><primary>FreeBSD</primary><secondary>IPC configuration</secondary></indexterm>
--->
       <indexterm><primary>FreeBSD</primary><secondary>IPC設定</secondary></indexterm>
       </term>
       <listitem>
@@ -1464,9 +1460,7 @@ FreeBSD jailを実行している場合、<literal>sysvshm</literal>パラメー
 
      <varlistentry>
       <term><systemitem class="osname">NetBSD</systemitem>
-<!--
       <indexterm><primary>NetBSD</primary><secondary>IPC configuration</secondary></indexterm>
--->
       <indexterm><primary>NetBSD</primary><secondary>IPC設定</secondary></indexterm>
       </term>
       <listitem>
@@ -1515,9 +1509,7 @@ FreeBSD jailを実行している場合、<literal>sysvshm</literal>パラメー
 
      <varlistentry>
       <term><systemitem class="osname">OpenBSD</systemitem>
-<!--
       <indexterm><primary>OpenBSD</primary><secondary>IPC configuration</secondary></indexterm>
--->
       <indexterm><primary>OpenBSD</primary><secondary>IPC設定</secondary></indexterm>
       </term>
       <listitem>
@@ -1556,9 +1548,7 @@ FreeBSD jailを実行している場合、<literal>sysvshm</literal>パラメー
 
      <varlistentry>
       <term><systemitem class="osname">HP-UX</systemitem>
-<!--
       <indexterm><primary>HP-UX</primary><secondary>IPC configuration</secondary></indexterm>
--->
       <indexterm><primary>HP-UX</primary><secondary>IPC設定</secondary></indexterm>
       </term>
       <listitem>
@@ -1585,9 +1575,7 @@ FreeBSD jailを実行している場合、<literal>sysvshm</literal>パラメー
 
      <varlistentry>
       <term><systemitem class="osname">Linux</systemitem>
-<!--
       <indexterm><primary>Linux</primary><secondary>IPC configuration</secondary></indexterm>
--->
       <indexterm><primary>Linux</primary><secondary>IPC設定</secondary></indexterm>
       </term>
       <listitem>
@@ -1626,9 +1614,7 @@ System V セマフォはこのプラットフォームでは使用しません�
 
      <varlistentry>
       <term><systemitem class="osname">macOS</systemitem>
-<!--
       <indexterm><primary>macOS</primary><secondary>IPC configuration</secondary></indexterm>
--->
       <indexterm><primary>macOS</primary><secondary>IPC設定</secondary></indexterm>
       </term>
       <listitem>
@@ -2006,9 +1992,9 @@ default:\
    <title>Linuxのメモリオーバーコミット</title>
 
    <indexterm>
-<!--
     <primary>memory overcommit</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>メモリオーバーコミット</primary>
    </indexterm>
 
@@ -2017,9 +2003,9 @@ default:\
    </indexterm>
 
    <indexterm>
-<!--
     <primary>overcommit</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>オーバーコミット</primary>
    </indexterm>
 
@@ -2283,9 +2269,9 @@ $ <userinput>grep Huge /proc/meminfo</userinput>
   <title>サーバのシャットダウン</title>
 
   <indexterm zone="server-shutdown">
-<!--
    <primary>shutdown</primary>
--->
+  </indexterm>
+  <indexterm zone="server-shutdown">
    <primary>シャットダウン</primary>
   </indexterm>
 
@@ -2453,17 +2439,17 @@ $ <userinput>kill -INT `head -1 /usr/local/pgsql/data/postmaster.pid`</userinput
   <title><productname>PostgreSQL</productname>クラスタのアップグレード処理</title>
 
   <indexterm zone="upgrading">
-<!--
    <primary>upgrading</primary>
--->
+  </indexterm>
+  <indexterm zone="upgrading">
    <primary>アップグレード処理</primary>
   </indexterm>
 
   <indexterm zone="upgrading">
-<!--
    <primary>version</primary>
    <secondary>compatibility</secondary>
--->
+  </indexterm>
+  <indexterm zone="upgrading">
    <primary>バージョン</primary>
    <secondary>互換性</secondary>
   </indexterm>
@@ -2715,9 +2701,10 @@ $ <userinput>kill -INT `head -1 /usr/local/pgsql/data/postmaster.pid`</userinput
      <para>
       <indexterm>
        <primary>pg_dumpall</primary>
-<!--
        <secondary>use during upgrade</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>pg_dumpall</primary>
        <secondary>アップグレード中の使用</secondary>
       </indexterm>
 
@@ -2961,9 +2948,9 @@ pg_dumpall -p 5432 | psql -d postgres -p 5433
   <title>サーバのなりすまし防止</title>
 
   <indexterm zone="preventing-server-spoofing">
-<!--
    <primary>server spoofing</primary>
--->
+  </indexterm>
+  <indexterm zone="preventing-server-spoofing">
    <primary>サーバのなりすまし</primary>
   </indexterm>
 
@@ -3061,9 +3048,9 @@ TCPクライアントは<literal>gssencmode=require</literal>を使用して接�
   <title>暗号化オプション</title>
 
   <indexterm zone="encryption-options">
-<!--
    <primary>encryption</primary>
--->
+  </indexterm>
+  <indexterm zone="encryption-options">
    <primary>暗号化</primary>
   </indexterm>
 

--- a/doc/src/sgml/sepgsql.sgml
+++ b/doc/src/sgml/sepgsql.sgml
@@ -380,9 +380,9 @@ $ sudo semodule -r sepgsql-regtest
     <term>
      <varname>sepgsql.permissive</varname> (<type>boolean</type>)
      <indexterm>
-<!--
       <primary><varname>sepgsql.permissive</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>sepgsql.permissive</varname>設定パラメータ</primary>
      </indexterm>
     </term>
@@ -416,9 +416,9 @@ $ sudo semodule -r sepgsql-regtest
     <term>
      <varname>sepgsql.debug_audit</varname> (<type>boolean</type>)
      <indexterm>
-<!--
       <primary><varname>sepgsql.debug_audit</varname> configuration parameter</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary><varname>sepgsql.debug_audit</varname>設定パラメータ</primary>
      </indexterm>
     </term>

--- a/doc/src/sgml/spgist.sgml
+++ b/doc/src/sgml/spgist.sgml
@@ -7,9 +7,9 @@
 <title>SP-GiSTインデックス</title>
 
    <indexterm>
-<!--
     <primary>index</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>インデックス</primary>
     <secondary>SP-GiST</secondary>
    </indexterm>

--- a/doc/src/sgml/spi.sgml
+++ b/doc/src/sgml/spi.sgml
@@ -3784,10 +3784,10 @@ SPIPlanPtr SPI_saveplan(SPIPlanPtr <parameter>plan</parameter>)
  <indexterm><primary>SPI_register_relation</primary></indexterm>
 
  <indexterm>
-<!--
   <primary>ephemeral named relation</primary>
   <secondary>registering with SPI</secondary>
--->
+ </indexterm>
+ <indexterm>
   <primary>短命の名前付きリレーション</primary>
   <secondary>SPIで登録する</secondary>
  </indexterm>
@@ -3931,10 +3931,10 @@ int SPI_register_relation(EphemeralNamedRelation <parameter>enr</parameter>)
  <indexterm><primary>SPI_unregister_relation</primary></indexterm>
 
  <indexterm>
-<!--
   <primary>ephemeral named relation</primary>
   <secondary>unregistering from SPI</secondary>
--->
+ </indexterm>
+ <indexterm>
   <primary>短命の名前付きリレーション</primary>
   <secondary>SPIから登録解除する</secondary>
  </indexterm>
@@ -4076,19 +4076,19 @@ int SPI_unregister_relation(const char * <parameter>name</parameter>)
  <indexterm><primary>SPI_register_trigger_data</primary></indexterm>
 
  <indexterm>
-<!--
   <primary>ephemeral named relation</primary>
   <secondary>registering with SPI</secondary>
--->
+ </indexterm>
+ <indexterm>
   <primary>短命の名前付きリレーション</primary>
   <secondary>SPIで登録する</secondary>
  </indexterm>
 
  <indexterm>
-<!--
   <primary>transition tables</primary>
   <secondary>implementation in PLs</secondary>
--->
+ </indexterm>
+ <indexterm>
   <primary>遷移テーブル</primary>
   <secondary>PLでの実装</secondary>
  </indexterm>
@@ -5125,10 +5125,10 @@ const char * SPI_result_code_string(int <parameter>code</parameter>);
 
   <para>
     <indexterm>
-<!--
      <primary>memory context</primary>
      <secondary>in SPI</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>メモリコンテキスト</primary>
      <secondary>SPI内部の</secondary>
     </indexterm>

--- a/doc/src/sgml/start.sgml
+++ b/doc/src/sgml/start.sgml
@@ -192,10 +192,10 @@
    <title>データベースの作成</title>
 
    <indexterm zone="tutorial-createdb">
-<!--
     <primary>database</primary>
     <secondary>creating</secondary>
--->
+   </indexterm>
+   <indexterm zone="tutorial-createdb">
     <primary>データベース</primary>
     <secondary>作成</secondary>
    </indexterm>

--- a/doc/src/sgml/storage.sgml
+++ b/doc/src/sgml/storage.sgml
@@ -473,9 +473,7 @@ where <replaceable>PPP</replaceable> is the PID of the owning backend and
     <indexterm>
      <primary>TOAST</primary>
     </indexterm>
-<!--
     <indexterm><primary>sliced bread</primary><see>TOAST</see></indexterm>
--->
     <indexterm><primary>スライスパン</primary><see>TOAST</see></indexterm>
 
 <para>
@@ -916,14 +914,12 @@ tuple would otherwise be too big.
 <title>空き領域マップ</title>
 
 <indexterm>
-<!--
  <primary>Free Space Map</primary>
--->
+</indexterm>
+<indexterm>
  <primary>空き領域マップ</primary>
 </indexterm>
-<!--
 <indexterm><primary>FSM</primary><see>Free Space Map</see></indexterm>
--->
 <indexterm><primary>FSM</primary><see>空き領域マップ</see></indexterm>
 
 <para>
@@ -987,14 +983,12 @@ can be used to examine the information stored in free space maps.
 <title>可視性マップ</title>
 
 <indexterm>
-<!--
  <primary>Visibility Map</primary>
--->
+</indexterm>
+<indexterm>
  <primary>可視性マップ</primary>
 </indexterm>
-<!--
 <indexterm><primary>VM</primary><see>Visibility Map</see></indexterm>
--->
 <indexterm><primary>VM</primary><see>可視性マップ</see></indexterm>
 
 <para>
@@ -1063,9 +1057,9 @@ information stored in the visibility map.
 <title>初期化フォーク</title>
 
 <indexterm>
-<!--
  <primary>Initialization Fork</primary>
--->
+</indexterm>
+<indexterm>
  <primary>初期化フォーク</primary>
 </indexterm>
 

--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -7,9 +7,9 @@
  <title>SQLの構文</title>
 
  <indexterm zone="sql-syntax">
-<!--
   <primary>syntax</primary>
--->
+ </indexterm>
+ <indexterm zone="sql-syntax">
   <primary>構文</primary>
   <secondary>SQL</secondary>
  </indexterm>
@@ -41,9 +41,9 @@
   <title>字句の構造</title>
 
   <indexterm>
-<!--
    <primary>token</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>トークン</primary>
   </indexterm>
 
@@ -131,28 +131,28 @@ SQL構文は、どのトークンがコマンドを識別し、どれがオペ�
    <title>識別子とキーワード</title>
 
    <indexterm zone="sql-syntax-identifiers">
-<!--
     <primary>identifier</primary>
     <secondary>syntax of</secondary>
--->
+   </indexterm>
+   <indexterm zone="sql-syntax-identifiers">
     <primary>識別子</primary>
     <secondary>の構文</secondary>
    </indexterm>
 
    <indexterm zone="sql-syntax-identifiers">
-<!--
     <primary>name</primary>
     <secondary>syntax of</secondary>
--->
+   </indexterm>
+   <indexterm zone="sql-syntax-identifiers">
     <primary>名前</primary>
     <secondary>の構文</secondary>
    </indexterm>
 
    <indexterm zone="sql-syntax-identifiers">
-<!--
     <primary>key word</primary>
     <secondary>syntax of</secondary>
--->
+   </indexterm>
+   <indexterm zone="sql-syntax-identifiers">
     <primary>キーワード</primary>
     <secondary>の構文</secondary>
    </indexterm>
@@ -207,9 +207,7 @@ SQL識別子とキーワードは、文字（<literal>a</literal>〜<literal>z</
    </para>
 
    <para>
-<!--
     <indexterm><primary>identifier</primary><secondary>length</secondary></indexterm>
--->
     <indexterm><primary>識別子</primary><secondary>長さ</secondary></indexterm>
 <!--
     The system uses no more than <symbol>NAMEDATALEN</symbol>-1
@@ -228,10 +226,10 @@ SQL識別子とキーワードは、文字（<literal>a</literal>〜<literal>z</
 
    <para>
     <indexterm>
-<!--
      <primary>case sensitivity</primary>
      <secondary>of SQL commands</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>大文字小文字の区別</primary>
      <secondary>SQLコマンドの</secondary>
     </indexterm>
@@ -263,10 +261,10 @@ UPDATE my_table SET a = 5;
 
    <para>
     <indexterm>
-<!--
      <primary>quotation marks</primary>
      <secondary>and identifiers</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>引用符</primary>
      <secondary>および識別子</secondary>
     </indexterm>
@@ -334,10 +332,10 @@ UPDATE "my_table" SET "a" = 5;
    </para>
 
    <indexterm>
-<!--
      <primary>Unicode escape</primary>
      <secondary>in identifiers</secondary>
--->
+   </indexterm>
+   <indexterm>
      <primary>Unicodeエスケープ</primary>
      <secondary>識別子中</secondary>
    </indexterm>
@@ -440,9 +438,9 @@ U+FFFFより大きなコードポイントを持つ文字を構成するUTF-16�
    <title>定数</title>
 
    <indexterm zone="sql-syntax-constants">
-<!--
     <primary>constant</primary>
--->
+   </indexterm>
+   <indexterm zone="sql-syntax-constants">
     <primary>定数</primary>
    </indexterm>
 
@@ -469,20 +467,20 @@ U+FFFFより大きなコードポイントを持つ文字を構成するUTF-16�
     <title>文字列定数</title>
 
     <indexterm zone="sql-syntax-strings">
-<!--
      <primary>character string</primary>
      <secondary>constant</secondary>
--->
+    </indexterm>
+    <indexterm zone="sql-syntax-strings">
      <primary>文字列</primary>
      <secondary>定数</secondary>
     </indexterm>
 
     <para>
      <indexterm>
-<!--
       <primary>quotation marks</primary>
       <secondary>escaping</secondary>
--->
+     </indexterm>
+     <indexterm>
       <primary>引用符</primary>
       <secondary>エスケープ</secondary>
      </indexterm>
@@ -548,15 +546,15 @@ SELECT 'foo'      'bar';
     <title>C形式エスケープでの文字列定数</title>
 
      <indexterm zone="sql-syntax-strings-escape">
-<!--
       <primary>escape string syntax</primary>
--->
+     </indexterm>
+     <indexterm zone="sql-syntax-strings-escape">
       <primary>エスケープ文字列構文</primary>
      </indexterm>
      <indexterm zone="sql-syntax-strings-escape">
-<!--
       <primary>backslash escapes</primary>
--->
+     </indexterm>
+     <indexterm zone="sql-syntax-strings-escape">
       <primary>バックスラッシュエスケープ</primary>
      </indexterm>
 
@@ -749,10 +747,10 @@ SELECT 'foo'      'bar';
     <title>Unicodeエスケープがある文字列定数</title>
 
     <indexterm  zone="sql-syntax-strings-uescape">
-<!--
      <primary>Unicode escape</primary>
      <secondary>in string constants</secondary>
--->
+    </indexterm>
+    <indexterm  zone="sql-syntax-strings-uescape">
      <primary>Unicodeエスケープ</primary>
      <secondary>文字列定数中</secondary>
     </indexterm>
@@ -867,9 +865,9 @@ U+FFFFより大きなコードポイントを持つ文字を構成するUTF-16�
     <title>ドル記号で引用符付けされた文字列定数</title>
 
      <indexterm>
-<!--
       <primary>dollar quoting</primary>
--->
+     </indexterm>
+     <indexterm>
       <primary>ドル引用符付け</primary>
      </indexterm>
 
@@ -991,10 +989,10 @@ $function$
     <title>ビット文字列定数</title>
 
     <indexterm zone="sql-syntax-bit-strings">
-<!--
      <primary>bit string</primary>
      <secondary>constant</secondary>
--->
+    </indexterm>
+    <indexterm zone="sql-syntax-bit-strings">
      <primary>ビット文字列</primary>
      <secondary>定数</secondary>
     </indexterm>
@@ -1042,10 +1040,10 @@ $function$
     <title>数値定数</title>
 
     <indexterm>
-<!--
      <primary>number</primary>
      <secondary>constant</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>数値</primary>
      <secondary>定数</secondary>
     </indexterm>
@@ -1155,10 +1153,10 @@ REAL '1.23'  -- 文字列書式
     <title>他の型の定数</title>
 
     <indexterm>
-<!--
      <primary>data type</primary>
      <secondary>constant</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>データ型</primary>
      <secondary>定数</secondary>
     </indexterm>
@@ -1259,10 +1257,10 @@ SQLでは、この構文を数個のデータ型でのみ規定しています�
    <title>演算子</title>
 
    <indexterm zone="sql-syntax-operators">
-<!--
     <primary>operator</primary>
     <secondary>syntax</secondary>
--->
+   </indexterm>
+   <indexterm zone="sql-syntax-operators">
     <primary>演算子</primary>
     <secondary>構文</secondary>
    </indexterm>
@@ -1463,10 +1461,10 @@ SQLでは、この構文を数個のデータ型でのみ規定しています�
    <title>コメント</title>
 
    <indexterm zone="sql-syntax-comments">
-<!--
     <primary>comment</primary>
     <secondary sortas="SQL">in SQL</secondary>
--->
+   </indexterm>
+   <indexterm zone="sql-syntax-comments">
     <primary>コメント</primary>
     <secondary>SQL内の</secondary>
    </indexterm>
@@ -1528,10 +1526,10 @@ SQLでは、この構文を数個のデータ型でのみ規定しています�
    <title>演算子の優先順位</title>
 
    <indexterm zone="sql-precedence">
-<!--
     <primary>operator</primary>
     <secondary>precedence</secondary>
--->
+   </indexterm>
+   <indexterm zone="sql-precedence">
     <primary>演算子</primary>
     <secondary>優先順位</secondary>
    </indexterm>
@@ -1792,26 +1790,26 @@ SELECT 3 OPERATOR(pg_catalog.+) 4;
   <title>評価式</title>
 
   <indexterm zone="sql-expressions">
-<!--
    <primary>expression</primary>
    <secondary>syntax</secondary>
--->
+  </indexterm>
+  <indexterm zone="sql-expressions">
    <primary>式</primary>
    <secondary>の構文</secondary>
   </indexterm>
 
   <indexterm zone="sql-expressions">
-<!--
    <primary>value expression</primary>
--->
+  </indexterm>
+  <indexterm zone="sql-expressions">
    <primary>評価式</primary>
   </indexterm>
 
   <indexterm>
-<!--
    <primary>scalar</primary>
    <see>expression</see>
--->
+  </indexterm>
+  <indexterm>
    <primary>スカラ</primary>
    <see>式</see>
   </indexterm>
@@ -2015,9 +2013,9 @@ SELECT 3 OPERATOR(pg_catalog.+) 4;
    <title>列の参照</title>
 
    <indexterm>
-<!--
     <primary>column reference</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>列の参照</primary>
    </indexterm>
 
@@ -2052,10 +2050,10 @@ correlationの名前と区切り用のドットは、もし列名が現在の問
    <title>位置パラメータ</title>
 
    <indexterm>
-<!--
     <primary>parameter</primary>
     <secondary>syntax</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>パラメータ</primary>
     <secondary>の構文</secondary>
    </indexterm>
@@ -2112,9 +2110,9 @@ CREATE FUNCTION dept(text) RETURNS dept
    <title>添字</title>
 
    <indexterm>
-<!--
     <primary>subscript</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>添字</primary>
    </indexterm>
 
@@ -2180,9 +2178,9 @@ $1[10:42]
    <title>フィールド選択</title>
 
    <indexterm>
-<!--
     <primary>field selection</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>フィールド選択</primary>
    </indexterm>
 
@@ -2260,10 +2258,10 @@ $1.somecolumn
    <title>演算子の呼び出し</title>
 
    <indexterm>
-<!--
     <primary>operator</primary>
     <secondary>invocation</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>演算子</primary>
     <secondary>呼び出し</secondary>
    </indexterm>
@@ -2311,10 +2309,10 @@ $1.somecolumn
    <title>関数呼び出し</title>
 
    <indexterm>
-<!--
     <primary>function</primary>
     <secondary>invocation</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>関数</primary>
     <secondary>呼び出し</secondary>
    </indexterm>
@@ -2396,18 +2394,18 @@ sqrt(2)
    <title>集約式</title>
 
    <indexterm zone="syntax-aggregates">
-<!--
     <primary>aggregate function</primary>
     <secondary>invocation</secondary>
--->
+   </indexterm>
+   <indexterm zone="syntax-aggregates">
     <primary>集約関数</primary>
     <secondary>呼び出し</secondary>
    </indexterm>
 
    <indexterm zone="syntax-aggregates">
-<!--
     <primary>ordered-set aggregate</primary>
--->
+   </indexterm>
+   <indexterm zone="syntax-aggregates">
     <primary>順序集合集約</primary>
    </indexterm>
 
@@ -2625,10 +2623,10 @@ SELECT string_agg(a ORDER BY a, ',') FROM table;  -- incorrect
 
    <para>
     <indexterm>
-<!--
      <primary>median</primary>
      <seealso>percentile</seealso>
--->
+    </indexterm>
+    <indexterm>
      <primary>中央値(メジアン)</primary>
      <seealso>百分位数</seealso>
     </indexterm>
@@ -2729,18 +2727,18 @@ FROM generate_series(1,10) AS s(i);
    <title>ウィンドウ関数呼び出し</title>
 
    <indexterm zone="syntax-window-functions">
-<!--
     <primary>window function</primary>
     <secondary>invocation</secondary>
--->
+   </indexterm>
+   <indexterm zone="syntax-window-functions">
     <primary>ウィンドウ関数</primary>
     <secondary>起動</secondary>
    </indexterm>
 
    <indexterm zone="syntax-window-functions">
-<!--
     <primary>OVER clause</primary>
--->
+   </indexterm>
+   <indexterm zone="syntax-window-functions">
     <primary>OVER句</primary>
    </indexterm>
 
@@ -3122,18 +3120,18 @@ EXCLUDE NO OTHERS
    <title>型キャスト</title>
 
    <indexterm>
-<!--
     <primary>data type</primary>
     <secondary>type cast</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>データ型</primary>
     <secondary>型キャスト</secondary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>type cast</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>型キャスト</primary>
    </indexterm>
 
@@ -3345,9 +3343,9 @@ SELECT * FROM tbl WHERE (a &gt; 'foo') COLLATE "C";
    <title>スカラ副問い合わせ</title>
 
    <indexterm>
-<!--
     <primary>subquery</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>副問い合わせ</primary>
    </indexterm>
 
@@ -3397,10 +3395,10 @@ SELECT name, (SELECT max(pop) FROM cities WHERE cities.state = states.name)
    <title>配列コンストラクタ</title>
 
    <indexterm>
-<!--
     <primary>array</primary>
     <secondary>constructor</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>配列</primary>
     <secondary>コンストラクタ</secondary>
    </indexterm>
@@ -3584,19 +3582,19 @@ SELECT ARRAY(SELECT ARRAY[i, i*2] FROM generate_series(1,5) AS a(i));
    <title>行コンストラクタ</title>
 
    <indexterm>
-<!--
     <primary>composite type</primary>
     <secondary>constructor</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>複合型</primary>
     <secondary>のコンストラクタ</secondary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>row type</primary>
     <secondary>constructor</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>行型</primary>
     <secondary>のコンストラクタ</secondary>
    </indexterm>
@@ -3752,10 +3750,10 @@ SELECT ROW(table.*) IS NULL FROM table;  -- すべてがNULLの行を検出し�
    <title>式の評価規則</title>
 
    <indexterm>
-<!--
     <primary>expression</primary>
     <secondary>order of evaluation</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>式</primary>
     <secondary>の評価順</secondary>
    </indexterm>
@@ -3922,10 +3920,10 @@ SELECT CASE WHEN min(employees) > 0
   <title>関数呼び出し</title>
 
    <indexterm zone="sql-syntax-calling-funcs">
-<!--
     <primary>notation</primary>
     <secondary>functions</secondary>
--->
+   </indexterm>
+   <indexterm zone="sql-syntax-calling-funcs">
     <primary>表記</primary>
     <secondary>関数</secondary>
    </indexterm>
@@ -4018,10 +4016,10 @@ LANGUAGE SQL IMMUTABLE STRICT;
     <title>位置表記の使用</title>
 
     <indexterm>
-<!--
      <primary>function</primary>
      <secondary>positional notation</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>関数</primary>
      <secondary>位置表記</secondary>
     </indexterm>
@@ -4072,10 +4070,10 @@ SELECT concat_lower_or_upper('Hello', 'World');
     <title>名前付け表記の使用</title>
 
     <indexterm>
-<!--
      <primary>function</primary>
      <secondary>named notation</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>関数</primary>
      <secondary>名前付け表記</secondary>
     </indexterm>
@@ -4141,10 +4139,10 @@ SELECT concat_lower_or_upper(a := 'Hello', uppercase := true, b := 'World');
    <title>混在表記の利用</title>
 
    <indexterm>
-<!--
     <primary>function</primary>
     <secondary>mixed notation</secondary>
--->
+   </indexterm>
+   <indexterm>
      <primary>関数</primary>
      <secondary>混在表記</secondary>
    </indexterm>

--- a/doc/src/sgml/tableam.sgml
+++ b/doc/src/sgml/tableam.sgml
@@ -7,16 +7,17 @@
  <title>テーブルアクセスメソッドのインタフェース定義</title>
 
  <indexterm>
-<!--
   <primary>Table Access Method</primary>
--->
+ </indexterm>
+ <indexterm>
   <primary>テーブルアクセスメソッド</primary>
  </indexterm>
  <indexterm>
   <primary>tableam</primary>
-<!--
   <secondary>Table Access Method</secondary>
--->
+ </indexterm>
+ <indexterm>
+  <primary>tableam</primary>
   <secondary>テーブルアクセスメソッド</secondary>
  </indexterm>
 

--- a/doc/src/sgml/tablesample-method.sgml
+++ b/doc/src/sgml/tablesample-method.sgml
@@ -7,16 +7,16 @@
  <title>テーブルサンプリングメソッドの書き方</title>
 
  <indexterm zone="tablesample-method">
-<!--
   <primary>table sampling method</primary>
--->
+ </indexterm>
+ <indexterm zone="tablesample-method">
   <primary>テーブルサンプリングメソッド</primary>
  </indexterm>
 
  <indexterm zone="tablesample-method">
-<!--
   <primary><literal>TABLESAMPLE</literal> method</primary>
--->
+ </indexterm>
+ <indexterm zone="tablesample-method">
   <primary><literal>TABLESAMPLE</literal>メソッド</primary>
  </indexterm>
 

--- a/doc/src/sgml/textsearch.sgml
+++ b/doc/src/sgml/textsearch.sgml
@@ -7,16 +7,16 @@
  <title>全文検索</title>
 
   <indexterm zone="textsearch">
-<!--
    <primary>full text search</primary>
--->
+  </indexterm>
+  <indexterm zone="textsearch">
    <primary>全文検索</primary>
   </indexterm>
 
   <indexterm zone="textsearch">
-<!--
    <primary>text search</primary>
--->
+  </indexterm>
+  <indexterm zone="textsearch">
    <primary>テキスト検索</primary>
   </indexterm>
 
@@ -256,10 +256,10 @@
    <title>文書とは何か?</title>
 
    <indexterm zone="textsearch-document">
-<!--
     <primary>document</primary>
     <secondary>text search</secondary>
--->
+   </indexterm>
+   <indexterm zone="textsearch-document">
     <primary>文書</primary>
     <secondary>全文検索</secondary>
    </indexterm>
@@ -1966,10 +1966,10 @@ occurrences to display in the result.',
 
      <term>
      <indexterm>
-<!--
       <primary>tsvector concatenation</primary>
--->
-      <primary>tsvectorの結合</primary>
+     </indexterm>
+     <indexterm>
+       <primary>tsvectorの結合</primary>
      </indexterm>
 
       <literal><type>tsvector</type> || <type>tsvector</type></literal>
@@ -2486,10 +2486,10 @@ SELECT ts_rewrite('a &amp; b'::tsquery,
    <title>自動更新のためのトリガ</title>
 
    <indexterm>
-<!--
     <primary>trigger</primary>
     <secondary>for updating a derived tsvector column</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>トリガ</primary>
     <secondary>tsvectorから派生した列を更新する</secondary>
    </indexterm>
@@ -4839,10 +4839,10 @@ SELECT plainto_tsquery('supernovae stars');
   <title>GINおよびGiSTインデックス種類</title>
 
   <indexterm zone="textsearch-indexes">
-<!--
    <primary>text search</primary>
    <secondary>indexes</secondary>
--->
+  </indexterm>
+  <indexterm zone="textsearch-indexes">
    <primary>全文検索</primary>
    <secondary>インデックス</secondary>
   </indexterm>
@@ -4863,14 +4863,13 @@ SELECT plainto_tsquery('supernovae stars');
 
      <term>
      <indexterm zone="textsearch-indexes">
-<!--
       <primary>index</primary>
--->
+      <secondary>GIN</secondary>
+      <tertiary>text search</tertiary>
+     </indexterm>
+     <indexterm zone="textsearch-indexes">
       <primary>インデックス</primary>
       <secondary>GIN</secondary>
-<!--
-      <tertiary>text search</tertiary>
--->
       <tertiary>全文検索</tertiary>
      </indexterm>
 
@@ -4893,16 +4892,15 @@ GIN (Generalized Inverted Index)インデックスを作ります。
 
      <term>
      <indexterm zone="textsearch-indexes">
-<!--
       <primary>index</primary>
--->
+      <secondary>GiST</secondary>
+      <tertiary>text search</tertiary>
+     </indexterm>
+     <indexterm zone="textsearch-indexes">
       <primary>インデックス</primary>
       <secondary>GiST</secondary>
-<!--
-      <tertiary>text search</tertiary>
--->
       <tertiary>全文検索</tertiary>
-     </indexterm>
+    </indexterm>
 
       <literal>CREATE INDEX <replaceable>name</replaceable> ON <replaceable>table</replaceable> USING GIST (<replaceable>column</replaceable> [ { DEFAULT | tsvector_ops } (siglen = <replaceable>number</replaceable>) ] );</literal>
      </term>

--- a/doc/src/sgml/trigger.sgml
+++ b/doc/src/sgml/trigger.sgml
@@ -7,9 +7,9 @@
 <title>トリガ</title>
 
   <indexterm zone="triggers">
-<!--
    <primary>trigger</primary>
--->
+  </indexterm>
+  <indexterm zone="triggers">
    <primary>トリガ</primary>
   </indexterm>
 
@@ -469,10 +469,10 @@ C言語インタフェースでは、この時点では列の内容は未定義�
 
    <para>
     <indexterm>
-<!--
      <primary>trigger</primary>
      <secondary>arguments for trigger functions</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>トリガ</primary>
      <secondary>トリガ関数の引数</secondary>
     </indexterm>
@@ -657,19 +657,19 @@ C言語インタフェースでは、この時点では列の内容は未定義�
    <title>Cによるトリガ関数の作成</title>
 
    <indexterm zone="trigger-interface">
-<!--
     <primary>trigger</primary>
     <secondary>in C</secondary>
--->
+   </indexterm>
+   <indexterm zone="trigger-interface">
     <primary>トリガ</primary>
     <secondary>Cによる</secondary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>transition tables</primary>
     <secondary>referencing from C trigger</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>遷移テーブル</primary>
     <secondary>Cトリガからの参照</secondary>
    </indexterm>

--- a/doc/src/sgml/typeconv.sgml
+++ b/doc/src/sgml/typeconv.sgml
@@ -7,10 +7,10 @@
 <title>型変換</title>
 
 <indexterm zone="typeconv">
-<!--
  <primary>data type</primary>
  <secondary>conversion</secondary>
--->
+</indexterm>
+<indexterm zone="typeconv">
  <primary>データ型</primary>
  <secondary>変換</secondary>
 </indexterm>
@@ -229,10 +229,10 @@ altered.)
 </para>
 
 <indexterm>
-<!--
  <primary>data type</primary>
  <secondary>category</secondary>
--->
+ </indexterm>
+<indexterm>
  <primary>データ型</primary>
  <secondary>カテゴリ</secondary>
 </indexterm>
@@ -312,10 +312,10 @@ should use this new function and no longer do implicit conversion to use the old
 <title>演算子</title>
 
 <indexterm zone="typeconv-oper">
-<!--
  <primary>operator</primary>
  <secondary>type resolution in an invocation</secondary>
--->
+ </indexterm>
+<indexterm zone="typeconv-oper">
  <primary>演算子</primary>
  <secondary>の呼び出しにおける型の解決</secondary>
 </indexterm>
@@ -838,10 +838,10 @@ usable in all the same cases as a similarly-named operator on the base type.
 <title>関数</title>
 
 <indexterm zone="typeconv-func">
-<!--
  <primary>function</primary>
  <secondary>type resolution in an invocation</secondary>
--->
+ </indexterm>
+<indexterm zone="typeconv-func">
  <primary>関数</primary>
  <secondary>の呼び出しにおける型解決</secondary>
 </indexterm>
@@ -1497,49 +1497,55 @@ padding spaces.
 
 <indexterm zone="typeconv-union-case">
  <primary>UNION</primary>
-<!--
  <secondary>determination of result type</secondary>
--->
+ </indexterm>
+<indexterm zone="typeconv-union-case">
+ <primary>UNION</primary>
  <secondary>結果型の決定</secondary>
 </indexterm>
 
 <indexterm zone="typeconv-union-case">
  <primary>CASE</primary>
-<!--
  <secondary>determination of result type</secondary>
--->
+ </indexterm>
+<indexterm zone="typeconv-union-case">
+ <primary>CASE</primary>
  <secondary>結果型の決定</secondary>
 </indexterm>
 
 <indexterm zone="typeconv-union-case">
  <primary>ARRAY</primary>
-<!--
  <secondary>determination of result type</secondary>
--->
+ </indexterm>
+<indexterm zone="typeconv-union-case">
+ <primary>ARRAY</primary>
  <secondary>結果型の決定</secondary>
 </indexterm>
 
 <indexterm zone="typeconv-union-case">
  <primary>VALUES</primary>
-<!--
  <secondary>determination of result type</secondary>
--->
+ </indexterm>
+<indexterm zone="typeconv-union-case">
+ <primary>VALUES</primary>
  <secondary>結果型の決定</secondary>
 </indexterm>
 
 <indexterm zone="typeconv-union-case">
  <primary>GREATEST</primary>
-<!--
  <secondary>determination of result type</secondary>
--->
+ </indexterm>
+<indexterm zone="typeconv-union-case">
+ <primary>GREATEST</primary>
  <secondary>結果型の決定</secondary>
 </indexterm>
 
 <indexterm zone="typeconv-union-case">
  <primary>LEAST</primary>
-<!--
  <secondary>determination of result type</secondary>
--->
+ </indexterm>
+<indexterm zone="typeconv-union-case">
+ <primary>LEAST</primary>
  <secondary>結果型の決定</secondary>
 </indexterm>
 
@@ -1806,9 +1812,10 @@ section consider all of their inputs in one resolution step.
 
 <indexterm zone="typeconv-select">
  <primary>SELECT</primary>
-<!--
  <secondary>determination of result type</secondary>
--->
+ </indexterm>
+<indexterm zone="typeconv-select">
+ <primary>SELECT</primary>
  <secondary>結果型の決定</secondary>
 </indexterm>
 

--- a/doc/src/sgml/user-manag.sgml
+++ b/doc/src/sgml/user-manag.sgml
@@ -55,16 +55,16 @@
 <title>データベースロール</title>
 
   <indexterm zone="database-roles">
-<!--
    <primary>role</primary>
--->
+  </indexterm>
+  <indexterm zone="database-roles">
    <primary>ロール</primary>
   </indexterm>
 
   <indexterm zone="database-roles">
-<!--
    <primary>user</primary>
--->
+  </indexterm>
+  <indexterm zone="database-roles">
    <primary>ユーザ</primary>
   </indexterm>
 
@@ -438,9 +438,9 @@ ALTER ROLE myname SET enable_indexscan TO off;
 <title>ロールのメンバ資格</title>
 
   <indexterm zone="role-membership">
-<!--
    <primary>role</primary><secondary>membership in</secondary>
--->
+  </indexterm>
+  <indexterm zone="role-membership">
    <primary>ロール</primary><secondary>内のメンバ資格</secondary>
   </indexterm>
 

--- a/doc/src/sgml/wal.sgml
+++ b/doc/src/sgml/wal.sgml
@@ -362,9 +362,9 @@ CRCの値はそれぞれのWALレコードを書き込み、クラッシュ回�
    </indexterm>
 
    <indexterm>
-<!--
     <primary>transaction log</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>トランザクションログ</primary>
     <see>WAL</see>
    </indexterm>
@@ -460,16 +460,16 @@ WALのデータを保持することにより、そのWALデータが範囲内�
   <title>非同期コミット</title>
 
    <indexterm>
-<!--
     <primary>synchronous commit</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>同期コミット</primary>
    </indexterm>
 
    <indexterm>
-<!--
     <primary>asynchronous commit</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>非同期コミット</primary>
    </indexterm>
 

--- a/doc/src/sgml/xaggr.sgml
+++ b/doc/src/sgml/xaggr.sgml
@@ -7,10 +7,10 @@
   <title>ユーザ定義の集約</title>
 
   <indexterm zone="xaggr">
-<!--
    <primary>aggregate function</primary>
    <secondary>user-defined</secondary>
--->
+  </indexterm>
+  <indexterm zone="xaggr">
    <primary>集約関数</primary>
    <secondary>ユーザ定義</secondary>
   </indexterm>
@@ -217,17 +217,17 @@ SQLの集約関数はオプションにより<literal>DISTINCT</literal>と<lite
   <title>移動集約モード</title>
 
   <indexterm>
-<!--
    <primary>moving-aggregate mode</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>移動集約モード</primary>
   </indexterm>
 
   <indexterm>
-<!--
    <primary>aggregate function</primary>
    <secondary>moving aggregate</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>集約関数</primary>
    <secondary>移動集約</secondary>
   </indexterm>
@@ -400,19 +400,19 @@ FROM (VALUES (1, 1.0e20::float8),
   <title>多様引数と可変長引数集約</title>
 
   <indexterm>
-<!--
    <primary>aggregate function</primary>
    <secondary>polymorphic</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>集約関数</primary>
    <secondary>多様引数</secondary>
   </indexterm>
 
   <indexterm>
-<!--
    <primary>aggregate function</primary>
    <secondary>variadic</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>集約関数</primary>
    <secondary>可変長引数</secondary>
   </indexterm>
@@ -604,10 +604,10 @@ SELECT myaggregate(a, b, c ORDER BY a) FROM ...
   <title>順序集合の集約</title>
 
   <indexterm>
-<!--
    <primary>aggregate function</primary>
    <secondary>ordered set</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>集約関数</primary>
    <secondary>順序集合</secondary>
   </indexterm>
@@ -744,10 +744,10 @@ SELECT percentile_disc(0.5) WITHIN GROUP (ORDER BY income) FROM households;
   <title>部分集約</title>
 
   <indexterm>
-<!--
    <primary>aggregate function</primary>
    <secondary>partial aggregation</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>集約関数</primary>
    <secondary>部分集約</secondary>
   </indexterm>
@@ -889,10 +889,10 @@ SELECT percentile_disc(0.5) WITHIN GROUP (ORDER BY income) FROM households;
   <title>集約サポート関数</title>
 
   <indexterm>
-<!--
    <primary>aggregate function</primary>
    <secondary>support functions for</secondary>
--->
+  </indexterm>
+  <indexterm>
    <primary>集約関数</primary>
    <secondary>サポート関数</secondary>
   </indexterm>

--- a/doc/src/sgml/xfunc.sgml
+++ b/doc/src/sgml/xfunc.sgml
@@ -7,10 +7,10 @@
   <title>ユーザ定義関数</title>
 
   <indexterm zone="xfunc">
-<!--
    <primary>function</primary>
    <secondary>user-defined</secondary>
--->
+  </indexterm>
+  <indexterm zone="xfunc">
    <primary>関数</primary>
    <secondary>ユーザ定義</secondary>
   </indexterm>
@@ -119,10 +119,10 @@ C言語関数（<xref linkend="xfunc-c"/>）
    <title>ユーザ定義プロシージャ</title>
 
   <indexterm zone="xproc">
-<!--
    <primary>procedure</primary>
    <secondary>user-defined</secondary>
--->
+  </indexterm>
+  <indexterm zone="xproc">
    <primary>プロシージャ</primary>
    <secondary>ユーザ定義</secondary>
   </indexterm>
@@ -176,11 +176,11 @@ CALLコマンドが明示的なトランザクション内で無い場合、多�
 <title>問い合わせ言語（<acronym>SQL</acronym>）関数</title>
 
    <indexterm zone="xfunc-sql">
-<!--
     <primary>function</primary>
     <secondary>user-defined</secondary>
     <tertiary>in SQL</tertiary>
--->
+   </indexterm>
+   <indexterm zone="xfunc-sql">
     <primary>関数</primary>
     <secondary>ユーザ定義</secondary>
     <tertiary>SQLで作成した</tertiary>
@@ -316,10 +316,10 @@ SQL関数はシステムカタログを変更するコマンド(例えば<comman
     <title><acronym>SQL</acronym>関数用の引数</title>
 
    <indexterm>
-<!--
     <primary>function</primary>
     <secondary>named argument</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>関数</primary>
     <secondary>名前付き引数</secondary>
    </indexterm>
@@ -906,10 +906,10 @@ SELECT getname(new_emp());
     <title>出力パラメータを持つ<acronym>SQL</acronym>関数</title>
 
    <indexterm>
-<!--
     <primary>function</primary>
     <secondary>output parameter</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>関数</primary>
     <secondary>出力パラメータ</secondary>
    </indexterm>
@@ -1029,17 +1029,17 @@ DROP FUNCTION sum_n_product (int, int);
     <title>可変長引数を取る<acronym>SQL</acronym>関数</title>
 
     <indexterm>
-<!--
      <primary>function</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>関数</primary>
      <secondary>variadic</secondary>
     </indexterm>
 
     <indexterm>
-<!--
      <primary>variadic function</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>variadic関数</primary>
     </indexterm>
 
@@ -1183,10 +1183,10 @@ SELECT mleast(arr =&gt; ARRAY[10, -1, 5, 4.4]);
     <title>引数にデフォルト値を持つ<acronym>SQL</acronym>関数</title>
 
     <indexterm>
-<!--
      <primary>function</primary>
      <secondary>default values for arguments</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>関数</primary>
      <secondary>引数のデフォルト値</secondary>
     </indexterm>
@@ -1326,10 +1326,10 @@ SELECT *, upper(fooname) FROM getfoo(1) AS t1;
 <title>集合を返す<acronym>SQL</acronym>関数</title>
 
     <indexterm>
-<!--
      <primary>function</primary>
      <secondary>with SETOF</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>関数</primary>
      <secondary>SETOF 付き</secondary>
     </indexterm>
@@ -1703,9 +1703,9 @@ SELECT x, case_generate_series(y &gt; 0, 1, z, 5) FROM tab;
     <title><literal>TABLE</literal>を返す<acronym>SQL</acronym>関数</title>
 
     <indexterm>
-<!--
      <primary>function</primary>
--->
+    </indexterm>
+    <indexterm>
      <primary>関数</primary>
      <secondary>RETURNS TABLE</secondary>
     </indexterm>
@@ -1935,10 +1935,10 @@ SELECT concat_values('|', 1, 4, 2);
     <title>照合順序を持つ<acronym>SQL</acronym>関数</title>
 
     <indexterm>
-<!--
      <primary>collation</primary>
      <secondary>in SQL functions</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>照合順序</primary>
      <secondary>SQL関数における</secondary>
     </indexterm>
@@ -2023,10 +2023,10 @@ $$ LANGUAGE SQL;
 <title>関数のオーバーロード</title>
 
    <indexterm zone="xfunc-overload">
-<!--
     <primary>overloading</primary>
     <secondary>functions</secondary>
--->
+   </indexterm>
+   <indexterm zone="xfunc-overload">
     <primary>オーバーロード</primary>
     <secondary>関数</secondary>
    </indexterm>
@@ -2152,10 +2152,10 @@ CREATE FUNCTION test(int, int) RETURNS int
    <title>関数の変動性分類</title>
 
    <indexterm zone="xfunc-volatility">
-<!--
     <primary>volatility</primary>
     <secondary>functions</secondary>
--->
+   </indexterm>
+   <indexterm zone="xfunc-volatility">
     <primary>変動性</primary>
     <secondary>関数</secondary>
    </indexterm>
@@ -2418,9 +2418,7 @@ SQLもしくは標準手続き言語で作成された関数では、変動性�
 -->
 <title>内部関数</title>
 
-<!--
    <indexterm zone="xfunc-internal"><primary>function</primary><secondary>internal</secondary></indexterm>
--->
    <indexterm zone="xfunc-internal"><primary>関数</primary><secondary>内部</secondary></indexterm>
 
    <para>
@@ -2486,11 +2484,11 @@ SQLで作成された定義済み関数もあります。
 <title>C言語関数</title>
 
    <indexterm zone="xfunc-c">
-<!--
     <primary>function</primary>
     <secondary>user-defined</secondary>
     <tertiary>in C</tertiary>
--->
+   </indexterm>
+   <indexterm zone="xfunc-c">
     <primary>関数</primary>
     <secondary>ユーザ定義</secondary>
     <tertiary>Cで作成された</tertiary>
@@ -2533,9 +2531,9 @@ SQLで作成された定義済み関数もあります。
 <title>動的ロード</title>
 
    <indexterm zone="xfunc-c-dynload">
-<!--
     <primary>dynamic loading</primary>
--->
+   </indexterm>
+   <indexterm zone="xfunc-c-dynload">
     <primary>動的ロード</primary>
    </indexterm>
 
@@ -2677,9 +2675,9 @@ C名称が明示的に指定されなかった場合、SQLにおける関数名�
    </note>
 
    <indexterm zone="xfunc-c-dynload">
-<!--
     <primary>magic block</primary>
--->
+   </indexterm>
+   <indexterm zone="xfunc-c-dynload">
     <primary>マジックブロック</primary>
    </indexterm>
 
@@ -2723,15 +2721,15 @@ PG_MODULE_MAGIC;
     <primary>_PG_fini</primary>
    </indexterm>
    <indexterm zone="xfunc-c-dynload">
-<!--
     <primary>library initialization function</primary>
--->
+   </indexterm>
+   <indexterm zone="xfunc-c-dynload">
     <primary>ライブラリ初期化処理関数</primary>
    </indexterm>
    <indexterm zone="xfunc-c-dynload">
-<!--
     <primary>library finalization function</primary>
--->
+   </indexterm>
+   <indexterm zone="xfunc-c-dynload">
     <primary>ライブラリ最終処理関数</primary>
    </indexterm>
 
@@ -2767,10 +2765,10 @@ PG_MODULE_MAGIC;
 <title>C言語関数における基本型</title>
 
     <indexterm zone="xfunc-c-basetype">
-<!--
      <primary>data type</primary>
      <secondary>internal organization</secondary>
--->
+    </indexterm>
+    <indexterm zone="xfunc-c-basetype">
      <primary>データ型</primary>
      <secondary>内部構成</secondary>
     </indexterm>
@@ -4946,10 +4944,10 @@ C++コードからバックエンド関数を呼び出す場合には、C++呼�
    <title>関数最適化に関する情報</title>
 
   <indexterm zone="xfunc-optimization">
-<!--
    <primary>optimization information</primary>
    <secondary>for functions</secondary>
--->
+  </indexterm>
+  <indexterm zone="xfunc-optimization">
    <primary>最適化情報</primary>
    <secondary>関数に対する</secondary>
   </indexterm>

--- a/doc/src/sgml/xindex.sgml
+++ b/doc/src/sgml/xindex.sgml
@@ -7,10 +7,10 @@
  <title>インデックス拡張機能へのインタフェース</title>
 
  <indexterm zone="xindex">
-<!--
   <primary>index</primary>
   <secondary>for user-defined data type</secondary>
--->
+ </indexterm>
+ <indexterm zone="xindex">
   <primary>インデックス</primary>
   <secondary>ユーザ定義データ型用の</secondary>
  </indexterm>
@@ -1836,9 +1836,9 @@ BRINでは、要求は演算子クラスを提供するフレームワークに�
   <title>システムの演算子クラスに対する依存性</title>
 
    <indexterm>
-<!--
     <primary>ordering operator</primary>
--->
+   </indexterm>
+   <indexterm>
     <primary>順序付け演算子</primary>
    </indexterm>
 

--- a/doc/src/sgml/xoper.sgml
+++ b/doc/src/sgml/xoper.sgml
@@ -7,10 +7,10 @@
   <title>ユーザ定義の演算子</title>
 
   <indexterm zone="xoper">
-<!--
    <primary>operator</primary>
    <secondary>user-defined</secondary>
--->
+  </indexterm>
+  <indexterm zone="xoper">
    <primary>演算子</primary>
    <secondary>ユーザ定義</secondary>
   </indexterm>
@@ -119,10 +119,10 @@ SELECT (a + b) AS c FROM test_complex;
    <title>演算子最適化に関する情報</title>
 
   <indexterm zone="xoper-optimization">
-<!--
    <primary>optimization information</primary>
    <secondary>for operators</secondary>
--->
+  </indexterm>
+  <indexterm zone="xoper-optimization">
    <primary>最適化情報</primary>
    <secondary>演算子に対する</secondary>
   </indexterm>

--- a/doc/src/sgml/xplang.sgml
+++ b/doc/src/sgml/xplang.sgml
@@ -7,9 +7,9 @@
   <title>手続き言語</title>
 
   <indexterm zone="xplang">
-<!--
    <primary>procedural language</primary>
--->
+  </indexterm>
+  <indexterm zone="xplang">
    <primary>手続き言語</primary>
   </indexterm>
 

--- a/doc/src/sgml/xtypes.sgml
+++ b/doc/src/sgml/xtypes.sgml
@@ -7,10 +7,10 @@
   <title>ユーザ定義の型</title>
 
   <indexterm zone="xtypes">
-<!--
    <primary>data type</primary>
    <secondary>user-defined</secondary>
--->
+  </indexterm>
+  <indexterm zone="xtypes">
    <primary>データ型</primary>
    <secondary>ユーザ定義の</secondary>
   </indexterm>
@@ -43,15 +43,15 @@
 
  <para>
   <indexterm>
-<!--
    <primary>input function</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>入力関数</primary>
   </indexterm>
   <indexterm>
-<!--
    <primary>output function</primary>
--->
+  </indexterm>
+  <indexterm>
    <primary>出力関数</primary>
   </indexterm>
 <!--
@@ -285,10 +285,10 @@ CREATE TYPE complex (
 
  <para>
   <indexterm>
-<!--
     <primary>array</primary>
     <secondary>of user-defined type</secondary>
--->
+  </indexterm>
+  <indexterm>
     <primary>配列</primary>
     <secondary>ユーザ定義型の</secondary>
   </indexterm>
@@ -347,10 +347,10 @@ CREATE TYPE complex (
 -->
   <title>TOASTの考慮</title>
    <indexterm>
-<!--
     <primary>TOAST</primary>
     <secondary>and user-defined types</secondary>
--->
+   </indexterm>
+   <indexterm>
     <primary>TOAST</primary>
     <secondary>とユーザ定義型</secondary>
    </indexterm>


### PR DESCRIPTION
resolves#2032
indexterm内の英語をコメントアウトしていた部分を戻して、
日本語用のindextermを追加しました。

本文内のindextermは自動では難しいので未着手です。