### PR TITLE
identifiesの修正

### DIFF
--- a/doc/src/sgml/information_schema.sgml
+++ b/doc/src/sgml/information_schema.sgml
@@ -272,7 +272,7 @@
    identifies all roles that the current user has the admin option
    for.
 -->
-<literal>administrable_role_authorizations</literal>ビューは、現在のユーザがアドミンオプションを持つすべてのロールを識別します。
+<literal>administrable_role_authorizations</literal>ビューは、現在のユーザがアドミンオプションを持つすべてのロールを示します。
   </para>
 
   <table>
@@ -355,7 +355,7 @@
    <indexterm><primary>applicable role</primary></indexterm>
    <indexterm><primary>role</primary><secondary>applicable</secondary></indexterm>
 -->
-<literal>applicable_roles</literal>ビューは、その権限を現在のユーザが使用することができるすべてのロールを識別します。
+<literal>applicable_roles</literal>ビューは、その権限を現在のユーザが使用することができるすべてのロールを示します。
 これは、現在のユーザから問題のロールに付与されたロールの連鎖が存在することを意味します。
 現在のユーザ自身もまた適用可能なロールです。
 適用可能なロール群は通常権限の検査に使用されます。
@@ -588,7 +588,7 @@
        string type, the declared maximum length; null for all other
        data types or if no maximum length was declared.
 -->
-<literal>data_type</literal>が文字列またはビット列を識別する場合、その宣言された最大長です。
+<literal>data_type</literal>が文字列またはビット列と識別される場合、その宣言された最大長です。
 他のデータ型または最大長が宣言されていない場合はNULLです。
       </para></entry>
      </row>
@@ -605,7 +605,7 @@
        the declared character maximum length (see above) and the
        server encoding.
 -->
-<literal>data_type</literal>が文字列を識別する場合、オクテット（バイト）単位で表したデータの最大長です。
+<literal>data_type</literal>が文字列と識別される場合、オクテット（バイト）単位で表したデータの最大長です。
 他のデータ型ではNULLです。
 最大オクテット長は宣言された文字最大長(上述)とサーバ符号化方式に依存します。
       </para></entry>
@@ -702,7 +702,7 @@
        <literal>numeric_precision_radix</literal>.  For all other data
        types, this column is null.
 -->
-<literal>data_type</literal>が数値型を識別する場合、この列は属性の型の（宣言された、あるいは暗黙的な）精度です。
+<literal>data_type</literal>が数値型と識別される場合、この列は属性の型の（宣言された、あるいは暗黙的な）精度です。
 この精度は有効桁を意味します。
 <literal>numeric_precision_radix</literal>列の指定に従って、(10を基とした)10進数、または(2を基とした)2進数表記で表現されます。
 他の全ての型の場合では、この列はNULLです。
@@ -721,7 +721,7 @@
        <literal>numeric_scale</literal> are expressed.  The value is
        either 2 or 10.  For all other data types, this column is null.
 -->
-<literal>data_type</literal>が数値型を識別する場合、この列は、<literal>numeric_precision</literal>および<literal>numeric_scale</literal>で表現される値の基が何かを識別します。
+<literal>data_type</literal>が数値型と識別される場合、この列は、<literal>numeric_precision</literal>および<literal>numeric_scale</literal>で表現される値の基が何かを示します。
 この値は2または10です。
 他の全ての型の場合では、この列はNULLです。
       </para></entry>
@@ -742,7 +742,7 @@
        <literal>numeric_precision_radix</literal>.  For all other data
        types, this column is null.
 -->
-<literal>data_type</literal>が数値型を識別する場合、この列は、属性の型の（宣言された、あるいは暗黙的な）位取りが含まれます。
+<literal>data_type</literal>が数値型と識別される場合、この列は、属性の型の（宣言された、あるいは暗黙的な）位取りが含まれます。
 位取りは小数点以下の有効桁数を意味します。
 <literal>numeric_precision_radix</literal>列の指定に従って、(10を基とした)10進数、または(2を基とした)2進数表記で表現されます。
 他の全ての型の場合では、この列はNULLです。
