### PR TITLE
high-availability.sgmlの翻訳文の修正（#2096の13へのバックポート）

### DIFF
--- a/doc/src/sgml/high-availability.sgml
+++ b/doc/src/sgml/high-availability.sgml
@@ -3295,7 +3295,7 @@ WALに記録された操作はすでにプライマリで発生したもので�
     <varname>max_standby_streaming_delay</varname> to avoid rapid cancellations
     by newly-arrived streaming WAL entries after reconnection.
 -->
-スタンバイのクエリが中断される受け入れがたいほど多い場合、この問題を解決する方法が用意されています。
+スタンバイにおける問い合わせの中断が受け入れがたいほど多い場合、この問題を改善する方法が用意されています。
 １つ目の選択肢は、<varname>hot_standby_feedback</varname>パラメータを設定することです。
 これは<command>VACUUM</command>による最近不要になった行の削除を防止しますので、消去によるコンフリクトが発生しません。
 これを行う場合、プライマリで不要になった行の消去が遅延することに注意が必要です。望まないテーブルの膨張が発生してしまうかもしれません。


### PR DESCRIPTION
・「クエリが中断される受け入れがたいほど多い」という表現の修正
・「クエリ」は他に合わせて「問い合わせ」に変更
・「解決」は「改善」の方が適切かと思われるので変更