### PR TITLE
fix typos in term index for 14.0

### DIFF
--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -921,7 +921,10 @@ NUMERIC
 
     <indexterm>
      <primary>infinity</primary>
+<!--
      <secondary>numeric (data type)</secondary>
+-->
+     <secondary>numeric (データ型)</secondary>
     </indexterm>
 
     <indexterm>
@@ -1236,12 +1239,19 @@ FROM generate_series(-3.5, 3.5, 1) as x;
 
     <indexterm>
      <primary>infinity</primary>
+<!--
      <secondary>floating point</secondary>
+-->
+     <secondary>浮動小数点</secondary>
     </indexterm>
 
     <indexterm>
+<!--
      <primary>not a number</primary>
      <secondary>floating point</secondary>
+-->
+     <primary>非数</primary>
+     <secondary>浮動小数点</secondary>
     </indexterm>
 
     <para>

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -28801,16 +28801,25 @@ SELECT * FROM pg_ls_dir('.') WITH ORDINALITY AS t(ls,n);
         </indexterm>
         <indexterm>
          <primary>Logging</primary>
+<!--
          <secondary>pg_current_logfile function</secondary>
+-->
+         <secondary>pg_current_logfile関数</secondary>
         </indexterm>
         <indexterm>
           <primary>current_logfiles</primary>
+<!--
           <secondary>and the pg_current_logfile function</secondary>
+-->
+          <secondary>とpg_current_logfile関数</secondary>
         </indexterm>
         <indexterm>
          <primary>Logging</primary>
+<!--
          <secondary>current_logfiles file and the pg_current_logfile
          function</secondary>
+-->
+         <secondary>current_logfilesファイルとpg_current_logfile関数</secondary>
         </indexterm>
         <function>pg_current_logfile</function> ( <optional> <type>text</type> </optional> )
         <returnvalue>text</returnvalue>
@@ -32465,9 +32474,14 @@ OIDとそれを含むシステム型で指定されるデータベース共有�
    </indexterm>
 
    <indexterm>
+<!--
     <primary>configuration</primary>
     <secondary sortas="server">of the server</secondary>
     <tertiary>functions</tertiary>
+-->
+    <primary>設定</primary>
+    <secondary sortas="server">サーバの</secondary>
+    <tertiary>関数</tertiary>
    </indexterm>
 
    <para>

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -1712,16 +1712,25 @@ SELECT * FROM pg_ls_dir('.') WITH ORDINALITY AS t(ls,n);
         </indexterm>
         <indexterm>
          <primary>Logging</primary>
+<!--
          <secondary>pg_current_logfile function</secondary>
+-->
+         <secondary>pg_current_logfile関数</secondary>
         </indexterm>
         <indexterm>
           <primary>current_logfiles</primary>
+<!--
           <secondary>and the pg_current_logfile function</secondary>
+-->
+          <secondary>とpg_current_logfile関数</secondary>
         </indexterm>
         <indexterm>
          <primary>Logging</primary>
+<!--
          <secondary>current_logfiles file and the pg_current_logfile
          function</secondary>
+-->
+         <secondary>current_logfilesファイルとpg_current_logfile関数</secondary>
         </indexterm>
         <function>pg_current_logfile</function> ( <optional> <type>text</type> </optional> )
         <returnvalue>text</returnvalue>
@@ -5376,9 +5385,14 @@ OIDとそれを含むシステム型で指定されるデータベース共有�
    </indexterm>
 
    <indexterm>
+<!--
     <primary>configuration</primary>
     <secondary sortas="server">of the server</secondary>
     <tertiary>functions</tertiary>
+-->
+    <primary>設定</primary>
+    <secondary sortas="server">サーバの</secondary>
+    <tertiary>関数</tertiary>
    </indexterm>
 
    <para>

--- a/doc/src/sgml/high-availability.sgml
+++ b/doc/src/sgml/high-availability.sgml
@@ -3086,7 +3086,7 @@ WALに記録された操作はすでにプライマリで発生したもので�
     To confirm the server has come up, either loop trying to connect from
     the application, or look for these messages in the server logs:
 -->
-<filename>postgresql.conf</filename>において<varname>hot_standby</varname>が<literal>on</literal>で（これはデフォルトです）、かつ<link linkend="file-standby-signal"><filename>standby.signal</filename></link><indexterm><primary>standby.signal</primary><secondary>for hot standby</secondary></indexterm>が存在すれば、サーバはホットスタンバイモードで稼動します。
+<filename>postgresql.conf</filename>において<varname>hot_standby</varname>が<literal>on</literal>で（これはデフォルトです）、かつ<link linkend="file-standby-signal"><filename>standby.signal</filename></link><indexterm><primary>standby.signal</primary><secondary>ホットスタンバイのための</secondary></indexterm>が存在すれば、サーバはホットスタンバイモードで稼動します。
 しかし、サーバはまず問い合わせが実行できる程度の一貫性を持つ状態を提供するために十分なリカバリを完了させなければなりませんので、ホットスタンバイでの接続が有効になるまでに多少の時間がかかるかもしれません。
 サーバの準備ができたことを確認するために、アプリケーションで接続試行を繰り返すか、サーバログに以下のメッセージがあるかどうかを確認します。
 

--- a/doc/src/sgml/xfunc.sgml
+++ b/doc/src/sgml/xfunc.sgml
@@ -1107,10 +1107,10 @@ DROP FUNCTION sum_n_product (int, int);
     <title>出力パラメータを持つ<acronym>SQL</acronym>プロシージャ</title>
 
     <indexterm>
+<!--
      <primary>procedures</primary>
      <secondary>output parameter</secondary>
-    </indexterm>
-    <indexterm>
+-->
      <primary>プロシージャ</primary>
      <secondary>出力パラメータ</secondary>
     </indexterm>


### PR DESCRIPTION
（主に）索引の翻訳忘れに対応