@@ -762,7 +762,7 @@
        following the decimal point in the seconds value.  For all
        other data types, this column is null.
 -->
-<literal>data_type</literal>が日付、時刻、タイムスタンプ、または間隔型を示す場合、この列は（宣言されたか暗黙的な）この属性に対する分数秒精度を包含します。
+<literal>data_type</literal>が日付、時刻、タイムスタンプ、または間隔型と識別される場合、この列は（宣言されたか暗黙的な）この属性に対する分数秒精度を包含します。
 つまり、秒の値の小数点に続く保存された10進桁数です。
 他の全ての型の場合では、この列はNULLです。
       </para></entry>
@@ -782,7 +782,7 @@
        accepts all fields), and for all other data types, this field
        is null.
 -->
-もし<literal>data_type</literal>が時間間隔型を示す場合、この列はこの属性の時間間隔値がどのフィールドを含むかの仕様を含みます。例えば、<literal>YEAR TO MONTH</literal>、<literal>DAY TO SECOND</literal>などです。
+<literal>data_type</literal>が時間間隔型と識別される場合、この列はこの属性の時間間隔値がどのフィールドを含むかの仕様を含みます。例えば、<literal>YEAR TO MONTH</literal>、<literal>DAY TO SECOND</literal>などです。
 もしフィールド制約が指定されていない(時間間隔が全てのフィールドを受け付ける)場合や、他の全てのデータ型の場合はこのフィールドはNULLです。
       </para></entry>
      </row>
@@ -942,7 +942,8 @@
    support multiple character sets within one database, this view only
    shows one, which is the database encoding.
 -->
-この<literal>character_sets</literal>ビューは、現在のデータベースで利用可能な文字セットを識別します。PostgreSQLはひとつのデータベース内で複数の文字セットをサポートしないので、このビューは常にデータベースエンコーディングの一行だけを表示します。
+この<literal>character_sets</literal>ビューは、現在のデータベースで利用可能な文字セットを示します。
+PostgreSQLはひとつのデータベース内で複数の文字セットをサポートしないので、このビューは常にデータベースエンコーディングの一行だけを表示します。
   </para>
 
   <para>
@@ -1008,7 +1009,7 @@
        form <literal>UTF8</literal>, and some default collation.
 -->
 文字集合、文字符号化方式とデフォルトの照合を識別する順序名前つきのSQLオブジェクトです。定義済みの文字セットは、一般的に符号化形式と同じ名前を持ちますが、ユーザは他の名前を定義できます。
-例えば、文字セット<literal>UTF8</literal>は一般的に文字集合<literal>UCS</literal>、符号化形式<literal>UTF8</literal>と何らかのデフォルト照合を識別します。
+例えば、文字セット<literal>UTF8</literal>は一般的に文字集合<literal>UCS</literal>、符号化形式<literal>UTF8</literal>と何らかのデフォルト照合を示します。
       </para>
      </listitem>
     </varlistentry>
@@ -1161,7 +1162,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
    check constraint.  Only those routines are shown that are owned by
    a currently enabled role.
 -->
-<literal>check_constraint_routine_usage</literal>は検査制約で使用される処理（関数およびプロシージャ）を識別します。
+<literal>check_constraint_routine_usage</literal>は検査制約で使用される処理（関数およびプロシージャ）を示します。
 現在有効なロールが所有する処理のみが表示されます。
   </para>
 
@@ -1456,7 +1457,8 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
    in <xref linkend="infoschema-character-sets"/>), so this view does
    not provide much useful information.
 -->
