### PR TITLE
fix typos in index for 14.0

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -1526,6 +1526,8 @@ UNIXドメインソケットで接続しているセッションではこのパ�
       <term><varname>client_connection_check_interval</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>client_connection_check_interval</varname> configuration parameter</primary>
+      </indexterm>
+      <indexterm>
        <primary><varname>client_connection_check_interval</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1915,9 +1917,9 @@ SSLサーバ証明書失効リスト（CRL）が入っているファイル名�
      <varlistentry id="guc-ssl-crl-dir" xreflabel="ssl_crl_dir">
       <term><varname>ssl_crl_dir</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>ssl_crl_dir</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_crl_dir</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2590,9 +2592,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-huge-page-size" xreflabel="huge_page_size">
       <term><varname>huge_page_size</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>huge_page_size</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>huge_page_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3084,9 +3086,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-min-dynamic-shared-memory" xreflabel="min_dynamic_shared_memory">
       <term><varname>min_dynamic_shared_memory</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>min_dynamic_shared_memory</varname> configuration parameter</primary>
--->
+      <indexterm>
+      </indexterm>
        <primary><varname>min_dynamic_shared_memory</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3318,7 +3320,7 @@ huge pageを自動管理するオペレーティングシステム上でより�
         <primary><varname>vacuum_cost_page_hit</varname> configuration parameter</primary>
        </indexterm>
        <indexterm>
-       <primary><varname>vacuum_cost_page_hit</varname>設定パラメータ</primary>
+        <primary><varname>vacuum_cost_page_hit</varname>設定パラメータ</primary>
        </indexterm>
        </term>
        <listitem>
@@ -3340,7 +3342,7 @@ huge pageを自動管理するオペレーティングシステム上でより�
         <primary><varname>vacuum_cost_page_miss</varname> configuration parameter</primary>
        </indexterm>
        <indexterm>
-       <primary><varname>vacuum_cost_page_miss</varname>設定パラメータ</primary>
+        <primary><varname>vacuum_cost_page_miss</varname>設定パラメータ</primary>
        </indexterm>
        </term>
        <listitem>
@@ -3362,7 +3364,7 @@ huge pageを自動管理するオペレーティングシステム上でより�
         <primary><varname>vacuum_cost_page_dirty</varname> configuration parameter</primary>
        </indexterm>
        <indexterm>
-       <primary><varname>vacuum_cost_page_dirty</varname>設定パラメータ</primary>
+        <primary><varname>vacuum_cost_page_dirty</varname>設定パラメータ</primary>
        </indexterm>
        </term>
        <listitem>
@@ -3385,7 +3387,7 @@ vacuumが、先だって掃除したブロックを変更するのに必要な�
         <primary><varname>vacuum_cost_limit</varname> configuration parameter</primary>
        </indexterm>
        <indexterm>
-       <primary><varname>vacuum_cost_limit</varname>設定パラメータ</primary>
+        <primary><varname>vacuum_cost_limit</varname>設定パラメータ</primary>
        </indexterm>
        </term>
        <listitem>
@@ -3460,7 +3462,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
         <primary><varname>bgwriter_delay</varname> configuration parameter</primary>
        </indexterm>
        <indexterm>
-       <primary><varname>bgwriter_delay</varname>設定パラメータ</primary>
+        <primary><varname>bgwriter_delay</varname>設定パラメータ</primary>
        </indexterm>
        </term>
        <listitem>
@@ -3531,7 +3533,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
         <primary><varname>bgwriter_lru_multiplier</varname> configuration parameter</primary>
        </indexterm>
        <indexterm>
-       <primary><varname>bgwriter_lru_multiplier</varname>設定パラメータ</primary>
+        <primary><varname>bgwriter_lru_multiplier</varname>設定パラメータ</primary>
        </indexterm>
        </term>
        <listitem>
@@ -3637,6 +3639,8 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
        <term><varname>backend_flush_after</varname> (<type>integer</type>)
        <indexterm>
         <primary><varname>backend_flush_after</varname> configuration parameter</primary>
+       <indexterm>
+       </indexterm>
         <primary><varname>backend_flush_after</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3680,7 +3684,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
         <primary><varname>effective_io_concurrency</varname> configuration parameter</primary>
        </indexterm>
        <indexterm>
