### PR TITLE
fix translation of "lossy"

### DIFF
--- a/doc/src/sgml/indexam.sgml
+++ b/doc/src/sgml/indexam.sgml
@@ -1320,7 +1320,7 @@ amparallelrescan (IndexScanDesc scan);
    all-visible page; else the heap tuple must be visited anyway to check
    MVCC visibility.  But that is no concern of the access method's.
 -->
-インデックスが設定された列値がインデックスに格納されている(かつ、不可逆表現ではない)場合、ヒープタプルのTIDではなくインデックスに格納された実際のデータを返す<link linkend="indexes-index-only-scans">インデックスオンリースキャン</link>をサポートするのに有用です。
+インデックスが設定された列値がインデックスに格納されている(かつ、損失のある表現ではない)場合、ヒープタプルのTIDではなくインデックスに格納された実際のデータを返す<link linkend="indexes-index-only-scans">インデックスオンリースキャン</link>をサポートするのに有用です。
 これは、可視性マップによってTIDが全可視のページ上にあると判断できる場合にI/Oを避けるだけのことです。
 判断できない場合はMVCCを確認するためにヒープタプルにアクセスしなくてはなりません。
 しかしその動作はアクセスメソッドでは考慮されていません。


### PR DESCRIPTION
#2213 で取り上げたものの一部です。

- ここだけ「不可逆」となっている（他のところでは「非可逆」）
- #2206 と同じ"lossy representation(s)"の訳

ということで、これだけ先走って対処します。

（原文がlossyとrepresentationの間に改行が入っており、単純に検索すると見落としそう、というのもあります。）