### PR TITLE
fix translation of 'read-only'

### DIFF
--- a/doc/src/sgml/ref/set_transaction.sgml
+++ b/doc/src/sgml/ref/set_transaction.sgml
@@ -22,7 +22,7 @@ PostgreSQL documentation
   <secondary>setting</secondary>
  </indexterm>
  <indexterm>
-  <primary>読み取りのみトランザクション</primary>
+  <primary>読み取り専用トランザクション</primary>
   <secondary>の設定</secondary>
  </indexterm>
 
@@ -99,7 +99,7 @@ SET SESSION CHARACTERISTICS AS TRANSACTION <replaceable class="parameter">transa
    In addition, a snapshot can be selected, though only for the current
    transaction, not as a session default.
 -->
-利用可能なトランザクション特性はトランザクションの分離レベル、トランザクションのアクセスモード（読み書きモードもしくは読み取りのみモード）、遅延モードです。
+利用可能なトランザクション特性はトランザクションの分離レベル、トランザクションのアクセスモード（読み書きモードもしくは読み取り専用モード）、遅延モードです。
 さらに、セッションのデフォルトとしてではなく、現在のトランザクションのみに対してスナップショットを選択することができます。
   </para>
 
@@ -199,9 +199,9 @@ SET SESSION CHARACTERISTICS AS TRANSACTION <replaceable class="parameter">transa
    among those listed.  This is a high-level notion of read-only that
    does not prevent all writes to disk.
 -->
-トランザクションのアクセスモードは、そのトランザクションが読み書き可能か読み取りのみかを決定します。
+トランザクションのアクセスモードは、そのトランザクションが読み書き可能か読み取り専用かを決定します。
 デフォルトは読み書き可能です。
-読み取りのみのトランザクションでは、以下のSQLコマンドの実行が制限されます。
+読み取り専用のトランザクションでは、以下のSQLコマンドの実行が制限されます。
 書き込み対象のテーブルが一時テーブルでない場合、<literal>INSERT</literal>、<literal>UPDATE</literal>、<literal>DELETE</literal>、<literal>COPY FROM</literal>などのSQLコマンドを実行できません。
 すべての<literal>CREATE</literal>、<literal>ALTER</literal>、<literal>DROP</literal>系のSQLコマンド、<literal>COMMENT</literal>、<literal>GRANT</literal>、<literal>REVOKE</literal>、<literal>TRUNCATE</literal>は、実行できません。
 さらに、上述のコマンドが含まれる<literal>EXPLAIN ANALYZE</literal>と<literal>EXECUTE</literal>コマンドも実行できません。


### PR DESCRIPTION
索引を眺めていて気づいたので。

読み取りのみ -> 読み取り専用

単独であれば「読み取りのみ」が悪いとは思わないのですが、「読み取りのみ（の）トランザクション」としているのがこのファイルだけのようでしたので、「読み取り専用」に揃えました。indexterm内だけのつもりでしたが、地の文でもそうなっていたので、地の文の方も修正しています。
