### PR TITLE
fix typo in config of 14.0

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -5417,15 +5417,20 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
 
   <sect2 id="runtime-config-wal-archive-recovery">
 
-    <title>Archive Recovery</title>
 <!--
-    <title>アーカイブからのリカバリ</title>
+    <title>Archive Recovery</title>
 -->
+    <title>アーカイブからのリカバリ</title>
 
     <indexterm>
+<!--
      <primary>configuration</primary>
      <secondary>of recovery</secondary>
      <tertiary>of a standby server</tertiary>
+-->
+     <primary>設定</primary>
+     <secondary>リカバリの</secondary>
+     <tertiary>スタンバイサーバの</tertiary>
     </indexterm>
 
     <para>

--- a/doc/src/sgml/config1.sgml
+++ b/doc/src/sgml/config1.sgml
@@ -1412,15 +1412,20 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
 
   <sect2 id="runtime-config-wal-archive-recovery">
 
-    <title>Archive Recovery</title>
 <!--
-    <title>アーカイブからのリカバリ</title>
+    <title>Archive Recovery</title>
 -->
+    <title>アーカイブからのリカバリ</title>
 
     <indexterm>
+<!--
      <primary>configuration</primary>
      <secondary>of recovery</secondary>
      <tertiary>of a standby server</tertiary>
+-->
+     <primary>設定</primary>
+     <secondary>リカバリの</secondary>
+     <tertiary>スタンバイサーバの</tertiary>
     </indexterm>
 
     <para>


### PR DESCRIPTION
config.sgmlで原文と日本語のコメントアウトが逆、あと訳がされていないところを見つけました。