### PR TITLE
Issue #2184 の対応

### DIFF
--- a/doc/src/sgml/textsearch.sgml
+++ b/doc/src/sgml/textsearch.sgml
@@ -4856,7 +4856,7 @@ SELECT plainto_tsquery('supernovae stars');
    cases where a column is searched on a regular basis, an index is
    usually desirable.
 -->
-全文検索を高速化するために、2種類のインデックスが使えます。全文検索のためにインデックスが必須だと言うわけではないことを言っておかなければなりませんが、日常的に検索される列には、インデックスを使った方が良いでしょう。
+全文検索を高速化するために、2種類のインデックスが使えます。全文検索でインデックスが必須ではありませんが、日常的に検索される列には、インデックスを使った方が良いでしょう。
 
    <variablelist>
 


### PR DESCRIPTION
Issue #2184 の対応
『全文検索のためにインデックスが必須だと言うわけではないことを言っておかなければなりませんが』を『全文検索でインデックスが必須ではありませんが』に修正しました。