-<literal>collation_character_set_applicability</literal>ビューは、利用可能な照合がどの文字セットに適用可能かを識別します。PostgreSQLでは、データベースごとに一つの文字セットしか存在しない(<xref linkend="infoschema-character-sets"/>の説明を参照してください)ので、このビューは有益な情報を提供しません。
+<literal>collation_character_set_applicability</literal>ビューは、利用可能な照合がどの文字セットに適用可能かを示します。
+PostgreSQLでは、データベースごとに一つの文字セットしか存在しない(<xref linkend="infoschema-character-sets"/>の説明を参照してください)ので、このビューは有益な情報を提供しません。
   </para>
 
   <table>
@@ -1568,7 +1570,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
    columns that depend on another base column in the same table.  Only tables
    owned by a currently enabled role are included.
 -->
-<literal>column_column_usage</literal>ビューは、同じテーブル内の別の基底列に基づくすべての生成列を識別します。
+<literal>column_column_usage</literal>ビューは、同じテーブル内の別の基底列に基づくすべての生成列を示します。
 現在有効なロールが所有するテーブルのみが含まれます。
   </para>
 
@@ -1669,7 +1671,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
    columns (of a table or a view) that make use of some domain defined
    in the current database and owned by a currently enabled role.
 -->
-<literal>column_domain_usage</literal>ビューは、現在のデータベース内で定義され、現在有効なロールが所有するあるドメインを使用する（テーブルもしくはビューの）全ての列を識別します。
+<literal>column_domain_usage</literal>ビューは、現在のデータベース内で定義され、現在有効なロールが所有するあるドメインを使用する（テーブルもしくはビューの）全ての列を示します。
   </para>
 
   <table>
@@ -1908,7 +1910,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
    currently enabled role.  There is one row for each combination of
    column, grantor, and grantee.
 -->
-<literal>column_privileges</literal>ビューは、現在有効なロールに対し、または現在有効なロールによって、列に与えられた権限を全て識別します。
+<literal>column_privileges</literal>ビューは、現在有効なロールに対し、または現在有効なロールによって、列に与えられた権限を全て示します。
 列と許可を与えた者、許可を受けた者の組み合わせごとに1行があります。
   </para>
 
@@ -2062,7 +2064,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
    like user-defined types, so they are included here as well.  See
    also <xref linkend="infoschema-columns"/> for details.
 -->
-<literal>column_udt_usage</literal>ビューは、現在有効なロールが所有するデータ型を使用する全ての列を識別します。
+<literal>column_udt_usage</literal>ビューは、現在有効なロールが所有するデータ型を使用する全ての列を示します。
 <productname>PostgreSQL</productname>では、組み込みデータ型がユーザ定義型同様に振舞いますので、組み込みデータ型も同様にここに含まれます。
 詳細は<xref linkend="infoschema-columns"/>も参照してください。
   </para>
@@ -2343,7 +2345,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
        string type, the declared maximum length; null for all other
        data types or if no maximum length was declared.
 -->
-<literal>data_type</literal>が文字列またはビット列を識別する場合、その宣言された最大長です。
+<literal>data_type</literal>が文字列またはビット列と識別される場合、その宣言された最大長です。
 他のデータ型または最大長が宣言されていない場合はNULLです。
       </para></entry>
      </row>
@@ -2360,7 +2362,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
        the declared character maximum length (see above) and the
        server encoding.
 -->
-<literal>data_type</literal>が文字列を識別する場合、オクテット（バイト）単位で表したデータの最大長です。
+<literal>data_type</literal>が文字列と識別される場合、オクテット（バイト）単位で表したデータの最大長です。
 他のデータ型ではNULLです。
 最大オクテット長は宣言された文字最大長(上述)とサーバ符号化方式に依存します。
       </para></entry>
@@ -2380,7 +2382,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
        <literal>numeric_precision_radix</literal>.  For all other data
        types, this column is null.
 -->
