### PR TITLE
fix typo in query of 14.0

### DIFF
--- a/doc/src/sgml/query.sgml
+++ b/doc/src/sgml/query.sgml
@@ -80,7 +80,7 @@
 -->
 <literal>\i</literal>は、指定したファイルからコマンドを読み込みます。
 <command>psql</command>の<literal>-s</literal>オプションによって、シングルステップモードとなり、それぞれの文をサーバに送る前に一時停止します。
-本節で使用するコマンドは<filename>basics.source</filename>ファイル内にあります。
+本節で使用するコマンドは<filename>basics.sql</filename>ファイル内にあります。
    </para>
   </sect1>
 


### PR DESCRIPTION
ファイル名が原文と違うところを見つけました。
おそらく追従漏れでしょうね。