### PR TITLE
update test-decoding and textsearch for 14.0

### DIFF
--- a/doc/src/sgml/test-decoding.sgml
+++ b/doc/src/sgml/test-decoding.sgml
@@ -50,8 +50,11 @@ postgres=# SELECT * FROM pg_logical_slot_get_changes('test_slot', NULL, NULL, 'i
  </para>
 
 <para>
+<!--
   We can also get the changes of the in-progress transaction and the typical
   output, might be:
+-->
+進行中のトランザクションの変化を知ることもでき、典型的な出力は以下のようになるでしょう。
 
 <programlisting>
 postgres[33712]=#* SELECT * FROM pg_logical_slot_get_changes('test_slot', NULL, NULL, 'stream-changes', '1');

--- a/doc/src/sgml/textsearch.sgml
+++ b/doc/src/sgml/textsearch.sgml
@@ -24,8 +24,8 @@
 <!--
   <title>Introduction</title>
 -->
-
   <title>導入</title>
+
   <para>
 <!--
    Full Text Searching (or just <firstterm>text search</firstterm>) provides
@@ -2983,7 +2983,8 @@ LIMIT 10;
     Specifically, the only non-alphanumeric characters supported for
     email user names are period, dash, and underscore.
 -->
-<literal>email</literal>はRFC5322で定義されたすべての有効なメールアドレス文字をサポートしません。メールアドレスのユーザ名としてサポートされる英数字以外の文字はピリオド、ダッシュ、アンダースコアのみです。
+<literal>email</literal>は<ulink url="https://tools.ietf.org/html/rfc5322">RFC 5322</ulink>で定義されたすべての有効なメールアドレス文字をサポートしません。
+特に、メールアドレスのユーザ名としてサポートされる英数字以外の文字はピリオド、ダッシュ、アンダースコアのみです。
    </para>
   </note>
 


### PR DESCRIPTION
以下のファイルの１４．０対応です。

- test-decoding.sgml
- textsearch.sgml