-<literal>data_type</literal>が数値型を示す場合、ここには、その列の型の（宣言された、もしくは暗黙的な）精度が含まれます。
+<literal>data_type</literal>が数値型と識別される場合、ここには、その列の型の（宣言された、もしくは暗黙的な）精度が含まれます。
 この精度は有意な桁数を示します。
 <literal>numeric_precision_radix</literal>列の指定に従い、10進数（10を底）、もしくは2進数（2を底）で表現されます。
 他の全ての型の場合では、この列はNULLです。
@@ -2399,7 +2401,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
        <literal>numeric_scale</literal> are expressed.  The value is
        either 2 or 10.  For all other data types, this column is null.
 -->
-<literal>data_type</literal>が数値型を識別する場合、この列は、<literal>numeric_precision</literal>および<literal>numeric_scale</literal>で表現される値の基が何かを識別します。
+<literal>data_type</literal>が数値型と識別される場合、この列は、<literal>numeric_precision</literal>および<literal>numeric_scale</literal>で表現される値の基が何かを示します。
 この値は2または10です。
 他の全ての型の場合では、この列はNULLです。
       </para></entry>
@@ -2420,8 +2422,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
        <literal>numeric_precision_radix</literal>.  For all other data
        types, this column is null.
 -->
-<literal>data_type</literal>が高精度数値型を示す場合、
-ここには、その列の型の（宣言された、あるいは暗黙的な）位取りが含まれます。
+<literal>data_type</literal>が高精度数値型と識別される場合、ここには、その列の型の（宣言された、あるいは暗黙的な）位取りが含まれます。
 位取りとは、小数点より右側の有意な桁数です。
 <literal>numeric_precision_radix</literal>列の指定に従い、10進数（10を底）、もしくは2進数（2を底）で表現されます。
 他の全ての型の場合では、この列はNULLです。
@@ -2441,7 +2442,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
        following the decimal point in the seconds value.  For all
        other data types, this column is null.
 -->
-<literal>data_type</literal>が日付、時刻、タイムスタンプ、間隔型を示す場合、この列の型の秒以下の（宣言された、または暗黙的な）精度、つまり、秒値の小数点以降に保持する10進桁数、です。
+<literal>data_type</literal>が日付、時刻、タイムスタンプ、間隔型と識別される場合、この列の型の秒以下の（宣言された、または暗黙的な）精度、つまり、秒値の小数点以降に保持する10進桁数、です。
 他の全ての型の場合では、この列はNULLです。
       </para></entry>
      </row>
@@ -2460,7 +2461,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
        accepts all fields), and for all other data types, this field
        is null.
 -->
-もし<literal>data_type</literal>が時間間隔型を示す場合、この列はこの属性の時間間隔値がどのフィールドを含むかの仕様を含みます。例えば、<literal>YEAR TO MONTH</literal>、<literal>DAY TO SECOND</literal>などです。
+<literal>data_type</literal>が時間間隔型と識別される場合、この列はこの属性の時間間隔値がどのフィールドを含むかの仕様を含みます。例えば、<literal>YEAR TO MONTH</literal>、<literal>DAY TO SECOND</literal>などです。
 もしフィールド制約が指定されていない(時間間隔が全てのフィールドを受け付ける)場合や、他の全てのデータ型の場合はこのフィールドはNULLです。
       </para></entry>
      </row>
@@ -2911,11 +2912,11 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
    foreign key references.  For a unique or primary key constraint,
    this view identifies the constrained columns.
 -->
-<literal>constraint_column_usage</literal>ビューは、現在のデータベースで制約を使用する全ての列を識別します。
+<literal>constraint_column_usage</literal>ビューは、現在のデータベースで制約を使用する全ての列を示します。
 現在有効なロールが所有するテーブル内の列のみが表示されます。