-       <primary><varname>effective_io_concurrency</varname>設定パラメータ</primary>
+        <primary><varname>effective_io_concurrency</varname>設定パラメータ</primary>
        </indexterm>
        </term>
        <listitem>
@@ -6074,7 +6078,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         <primary><varname>max_wal_senders</varname> configuration parameter</primary>
        </indexterm>
        <indexterm>
-       <primary><varname>max_wal_senders</varname>設定パラメータ</primary>
+        <primary><varname>max_wal_senders</varname>設定パラメータ</primary>
        </indexterm>
        </term>
        <listitem>
@@ -7320,6 +7324,8 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       <term><varname>enable_async_append</varname> (<type>boolean</type>)
       <indexterm>
        <primary><varname>enable_async_append</varname> configuration parameter</primary>
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_async_append</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7521,6 +7527,8 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       <term><varname>enable_memoize</varname> (<type>boolean</type>)
       <indexterm>
        <primary><varname>enable_memoize</varname> configuration parameter</primary>
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_memoize</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -10616,6 +10624,8 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
       <term><varname>log_recovery_conflict_waits</varname> (<type>boolean</type>)
       <indexterm>
        <primary><varname>log_recovery_conflict_waits</varname> configuration parameter</primary>
+      </indexterm>
+      <indexterm>
        <primary><varname>log_recovery_conflict_waits</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -11311,6 +11321,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <indexterm>
        <primary><varname>track_wal_io_timing</varname> configuration parameter</primary>
       </indexterm>
+      <indexterm>
+       <primary><varname>track_wal_io_timing</varname>設定パラメータ</primary>
+      </indexterm>
       </term>
       <listitem>
        <para>
@@ -11414,9 +11427,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
      <varlistentry id="guc-compute-query-id" xreflabel="compute_query_id">
       <term><varname>compute_query_id</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>compute_query_id</varname> configuration parameter</primary>
--->
+      <indexterm>
+      </indexterm>
        <primary><varname>compute_query_id</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -11830,6 +11843,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       <indexterm>
        <primary><varname>autovacuum_freeze_max_age</varname></primary>
        <secondary>configuration parameter</secondary>
+      </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_freeze_max_age</varname></primary>
+       <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
       <listitem>
@@ -12324,6 +12341,8 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       <term><varname>default_toast_compression</varname> (<type>enum</type>)
       <indexterm>
        <primary><varname>default_toast_compression</varname> configuration parameter</primary>
+      </indexterm>
+      <indexterm>
        <primary><varname>default_toast_compression</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12607,6 +12626,8 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </indexterm>
       <indexterm>
        <primary><varname>transaction_isolation</varname> configuration parameter</primary>
+      </indexterm>
+      <indexterm>
        <primary><varname>transaction_isolation</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12633,6 +12654,8 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </indexterm>
       <indexterm>
        <primary><varname>transaction_read_only</varname> configuration parameter</primary>
+      </indexterm>
+      <indexterm>
        <primary><varname>transaction_read_only</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12659,6 +12682,8 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </indexterm>
       <indexterm>
        <primary><varname>transaction_deferrable</varname> configuration parameter</primary>
+      </indexterm>
+      <indexterm>
        <primary><varname>transaction_deferrable</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12893,9 +12918,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-idle-session-timeout" xreflabel="idle_session_timeout">
       <term><varname>idle_session_timeout</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>idle_session_timeout</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>idle_session_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13010,6 +13035,8 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
       <term><varname>vacuum_failsafe_age</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>vacuum_failsafe_age</varname> configuration parameter</primary>
+      </indexterm>
+      <indexterm>
        <primary><varname>vacuum_failsafe_age</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14885,6 +14912,8 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
       <term><varname>recovery_init_sync_method</varname> (<type>enum</type>)
        <indexterm>
         <primary><varname>recovery_init_sync_method</varname> configuration parameter</primary>
+       <indexterm>
+       </indexterm>
         <primary><varname>recovery_init_sync_method</varname>設定パラメータ</primary>
        </indexterm>
       </term>
