### PR TITLE
fix typo in ddl of 14.0

### DIFF
--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -3660,9 +3660,9 @@ postgres=&gt; table passwd;
 (3 rows)
 
 <!--
-&#045;- Aliceに何ができるか試してみる
+&#45;- Test what Alice is able to do
 -->
--- Test what Alice is able to do
+-- Aliceに何ができるか試してみる
 postgres=&gt; set role alice;
 SET
 postgres=&gt; table passwd;


### PR DESCRIPTION
日本語訳の方がコメントアウトされていましたので修正しました。