-検査制約では、このビューは検査式で使用される列を識別します。
-外部キー制約では、このビューは外部キーを参照する列を識別します。
-一意性制約もしくは主キー制約では、このビューは制約される列を識別します。
+検査制約では、このビューは検査式で使用される列を示します。
+外部キー制約では、このビューは外部キーを参照する列を示します。
+一意性制約もしくは主キー制約では、このビューは制約される列を示します。
   </para>
 
   <table>
@@ -3053,8 +3054,8 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
 -->
 <literal>constraint_table_usage</literal>ビューは、ある制約で使用され、かつ、現在有効なロールが所有する、現在のデータベース内の全てのテーブルを識別します
 （これは、全てのテーブル制約とそれを定義したテーブルを識別する<literal>table_constraints</literal>とは異なります）。
-外部キー制約では、このビューは外部キーが参照するテーブルを識別します。
-一意性制約もしくは主キー制約では、このビューは単に制約が属するテーブルを識別します。
+外部キー制約では、このビューは外部キーが参照するテーブルを示します。
+一意性制約もしくは主キー制約では、このビューは単に制約が属するテーブルを示します。
 検査制約と非NULL制約はこのビューには含まれません。
   </para>
 
@@ -3180,7 +3181,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
    applications, but it is used to define some other views in the
    information schema.
 -->
-<literal>data_type_privileges</literal>ビューは、記述子が示すオブジェクトの所有者である、何かしらの権限を持っているといった方法で現在のユーザがアクセスできる全てのデータ型記述子を識別します。
+<literal>data_type_privileges</literal>ビューは、記述子が示すオブジェクトの所有者である、何かしらの権限を持っているといった方法で現在のユーザがアクセスできる全てのデータ型記述子を示します。
 あるデータ型がテーブル列やドメイン、関数（パラメータとして、あるいは戻り値として）の定義内で使用されると、そのデータ型記述子は生成され、そして、データ型がそのインスタンスでどのように使用されるか（例えば、もし適切ならば、宣言された最大長）についての情報が格納されます。
 各データ型記述子は、1つのオブジェクト（テーブル、ドメイン、関数）に割り当てられたデータ型記述子の中で一意となる任意の識別子が割り振られます。
 このビューはおそらくアプリケーションではあまり使用されませんが、情報スキーマ内の他のビューを定義する際に使用されます。
@@ -3431,7 +3432,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
    types behave like user-defined types, so they are included here as
    well.
 -->
-<literal>domain_udt_usage</literal>ビューは、現在有効なロールが所有するデータ型に基づいたすべてのドメインを識別します。
+<literal>domain_udt_usage</literal>ビューは、現在有効なロールが所有するデータ型に基づいたすべてのドメインを示します。
 <productname>PostgreSQL</productname>では組み込みデータ型はユーザ定義型と同様に振舞いますので、ここにも同様に現れることに注意してください。
   </para>
 
@@ -3809,7 +3810,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
        following the decimal point in the seconds value.  For all
        other data types, this column is null.
 -->
-<literal>data_type</literal>が日付、時刻、タイムスタンプ、間隔型を示す場合、この列はこのドメインの型で（宣言された、または暗黙的な）秒の端数の精度、つまり、秒値の小数点以下で保持される10進の桁数です。
+<literal>data_type</literal>が日付、時刻、タイムスタンプ、間隔型と識別される場合、この列はこのドメインの型で（宣言された、または暗黙的な）秒の端数の精度、つまり、秒値の小数点以下で保持される10進の桁数です。
 他の全ての型の場合では、この列はNULLです。
       </para></entry>
      </row>
@@ -3828,7 +3829,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
        accepts all fields), and for all other data types, this field
        is null.
 -->
-もし<literal>data_type</literal>が時間間隔型を示す場合、この列はこのドメインの時間間隔値がどのフィールドを含むかの仕様を含みます。例えば、<literal>YEAR TO MONTH</literal>、<literal>DAY TO SECOND</literal>などです。
+<literal>data_type</literal>が時間間隔型と識別される場合、この列はこのドメインの時間間隔値がどのフィールドを含むかの仕様を含みます。例えば、<literal>YEAR TO MONTH</literal>、<literal>DAY TO SECOND</literal>などです。
 もしフィールド制約が指定されていない(時間間隔が全てのフィールドを受け付ける)場合や、他の全てのデータ型の場合はこのフィールドはNULLです。
       </para></entry>
      </row>