@@ -15093,9 +15122,9 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
      <varlistentry id="guc-in-hot-standby" xreflabel="in_hot_standby">
       <term><varname>in_hot_standby</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>in_hot_standby</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>in_hot_standby</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15530,9 +15559,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-debug-discard-caches" xreflabel="debug_discard_caches">
       <term><varname>debug_discard_caches</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>debug_discard_caches</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>debug_discard_caches</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -15587,9 +15616,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-force-parallel-mode" xreflabel="force_parallel_mode">
       <term><varname>force_parallel_mode</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>force_parallel_mode</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>force_parallel_mode</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -16362,6 +16391,8 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
       <term><varname>remove_temp_files_after_crash</varname> (<type>boolean</type>)
       <indexterm>
        <primary><varname>remove_temp_files_after_crash</varname> configuration parameter</primary>
+      </indexterm>
+      <indexterm>
        <primary><varname>remove_temp_files_after_crash</varname>設定パラメータ</primary>
       </indexterm>
       </term>

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -3087,8 +3087,8 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       <term><varname>min_dynamic_shared_memory</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>min_dynamic_shared_memory</varname> configuration parameter</primary>
-      <indexterm>
       </indexterm>
+      <indexterm>
        <primary><varname>min_dynamic_shared_memory</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3639,8 +3639,8 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
        <term><varname>backend_flush_after</varname> (<type>integer</type>)
        <indexterm>
         <primary><varname>backend_flush_after</varname> configuration parameter</primary>
-       <indexterm>
        </indexterm>
+       <indexterm>
         <primary><varname>backend_flush_after</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -11428,8 +11428,8 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       <term><varname>compute_query_id</varname> (<type>enum</type>)
       <indexterm>
        <primary><varname>compute_query_id</varname> configuration parameter</primary>
-      <indexterm>
       </indexterm>
+      <indexterm>
        <primary><varname>compute_query_id</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14912,8 +14912,8 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
       <term><varname>recovery_init_sync_method</varname> (<type>enum</type>)
        <indexterm>
         <primary><varname>recovery_init_sync_method</varname> configuration parameter</primary>
-       <indexterm>
        </indexterm>
+       <indexterm>
         <primary><varname>recovery_init_sync_method</varname>設定パラメータ</primary>
        </indexterm>
       </term>

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -574,7 +574,7 @@ env PGOPTIONS="-c geqo=off -c statement_timeout=5min" psql
       </indexterm>
       <indexterm>
        <primary><literal>include</literal></primary>
-       <secondary>設定ファイルの中</secondary>
+       <secondary>設定ファイルにおける</secondary>
       </indexterm>
       <!--
       In addition to individual parameter settings,
@@ -1525,9 +1525,7 @@ UNIXドメインソケットで接続しているセッションではこのパ�
      <varlistentry id="guc-client-connection-check-interval" xreflabel="client_connection_check_interval">
       <term><varname>client_connection_check_interval</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>client_connection_check_interval</varname> configuration parameter</primary>
--->
        <primary><varname>client_connection_check_interval</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3638,9 +3636,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
       <varlistentry id="guc-backend-flush-after" xreflabel="backend_flush_after">
        <term><varname>backend_flush_after</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>backend_flush_after</varname> configuration parameter</primary>
--->
         <primary><varname>backend_flush_after</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -7323,9 +7319,7 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-async-append" xreflabel="enable_async_append">
       <term><varname>enable_async_append</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_async_append</varname> configuration parameter</primary>
--->
        <primary><varname>enable_async_append</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -7526,9 +7520,7 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-memoize" xreflabel="enable_memoize">
       <term><varname>enable_memoize</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_memoize</varname> configuration parameter</primary>
--->
        <primary><varname>enable_memoize</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -8076,7 +8068,7 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
        <primary><varname>min_parallel_table_scan_size</varname> configuration parameter</primary>
       </indexterm>
       <indexterm>
-       <primary><varname>min_parallel_relation_size</varname>設定パラメータ</primary>
+       <primary><varname>min_parallel_table_scan_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
       <listitem>
@@ -10623,9 +10615,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      <varlistentry id="guc-log-recovery-conflict-waits" xreflabel="log_recovery_conflict_waits">
       <term><varname>log_recovery_conflict_waits</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>log_recovery_conflict_waits</varname> configuration parameter</primary>
--->
        <primary><varname>log_recovery_conflict_waits</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -11782,7 +11772,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </indexterm>
       <indexterm>
        <primary><varname>autovacuum_vacuum_insert_scale_factor</varname></primary>
-       <secondary>>設定パラメータ</secondary>
+       <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
       <listitem>
