### PR TITLE
cosmetics!

### DIFF
--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -3309,7 +3309,10 @@ SELECT * FROM tbl WHERE a &gt; 'foo' COLLATE "C";
     error.  For more details see <xref linkend="collation"/>.)
     Thus, this gives the same result as the previous example:
 -->
-とします。後者の場合、<literal>COLLATE</literal>句が、処理対象と想定している入力演算子の引数に対して付与されることに注意してください。演算子や関数の呼び出しのどの引数に対して<literal>COLLATE</literal>句が付与されるかは問題ではありません。演算子や関数により適用される照合順序は対象となる全ての引数を考慮して引き出され、そして明示的に指定された<literal>COLLATE</literal>句がその他の全ての引数に対しての照合順序を上書きするからです。(しかし、複数の引数に対して一致しない<literal>COLLATE</literal>句の付与はエラーとなります。詳細は<xref linkend="collation"/>を参照してください)。このため、前述の例と同じ結果を次の様にして取得することができます。
+後者の場合、<literal>COLLATE</literal>句が、処理対象と想定している入力演算子の引数に対して付与されることに注意してください。
+演算子や関数の呼び出しのどの引数に対して<literal>COLLATE</literal>句が付与されるかは問題ではありません。演算子や関数により適用される照合順序は対象となる全ての引数を考慮して引き出され、そして明示的に指定された<literal>COLLATE</literal>句がその他の全ての引数に対しての照合順序を上書きするからです。
+(しかし、複数の引数に対して一致しない<literal>COLLATE</literal>句の付与はエラーとなります。詳細は<xref linkend="collation"/>を参照してください。)
+このため、前述の例と同じ結果を次のようにして取得することができます。
 <programlisting>
 SELECT * FROM tbl WHERE a COLLATE "C" &gt; 'foo';
 </programlisting>
@@ -3427,9 +3430,9 @@ SELECT ARRAY[1,2,3+4];
     <literal>CASE</literal> constructs (see <xref linkend="typeconv-union-case"/>).
     You can override this by explicitly casting the array constructor to the
     desired type, for example:
-    -->
-    デフォルトで配列要素型は、メンバ式の型と同じで、<literal>UNION</literal>や<literal>CASE</literal>構文と同じ規則を使用して決定されます
-（<xref linkend="typeconv-union-case"/>を参照してください）。これを明示的に配列コンストラクタを希望する型にキャストすることで書き換えることができます。例をあげます。
+-->
+デフォルトで配列要素型は、メンバ式の型と同じで、<literal>UNION</literal>や<literal>CASE</literal>構文と同じ規則を使用して決定されます（<xref linkend="typeconv-union-case"/>を参照してください）。
+これを明示的に配列コンストラクタを希望する型にキャストすることで書き換えることができます。例をあげます。
 <programlisting>
 SELECT ARRAY[1,2,22.7]::integer[];
   array


### PR DESCRIPTION
syntaxを見ていて気になったところがあったので、手を入れています。
基本的には改行の追加や修正ですが、「とします。」の削除もしています。

次のようにします。
SQLの例
とします。

は、これ単体ならそれほど悪くはないのですが、そのすぐ上では

次のようにします。
SQLの例
（次の文）

となってますので、揃えてみました。