@@ -4428,7 +4429,7 @@ ORDER BY c.ordinal_position;
    <indexterm><primary>enabled role</primary></indexterm>
    <indexterm><primary>role</primary><secondary>enabled</secondary></indexterm>
 -->
-<literal>enabled_roles</literal>ビューは、現在<quote>有効なロール</quote>を識別します。
+<literal>enabled_roles</literal>ビューは、現在<quote>有効なロール</quote>を示します。
 有効なロールは、現在のユーザと自動継承によって有効なロールに付与されたすべてのロールとして再帰的に定義されます。
 言い換えると、これは、現在のユーザが直接または間接的に属するメンバ資格の継承により自動的に持つすべてのロールです。
    <indexterm><primary>有効なロール</primary></indexterm>
@@ -5114,7 +5115,7 @@ ORDER BY c.ordinal_position;
    in this view.  Only those columns are shown that the current user
    has access to, by way of being the owner or having some privilege.
 -->
-<literal>key_column_usage</literal>ビューは、現在のデータベースにおいて、ある一意性制約、主キー制約、外部キー制約によって制限を受けている全ての列を識別します。
+<literal>key_column_usage</literal>ビューは、現在のデータベースにおいて、ある一意性制約、主キー制約、外部キー制約によって制限を受けている全ての列を示します。
 検査制約はこのビューには含まれません。
 現在のユーザが所有者である、または何らかの権限を持ち、アクセスできるテーブル内のこうした列のみがここに示されます。
   </para>
@@ -5907,7 +5908,7 @@ ORDER BY c.ordinal_position;
    columns that have been made accessible to the current user by way
    of a grant to <literal>PUBLIC</literal>.
 -->
-<literal>role_column_grants</literal>ビューは、譲与者または被譲与者が現在有効なロールである場合、列に付与された全ての権限を識別します。
+<literal>role_column_grants</literal>ビューは、譲与者または被譲与者が現在有効なロールである場合、列に付与された全ての権限を示します。
 詳細な情報は<literal>column_privileges</literal>の中にあります。
 このビューと<literal>column_privileges</literal>との間の実質的な違いは、このビューでは現在のユーザが<literal>PUBLIC</literal>に与えられた権限によりアクセスできるようになった列を省略していることだけです。
   </para>
@@ -6053,7 +6054,7 @@ ORDER BY c.ordinal_position;
    functions that have been made accessible to the current user by way
    of a grant to <literal>PUBLIC</literal>.
 -->
-<literal>role_routine_grants</literal>ビューは、現在有効なロールが譲与者、または被譲与者で関数上に与えられた全ての権限を識別します。
+<literal>role_routine_grants</literal>ビューは、現在有効なロールが譲与者、または被譲与者で関数上に与えられた全ての権限を示します。
 詳細な情報は<literal>routine_privileges</literal>の中にあります。
 このビューと<literal>routine_privileges</literal>との間の実質的な違いは、このビューでは現在のユーザが<literal>PUBLIC</literal>に与えられた権限によりアクセスできるようになった関数を省略していることだけです。
   </para>
@@ -6221,7 +6222,7 @@ ORDER BY c.ordinal_position;
    tables that have been made accessible to the current user by way of
    a grant to <literal>PUBLIC</literal>.
 -->
