### PR TITLE
indextermのミス修正

### DIFF
--- a/doc/src/sgml/array.sgml
+++ b/doc/src/sgml/array.sgml
@@ -994,6 +994,7 @@ SELECT array_positions(ARRAY[1, 4, 3, 1, 3, 4, 2, 1], 1);
 
   <indexterm>
    <primary>array</primary>
+   <secondary>I/O</secondary>
   </indexterm>
   <indexterm>
    <primary>配列</primary>

--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -788,6 +788,7 @@
 
     <indexterm>
      <primary>decimal</primary>
+     <see>numeric</see>
     </indexterm>
     <indexterm>
      <primary>10進数</primary>
@@ -921,20 +922,21 @@ NUMERIC
 
     <indexterm>
      <primary>infinity</primary>
-<!--
      <secondary>numeric (data type)</secondary>
--->
+    </indexterm>
+    <indexterm>
+     <primary>無限</primary>
      <secondary>numeric (データ型)</secondary>
     </indexterm>
 
     <indexterm>
      <primary>NaN</primary>
      <see>not a number</see>
-    </indexterm>
+   </indexterm>
     <indexterm>
      <primary>NaN</primary>
      <see>非数</see>
-   </indexterm>
+    </indexterm>
 
     <indexterm>
      <primary>not a number</primary>
@@ -1075,6 +1077,9 @@ FROM generate_series(-3.5, 3.5, 1) as x;
 
     <indexterm zone="datatype-float">
      <primary>double precision</primary>
+    </indexterm>
+    <indexterm zone="datatype-float">
+     <primary>倍精度</primary>
     </indexterm>
 
     <indexterm>
@@ -1239,8 +1244,17 @@ FROM generate_series(-3.5, 3.5, 1) as x;
     </note>
 
     <indexterm>
+     <primary>infinity</primary>
+     <secondary>floating point</secondary>
+    </indexterm>
+    <indexterm>
+     <primary>無限</primary>
+     <secondary>浮動小数点</secondary>
+    </indexterm>
+
+    <indexterm>
      <primary>not a number</primary>
-     <secondary>double precision</secondary>
+     <secondary>floating point</secondary>
     </indexterm>
     <indexterm>
      <primary>非数</primary>
@@ -1346,6 +1360,7 @@ IEEE 754では、<literal>NaN</literal>は（<literal>NaN</literal>を含む）�
 
     <indexterm>
      <primary>auto-increment</primary>
+     <see>serial</see>
     </indexterm>
     <indexterm>
      <primary>自動増分</primary>
@@ -4694,7 +4709,7 @@ SELECT * FROM test1 WHERE a;
     <secondary>列挙（enum）</secondary>
    </indexterm>
 
-   <indexterm zone="datatype-enum">   
+   <indexterm zone="datatype-enum">
     <primary>enumerated types</primary>
    </indexterm>
    <indexterm zone="datatype-enum">   
@@ -5744,6 +5759,7 @@ IPv6ではアドレス長は128ビットですので、128ビットが一意な�
 
     <indexterm>
      <primary>MAC address</primary>
+     <see>macaddr</see>
     </indexterm>
     <indexterm>
      <primary>MACアドレス</primary>
@@ -5819,6 +5835,7 @@ PostgreSQLではビット反転に関する準備をしていません。
 
     <indexterm>
      <primary>MAC address (EUI-64 format)</primary>
+     <see>macaddr</see>
     </indexterm>
     <indexterm>
      <primary>MACアドレス (EUI-64 形式)</primary>

--- a/doc/src/sgml/gin.sgml
+++ b/doc/src/sgml/gin.sgml
@@ -8,6 +8,7 @@
 
    <indexterm>
     <primary>index</primary>
+    <secondary>GIN</secondary>
    </indexterm>
    <indexterm>
     <primary>インデックス</primary>

--- a/doc/src/sgml/gist.sgml
+++ b/doc/src/sgml/gist.sgml
@@ -8,6 +8,7 @@
 
    <indexterm>
     <primary>index</primary>
+    <secondary>GiST</secondary>
    </indexterm>
    <indexterm>
     <primary>インデックス</primary>

--- a/doc/src/sgml/indices.sgml
+++ b/doc/src/sgml/indices.sgml
@@ -209,6 +209,7 @@ CREATE INDEX <replaceable>name</replaceable> ON <replaceable>table</replaceable>
 
    <indexterm>
     <primary>index</primary>
+    <secondary>B-Tree</secondary>
    </indexterm>
    <indexterm>
     <primary>インデックス</primary>
@@ -326,6 +327,7 @@ B-treeインデックスをソートされた順序でデータを受けとる�
 
    <indexterm>
     <primary>index</primary>
+    <secondary>GiST</secondary>
    </indexterm>
    <indexterm>
     <primary>インデックス</primary>
@@ -401,6 +403,7 @@ SELECT * FROM places ORDER BY location <-> point '(101,456)' LIMIT 10;
 
    <indexterm>
     <primary>index</primary>
+    <secondary>SP-GiST</secondary>
    </indexterm>
    <indexterm>
     <primary>インデックス</primary>
@@ -462,6 +465,7 @@ GiSTと同様に、SP-GiSTは<quote>最近傍</quote>検索をサポートしま
 
    <indexterm>
     <primary>index</primary>
