### PR TITLE
最新の記述に訳も合わせた

### DIFF
--- a/doc/src/sgml/installation.sgml
+++ b/doc/src/sgml/installation.sgml
@@ -654,9 +654,6 @@ Windows上で構築する場合、いずれにしても<application>Perl</applic
 -->
 （<acronym>GNU</acronym> <application>make</application>を使用することを忘れないでください。）
 ハードウェアに依存しますが、構築作業には数分かかります。
-<screen>
-All of PostgreSQL successfully made. Ready to install.
-</screen>
    </para>
 
   <para>
@@ -2354,7 +2351,7 @@ GCCを使用する場合、すべてのプログラムとライブラリがプ�
          using the GCC compiler:
 -->
 さらに<command>dtrace</command>プログラム用のコマンドラインオプションを<envar>DTRACEFLAGS</envar>環境変数で指定できます。
-Solarisで64ビットバイナリでDTraceをサポートするには、<literal>DTRACEFLAGS="-64"</literal>をconfigureに指定してください。
+Solarisで64ビットバイナリでDTraceをサポートするには、<literal>DTRACEFLAGS="-64"</literal>を指定してください。
 例えばGCCコンパイラを使用する場合は以下のようにします。
 <screen>
 ./configure CC='gcc -m64' --enable-dtrace DTRACEFLAGS='-64' ...
@@ -3434,7 +3431,7 @@ Windows NTサービスとして<command>cygserver</command>とPostgreSQLサー�
     on <productname>macOS</productname>, you will need to install Apple's
     command line developer tools, which can be done by issuing
 -->
-<productname>PostgreSQL</productname>を<productname>macOS</productname>でソースから構築するには、Appleのコマンドライン開発ツールをインストールすることが必要で、次のようにすれば行なえます(確認のためGUIダイアローグウィンドウが現れることに注意してください)。
+<productname>PostgreSQL</productname>を<productname>macOS</productname>でソースから構築するには、Appleのコマンドライン開発ツールをインストールすることが必要で、次のようにすれば行えます
 <programlisting>
 xcode-select --install
 </programlisting>
@@ -3442,6 +3439,7 @@ xcode-select --install
     (note that this will pop up a GUI dialog window for confirmation).
     You may or may not wish to also install Xcode.
 -->
+（確認のためGUIダイアログウィンドウが現れることに注意してください）。
 Xcodeもインストールして構いませんし、しなくても構いません。
    </para>
 


### PR DESCRIPTION
All of PostgreSQL successfull...の表記は無くなっているので削除。

configureは原文にないため(configure以外でも指定可能なため)削除。

ダイアローグをダイアログに修正。
原文の並びに合わせても違和感なかったため修正。