-<literal>role_table_grants</literal>ビューは、現在有効なロールが譲与者または被譲与者であるテーブルやビュー上に与えられた全ての権限を識別します。
+<literal>role_table_grants</literal>ビューは、現在有効なロールが譲与者または被譲与者であるテーブルやビュー上に与えられた全ての権限を示します。
 詳細な情報は<literal>table_privileges</literal>の中にあります。
 このビューと<literal>table_privileges</literal>との間の実質的な違いは、このビューでは現在のユーザが<literal>PUBLIC</literal>に与えられた権限によりアクセスできるようになったテーブルを省略していることだけです。
   </para>
@@ -6507,7 +6508,7 @@ PostgreSQLではデータ型は実際の権限を持たず、<literal>PUBLIC</li
    this view omits objects that have been made accessible to the
    current user by way of a grant to <literal>PUBLIC</literal>.
 -->
-<literal>role_usage_grants</literal>ビューは、譲与者または被譲与者が現在有効なロールである多くの種類のオブジェクトに対し、<literal>USAGE</literal>権限を識別します。
+<literal>role_usage_grants</literal>ビューは、譲与者または被譲与者が現在有効なロールである多くの種類のオブジェクトに対し、<literal>USAGE</literal>権限を示します。
 詳細な情報は<literal>usage_privileges</literal>の中にあります。
 このビューと<literal>usage_privileges</literal>ビューとの間の実質的な違いは、このビューでは現在のユーザが<literal>PUBLIC</literal>に与えられた権限によりアクセスできるようになったオブジェクトを省略していることだけです。
   </para>
@@ -6805,7 +6806,7 @@ PostgreSQLではデータ型は実際の権限を持たず、<literal>PUBLIC</li
    currently enabled role.  There is one row for each combination of function,
    grantor, and grantee.
 -->
-<literal>routine_privileges</literal>ビューは、現在有効なロールに与えられた権限、あるいは現在有効なロールによって関数に与えられた権限を全て識別します。
+<literal>routine_privileges</literal>ビューは、現在有効なロールに与えられた権限、あるいは現在有効なロールによって関数に与えられた権限を全て示します。
 関数、権限の譲与者と被譲与者の組み合わせごとに1行あります。
   </para>
 
@@ -8714,7 +8715,7 @@ PostgreSQLではデータ型は実際の権限を持たず、<literal>PUBLIC</li
        <literal>numeric_scale</literal> are expressed.  The value is
        either 2 or 10.
 -->
-この列は、<literal>numeric_precision</literal>および<literal>numeric_scale</literal>で表現される値の基が何かを識別します。
+この列は、<literal>numeric_precision</literal>および<literal>numeric_scale</literal>で表現される値の基が何かを示します。
 値は2または10です。
       </para></entry>
      </row>
@@ -9435,7 +9436,7 @@ ODBCインタフェースの説明でそれらを説明します。
    or by a currently enabled role.  There is one row for each
    combination of table, grantor, and grantee.
 -->
-<literal>table_privileges</literal>ビューは、現在有効なロールに対し、または現在有効なロールによって、テーブルもしくはビューに与えられた権限を全て識別します。
+<literal>table_privileges</literal>ビューは、現在有効なロールに対し、または現在有効なロールによって、テーブルもしくはビューに与えられた権限を全て示します。
 テーブル、譲与者、被譲与者の組み合わせごとに1行があります。
   </para>
 
@@ -9932,7 +9933,7 @@ PostgreSQLはこれをサポートしていません。
    current user owns or has some privilege other than
    <literal>SELECT</literal> on.
 -->
-列リスト(<literal>UPDATE OF column1, column2</literal>など)を指定する現在のデータベース内のトリガに関して、<literal>triggered_update_columns</literal>ビューはこれらの列を識別します。
+列リスト(<literal>UPDATE OF column1, column2</literal>など)を指定する現在のデータベース内のトリガに関して、<literal>triggered_update_columns</literal>ビューはこれらの列を示します。
 列リストを指定しないトリガはこのビューには含まれません。
 これらの列の内、現在のユーザが所有するまたはSELECT以外の何らかの権限を持つもののみが示されます。
   </para>