+    <secondary>GIN</secondary>
    </indexterm>
    <indexterm>
     <primary>インデックス</primary>
@@ -526,6 +530,7 @@ GiSTやSP-GiST同様、GINも多くの異なるユーザ定義のインデック
 
    <indexterm>
     <primary>index</primary>
+    <secondary>BRIN</secondary>
    </indexterm>
    <indexterm>
     <primary>インデックス</primary>

--- a/doc/src/sgml/plperl.sgml
+++ b/doc/src/sgml/plperl.sgml
@@ -846,11 +846,11 @@ SELECT * from lotsa_md5(500);
       <indexterm>
        <primary>spi_prepare</primary>
        <secondary>in PL/Perl</secondary>
-      </indexterm>
+     </indexterm>
       <indexterm>
        <primary>spi_prepare</primary>
        <secondary>PL/Perlにおける</secondary>
-     </indexterm>
+      </indexterm>
      </term>
      <term>
       <literal><function>spi_query_prepared(<replaceable>plan</replaceable>, <replaceable>arguments</replaceable>)</function></literal>

--- a/doc/src/sgml/queries.sgml
+++ b/doc/src/sgml/queries.sgml
@@ -2993,6 +2993,7 @@ SELECT <replaceable>select_list</replaceable> FROM <replaceable>table_expression
 
   <indexterm>
    <primary>common table expression</primary>
+   <see>WITH</see>
   </indexterm>
   <indexterm>
    <primary>共通テーブル式</primary>

--- a/doc/src/sgml/ref/declare.sgml
+++ b/doc/src/sgml/ref/declare.sgml
@@ -10,6 +10,7 @@ PostgreSQL documentation
 
  <indexterm zone="sql-declare">
   <primary>cursor</primary>
+  <secondary>DECLARE</secondary>
  </indexterm>
  <indexterm zone="sql-declare">
   <primary>カーソル</primary>

--- a/doc/src/sgml/ref/fetch.sgml
+++ b/doc/src/sgml/ref/fetch.sgml
@@ -11,6 +11,7 @@ PostgreSQL documentation
 
  <indexterm zone="sql-fetch">
   <primary>cursor</primary>
+  <secondary>FETCH</secondary>
  </indexterm>
  <indexterm zone="sql-fetch">
   <primary>カーソル</primary>

--- a/doc/src/sgml/ref/move.sgml
+++ b/doc/src/sgml/ref/move.sgml
@@ -10,6 +10,7 @@ PostgreSQL documentation
 
  <indexterm zone="sql-move">
   <primary>cursor</primary>
+  <secondary>MOVE</secondary>
  </indexterm>
  <indexterm zone="sql-move">
   <primary>カーソル</primary>

--- a/doc/src/sgml/rules.sgml
+++ b/doc/src/sgml/rules.sgml
@@ -61,7 +61,7 @@
 
 <indexterm zone="querytree">
  <primary>query tree</primary>
- </indexterm>
+</indexterm>
 <indexterm zone="querytree">
  <primary>問い合わせツリー</primary>
 </indexterm>
@@ -416,7 +416,7 @@
 <indexterm zone="rules-views">
  <primary>rule</primary>
  <secondary>and views</secondary>
- </indexterm>
+</indexterm>
 <indexterm zone="rules-views">
  <primary>ルール</primary>
  <secondary>とビュー</secondary>
@@ -425,7 +425,7 @@
 <indexterm zone="rules-views">
  <primary>view</primary>
  <secondary>implementation through rules</secondary>
- </indexterm>
+</indexterm>
 <indexterm zone="rules-views">
  <primary>ビュー</primary>
  <secondary>ルールを使用した実装</secondary>

--- a/doc/src/sgml/xfunc.sgml
+++ b/doc/src/sgml/xfunc.sgml
@@ -1107,10 +1107,10 @@ DROP FUNCTION sum_n_product (int, int);
     <title>出力パラメータを持つ<acronym>SQL</acronym>プロシージャ</title>
 
     <indexterm>
-<!--
      <primary>procedures</primary>
      <secondary>output parameter</secondary>
--->
+    </indexterm>
+    <indexterm>
      <primary>プロシージャ</primary>
      <secondary>出力パラメータ</secondary>
     </indexterm>
@@ -1173,6 +1173,7 @@ CALL tp1(17, 100.0, NULL);
 
     <indexterm>
      <primary>function</primary>
+     <secondary>variadic</secondary>
     </indexterm>
     <indexterm>
      <primary>関数</primary>
@@ -1847,6 +1848,7 @@ SELECT x, case_generate_series(y &gt; 0, 1, z, 5) FROM tab;
 
     <indexterm>
      <primary>function</primary>
+     <secondary>RETURNS TABLE</secondary>
     </indexterm>
     <indexterm>
      <primary>関数</primary>


### PR DESCRIPTION
secondaryやsee等が英語の方に必要だったのを誤って日本語側のみにしてしまったミスの修正。
indextermの差分がちゃんとブロックになるように修正。

indextermの差分は
```
<indexterm>
+</indexterm>
+<indexterm>
<indexterm>
```

ではなく

```
<indexterm>
</indexterm>
+<indexterm>
+<indexterm>
```

になるようにするとミスが判明しやすくなるためインデントも含めて修正しました。