### PR TITLE
fix typos in fdwhandler of 14.0

### DIFF
--- a/doc/src/sgml/fdwhandler.sgml
+++ b/doc/src/sgml/fdwhandler.sgml
@@ -670,7 +670,7 @@ FDWは、更新や削除の対象行を厳密に識別できるように行IDや
 それを行うには、必要な追加の値を表す<structname>Var</structname>を作成し、それをジャンク列の名前とともに<function>add_row_identity_var</function>に渡します。（複数の列が必要な場合は、これを二回以上実行できます。）
 必要とするそれぞれの<structname>Var</structname>に個別のジャンク列名を選択する必要があります。ただし、<structname>Var</structname>が<structfield>varno</structfield>フィールドを除いて同一である場合は、列名を共有することができるのでそうすべきです。
 コアシステムは、テーブルの<structfield>tableoid</structfield>列をジャンク列名<literal>tableoid</literal>に、<literal>ctid</literal>または<literal>ctid<replaceable>N</replaceable></literal>を<structfield>ctid</structfield>に使用し、<structfield>vartype</structfield> = <type>RECORD</type>と記された行全体の<structname>Var</structname>を<literal>wholerow</literal>に、<structfield>vartype</structfield>を記された行全体の<structname>Var</structname>を<literal>wholerow<replaceable>N</replaceable></literal>使用しており、テーブルで宣言された行型が同じです。
-できる限りこれらの名前を再利用してください（プランナーは同一のジャンク列に対する重複したリクエストを結合します）。 
+できる限りこれらの名前を再利用してください（プランナは同一のジャンク列に対する重複したリクエストを結合します）。
 もしこれらとは別の種類のジャンク列が必要なら、他のFDWとの衝突を避けるために拡張子名をプレフィックスとした名前を選ぶのが賢明かもしれません。
     </para>
 
@@ -958,7 +958,7 @@ ExecForeignBatchInsert(EState *estate,
      a foreign-table partition.  See the callback functions
      described below that allow the FDW to support that.
 -->
-この関数は、ルーティングされたタプルを外部テーブルパーティションに挿入するときにも呼び出されることに注意してください。 
+この関数は、ルーティングされたタプルを外部テーブルパーティションに挿入するときにも呼び出されることに注意してください。
 FDWがそれをサポートすることを可能にしている後述のコールバック関数を参照してください。
     </para>
 
@@ -2335,7 +2335,7 @@ ForeignAsyncConfigureWait(AsyncRequest *areq);
 -->
 <structname>ForeignScan</structname>ノードが待機したいファイル記述子イベントを設定します。
 この関数は、<structname>ForeignScan</structname>ノードに<literal>areq-&gt;callback_pending</literal>フラグが設定されている場合にのみ呼び出され、<literal>areq</literal>で記述された親ノード<structname>Append</structname>の<structfield>as_eventset</structfield>にイベントを追加しなければなりません。
-詳細は<filename>src/backend/executor/execAsync.c</filename>の<function>ExecAsyncConfigureWait</function>に対するコメントを参照してください。 
+詳細は<filename>src/backend/executor/execAsync.c</filename>の<function>ExecAsyncConfigureWait</function>に対するコメントを参照してください。
 ファイルディスクリプタのイベントが発生すると、<function>ForeignAsyncNotify</function>が呼ばれます。
     </para>
 


### PR DESCRIPTION
主に行末の空白の削除です。ついでに用語統一。