@@ -10399,7 +10400,7 @@ PostgreSQLはこれをサポートしていません。
    for why); see
    <xref linkend="infoschema-usage-privileges"/> for domain privileges.
 -->
-<literal>udt_privileges</literal>ビューは、現在有効なロールが付与者または被付与者である、ユーザ定義型に付与された<literal>USAGE</literal>権限を識別します。
+<literal>udt_privileges</literal>ビューは、現在有効なロールが付与者または被付与者である、ユーザ定義型に付与された<literal>USAGE</literal>権限を示します。
 型、付与者、被付与者の組み合わせごとに行があります。
 このビューは複合データ型のみを表示します（理由は<xref linkend="infoschema-user-defined-types"/>を参照してください）。
 ドメイン権限については<xref linkend="infoschema-usage-privileges"/>を参照してください。
@@ -10529,7 +10530,7 @@ PostgreSQLはこれをサポートしていません。
    collations, domains, foreign-data wrappers, foreign servers, and sequences.  There is one
    row for each combination of object, grantor, and grantee.
 -->
-<literal>usage_privileges</literal>ビューは、現在有効なロールに、もしくは現在有効なロールによって与えられた、各種オブジェクト上の<literal>USAGE</literal>権限を識別します。
+<literal>usage_privileges</literal>ビューは、現在有効なロールに、もしくは現在有効なロールによって与えられた、各種オブジェクト上の<literal>USAGE</literal>権限を示します。
 これは今のところ、<productname>PostgreSQL</productname>では照合、ドメイン、外部データラッパ、外部サーバ、およびシーケンスに適用します。
 オブジェクトと許可を与えた者、許可を受けた者の組み合わせごとに1行があります。
   </para>
@@ -11292,7 +11293,7 @@ SQLは二種類のユーザ定義データ型を知っています。構造化�
    column is only included if the table that contains the column is
    owned by a currently enabled role.
 -->
-<literal>view_column_usage</literal>ビューは、ビューの問い合わせ式（ビューを定義する<command>SELECT</command>文）で使用される全ての列を識別します。
+<literal>view_column_usage</literal>ビューは、ビューの問い合わせ式（ビューを定義する<command>SELECT</command>文）で使用される全ての列を示します。
 現在有効なロールがその列を含むテーブルの所有者であるもののみが含まれます。
   </para>
 
@@ -11434,7 +11435,7 @@ SQLは二種類のユーザ定義データ型を知っています。構造化�
    defines the view).  A routine is only included if that routine is
    owned by a currently enabled role.
 -->
-<literal>view_routine_usage</literal>ビューは、ビューの問い合わせ式（ビューを定義する<command>SELECT</command>文）で使用されるすべてのルーチン（関数およびプロシージャ）を識別します。
+<literal>view_routine_usage</literal>ビューは、ビューの問い合わせ式（ビューを定義する<command>SELECT</command>文）で使用されるすべてのルーチン（関数およびプロシージャ）を示します。
 現在有効なロールが所有するルーチンのみが含まれます。
   </para>
 
@@ -11550,7 +11551,7 @@ SQLは二種類のユーザ定義データ型を知っています。構造化�
    table is only included if that table is owned by a currently
    enabled role.
 -->
-<literal>view_table_usage</literal>ビューは、ビューの問い合わせ式（ビューを定義する<command>SELECT</command>文）で使用されるすべてのテーブルを識別します。
+<literal>view_table_usage</literal>ビューは、ビューの問い合わせ式（ビューを定義する<command>SELECT</command>文）で使用されるすべてのテーブルを示します。
 現在有効なロールがそのテーブルの所有者であるもののみが含まれます。
   </para>
 


### PR DESCRIPTION
指摘された #2210 の修正です。
If <literal>data_type</literal> identifies 〜を「〜識別された場合」
に統一しました。
viewの「識別します」を「示します」に変更しました。