### PR TITLE
再開始点をリスタートポイントに統一（wal.sgml翻訳文の修正)

### DIFF
--- a/doc/src/sgml/wal.sgml
+++ b/doc/src/sgml/wal.sgml
@@ -970,10 +970,10 @@ WALが生成されるペースにWALのアーカイブ処理が追いつかな�
    (<varname>max_wal_size</varname> is never a hard limit anyway, so you should
    always leave plenty of headroom to avoid running out of disk space.)
 -->
-アーカイブからのリカバリもしくはスタンバイモードにおいて、サーバでは定期的に通常運用でのチェックポイント処理と似た<firstterm>再開始点</firstterm><indexterm><primary>restartpoint</primary></indexterm>処理を行います。これは、すでに再生されたWALを再度読み込む必要がないよう、ディスクに現在の状態を強制的に書き込み、<filename>pg_control</filename>ファイルを更新します。また<filename>pg_wal</filename>ディレクトリの中の古いログセグメントを再利用できるようにします。
-再開始点処理はチェックポイントレコードに対してしか実施されないので、マスタ側のチェックポイント処理よりも発生頻度が多いということはありません。
-再開始点は、最後の再開始点より少なくとも<varname>checkpoint_timeout</varname>秒が経過しているか、あるいは<varname>max_wal_size</varname>を超えそうな場合に起動されます。
-しかし、再開始点が実施できるための制約事項により、リカバリの際には1回のチェックポイント分のWALを上限に、<varname>max_wal_size</varname>を超えてしまいがちです。
+アーカイブからのリカバリもしくはスタンバイモードにおいて、サーバでは定期的に通常運用でのチェックポイント処理と似た<firstterm>リスタートポイント</firstterm><indexterm><primary>restartpoint</primary></indexterm>処理を行います。これは、すでに再生されたWALを再度読み込む必要がないよう、ディスクに現在の状態を強制的に書き込み、<filename>pg_control</filename>ファイルを更新します。また<filename>pg_wal</filename>ディレクトリの中の古いログセグメントを再利用できるようにします。
+リスタートポイント処理はチェックポイントレコードに対してしか実施されないので、マスタ側のチェックポイント処理よりも発生頻度が多いということはありません。
+リスタートポイントは、最後のリスタートポイントより少なくとも<varname>checkpoint_timeout</varname>秒が経過しているか、あるいは<varname>max_wal_size</varname>を超えそうな場合に起動されます。
+しかし、リスタートポイントが実施できるための制約事項により、リカバリの際には1回のチェックポイント分のWALを上限に、<varname>max_wal_size</varname>を超えてしまいがちです。
 (どのみち<varname>max_wal_size</varname>はハードリミットではないので、ディスクスペースを使い尽くしてしまわないように、常に十分な余裕を持っておくべきです)
   </para>
 


### PR DESCRIPTION
翻訳のご対応ありがとうございます。
いつも大変お世話になっております。

「リスタートポイント」と「再開始点」が統一されておらず、ブラウザ上での検索が出来ず、少し困りましたので、本PRを作成致しました。どちらに統一するか迷いましたが、本PRでは「チェックポイント」と同様にカタカナ表記で統一しています。

具体的に困った点は、CHECKPOINT(1)の記載から、「リスタートポイント」についてのリンクに飛ぶと、そのページ(2)では、「再開始点」との記載になっており、ブラウザ上での検索でヒットせず、リンクが張られているのに詳細が記載されていないと誤解してしまいました。

(1) https://www.postgresql.jp/document/13/html/sql-checkpoint.html
(2) https://www.postgresql.jp/document/13/html/wal-configuration.html

不足点などありましたら、ご指摘頂ければと思います。