@@ -12333,9 +12323,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
      <varlistentry id="guc-default-toast-compression" xreflabel="default_toast_compression">
       <term><varname>default_toast_compression</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>default_toast_compression</varname> configuration parameter</primary>
--->
        <primary><varname>default_toast_compression</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12618,9 +12606,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
        <primary>transaction isolation level</primary>
       </indexterm>
       <indexterm>
-<!--
        <primary><varname>transaction_isolation</varname> configuration parameter</primary>
--->
        <primary><varname>transaction_isolation</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12646,9 +12632,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
        <primary>read-only transaction</primary>
       </indexterm>
       <indexterm>
-<!--
        <primary><varname>transaction_read_only</varname> configuration parameter</primary>
--->
        <primary><varname>transaction_read_only</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -12674,9 +12658,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
        <primary>deferrable transaction</primary>
       </indexterm>
       <indexterm>
-<!--
        <primary><varname>transaction_deferrable</varname> configuration parameter</primary>
--->
        <primary><varname>transaction_deferrable</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -13027,9 +13009,7 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-vacuum-failsafe-age" xreflabel="vacuum_failsafe_age">
       <term><varname>vacuum_failsafe_age</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>vacuum_failsafe_age</varname> configuration parameter</primary>
--->
        <primary><varname>vacuum_failsafe_age</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -14578,7 +14558,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
        <primary><varname>lo_compat_privileges</varname> configuration parameter</primary>
       </indexterm>
       <indexterm>
-       <primary><varname>lo-compat-privileges</varname>設定パラメータ</primary>
+       <primary><varname>lo_compat_privileges</varname>設定パラメータ</primary>
       </indexterm>
       </term>
       <listitem>
@@ -14904,9 +14884,7 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-recovery-init-sync-method" xreflabel="recovery_init_sync_method">
       <term><varname>recovery_init_sync_method</varname> (<type>enum</type>)
        <indexterm>
-<!--
         <primary><varname>recovery_init_sync_method</varname> configuration parameter</primary>
--->
         <primary><varname>recovery_init_sync_method</varname>設定パラメータ</primary>
        </indexterm>
       </term>
@@ -16383,9 +16361,7 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
      <varlistentry id="guc-remove-temp-files-after-crash" xreflabel="remove_temp_files_after_crash">
       <term><varname>remove_temp_files_after_crash</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>remove_temp_files_after_crash</varname> configuration parameter</primary>
--->
        <primary><varname>remove_temp_files_after_crash</varname>設定パラメータ</primary>
       </indexterm>
       </term>

--- a/doc/src/sgml/pgtrgm.sgml
+++ b/doc/src/sgml/pgtrgm.sgml
@@ -527,6 +527,8 @@
      <varname>pg_trgm.strict_word_similarity_threshold</varname> (<type>real</type>)
      <indexterm>
       <primary><varname>pg_trgm.strict_word_similarity_threshold</varname> configuration parameter</primary>
+     </indexterm>
+     <indexterm>
       <primary>
        <varname>pg_trgm.strict_word_similarity_threshold</varname>設定パラメータ
       </primary>

--- a/doc/src/sgml/pgtrgm.sgml
+++ b/doc/src/sgml/pgtrgm.sgml
@@ -526,9 +526,7 @@
     <term>
      <varname>pg_trgm.strict_word_similarity_threshold</varname> (<type>real</type>)
      <indexterm>
-<!--
       <primary><varname>pg_trgm.strict_word_similarity_threshold</varname> configuration parameter</primary>
--->
       <primary>
        <varname>pg_trgm.strict_word_similarity_threshold</varname>設定パラメータ
       </primary>


### PR DESCRIPTION
英語の索引でまだコメントアウトされているところがいくつかありましたので、コメントアウトを解除しました。
（＜primary＞＜varname＞となっていると対象外と判断してしまっている、ということかな、と思いました）
あと、それ以外にも変なところを直しています。（「設定ファイルにおける」は変ではなかったのですが、周辺と調子を合わせました。）

で、シェルスクリプトで分割すればいいのですが、手元にはBSD系のものしかなくてBSD系だとシェルスクリプトが動かないので（多分sedがGNU sed依存）分割ファイルはコミットしてないです。誰かお願い。（やってやれなくはないはずですが、酒が入った状態でやると事故に繋がりそうなので、、、、）