### PR TITLE
config.sgmlのインデント修正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -3,7 +3,7 @@
 <chapter id="runtime-config">
 <!--
   <title>Server Configuration</title>
-  -->
+-->
   <title>サーバの設定</title>
 
   <indexterm>
@@ -16,38 +16,38 @@
   </indexterm>
 
   <para>
-  <!--
+<!--
    There are many configuration parameters that affect the behavior of
    the database system. In the first section of this chapter we
    describe how to interact with configuration parameters. The subsequent sections
    discuss each parameter in detail.
-   -->
-   データベースシステムの動作に影響を与える数多くのパラメータがあります。
-   この章の最初の節で、どのように設定パラメータを操作するのかについて説明します。
-   引き続く節で、それぞれのパラメータの詳細を説明します。
+-->
+データベースシステムの動作に影響を与える数多くのパラメータがあります。
+この章の最初の節で、どのように設定パラメータを操作するのかについて説明します。
+引き続く節で、それぞれのパラメータの詳細を説明します。
   </para>
 
   <sect1 id="config-setting">
-  <!--
+<!--
    <title>Setting Parameters</title>
-   -->
+-->
    <title>パラメータの設定</title>
 
    <sect2 id="config-setting-names-values">
-   <!--
+<!--
     <title>Parameter Names and Values</title>
-    -->
+-->
     <title>パラメータ名とその値</title>
 
     <para>
-    <!--
+<!--
      All parameter names are case-insensitive. Every parameter takes a
      value of one of five types: boolean, string, integer, floating point,
      or enumerated (enum).  The type determines the syntax for setting the
      parameter:
-    -->
-    全てのパラメータの名前は大文字と小文字を区別しません。
-    それぞれのパラメータは、論理値、整数、浮動小数点、文字列、またはenum（列挙型）の5つの型のいずれかの値を取ります。
+-->
+全てのパラメータの名前は大文字と小文字を区別しません。
+それぞれのパラメータは、論理値、整数、浮動小数点、文字列、またはenum（列挙型）の5つの型のいずれかの値を取ります。
 型はパラメータをセットするための記法を定義します。
     </para>
 
@@ -193,8 +193,8 @@
        <structname>pg_settings</structname>.<structfield>enumvals</structfield>.
        Enum parameter values are case-insensitive.
 -->
-       <emphasis>列挙型:</emphasis>
-       列挙型のパラメータは文字列パラメータと同じように記述します。
+<emphasis>列挙型:</emphasis>
+列挙型のパラメータは文字列パラメータと同じように記述します。
 ただ、使用できる文字列の種類が決まっているだけです。
 使用できる文字列は <structname>pg_settings</structname>.<structfield>enumvals</structfield> で定義されています。
 列挙型の値は大文字小文字を区別しません。
@@ -204,20 +204,20 @@
    </sect2>
 
    <sect2 id="config-setting-configuration-file">
-   <!--
+<!--
     <title>Parameter Interaction via the Configuration File</title>
-    -->
+-->
     <title>設定ファイルによるパラメータ操作</title>
 
     <para>
-   <!--
+<!--
      The most fundamental way to set these parameters is to edit the file
      <filename>postgresql.conf</filename><indexterm><primary>postgresql.conf</primary></indexterm>,
      which is normally kept in the data directory.  A default copy is
      installed when the database cluster directory is initialized.
      An example of what this file might look like is:
-    -->
-    これらのパラメータを設定する最も基本的な方法は、<filename>postgresql.conf</filename><indexterm><primary>postgresql.conf</primary></indexterm>ファイルを編集することで、これは通常 data ディレクトリに格納されています。
+-->
+これらのパラメータを設定する最も基本的な方法は、<filename>postgresql.conf</filename><indexterm><primary>postgresql.conf</primary></indexterm>ファイルを編集することで、これは通常 data ディレクトリに格納されています。
 デフォルトのコピーはデータベースクラスタディレクトリが初期化されるときそこにインストールされます。このファイルがどういったものかの例を示します。
 <programlisting>
 # This is a comment
@@ -237,7 +237,7 @@ shared_buffers = 128MB
      or backslash-quote.
      If the file contains multiple entries for the same parameter,
      all but the last one are ignored.
-    -->
+-->
 1つの行毎に1つのパラメータが指定されます。
 名前と値の間の等号は省略可能です。
 （引用符付きのパラメータ値内を除き）空白は特に意味を持たず、何もない行は無視されます。
@@ -263,7 +263,7 @@ shared_buffers = 128MB
      <indexterm>
       <primary>SIGHUP</primary>
      </indexterm>
-     <!--
+<!--
      The configuration file is reread whenever the main server process
      receives a <systemitem>SIGHUP</systemitem> signal; this signal is most easily
      sent by running <literal>pg_ctl reload</literal> from the command line or by
@@ -277,7 +277,7 @@ shared_buffers = 128MB
      configuration file will be ignored until the server is restarted.
      Invalid parameter settings in the configuration file are likewise
      ignored (but logged) during <systemitem>SIGHUP</systemitem> processing.
-    -->
+-->
 設定ファイルは、メインサーバプロセスが<systemitem>SIGHUP</systemitem>シグナルを受け取るたびに再読み込みされます。
 このシグナルを手っ取り早く送信するには、コマンドラインから<literal>pg_ctl reload</literal>を実行するか、SQL関数の<function>pg_reload_conf()</function>を呼び出します。
 メインサーバプロセスは同時にこのシグナルを、現存のセッションが同様に新しい値を入手できるように、全ての現在実行しているサーバプロセスに伝播します(これは現在実行中のクライアントコマンドの処理を完了してから行われます)。
@@ -349,8 +349,8 @@ shared_buffers = 128MB
       In addition, there are two commands that allow setting of defaults
       on a per-database or per-role basis:
 -->
-    <productname>PostgreSQL</productname>は3つのSQLコマンドでデフォルト値を設定します。
-    すでに説明した<command>ALTER SYSTEM</command>コマンドは、SQLによってグローバルな設定値を変更する方法を提供します; <filename>postgresql.conf</filename>を編集するのと等価です。これに加え、データベース単位あるいはロール単位で設定するためのコマンドがあります:
+<productname>PostgreSQL</productname>は3つのSQLコマンドでデフォルト値を設定します。
+すでに説明した<command>ALTER SYSTEM</command>コマンドは、SQLによってグローバルな設定値を変更する方法を提供します; <filename>postgresql.conf</filename>を編集するのと等価です。これに加え、データベース単位あるいはロール単位で設定するためのコマンドがあります:
      </para>
 
      <itemizedlist>
@@ -360,7 +360,7 @@ shared_buffers = 128MB
        The <link linkend="sql-alterdatabase"><command>ALTER DATABASE</command></link> command allows global
        settings to be overridden on a per-database basis.
 -->
-      <link linkend="sql-alterdatabase"><command>ALTER DATABASE</command></link>コマンドはデータベース単位でグローバルな設定値を上書きします。
+<link linkend="sql-alterdatabase"><command>ALTER DATABASE</command></link>コマンドはデータベース単位でグローバルな設定値を上書きします。
       </para>
      </listitem>
 
@@ -370,7 +370,7 @@ shared_buffers = 128MB
        The <link linkend="sql-alterrole"><command>ALTER ROLE</command></link> command allows both global and
        per-database settings to be overridden with user-specific values.
 -->
-      <link linkend="sql-alterrole"><command>ALTER ROLE</command></link>コマンドはグローバルと、データベース単位の両方をユーザ固有の設定値で上書きします。
+<link linkend="sql-alterrole"><command>ALTER ROLE</command></link>コマンドはグローバルと、データベース単位の両方をユーザ固有の設定値で上書きします。
       </para>
      </listitem>
     </itemizedlist>
@@ -384,7 +384,7 @@ shared_buffers = 128MB
       Note that some settings cannot be changed after server start, and
       so cannot be set with these commands (or the ones listed below).
 -->
-     <command>ALTER DATABASE</command>と<command>ALTER ROLE</command>による設定値は新しくデータベースセッションを開始した時にのみ適用されます。
+<command>ALTER DATABASE</command>と<command>ALTER ROLE</command>による設定値は新しくデータベースセッションを開始した時にのみ適用されます。
 これらのコマンドは設定ファイルやサーバへのコマンド引数による設定値を上書きし、セッションの以後の状態に適用します。なお、一部の設定はサーバを起動した後では変更できず、これらのコマンドを使っては設定できません(以下に記述するコマンドでも同じことが言えます)。
     </para>
 
@@ -406,7 +406,7 @@ shared_buffers = 128MB
       <function>current_setting(setting_name text)</function>
       (see <xref linkend="functions-admin-set"/>).
 -->
-     <link linkend="sql-show"><command>SHOW</command></link>コマンドを使ってすべてのパラメータの現在の値を調べることができます。
+<link linkend="sql-show"><command>SHOW</command></link>コマンドを使ってすべてのパラメータの現在の値を調べることができます。
 対応する関数は<function>current_setting(setting_name text)</function>です（<xref linkend="functions-admin-set"/>を参照してください）。
      </para>
      </listitem>
@@ -445,7 +445,7 @@ shared_buffers = 128MB
        provides more detail.  It is also more flexible, since it's possible
        to specify filter conditions or join against other relations.
 -->
-     このビューを問い合わせるのは、<command>SHOW ALL</command>を使うのと同じですが、更に詳細な情報を提供します。
+このビューを問い合わせるのは、<command>SHOW ALL</command>を使うのと同じですが、更に詳細な情報を提供します。
 フィルター条件を指定したり他のリレーションと結合ができるので、より柔軟です。
       </para>
      </listitem>
@@ -490,7 +490,7 @@ UPDATE pg_settings SET setting = reset_val WHERE name = 'configuration_parameter
       Both the server and <application>libpq</application> client library
       accept parameter values via the shell.
 -->
-      グローバルなデフォルト値を設定したりデータベース、ロール単位で上書きを行えるだけでなく、シェル機能を使って<productname>PostgreSQL</productname>に設定値を渡すことができます。
+グローバルなデフォルト値を設定したりデータベース、ロール単位で上書きを行えるだけでなく、シェル機能を使って<productname>PostgreSQL</productname>に設定値を渡すことができます。
 サーバも<application>libpq</application>クライアントライブラリもシェル経由でパラメータ値を受けとることができます。
      </para>
 
@@ -502,7 +502,7 @@ UPDATE pg_settings SET setting = reset_val WHERE name = 'configuration_parameter
        passed to the <command>postgres</command> command via the
        <option>-c</option> command-line parameter.  For example,
 -->
-      サーバ起動時に、<option>-c</option>コマンドラインパラメータを使ってパラメータ設定値を<command>postgres</command>に渡すことができます。たとえば、
+サーバ起動時に、<option>-c</option>コマンドラインパラメータを使ってパラメータ設定値を<command>postgres</command>に渡すことができます。たとえば、
 <programlisting>
 postgres -c log_connections=yes -c log_destination='syslog'
 </programlisting>
@@ -511,7 +511,7 @@ postgres -c log_connections=yes -c log_destination='syslog'
        <filename>postgresql.conf</filename> or <command>ALTER SYSTEM</command>,
        so they cannot be changed globally without restarting the server.
 -->
-       このようにして渡された設定値は、<filename>postgresql.conf</filename>や<command>ALTER SYSTEM</command>による設定を上書きします。
+このようにして渡された設定値は、<filename>postgresql.conf</filename>や<command>ALTER SYSTEM</command>による設定を上書きします。
 したがってサーバを再起動しない限りこれらの設定値をグローバルに変更することはできません。
      </para>
     </listitem>
@@ -529,7 +529,7 @@ postgres -c log_connections=yes -c log_destination='syslog'
       command; specifically, the <option>-c</option> flag must be specified.
       For example,
 -->
-      <application>libpq</application>を使ってクライアントセッションを開始するときに<envar>PGOPTIONS</envar>環境変数を使って設定値を指定できます。
+<application>libpq</application>を使ってクライアントセッションを開始するときに<envar>PGOPTIONS</envar>環境変数を使って設定値を指定できます。
 このようにして渡された設定値はセッションのデフォルトとなりますが、他のセッションには影響を与えません。
 歴史的な理由により、<envar>PGOPTIONS</envar>の形式は<command>postgres</command>を起動するときのものと似ています。たとえば、<option>-c</option>フラグを指定しなければならない点です。
 <programlisting>
@@ -543,7 +543,7 @@ env PGOPTIONS="-c geqo=off -c statement_timeout=5min" psql
       via the shell or otherwise, that allow the user to alter session
       settings without direct use of SQL commands.
 -->
-     他のクライアントやライブラリではそれぞれ固有の方法でシェルなどを経由して、SQLコマンドを直接使わずにセッションの設定を変更することができるかもしれません。
+他のクライアントやライブラリではそれぞれ固有の方法でシェルなどを経由して、SQLコマンドを直接使わずにセッションの設定を変更することができるかもしれません。
      </para>
     </listitem>
    </itemizedlist>
@@ -551,9 +551,9 @@ env PGOPTIONS="-c geqo=off -c statement_timeout=5min" psql
    </sect2>
 
    <sect2 id="config-includes">
-   <!--
+<!--
     <title>Managing Configuration File Contents</title>
-   -->
+-->
     <title>設定ファイルの内容の管理</title>
 
      <para>
@@ -563,7 +563,7 @@ env PGOPTIONS="-c geqo=off -c statement_timeout=5min" psql
       These features are especially useful when managing multiple servers
       with related, but not identical, configurations.
 -->
-      <productname>PostgreSQL</productname>は複雑な<filename>postgresql.conf</filename>ファイルを複数の小さなファイルに分割する複数の方法を提供しています。
+<productname>PostgreSQL</productname>は複雑な<filename>postgresql.conf</filename>ファイルを複数の小さなファイルに分割する複数の方法を提供しています。
 これは、とりわけお互いに関連しているものの設定が同じではない複数のサーバを管理する際に有用です。
      </para>
 
@@ -576,7 +576,7 @@ env PGOPTIONS="-c geqo=off -c statement_timeout=5min" psql
        <primary><literal>include</literal></primary>
        <secondary>設定ファイルにおける</secondary>
       </indexterm>
-      <!--
+<!--
       In addition to individual parameter settings,
       the <filename>postgresql.conf</filename> file can contain <firstterm>include
       directives</firstterm>, which specify another file to read and process as if
@@ -661,7 +661,7 @@ include_dir 'ディレクトリ名'
       files within an include directory are processed in file name order
       (according to C locale rules, i.e., numbers before letters, and
       uppercase letters before lowercase ones).
-       -->
+-->
 絶対パスではないディレクトリ名はその設定ファイルがあるディレクトリへの相対パスと見なされます。
 指定したディレクトリの中で、ディレクトリではないファイルで末尾が<literal>.conf</literal>で終わるファイルだけがincludeされます。
 また、文字<literal>.</literal> で開始するファイル名は一部のプラットフォームでは隠しファイルとされるので、間違いを防止するため無視されます。
@@ -670,7 +670,7 @@ includeされるディレクトリにある複数ファイルはファイル名�
      </para>
 
      <para>
-     <!--
+<!--
       Include files or directories can be used to logically separate portions
       of the database configuration, rather than having a single large
       <filename>postgresql.conf</filename> file.  Consider a company that has two
@@ -682,7 +682,7 @@ includeされるディレクトリにある複数ファイルはファイル名�
       configuration changes for your site into three files.  You could add
       this to the end of your <filename>postgresql.conf</filename> file to include
       them:
-      -->
+-->
 includeされるファイルもしくはディレクトリは、大きな単一の<filename>postgresql.conf</filename>ファイルを使う代わりに、データベース設定の一部分を論理的に分離するために使用することが可能です。
 異なるメモリー容量を持つ二つのデータベースサーバを所有する会社を考えてみてください。
 例えばログ取得のように、二つが共有する設定の要素があると思われます。
@@ -702,7 +702,7 @@ include 'server.conf'
       with 8GB of RAM, another for those having 16GB.  And
       finally <filename>server.conf</filename> could have truly server-specific
       configuration information in it.
-      -->
+-->
 全てのシステムは同一の<filename>shared.conf</filename>を所有する様になるでしょう。
 特定のメモリー容量を所有するそれぞれのサーバは同じ<filename>memory.conf</filename>を共有できます。
 RAMが8GBのすべてのサーバには共通の<filename>memory.conf</filename>を1つ使い、16GBのサーバ群には別のものを使う、ということもできるでしょう。
@@ -710,7 +710,7 @@ RAMが8GBのすべてのサーバには共通の<filename>memory.conf</filename>
      </para>
 
      <para>
-     <!--
+<!--
       Another possibility is to create a configuration file directory and
       put this information into files there. For example, a <filename>conf.d</filename>
       directory could be referenced at the end of <filename>postgresql.conf</filename>:
@@ -730,21 +730,21 @@ include_dir 'conf.d'
 01memory.conf
 02server.conf
 </programlisting>
- <!--
+<!--
        This naming convention establishes a clear order in which these
        files will be loaded.  This is important because only the last
        setting encountered for a particular parameter while the server is
        reading configuration files will be used.  In this example,
        something set in <filename>conf.d/02server.conf</filename> would override a
        value set in <filename>conf.d/01memory.conf</filename>.
-       -->
+-->
 この命名規則により、これらのファイルが読み込まれる順序が明確になります。
 サーバが設定を読み込んでいるときに各パラメータについて最後にあった設定だけが使用されるので、このことは重要です。
 この例では、<filename>conf.d/02server.conf</filename>でされた指定は<filename>conf.d/01memory.conf</filename>の設定値よりも優先します。
      </para>
 
      <para>
-     <!--
+<!--
       You might instead use this approach to naming the files
       descriptively:
 -->
@@ -754,13 +754,13 @@ include_dir 'conf.d'
 01memory-8GB.conf
 02server-foo.conf
 </programlisting>
- <!--
+<!--
       This sort of arrangement gives a unique name for each configuration file
       variation.  This can help eliminate ambiguity when several servers have
       their configurations all stored in one place, such as in a version
       control repository.  (Storing database configuration files under version
       control is another good practice to consider.)
-       -->
+-->
 こういった工夫で、設定ファイルのバリエーションに対して固有の名前を付与することができます。
 また、バージョン管理リポジトリのリポジトリに複数のサーバの設定ファイルを置く場合に生じる曖昧さを排除することができます。
 （データベース設定ファイルをバージョン管理することは、これもまた検討に値するやり方です）。
@@ -769,13 +769,13 @@ include_dir 'conf.d'
    </sect1>
 
    <sect1 id="runtime-config-file-locations">
-   <!--
+<!--
     <title>File Locations</title>
-    -->
+-->
     <title>ファイルの場所</title>
 
      <para>
-     <!--
+<!--
       In addition to the <filename>postgresql.conf</filename> file
       already mentioned, <productname>PostgreSQL</productname> uses
       two other manually-edited configuration files, which control
@@ -787,7 +787,7 @@ include_dir 'conf.d'
       administration.  In particular it is often easier to ensure that
       the configuration files are properly backed-up when they are
       kept separate.)
-      -->
+-->
 すでに説明した<filename>postgresql.conf</filename>ファイルに加え、<productname>PostgreSQL</productname>は、クライアント認証の管理を行うために、他の2つの手作業で編集される設定ファイルを使用します（これらの使用方法は<xref linkend="client-authentication"/>で説明します）。
 全ての3つの設定ファイルは、デフォルトではデータベースクラスタのdataディレクトリに格納されます。
 本節で説明するパラメータにより、設定ファイルを他の場所に置くことが可能になります。
@@ -807,12 +807,12 @@ include_dir 'conf.d'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
          Specifies the directory to use for data storage.
          This parameter can only be set at server start.
-        -->
-        データ格納に使用するディレクトリを指定します。
-        このパラメータはサーバ起動時のみ設定可能です
+-->
+データ格納に使用するディレクトリを指定します。
+このパラメータはサーバ起動時のみ設定可能です
        </para>
       </listitem>
      </varlistentry>
@@ -828,12 +828,12 @@ include_dir 'conf.d'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
          Specifies the main server configuration file
          (customarily called <filename>postgresql.conf</filename>).
          This parameter can only be set on the <command>postgres</command> command line.
-        -->
-        メインサーバ設定ファイルを指定します（通例<filename>postgresql.conf</filename>と呼ばれます）。
+-->
+メインサーバ設定ファイルを指定します（通例<filename>postgresql.conf</filename>と呼ばれます）。
 このパラメータは<command>postgres</command>コマンドライン上でのみ設定可能です。
        </para>
       </listitem>
@@ -850,12 +850,12 @@ include_dir 'conf.d'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
          Specifies the configuration file for host-based authentication
          (customarily called <filename>pg_hba.conf</filename>).
          This parameter can only be set at server start.
-        -->
-        ホストベース認証（HBA）用のファイルを指定します（通例<filename>pg_hba.conf</filename>と呼ばれます）。
+-->
+ホストベース認証（HBA）用のファイルを指定します（通例<filename>pg_hba.conf</filename>と呼ばれます）。
 このパラメータはサーバ起動時のみ設定可能です。
        </para>
       </listitem>
@@ -872,12 +872,12 @@ include_dir 'conf.d'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
          Specifies the configuration file for user name mapping
          (customarily called <filename>pg_ident.conf</filename>).
          This parameter can only be set at server start.
          See also <xref linkend="auth-username-maps"/>.
-        -->
+-->
 ユーザ名マッピングの設定ファイルを指定します（通例<filename>pg_ident.conf</filename>と呼ばれます）。
 このパラメータはサーバ起動時のみ設定可能です。
 <xref linkend="auth-username-maps"/>もご覧ください。
@@ -896,11 +896,11 @@ include_dir 'conf.d'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the name of an additional process-ID (PID) file that the
         server should create for use by server administration programs.
         This parameter can only be set at server start.
-       -->
+-->
 サーバ管理プログラムで使用するためにサーバが作成する、追加のプロセス識別子（PID)ファイルの名前を指定します。
 このパラメータはサーバ起動時のみ設定可能です。
        </para>
@@ -909,19 +909,19 @@ include_dir 'conf.d'
      </variablelist>
 
      <para>
-     <!--
+<!--
       In a default installation, none of the above parameters are set
       explicitly.  Instead, the
       data directory is specified by the <option>-D</option> command-line
       option or the <envar>PGDATA</envar> environment variable, and the
       configuration files are all found within the data directory.
-      -->
-      デフォルトのインストールでは、上記のいかなるパラメータも明示的に設定されません。
+-->
+デフォルトのインストールでは、上記のいかなるパラメータも明示的に設定されません。
 その代わり、data ディレクトリは<option>-D</option>コマンドラインオプション、または<envar>PGDATA</envar>環境変数で指定され、設定ファイル全てはその data ディレクトリ内に格納されます。
      </para>
 
      <para>
-     <!--
+<!--
       If you wish to keep the configuration files elsewhere than the
       data directory, the <command>postgres</command> <option>-D</option>
       command-line option or <envar>PGDATA</envar> environment variable
@@ -933,13 +933,13 @@ include_dir 'conf.d'
       <envar>PGDATA</envar> for the location
       of the data directory, but not for the location of the configuration
       files.
-      -->
-      dataディレクトリ以外の場所に設定ファイルを格納したいのであれば、<command>postgres</command>の<option>-D</option>コマンドラインオプション、または<envar>PGDATA</envar>環境変数で設定ファイルの場所を指し示し、そしてdataディレクトリが実際どこに存在するのかを示すため、<filename>postgresql.conf</filename>の（もしくはコマンドライン上で）<varname>data_directory</varname>パラメータを設定しなければなりません。
-      <varname>data_directory</varname>は、設定ファイルの場所ではなく、data ディレクトリの位置に関して、<option>-D</option>および<envar>PGDATA</envar>を上書きすることに注意してください。
+-->
+dataディレクトリ以外の場所に設定ファイルを格納したいのであれば、<command>postgres</command>の<option>-D</option>コマンドラインオプション、または<envar>PGDATA</envar>環境変数で設定ファイルの場所を指し示し、そしてdataディレクトリが実際どこに存在するのかを示すため、<filename>postgresql.conf</filename>の（もしくはコマンドライン上で）<varname>data_directory</varname>パラメータを設定しなければなりません。
+<varname>data_directory</varname>は、設定ファイルの場所ではなく、data ディレクトリの位置に関して、<option>-D</option>および<envar>PGDATA</envar>を上書きすることに注意してください。
      </para>
 
      <para>
-     <!--
+<!--
       If you wish, you can specify the configuration file names and locations
       individually using the parameters <varname>config_file</varname>,
       <varname>hba_file</varname> and/or <varname>ident_file</varname>.
@@ -948,32 +948,32 @@ include_dir 'conf.d'
       set within the main configuration file.  If all three parameters plus
       <varname>data_directory</varname> are explicitly set, then it is not necessary
       to specify <option>-D</option> or <envar>PGDATA</envar>.
-      -->
+-->
 必要に応じて、パラメータ<varname>config_file</varname>、<varname>hba_file</varname>、<varname>ident_file</varname>を使用し、設定ファイルの名前と場所を個別に指定することができます。
 <varname>config_file</varname>は<command>postgres</command>コマンドラインによってのみ指定されますが、その他は主設定ファイル内で設定できます。
 全ての3つのパラメータと<varname>data_directory</varname>が明示的に設定されていれば、<option>-D</option>または<envar>PGDATA</envar>を指定する必要はありません。
      </para>
 
      <para>
-     <!--
+<!--
       When setting any of these parameters, a relative path will be interpreted
       with respect to the directory in which <command>postgres</command>
       is started.
-      -->
+-->
 これらのパラメータのどれを設定する場合でも、相対パスは、<command>postgres</command>が起動されるディレクトリから見た相対パスとして解釈されます。
      </para>
    </sect1>
 
    <sect1 id="runtime-config-connection">
-   <!--
+<!--
     <title>Connections and Authentication</title>
-    -->
+-->
     <title>接続と認証</title>
 
     <sect2 id="runtime-config-connection-settings">
-    <!--
+<!--
      <title>Connection Settings</title>
-     -->
+-->
      <title>接続設定</title>
 
      <variablelist>
@@ -1034,14 +1034,14 @@ include_dir 'conf.d'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The TCP port the server listens on; 5432 by default.  Note that the
         same port number is used for all IP addresses the server listens on.
         This parameter can only be set at server start.
-       -->
-       サーバが監視するTCPポートで、デフォルトは 5432です。
-       サーバが監視する全てのIPアドレスに対し、同じポート番号が使用されることを覚えておいてください。
-       このパラメータはサーバ起動時のみ設定可能です。
+-->
+サーバが監視するTCPポートで、デフォルトは 5432です。
+サーバが監視する全てのIPアドレスに対し、同じポート番号が使用されることを覚えておいてください。
+このパラメータはサーバ起動時のみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1057,24 +1057,24 @@ include_dir 'conf.d'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Determines the maximum number of concurrent connections to the
         database server. The default is typically 100 connections, but
         might be less if your kernel settings will not support it (as
         determined during <application>initdb</application>).  This parameter can
         only be set at server start.
-       -->
+-->
 データベースサーバに同時接続する最大数を決定します。
 デフォルトは典型的に100接続ですが、カーネルの設定が（<application>initdb</application>の過程で）それをサポートしていない場合、もっと少なくなることがあります。
 このパラメータはサーバ起動時のみに設定可能です。
        </para>
 
        <para>
-       <!--
+<!--
         When running a standby server, you must set this parameter to the
         same or higher value than on the primary server. Otherwise, queries
         will not be allowed in the standby server.
-       -->
+-->
 スタンバイサーバを運用している場合、このパラメータはプライマリサーバでの設定と同じ、もしくはより高い値に設定しなければなりません。そうしないと問い合わせがスタンバイサーバ内で受け入れられません。
        </para>
       </listitem>
@@ -1093,7 +1093,7 @@ include_dir 'conf.d'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Determines the number of connection <quote>slots</quote> that
         are reserved for connections by <productname>PostgreSQL</productname>
         superusers.  At most <xref linkend="guc-max-connections"/>
@@ -1103,18 +1103,18 @@ include_dir 'conf.d'
         <varname>superuser_reserved_connections</varname>, new
         connections will be accepted only for superusers, and no
         new replication connections will be accepted.
-       -->
+-->
 <productname>PostgreSQL</productname>のスーパーユーザによる接続のために予約されている接続<quote>開口部（スロット）</quote>の数を決定します。
 最大、<xref linkend="guc-max-connections"/>の数までの接続を同時に有効にすることができます。
 有効な接続数が<varname>max_connections</varname>から<varname>superuser_reserved_connections</varname>を差し引いた数以上のときは、新規接続はスーパーユーザのみが許可され、新たなレプリケーション接続は受け入れられません。
        </para>
 
        <para>
-       <!--
+<!--
         The default value is three connections. The value must be less
         than <varname>max_connections</varname>.
         This parameter can only be set at server start.
-       -->
+-->
 デフォルトの値は3接続です。
 この値は <varname>max_connections</varname>より小さくなくてはなりません。
 このパラメータはサーバ起動時のみ設定可能です。
@@ -1210,7 +1210,7 @@ Windowsではデフォルトは空文字で、これはつまりUnixドメイン
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the owning group of the Unix-domain socket(s).  (The owning
         user of the sockets is always the user that starts the
         server.)  In combination with the parameter
@@ -1219,7 +1219,7 @@ Windowsではデフォルトは空文字で、これはつまりUnixドメイン
         By default this is the empty string, which uses the default
         group of the server user.  This parameter can only be set at
         server start.
-       -->
+-->
 Unixドメインソケット（複数も）を所有するグループを設定します（ソケットを所有するユーザは常にサーバを起動するユーザです）。
 <varname>unix_socket_permissions</varname>パラメータとの組合せで、Unixドメインソケット接続の追加的アクセス管理機構として使うことができます。
 デフォルトでは空文字列で、サーバユーザのデフォルトグループを使用します。
@@ -1250,7 +1250,7 @@ Unixドメインソケット（複数も）を所有するグループを設定�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the access permissions of the Unix-domain socket(s).  Unix-domain
         sockets use the usual Unix file system permission set.
         The parameter value is expected to be a numeric mode
@@ -1258,7 +1258,7 @@ Unixドメインソケット（複数も）を所有するグループを設定�
         <function>chmod</function> and <function>umask</function>
         system calls.  (To use the customary octal format the number
         must start with a <literal>0</literal> (zero).)
-       -->
+-->
 Unixドメインソケット（複数も）のアクセスパーミッションを設定します。
 Unixドメインソケットは通常のUnixファイルシステムパーミッション設定の一式を使用します。
 パラメータ値は、<function>chmod</function>および<function>umask</function>システムコールが受け付ける数値形式での指定を想定しています。
@@ -1281,27 +1281,27 @@ Unixドメインソケットは通常のUnixファイルシステムパーミッ
        </para>
 
        <para>
-       <!--
+<!--
         This access control mechanism is independent of the one
         described in <xref linkend="client-authentication"/>.
-       -->
+-->
 このアクセス制御機構は <xref linkend="client-authentication"/>で記述されたものとは別個のものです。
        </para>
 
        <para>
-       <!--
+<!--
         This parameter can only be set at server start.
-       -->
+-->
 このパラメータはサーバ起動時のみ設定可能です。
        </para>
 
        <para>
-       <!--
+<!--
         This parameter is irrelevant on systems, notably Solaris as of Solaris
         10, that ignore socket permissions entirely.  There, one can achieve a
         similar effect by pointing <varname>unix_socket_directories</varname> to a
         directory having search permission limited to the desired audience.
-       -->
+-->
 このパラメータはSolaris 10の時点でのSolarisなど、ソケットのパーミッションを完全に無視するシステムでは無関係です。
 こうしたシステムでは、許可したいユーザだけが検索パーミッションを持つディレクトリを<varname>unix_socket_directories</varname>で指すようにすることによって同じような効果を得ることができます。
        </para>
@@ -1327,12 +1327,12 @@ Unixドメインソケットは通常のUnixファイルシステムパーミッ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables advertising the server's existence via
         <productname>Bonjour</productname>.  The default is off.
         This parameter can only be set at server start.
-       -->
-       <productname>Bonjour</productname>によりサーバの存在を公表することを可能にします。デフォルトはoffです。このパラメータはサーバ起動時のみ設定可能です。
+-->
+<productname>Bonjour</productname>によりサーバの存在を公表することを可能にします。デフォルトはoffです。このパラメータはサーバ起動時のみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1348,15 +1348,15 @@ Unixドメインソケットは通常のUnixファイルシステムパーミッ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the <productname>Bonjour</productname> service
         name.  The computer name is used if this parameter is set to the
         empty string <literal>''</literal> (which is the default).  This parameter is
         ignored if the server was not compiled with
         <productname>Bonjour</productname> support.
         This parameter can only be set at server start.
-       -->
-       <productname>Bonjour</productname>サービス名を指定します。
+-->
+<productname>Bonjour</productname>サービス名を指定します。
 このパラメータが空文字列<literal>''</literal>（デフォルトです）に設定されていると、コンピュータ名が使用されます。
 サーバが<productname>Bonjour</productname>サポート付でコンパイルでされていない場合は無視されます。
 このオプションはサーバ起動時のみに設定可能です。
@@ -1375,7 +1375,7 @@ Unixドメインソケットは通常のUnixファイルシステムパーミッ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the amount of time with no network activity after which
         the operating system should send a TCP keepalive message to the client.
         If this value is specified without units, it is taken as seconds.
@@ -1385,7 +1385,7 @@ Unixドメインソケットは通常のUnixファイルシステムパーミッ
         Windows; on other systems, it must be zero.
         In sessions connected via a Unix-domain socket, this parameter is
         ignored and always reads as zero.
-       -->
+-->
 クライアントとのやり取りがなくなった後、オペレーティングシステムがTCPのkeepaliveパケットをクライアントに送信するまでの時間を指定します。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
 0（デフォルトです）の場合はオペレーティングシステムのデフォルト値を使用します。
@@ -1395,10 +1395,10 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
        </para>
        <note>
         <para>
-         <!--
+<!--
          On Windows, setting a value of 0 will set this parameter to 2 hours,
          since Windows does not provide a way to read the system default value.
-          -->
+-->
           Windowsでは0を指定するとこのパラメータを2時間に設定します。なぜなら、Windowsはシステムデフォルト値を読む手段を提供していないからです。
         </para>
        </note>
@@ -1416,7 +1416,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the amount of time after which a TCP keepalive message
         that has not been acknowledged by the client should be retransmitted.
         If this value is specified without units, it is taken as seconds.
@@ -1426,7 +1426,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
         Windows; on other systems, it must be zero.
         In sessions connected via a Unix-domain socket, this parameter is
         ignored and always reads as zero.
-       -->
+-->
 TCPのkeepaliveメッセージに対してクライアントから応答がない場合に、再送を行うまでの時間を指定します。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
 0（デフォルトです）の場合はシステムのデフォルト値を使用します。
@@ -1457,7 +1457,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the number of TCP keepalive messages that can be lost before
         the server's connection to the client is considered dead.
         A value of 0 (the default) selects the operating system's default.
@@ -1466,7 +1466,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
         on other systems, it must be zero.
         In sessions connected via a Unix-domain socket, this parameter is
         ignored and always reads as zero.
-       -->
+-->
 サーバのクライアントへの接続が切れたと判断されるまでのTCP keepaliveメッセージの数を指定します。
 0（デフォルトです）の場合はオペレーティングシステムのデフォルト値を使用します。
 このパラメータは<symbol>TCP_KEEPCNT</symbol>または同等のソケットオプションをサポートするシステムでのみサポートされます。
@@ -1475,9 +1475,9 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
        </para>
        <note>
         <para>
-         <!--
+<!--
          This parameter is not supported on Windows, and must be zero.
-          -->
+-->
 このパラメータはWindowsではサポートされておらず、ゼロでなければなりません。
         </para>
        </note>
@@ -1581,9 +1581,9 @@ UNIXドメインソケットで接続しているセッションではこのパ�
      </sect2>
 
      <sect2 id="runtime-config-connection-authentication">
-     <!--
+<!--
      <title>Authentication</title>
-     -->
+-->
      <title>認証</title>
 
      <variablelist>
@@ -1603,7 +1603,7 @@ UNIXドメインソケットで接続しているセッションではこのパ�
 
       <listitem>
        <para>
-       <!--
+<!--
         Maximum amount of time allowed to complete client authentication. If a
         would-be client has not completed the authentication protocol in
         this much time, the server closes the connection. This prevents
@@ -1612,7 +1612,7 @@ UNIXドメインソケットで接続しているセッションではこのパ�
         The default is one minute (<literal>1m</literal>).
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 クライアント認証を完了するまでの最大時間です。
 もし、この時間内に自称クライアントが認証プロトコルを完了しない場合、サーバは接続を閉じます。
 これはハングしたクライアントが接続を永久に占有することを防ぎます。
@@ -1871,13 +1871,13 @@ SSLサーバ認証局（CA）が入っているファイル名を設定します
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the name of the file containing the SSL server certificate.
         Relative paths are relative to the data directory.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
         The default is <filename>server.crt</filename>.
-       -->
+-->
 SSLサーバ証明書が入っているファイル名を設定します。
 相対パスの場合は、データディレクトリからの相対パスになります。
 このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
@@ -1978,13 +1978,13 @@ SSLサーバ証明書失効リスト（CRL）が入っているディレクト�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the name of the file containing the SSL server private key.
         Relative paths are relative to the data directory.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
         The default is <filename>server.key</filename>.
-       -->
+-->
 SSLサーバの秘密鍵が入っているファイル名を設定します。
 相対パスの場合は、データディレクトリからの相対パスになります。
 このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
@@ -2151,9 +2151,9 @@ TLSバージョン1.2あるいはそれ以下のバージョンを使用する�
         usually better because it is more likely that the server is appropriately
         configured.
 -->
-        古いバージョンのPostgreSQLにはこの設定がなく、常にクライアントの設定を使います。
-        この設定は、主に古いバージョンとの互換性のために設けられています。
-        通常サーバの設定に従うほうが良いです。大抵の場合、サーバはより適切に設定されているからです。
+古いバージョンのPostgreSQLにはこの設定がなく、常にクライアントの設定を使います。
+この設定は、主に古いバージョンとの互換性のために設けられています。
+通常サーバの設定に従うほうが良いです。大抵の場合、サーバはより適切に設定されているからです。
        </para>
       </listitem>
      </varlistentry>
@@ -2190,7 +2190,7 @@ TLSバージョン1.2あるいはそれ以下のバージョンを使用する�
         <productname>OpenSSL</productname> names for the most common curves
         are:
 -->
-        <productname>OpenSSL</productname>はよく使われる曲線に名前を付けています。
+<productname>OpenSSL</productname>はよく使われる曲線に名前を付けています。
         <literal>prime256v1</literal> (NIST P-256),
         <literal>secp384r1</literal> (NIST P-384),
         <literal>secp521r1</literal> (NIST P-521).
@@ -2199,7 +2199,7 @@ TLSバージョン1.2あるいはそれ以下のバージョンを使用する�
         <command>openssl ecparam -list_curves</command>.  Not all of them
         are usable in <acronym>TLS</acronym> though.
 -->
-        利用できる曲線の完全なリストは<command>openssl ecparam -list_curves</command>で得られます。ただし、<acronym>TLS</acronym>ではこのすべてが利用できるわけではありません。
+利用できる曲線の完全なリストは<command>openssl ecparam -list_curves</command>で得られます。ただし、<acronym>TLS</acronym>ではこのすべてが利用できるわけではありません。
        </para>
       </listitem>
      </varlistentry>
@@ -2419,15 +2419,15 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
    </sect1>
 
    <sect1 id="runtime-config-resource">
-   <!--
+<!--
     <title>Resource Consumption</title>
-    -->
+-->
     <title>資源の消費</title>
 
     <sect2 id="runtime-config-resource-memory">
-    <!--
+<!--
      <title>Memory</title>
-     -->
+-->
      <title>メモリ</title>
 
      <variablelist>
@@ -2442,7 +2442,7 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the amount of memory the database server uses for shared
         memory buffers.  The default is typically 128 megabytes
         (<literal>128MB</literal>), but might be less if your kernel settings will
@@ -2455,7 +2455,7 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
         (Non-default values of <symbol>BLCKSZ</symbol> change the minimum
         value.)
         This parameter can only be set at server start.
-       -->
+-->
 データベースサーバが共有メモリバッファのために使用するメモリ量を設定します。
 デフォルトは一般的に128メガバイト(<literal>128MB</literal>)です。
 しかし、稼働中のカーネルの設定がこの値をサポートしていない場合、より少なくなることがあります（<application>initdb</application>の過程で決定されます）。
@@ -2467,7 +2467,7 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
        </para>
 
        <para>
-       <!--
+<!--
         If you have a dedicated database server with 1GB or more of RAM, a
         reasonable starting value for <varname>shared_buffers</varname> is 25%
         of the memory in your system.  There are some workloads where even
@@ -2480,7 +2480,7 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
         <varname>max_wal_size</varname>, in order to spread out the
         process of writing large quantities of new or changed data over a
         longer period of time.
-       -->
+-->
 1GB以上のRAMを載せた専用データベースサーバを使用している場合、<varname>shared_buffers</varname>に対する妥当な初期値はシステムメモリの25%です。
 <varname>shared_buffers</varname>をこれよりも大きな値に設定することが有効なワークロードもあります。
 しかし、<productname>PostgreSQL</productname>はオペレーティングシステムキャッシュにも依存するため、<varname>shared_buffers</varname>にRAMの40%以上を割り当てても、それより小さい値の時より動作が良くなる見込みはありません。
@@ -2488,10 +2488,10 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
        </para>
 
        <para>
-       <!--
+<!--
         On systems with less than 1GB of RAM, a smaller percentage of RAM is
         appropriate, so as to leave adequate space for the operating system.
-       -->
+-->
 1GB未満のRAMのシステムでは、オペレーティングシステムに十分な余裕を残すために、RAMに対してより小さい割合を設定することが適切です。
        </para>
 
@@ -2532,8 +2532,8 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
         setting is ignored on other systems when set to
         <literal>try</literal>.
 -->
-        今のところこの機能はLinuxとWindowsでのみサポートされています。
-        他のシステムでは<literal>try</literal>と設定しても無視されます。
+今のところこの機能はLinuxとWindowsでのみサポートされています。
+他のシステムでは<literal>try</literal>と設定しても無視されます。
        </para>
 
        <para>
@@ -2644,7 +2644,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the maximum amount of memory used for temporary buffers within
         each database session.  These are session-local buffers used only
         for access to temporary tables.
@@ -2657,7 +2657,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
         sessions, but only before the first use of temporary tables
         within the session; subsequent attempts to change the value will
         have no effect on that session.
-       -->
+-->
 それぞれのデータベースセッションが使用する一時バッファの最大メモリ量を設定します。
 一時バッファは、一時テーブルにアクセスする時にのみ使用されるセッションローカルのバッファです。
 この値が単位なしで指定された場合は、ブロック単位であるとみなします。すなわち、<symbol>BLCKSZ</symbol>バイト、一般的には8kBです。
@@ -2667,7 +2667,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
        </para>
 
        <para>
-       <!--
+<!--
         A session will allocate temporary buffers as needed up to the limit
         given by <varname>temp_buffers</varname>.  The cost of setting a large
         value in sessions that do not actually need many temporary
@@ -2675,7 +2675,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
         increment in <varname>temp_buffers</varname>.  However if a buffer is
         actually used an additional 8192 bytes will be consumed for it
         (or in general, <symbol>BLCKSZ</symbol> bytes).
-       -->
+-->
 セッションは、<varname>temp_buffers</varname>を上限として、必要に応じて一時バッファを確保します。
 多くの一時バッファを実際に必要としないセッションで大きな値を設定するコストとは、<varname>temp_buffers</varname>の増分毎に、1つのバッファ記述子、約64バイトだけです。
 しかし、バッファが実際に使用されると、それに対して追加の8192バイト（汎用的に言えば<symbol>BLCKSZ</symbol>バイト）が消費されます。
@@ -2694,39 +2694,39 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the maximum number of transactions that can be in the
         <quote>prepared</quote> state simultaneously (see <xref
         linkend="sql-prepare-transaction"/>).
         Setting this parameter to zero (which is the default)
         disables the prepared-transaction feature.
         This parameter can only be set at server start.
-       -->
+-->
 同時に<quote>プリペアド</quote>状態にできるトランザクションの最大数を設定します（<xref linkend="sql-prepare-transaction"/>を参照してください）。
 このパラメータをゼロ（これがデフォルトです）に設定すると、プリペアドトランザクション機能が無効になります。
 このパラメータはサーバ起動時にのみ設定可能です。
        </para>
 
        <para>
-       <!--
+<!--
         If you are not planning to use prepared transactions, this parameter
         should be set to zero to prevent accidental creation of prepared
         transactions.  If you are using prepared transactions, you will
         probably want <varname>max_prepared_transactions</varname> to be at
         least as large as <xref linkend="guc-max-connections"/>, so that every
         session can have a prepared transaction pending.
-       -->
+-->
 プリペアドトランザクションの使用を意図しないのであれば、このパラメータはプリペアドトランザクションが偶然に作成されないようゼロに設定すべきです。
 プリペアドトランザクションを使用する場合、全てのセッションがプリペアドトランザクションを保留できるように、<varname>max_prepared_transactions</varname>を少なくとも<xref linkend="guc-max-connections"/>と同じ大きさに設定するのが良いでしょう。
        </para>
 
        <para>
-       <!--
+<!--
         When running a standby server, you must set this parameter to the
         same or higher value than on the primary server. Otherwise, queries
         will not be allowed in the standby server.
-       -->
-       スタンバイサーバを運用している場合、このパラメータはプライマリサーバ上の設定よりも同等かもしくはより高水準に設定しなければなりません。そうしないと問い合わせがスタンバイサーバ内で受け入れられません。
+-->
+スタンバイサーバを運用している場合、このパラメータはプライマリサーバ上の設定よりも同等かもしくはより高水準に設定しなければなりません。そうしないと問い合わせがスタンバイサーバ内で受け入れられません。
        </para>
       </listitem>
      </varlistentry>
@@ -2742,7 +2742,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the base maximum amount of memory to be used by a query operation
         (such as a sort or hash table) before writing to temporary disk files.
         If this value is specified without units, it is taken as kilobytes.
@@ -2760,7 +2760,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
         Hash tables are used in hash joins, hash-based aggregation, result
         cache nodes and hash-based processing of <literal>IN</literal>
         subqueries.
-       -->
+-->
 一時ディスクファイルに書き込むようになる前に、問い合わせ操作（たとえば並べ替えとハッシュテーブル操作）が使用する基本的な最大のメモリ容量を指定します。
 この値が単位なしで指定された場合は、キロバイト単位であるとみなします。
 デフォルト値は4メガバイト（<literal>4MB</literal>）です。
@@ -2844,7 +2844,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the maximum amount of memory to be used by maintenance
         operations, such as <command>VACUUM</command>, <command>CREATE
         INDEX</command>, and <command>ALTER TABLE ADD FOREIGN KEY</command>.
@@ -2856,7 +2856,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
         concurrently, it's safe to set this value significantly larger
         than <varname>work_mem</varname>.  Larger settings might improve
         performance for vacuuming and for restoring database dumps.
-       -->
+-->
 <command>VACUUM</command>、<command>CREATE INDEX</command>、および<command>ALTER TABLE ADD FOREIGN KEY</command>の様な保守操作で使用されるメモリの最大容量を指定します。
 この値が単位なしで指定された場合は、キロバイト単位であるとみなします。
 デフォルト値は64メガバイト（<literal>64MB</literal>）です。
@@ -2864,7 +2864,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
 大きい値を設定することでvacuum処理と、ダンプしたデータベースのリストア性能が向上します。
        </para>
        <para>
-       <!--
+<!--
         Note that when autovacuum runs, up to
         <xref linkend="guc-autovacuum-max-workers"/> times this memory
         may be allocated, so be careful not to set the default value
@@ -2907,7 +2907,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
         This parameter can only be set in the
         <filename>postgresql.conf</filename> file or on the server command
         line.
-       -->
+-->
 個々の自動バキュームワーカプロセスが使用する最大のメモリ量を指定します。
 この値が単位なしで指定された場合は、キロバイト単位であるとみなします。
 デフォルトは-1で、<xref linkend="guc-maintenance-work-mem"/>が代わりに使われる設定になります。
@@ -2969,7 +2969,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the maximum safe depth of the server's execution stack.
         The ideal setting for this parameter is the actual stack size limit
         enforced by the kernel (as set by <literal>ulimit -s</literal> or local
@@ -2981,7 +2981,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
         is conservatively small and unlikely to risk crashes.  However,
         it might be too small to allow execution of complex functions.
         Only superusers can change this setting.
-       -->
+-->
 サーバの実行スタックの最大安全深度を指定します。
 このパラメータの理想的な設定はカーネルにより強要される実際のスタック容量の（<literal>ulimit -s</literal>もしくはそれと同等の機能で設定された）限界から、1メガバイト程度の安全余裕度を差し引いたものです。
 この安全余裕度は、サーバがすべてのルーチンではスタック深度を検査をせず、再帰を行う可能性のある重要なルーチンでのみ検査をするために必要となるものです。
@@ -2992,7 +2992,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
        </para>
 
        <para>
-       <!--
+<!--
         Setting <varname>max_stack_depth</varname> higher than
         the actual kernel limit will mean that a runaway recursive function
         can crash an individual backend process.  On platforms where
@@ -3000,7 +3000,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
         the server will not allow this variable to be set to an unsafe
         value.  However, not all platforms provide the information,
         so caution is recommended in selecting a value.
-       -->
+-->
 <varname>max_stack_depth</varname>を実際のカーネルの制限よりも高い値に設定した場合、暴走した再帰関数により、個々のバックエンドプロセスがクラッシュするかもしれません。
 <productname>PostgreSQL</productname>がカーネルの制限を決定することができるプラットフォームでは、この変数を危険な値に設定させません。
 しかし、すべてのプラットフォームがこの情報を提供できるわけではありません。
@@ -3124,9 +3124,9 @@ huge pageを自動管理するオペレーティングシステム上でより�
      </sect2>
 
      <sect2 id="runtime-config-resource-disk">
-     <!--
+<!--
      <title>Disk</title>
-     -->
+-->
      <title>ディスク</title>
 
      <variablelist>
@@ -3141,7 +3141,7 @@ huge pageを自動管理するオペレーティングシステム上でより�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the maximum amount of disk space that a process can use
         for temporary files, such as sort and hash temporary files, or the
         storage file for a held cursor.  A transaction attempting to exceed
@@ -3149,7 +3149,7 @@ huge pageを自動管理するオペレーティングシステム上でより�
         If this value is specified without units, it is taken as kilobytes.
         <literal>-1</literal> (the default) means no limit.
         Only superusers can change this setting.
-       -->
+-->
 あるプロセスが一時ファイルとして使用できるディスクの最大容量を設定します。
 例えば、ソートやハッシュの一時ファイルであったり、カーソルを保持する格納ファイルです。
 この制限値を超えようとするトランザクションはキャンセルされます。
@@ -3158,15 +3158,15 @@ huge pageを自動管理するオペレーティングシステム上でより�
 この設定はスーパーユーザのみ変更可能です。
        </para>
        <para>
-       <!--
+<!--
         This setting constrains the total space used at any instant by all
         temporary files used by a given <productname>PostgreSQL</productname> process.
         It should be noted that disk space used for explicit temporary
         tables, as opposed to temporary files used behind-the-scenes in query
         execution, does <emphasis>not</emphasis> count against this limit.
-       -->
-       この設定により、ある <productname>PostgreSQL</productname> セッションによって使用される一時ファイルの合計の容量が常に制約されることになります。
-       なお、問い合わせの実行において暗黙的に使用される一時ファイルとは異なり、一時テーブルとして明示的に使用されるディスク容量は、この制限には<emphasis>含まれません</emphasis>。
+-->
+この設定により、ある <productname>PostgreSQL</productname> セッションによって使用される一時ファイルの合計の容量が常に制約されることになります。
+なお、問い合わせの実行において暗黙的に使用される一時ファイルとは異なり、一時テーブルとして明示的に使用されるディスク容量は、この制限には<emphasis>含まれません</emphasis>。
        </para>
       </listitem>
      </varlistentry>
@@ -3175,9 +3175,9 @@ huge pageを自動管理するオペレーティングシステム上でより�
      </sect2>
 
      <sect2 id="runtime-config-resource-kernel">
-     <!--
+<!--
      <title>Kernel Resource Usage</title>
-     -->
+-->
      <title>カーネル資源使用</title>
 
      <variablelist>
@@ -3192,7 +3192,7 @@ huge pageを自動管理するオペレーティングシステム上でより�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the maximum number of simultaneously open files allowed to each
         server subprocess. The default is one thousand files. If the kernel is enforcing
         a safe per-process limit, you don't need to worry about this setting.
@@ -3202,8 +3202,8 @@ huge pageを自動管理するオペレーティングシステム上でより�
         that many files. If you find yourself seeing <quote>Too many open
         files</quote> failures, try reducing this setting.
         This parameter can only be set at server start.
-       -->
-       それぞれのサーバ子プロセスが同時にオープンできるファイル数の最大値をセットします。
+-->
+それぞれのサーバ子プロセスが同時にオープンできるファイル数の最大値をセットします。
 デフォルトは1000ファイルです。
 もしもカーネルがプロセス毎の安全制限を強要している場合、この設定を気にかける必要はありません。
 しかし、いくつかのプラットフォーム（特にほとんどのBSDシステム）では、もし多くのプロセス全てがそれだけ多くのファイルを開くことを試みたとした場合、実際にサポートできるファイル数より多くのファイルを開くことを許しています。もしも<quote>Too many open files</quote>エラーが発生した場合、この設定を削減してみてください。
@@ -3215,13 +3215,13 @@ huge pageを自動管理するオペレーティングシステム上でより�
     </sect2>
 
     <sect2 id="runtime-config-resource-vacuum-cost">
-    <!--
+<!--
      <title>Cost-based Vacuum Delay</title>
-     -->
+-->
      <title>コストに基づくVacuum遅延</title>
 
      <para>
-     <!--
+<!--
       During the execution of <xref linkend="sql-vacuum"/>
       and <xref linkend="sql-analyze"/>
       commands, the system maintains an
@@ -3232,13 +3232,13 @@ huge pageを自動管理するオペレーティングシステム上でより�
       the operation will sleep for a short period of time, as specified by
       <varname>vacuum_cost_delay</varname>. Then it will reset the
       counter and continue execution.
-      -->
-      <xref linkend="sql-vacuum"/> および <xref linkend="sql-analyze"/> コマンドの実行中、実行される各種I/O操作の予測コストを追跡し続ける内部カウンタをシステムが保守します。
-      累積されたコストが（<varname>vacuum_cost_limit</varname>で指定された）限度に達すると、操作を実行しているプロセスは<varname>vacuum_cost_delay</varname>で指定されたちょっとの間スリープします。その後、カウンタをリセットし、実行を継続します。
+-->
+<xref linkend="sql-vacuum"/> および <xref linkend="sql-analyze"/> コマンドの実行中、実行される各種I/O操作の予測コストを追跡し続ける内部カウンタをシステムが保守します。
+累積されたコストが（<varname>vacuum_cost_limit</varname>で指定された）限度に達すると、操作を実行しているプロセスは<varname>vacuum_cost_delay</varname>で指定されたちょっとの間スリープします。その後、カウンタをリセットし、実行を継続します。
      </para>
 
      <para>
-     <!--
+<!--
       The intent of this feature is to allow administrators to reduce
       the I/O impact of these commands on concurrent database
       activity. There are many situations where it is not
@@ -3248,7 +3248,7 @@ huge pageを自動管理するオペレーティングシステム上でより�
       commands do not significantly interfere with the ability of the
       system to perform other database operations. Cost-based vacuum
       delay provides a way for administrators to achieve this.
-      -->
+-->
 この機能の目的は、同時に実行されているデータベースの活動に対するこれらコマンドによるI/Oへの影響を、管理者が軽減できるようにすることです。
 <command>VACUUM</command> および <command>ANALYZE</command>の様な保守用コマンドが即座に終了することが重要ではない事態が数多くあります。
 しかし、他のデータベースの操作を行うに当たって、これらのコマンドがシステムの能力に多大な阻害を与えないことは通常とても重要です。
@@ -3256,12 +3256,12 @@ huge pageを自動管理するオペレーティングシステム上でより�
      </para>
 
      <para>
-     <!--
+<!--
       This feature is disabled by default for manually issued
       <command>VACUUM</command> commands. To enable it, set the
       <varname>vacuum_cost_delay</varname> variable to a nonzero
       value.
-      -->
+-->
 手動で実行した<command>VACUUM</command>コマンドについては、デフォルトでこの機能は無効になっています。
 有効にするには、<varname>vacuum_cost_delay</varname>変数をゼロでない値に設定します。
      </para>
@@ -3278,13 +3278,13 @@ huge pageを自動管理するオペレーティングシステム上でより�
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          The amount of time that the process will sleep
          when the cost limit has been exceeded.
          If this value is specified without units, it is taken as milliseconds.
          The default value is zero, which disables the cost-based vacuum
          delay feature.  Positive values enable cost-based vacuuming.
-        -->
+-->
 コストの限度を越えた場合、プロセスがスリープする時間の長さです。
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
 デフォルトの値は0で、コストに基づいたvacuum遅延機能を無効にします。
@@ -3292,7 +3292,7 @@ huge pageを自動管理するオペレーティングシステム上でより�
         </para>
 
         <para>
-       <!--
+<!--
          When using cost-based vacuuming, appropriate values for
          <varname>vacuum_cost_delay</varname> are usually quite small, perhaps
          less than 1 millisecond.  While <varname>vacuum_cost_delay</varname>
@@ -3303,7 +3303,7 @@ huge pageを自動管理するオペレーティングシステム上でより�
          parameters.  You should, nonetheless,
          keep <varname>vacuum_cost_delay</varname> as small as your platform
          will consistently measure; large delays are not helpful.
-        -->
+-->
 コストに基づいたバキューム処理を使用する場合、<varname>vacuum_cost_delay</varname>の適切な値は通常かなり小さくなり、おそらく1ミリ秒以下になります。
 バキュームによるリソース消費の調整は、他のバキュームのコストパラメータを変更して行うことが最善です。
 <varname>vacuum_cost_delay</varname>を1ミリ秒以下に設定することは可能ですが、そうした遅延は古いプラットフォームでは正確には計測されないかも知れません。
@@ -3325,12 +3325,12 @@ huge pageを自動管理するオペレーティングシステム上でより�
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          The estimated cost for vacuuming a buffer found in the shared buffer
          cache. It represents the cost to lock the buffer pool, lookup
          the shared hash table and scan the content of the page. The
          default value is one.
-        -->
+-->
 共有バッファキャッシュの中のバッファにvacuumを掛ける予測コストです。バッファプールのロック、共有ハッシュテーブルの検索、およびページ内容走査のコストを示します。デフォルトの値は1です。
         </para>
        </listitem>
@@ -3347,12 +3347,12 @@ huge pageを自動管理するオペレーティングシステム上でより�
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          The estimated cost for vacuuming a buffer that has to be read from
          disk.  This represents the effort to lock the buffer pool,
          lookup the shared hash table, read the desired block in from
          the disk and scan its content. The default value is 2.
-        -->
+-->
 ディスクから読み込まれなければならないバッファにvacuumを掛ける予測コストです。これが示すものは、バッファプールロックの試み、共有ハッシュテーブルの参照、ディスクから目的ブロックの読み込み、そしてその内容走査です。デフォルトの値は2です。
         </para>
        </listitem>
@@ -3369,12 +3369,12 @@ huge pageを自動管理するオペレーティングシステム上でより�
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          The estimated cost charged when vacuum modifies a block that was
          previously clean. It represents the extra I/O required to
          flush the dirty block out to disk again. The default value is
          20.
-        -->
+-->
 vacuumが、先だって掃除したブロックを変更するのに必要な見積コストです。
 ダーティブロックを再度ディスクに吐き出すのに必要な余分なI/Oを表します。デフォルトの値は20です。
         </para>
@@ -3392,10 +3392,10 @@ vacuumが、先だって掃除したブロックを変更するのに必要な�
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          The accumulated cost that will cause the vacuuming process to sleep.
          The default value is 200.
-        -->
+-->
 vacuumを掛けるプロセスをスリープさせることになる累計されたコストです。
 デフォルトの値は200です。
         </para>
@@ -3405,7 +3405,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
 
      <note>
       <para>
-      <!--
+<!--
        There are certain operations that hold critical locks and should
        therefore complete as quickly as possible.  Cost-based vacuum
        delays do not occur during such operations.  Therefore it is
@@ -3415,7 +3415,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
        <varname>accumulated_balance</varname> /
        <varname>vacuum_cost_limit</varname> with a maximum of
        <varname>vacuum_cost_delay</varname> * 4.
-       -->
+-->
 重要なロックを保有し可能なかぎり早急に完了しなければならないある種の操作があります。コストに基づいたvacuum遅延はこの様な操作では起こりません。
 したがって、コストの累計が指定された限度をかなり高く越える可能性があります。
 このような場合無駄な長い遅延を防止するため、実際の遅延は<varname>vacuum_cost_delay</varname> * 4 を上限として、以下のように計算されます。
@@ -3425,13 +3425,13 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
     </sect2>
 
     <sect2 id="runtime-config-resource-background-writer">
-    <!--
+<!--
      <title>Background Writer</title>
-     -->
+-->
      <title>バックグラウンドライタ</title>
 
      <para>
-     <!--
+<!--
       There is a separate server
       process called the <firstterm>background writer</firstterm>, whose function
       is to issue writes of <quote>dirty</quote> (new or modified) shared
@@ -3446,7 +3446,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
       background writer might write it several times as it is dirtied
       in the same interval.  The parameters discussed in this subsection
       can be used to tune the behavior for local needs.
-      -->
+-->
 <firstterm>バックグラウンドライタ</firstterm>と呼ばれる個別のサーバプロセスがあり、その機能は（新規または更新された）<quote>ダーティ</quote>な共有バッファの書き込みを行うことです。
 クリーンなバッファの数が足りないことが分かると、バックグラウンドライタはダーティバッファをファイルシステムに書き込み、それらのバッファにクリーンであるという印を付けます。
 これにより、ユーザの問い合わせを処理するサーバプロセスがクリーンなバッファを見つけることができず、ダーティなバッファを自分で書き込まなければならなくなる可能性を減らすことができます。
@@ -3467,7 +3467,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          Specifies the delay between activity rounds for the
          background writer.  In each round the writer issues writes
          for some number of dirty buffers (controllable by the
@@ -3484,7 +3484,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
          might have the same results as setting it to the next higher multiple
          of 10.  This parameter can only be set in the
          <filename>postgresql.conf</filename> file or on the server command line.
-        -->
+-->
 バックグラウンドライタの動作周期間の遅延を指定します。
 それぞれの周期でライタは、（以下のパラメータで管理される）一部のダーティバッファの書き込みを行います。
 そして<varname>bgwriter_delay</varname>の長さスリープした後、これを繰りかえします。
@@ -3509,7 +3509,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          In each round, no more than this many buffers will be written
          by the background writer.  Setting this to zero disables
          background writing.  (Note that checkpoints, which are managed by
@@ -3517,12 +3517,12 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
          The default value is 100 buffers.
          This parameter can only be set in the <filename>postgresql.conf</filename>
          file or on the server command line.
-        -->
-        それぞれの周期で、この数以上のバッファはバックグラウンドライタにより書き込まれません。
-         ゼロに設定することでバックグラウンド書き込みは無効になります。
+-->
+それぞれの周期で、この数以上のバッファはバックグラウンドライタにより書き込まれません。
+ゼロに設定することでバックグラウンド書き込みは無効になります。
         （分離し、そして専用の補助プロセスにより管理されるチェックポイントは影響を受けません。）
-         デフォルト値は100バッファです。
-         このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみで設定可能です。
+デフォルト値は100バッファです。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみで設定可能です。
         </para>
        </listitem>
       </varlistentry>
@@ -3538,7 +3538,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          The number of dirty buffers written in each round is based on the
          number of new buffers that have been needed by server processes
          during recent rounds.  The average recent need is multiplied by
@@ -3555,8 +3555,8 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
          The default is 2.0.
          This parameter can only be set in the <filename>postgresql.conf</filename>
          file or on the server command line.
-        -->
-        各周期で書き出されるダーティバッファ数は、最近の周期でサーバプロセスが必要とした新しいバッファ数を基にします。
+-->
+各周期で書き出されるダーティバッファ数は、最近の周期でサーバプロセスが必要とした新しいバッファ数を基にします。
 次の周期で必要となるバッファ数を推定するために、最近必要とされた平均が<varname>bgwriter_lru_multiplier</varname>と掛け合わせられます。
 ダーティバッファの書き出しは、同数の整理済み、再利用可能なバッファが利用できるようになるまで行われます。
 （しかし1周期に<varname>bgwriter_lru_maxpages</varname>を越えるバッファ数を書き出しません。）
@@ -3617,21 +3617,21 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
      </variablelist>
 
      <para>
-     <!--
+<!--
       Smaller values of <varname>bgwriter_lru_maxpages</varname> and
       <varname>bgwriter_lru_multiplier</varname> reduce the extra I/O load
       caused by the background writer, but make it more likely that server
       processes will have to issue writes for themselves, delaying interactive
       queries.
-      -->
-      <varname>bgwriter_lru_maxpages</varname>および<varname>bgwriter_lru_multiplier</varname>の値がより少ないと、バックグラウンドライタで引き起こされる追加のI/O負荷を軽減しますが、サーバプロセスが自分自身で行わなければならない書き込みが増加することになり、会話型問い合わせを遅らせることになります。
+-->
+<varname>bgwriter_lru_maxpages</varname>および<varname>bgwriter_lru_multiplier</varname>の値がより少ないと、バックグラウンドライタで引き起こされる追加のI/O負荷を軽減しますが、サーバプロセスが自分自身で行わなければならない書き込みが増加することになり、会話型問い合わせを遅らせることになります。
      </para>
     </sect2>
 
     <sect2 id="runtime-config-resource-async-behavior">
-    <!--
+<!--
      <title>Asynchronous Behavior</title>
-     -->
+-->
      <title>非同期動作</title>
 
      <variablelist>
@@ -3689,7 +3689,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          Sets the number of concurrent disk I/O operations that
          <productname>PostgreSQL</productname> expects can be executed
          simultaneously.  Raising this value will increase the number of I/O
@@ -3697,7 +3697,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
          attempts to initiate in parallel.  The allowed range is 1 to 1000,
          or zero to disable issuance of asynchronous I/O requests. Currently,
          this setting only affects bitmap heap scans.
-        -->
+-->
 <productname>PostgreSQL</productname>が同時実行可能であると想定する同時ディスクI/O操作の数を設定します。
 この値を大きくすると、あらゆる個別の<productname>PostgreSQL</productname>セッションが並行して開始を試みるI/O操作の数が増加します。
 設定可能な範囲は1から1000まで、または非同期I/Oリクエストの発行を無効にするゼロです。
@@ -3705,7 +3705,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
         </para>
 
         <para>
-       <!--
+<!--
          For magnetic drives, a good starting point for this setting is the
          number of separate
          drives comprising a RAID 0 stripe or RAID 1 mirror being used for the
@@ -3724,17 +3724,17 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
         </para>
 
         <para>
-       <!--
+<!--
          Asynchronous I/O depends on an effective <function>posix_fadvise</function>
          function, which some operating systems lack.  If the function is not
          present then setting this parameter to anything but zero will result
          in an error.  On some operating systems (e.g., Solaris), the function
          is present but does not actually do anything.
-        -->
-        非同期I/Oは実質的に<function>posix_fadvise</function>関数に依存します。
-        これは一部のオペレーティングシステムには存在しません。
-        この関数が存在しない場合、この値をゼロ以外に設定するとエラーとなります。
-        一部のオペレーティングシステム（例えばSolaris）では存在するけれども、実際何も行わないものもあります。
+-->
+非同期I/Oは実質的に<function>posix_fadvise</function>関数に依存します。
+これは一部のオペレーティングシステムには存在しません。
+この関数が存在しない場合、この値をゼロ以外に設定するとエラーとなります。
+一部のオペレーティングシステム（例えばSolaris）では存在するけれども、実際何も行わないものもあります。
         </para>
 
         <para>
@@ -3884,7 +3884,7 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
          For more information on parallel query, see
          <xref linkend="parallel-query"/>.
 -->
-         パラレルクエリに関する更なる情報については、<xref linkend="parallel-query"/>をご覧ください。
+パラレルクエリに関する更なる情報については、<xref linkend="parallel-query"/>をご覧ください。
         </para>
        </listitem>
       </varlistentry>
@@ -4105,23 +4105,23 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
    </sect1>
 
    <sect1 id="runtime-config-wal">
-   <!--
+<!--
     <title>Write Ahead Log</title>
-    -->
+-->
     <title>ログ先行書き込み（WAL）</title>
 
    <para>
-   <!--
+<!--
     For additional information on tuning these settings,
     see <xref linkend="wal-configuration"/>.
-    -->
-    これらの設定をチューニングする追加情報は<xref linkend="wal-configuration"/>を参照してください。
+-->
+これらの設定をチューニングする追加情報は<xref linkend="wal-configuration"/>を参照してください。
    </para>
 
     <sect2 id="runtime-config-wal-settings">
-    <!--
+<!--
      <title>Settings</title>
-     -->
+-->
      <title>諸設定</title>
      <variablelist>
 
@@ -4241,20 +4241,20 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
        </para>
 
        <para>
-       <!--
+<!--
         While turning off <varname>fsync</varname> is often a performance
         benefit, this can result in unrecoverable data corruption in
         the event of a power failure or system crash.  Thus it
         is only advisable to turn off <varname>fsync</varname> if
         you can easily recreate your entire database from external
         data.
-       -->
+-->
 <varname>fsync</varname>を停止することはしばしば性能上の利益になるとは言っても、停電やクラッシュの際に回復不可能なデータ破壊になることがあります。
 従って外部データから全てのデータベースを簡単に再構築できる場合のみ<varname>fsync</varname>を停止してください。
        </para>
 
        <para>
-       <!--
+<!--
         Examples of safe circumstances for turning off
         <varname>fsync</varname> include the initial loading of a new
         database cluster from a backup file, using a database cluster
@@ -4264,7 +4264,7 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
         gets recreated frequently and is not used for failover.  High
         quality hardware alone is not a sufficient justification for
         turning off <varname>fsync</varname>.
-       -->
+-->
 <varname>fsync</varname>を停止しても安全な状況の例としては、以下があげられます。
 バックアップファイルから新しいデータベースクラスタにデータの初期読み込みを行う場合、バッチデータの処理のためにデータベースクラスタを使用し、その後データベースを削除して再構築する場合、読み込み専用のデータベースのクローンを頻繁に再作成するが、それをフェイルオーバーに使用しない場合、などです。
 高性能なハードウェアであるからと言って、<varname>fsync</varname>を停止することは正当性を主張する十分な理由とはなりません。
@@ -4284,22 +4284,22 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
        </para>
 
        <para>
-       <!--
+<!--
         In many situations, turning off <xref linkend="guc-synchronous-commit"/>
         for noncritical transactions can provide much of the potential
         performance benefit of turning off <varname>fsync</varname>, without
         the attendant risks of data corruption.
-       -->
+-->
 多くの場合、重要でないトランザクションに対して<xref linkend="guc-synchronous-commit"/>を無効にすることにより、データ破壊という付随的危険性を伴うことなく、<varname>fsync</varname>を無効にすることで得られるであろう性能上のメリットの多くを得ることができます。
        </para>
 
        <para>
-       <!--
+<!--
         <varname>fsync</varname> can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
         If you turn this parameter off, also consider turning off
         <xref linkend="guc-full-page-writes"/>.
-       -->
+-->
 <varname>fsync</varname> は<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
 このパラメータを無効にする場合、<xref linkend="guc-full-page-writes"/>も同時に無効にすることを検討してください。
        </para>
@@ -4414,7 +4414,7 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
        </para>
 
        <para>
-       <!--
+<!--
         This parameter can be changed at any time; the behavior for any
         one transaction is determined by the setting in effect when it
         commits.  It is therefore possible, and useful, to have some
@@ -4422,7 +4422,7 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
         For example, to make a single multistatement transaction commit
         asynchronously when the default is the opposite, issue <command>SET
         LOCAL synchronous_commit TO OFF</command> within the transaction.
-       -->
+-->
 このパラメータはいつでも変更可能です。
 どのトランザクションの動作も、コミット時に有効であった設定によって決まります。
 したがって、一部のトランザクションのコミットを同期的に、その他を非同期的にすることが可能で、かつ、有用です。
@@ -4525,58 +4525,58 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Method used for forcing WAL updates out to disk.
         If <varname>fsync</varname> is off then this setting is irrelevant,
         since WAL file updates will not be forced out at all.
         Possible values are:
-       -->
+-->
        WALの更新をディスクへ強制するのに使用される方法です。<varname>fsync</varname>がオフの場合この設定は役に立ちません。と言うのはWALファイルの更新が全く強制されないからです。取り得る値は以下のものです。
        </para>
        <itemizedlist>
         <listitem>
         <para>
-       <!--
+<!--
          <literal>open_datasync</literal> (write WAL files with <function>open()</function> option <symbol>O_DSYNC</symbol>)
-        -->
-        <literal>open_datasync</literal>（<function>open()</function>のオプション<symbol>O_DSYNC</symbol>でWALファイルに書き込む）
+-->
+<literal>open_datasync</literal>（<function>open()</function>のオプション<symbol>O_DSYNC</symbol>でWALファイルに書き込む）
         </para>
         </listitem>
         <listitem>
         <para>
-       <!--
+<!--
          <literal>fdatasync</literal> (call <function>fdatasync()</function> at each commit)
-        -->
-        <literal>fdatasync</literal>（コミット毎に<function>fdatasync()</function>を呼び出す）
+-->
+<literal>fdatasync</literal>（コミット毎に<function>fdatasync()</function>を呼び出す）
         </para>
         </listitem>
         <listitem>
         <para>
-        <!--
+<!--
          <literal>fsync</literal> (call <function>fsync()</function> at each commit)
-        -->
-        <literal>fsync</literal>（コミット毎に<function>fsync()</function>を呼び出す）
+-->
+<literal>fsync</literal>（コミット毎に<function>fsync()</function>を呼び出す）
         </para>
         </listitem>
         <listitem>
         <para>
-       <!--
+<!--
          <literal>fsync_writethrough</literal> (call <function>fsync()</function> at each commit, forcing write-through of any disk write cache)
-        -->
-        <literal>fsync_writethrough</literal>（すべてのディスク書き込みキャッシュをライトスルーさせるため、コミット毎に<function>fsync()</function>を呼び出す）
+-->
+<literal>fsync_writethrough</literal>（すべてのディスク書き込みキャッシュをライトスルーさせるため、コミット毎に<function>fsync()</function>を呼び出す）
         </para>
         </listitem>
         <listitem>
         <para>
-       <!--
+<!--
          <literal>open_sync</literal> (write WAL files with <function>open()</function> option <symbol>O_SYNC</symbol>)
-        -->
-        <literal>open_sync</literal>（<function>open()</function>のオプション<symbol>O_SYNC</symbol>でWALファイルに書き込む）
+-->
+<literal>open_sync</literal>（<function>open()</function>のオプション<symbol>O_SYNC</symbol>でWALファイルに書き込む）
         </para>
         </listitem>
        </itemizedlist>
        <para>
-       <!--
+<!--
         The <literal>open_</literal>* options also use <literal>O_DIRECT</literal> if available.
         Not all of these choices are available on all platforms.
         The default is the first method in the above list that is supported
@@ -4588,7 +4588,7 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
         These aspects are discussed in <xref linkend="wal-reliability"/>.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 可能なら<literal>open_</literal>*オプションも<literal>O_DIRECT</literal>を使用します。
 全てのプラットフォームでこれら全ての選択肢が使えるわけではありません。
 デフォルトは、上のリストのプラットフォームでサポートされるものの最初に列挙されているものです。
@@ -4612,7 +4612,7 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When this parameter is on, the <productname>PostgreSQL</productname> server
         writes the entire content of each disk page to WAL during the
         first modification of that page after a checkpoint.
@@ -4628,7 +4628,7 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
         to do this during the first change of each page after a checkpoint.
         Therefore, one way to reduce the cost of full-page writes is to
         increase the checkpoint interval parameters.)
-       -->
+-->
 このパラメータが有効の場合、<productname>PostgreSQL</productname>サーバは、チェックポイントの後にそのページが最初に変更された過程で、ディスクページの全ての内容をWALに書き込みます。
 オペレーティングシステムがクラッシュした時に進行中のページ書き込みは途中までしか終わっていない可能性があり、ディスク上のページが古いデータと新しいデータが混在する状態になるため、この機能が必要です。
 通常WAL内に保存される行レベルの変更データは、クラッシュ後のリカバリ時にこうしたページを完全に復旧させるには不十分です。
@@ -4638,33 +4638,33 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
        </para>
 
        <para>
-       <!--
+<!--
         Turning this parameter off speeds normal operation, but
         might lead to either unrecoverable data corruption, or silent
         data corruption, after a system failure. The risks are similar to turning off
         <varname>fsync</varname>, though smaller, and it should be turned off
         only based on the same circumstances recommended for that parameter.
-       -->
-       このパラメータを無効にすると、通常の操作速度が上がりますが、システム障害後に、回復不能なデータ破損、あるいは警告なしのデータ損壊をもたらすかもしれません。
+-->
+このパラメータを無効にすると、通常の操作速度が上がりますが、システム障害後に、回復不能なデータ破損、あるいは警告なしのデータ損壊をもたらすかもしれません。
 このリスクは小さいながら<varname>fsync</varname>を無効にした場合と似ています。そしてその<varname>fsync</varname>に対して推奨されている同一の状況に基づく限りにおいて停止されなければなりません。
        </para>
 
        <para>
-       <!--
+<!--
         Turning off this parameter does not affect use of
         WAL archiving for point-in-time recovery (PITR)
         (see <xref linkend="continuous-archiving"/>).
-       -->
-       このパラメータを無効にしてもポイントインタイムリカバリ（PITR）用のWALアーカイブの使用に影響ありません（ <xref linkend="continuous-archiving"/>を参照してください）。
+-->
+このパラメータを無効にしてもポイントインタイムリカバリ（PITR）用のWALアーカイブの使用に影響ありません（ <xref linkend="continuous-archiving"/>を参照してください）。
        </para>
 
        <para>
-       <!--
+<!--
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
         The default is <literal>on</literal>.
-       -->
-       このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみ設定可能です。
+-->
+このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみ設定可能です。
 デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
@@ -4687,7 +4687,7 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
         first modification of that page after a checkpoint, even for
         non-critical modifications of so-called hint bits.
 -->
-        このパラメータが<literal>on</literal>の場合、<productname>PostgreSQL</productname>サーバはチェックポイント後にはじめてページを変更する際に、ディスクページの全内容をWALに書き出します。
+このパラメータが<literal>on</literal>の場合、<productname>PostgreSQL</productname>サーバはチェックポイント後にはじめてページを変更する際に、ディスクページの全内容をWALに書き出します。
 これは、あまり重要でない、ヒントビットと呼ばれるものに対する変更にさえ当てはまります。
        </para>
 
@@ -4698,14 +4698,14 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
         extra WAL-logging would occur if your database had data checksums
         enabled.
 -->
-        データチェックサムが有効であると、ヒントビットの更新は常にWALにログされ、この設定パラメータは無視されます。この設定パラメータを使って、データチェックサムが有効なときにどれだけのWALログは余計に書きだされるかをテストすることができます。
+データチェックサムが有効であると、ヒントビットの更新は常にWALにログされ、この設定パラメータは無視されます。この設定パラメータを使って、データチェックサムが有効なときにどれだけのWALログは余計に書きだされるかをテストすることができます。
        </para>
 
        <para>
 <!--
         This parameter can only be set at server start. The default value is <literal>off</literal>.
 -->
-       このパラメータはサーバ起動時のみ設定可能です。
+このパラメータはサーバ起動時のみ設定可能です。
 デフォルト値は<literal>off</literal>です。
        </para>
       </listitem>
@@ -4811,7 +4811,7 @@ COWファイルシステムでは、新しいファイルを作るほうが速�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The amount of shared memory used for WAL data that has not yet been
         written to disk.  The default setting of -1 selects a size equal to
         1/32nd (about 3%) of <xref linkend="guc-shared-buffers"/>, but not less
@@ -4823,7 +4823,7 @@ COWファイルシステムでは、新しいファイルを作るほうが速�
         If this value is specified without units, it is taken as WAL blocks,
         that is <symbol>XLOG_BLCKSZ</symbol> bytes, typically 8kB.
         This parameter can only be set at server start.
-       -->
+-->
 未だディスクに書き込まれていないWALデータに対して使用される共有メモリ容量です。
 デフォルトの設定である-1は、<xref linkend="guc-shared-buffers"/>の1/32（約3%）の容量に等しい大きさを選択します。
 しかし、<literal>64kB</literal>未満ではなく、かつ典型的に<literal>16MB</literal>であるWALセグメントの大きさを越えることはありません。
@@ -4834,7 +4834,7 @@ COWファイルシステムでは、新しいファイルを作るほうが速�
        </para>
 
        <para>
-       <!--
+<!--
         The contents of the WAL buffers are written out to disk at every
         transaction commit, so extremely large values are unlikely to
         provide a significant benefit.  However, setting this value to at
@@ -4842,11 +4842,11 @@ COWファイルシステムでは、新しいファイルを作るほうが速�
         server where many clients are committing at once.  The auto-tuning
         selected by the default setting of -1 should give reasonable
         results in most cases.
-       -->
+-->
        WALバッファの内容はトランザクションのコミット毎にディスクに書き込まれます。
-       したがって、極端に大きな値は有意な効果を期待できません。
-       しかし、この値を数メガバイトに設定することにより、多くのクライアントが同時にコミットするトラフィック量の多いサーバでは書き込み性能が向上します。
-       デフォルト設定の-1で選択される自動チューニングによると、ほとんどの場合妥当な結果が得られます。
+したがって、極端に大きな値は有意な効果を期待できません。
+しかし、この値を数メガバイトに設定することにより、多くのクライアントが同時にコミットするトラフィック量の多いサーバでは書き込み性能が向上します。
+デフォルト設定の-1で選択される自動チューニングによると、ほとんどの場合妥当な結果が得られます。
        </para>
 
       </listitem>
@@ -4996,7 +4996,7 @@ WALライタがWALを吐き出す頻度を量で指定します。
 この設定はスーパーユーザのみ変更可能です。
        </para>
        <para>
-       <!--
+<!--
         In <productname>PostgreSQL</productname> releases prior to 9.3,
         <varname>commit_delay</varname> behaved differently and was much
         less effective: it affected only commits, rather than all WAL flushes,
@@ -5005,9 +5005,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
         the first process that becomes ready to flush waits for the configured
         interval, while subsequent processes wait only until the leader
         completes the flush operation.
-       -->
+-->
         9.3より前の<productname>PostgreSQL</productname>では、<varname>commit_delay</varname>の振る舞いは異なっており、あまり効果がありませんでした。
-       全てのWALフラッシュではなく、コミットだけに影響していました。また、そしてWALフラッシュが早めに完了しても設定された遅延分待機していました。
+全てのWALフラッシュではなく、コミットだけに影響していました。また、そしてWALフラッシュが早めに完了しても設定された遅延分待機していました。
        <productname>PostgreSQL</productname> 9.3以降では、フラッシュの準備が整った最初のプロセスが設定値分待機し、後続のプロセスは最初のプロセスがフラッシュ操作を完了するまでの間だけ待機をします。
        </para>
       </listitem>
@@ -5024,13 +5024,13 @@ WALライタがWALを吐き出す頻度を量で指定します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Minimum number of concurrent open transactions to require
         before performing the <varname>commit_delay</varname> delay. A larger
         value makes it more probable that at least one other
         transaction will become ready to commit during the delay
         interval. The default is five transactions.
-       -->
+-->
 <varname>commit_delay</varname>の遅延を実行するときに必要とされる同時に開いているトランザクションの最小数です。
 より大きい値にすると、遅延周期の間に、少なくとも1つの他のトランザクションのコミットの準備が整う確率が高くなります。
 デフォルトは5トランザクションです。
@@ -5041,9 +5041,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
      </variablelist>
      </sect2>
      <sect2 id="runtime-config-wal-checkpoints">
-     <!--
+<!--
      <title>Checkpoints</title>
-     -->
+-->
      <title>チェックポイント</title>
 
     <variablelist>
@@ -5058,7 +5058,7 @@ WALライタがWALを吐き出す頻度を量で指定します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Maximum time between automatic WAL checkpoints.
         If this value is specified without units, it is taken as seconds.
         The valid range is between 30 seconds and one day.
@@ -5067,7 +5067,7 @@ WALライタがWALを吐き出す頻度を量で指定します。
         for crash recovery.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 自動的WALチェックポイント間の最大間隔を指定します。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
 有効な範囲は、30秒から1日の間です。
@@ -5089,7 +5089,7 @@ WALライタがWALを吐き出す頻度を量で指定します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the target of checkpoint completion, as a fraction of
         total time between checkpoints. The default is 0.9, which spreads the
         checkpoint across almost all of the available interval, providing fairly
@@ -5100,7 +5100,7 @@ WALライタがWALを吐き出す頻度を量で指定します。
         the checkpoint completion and the next scheduled checkpoint.  This
         parameter can only be set in the <filename>postgresql.conf</filename> file
         or on the server command line.
-       -->
+-->
 チェックポイントの間の時間のうち、どの程度の割合を使うかをチェックポイントの完了目標として指定します。
 デフォルトは0.9で、可能な限りの間隔のほとんどにチェックポイントを拡散し、かなり一定のI/O負荷をもたらしますが、チェックポイントが完了するにあたってオーバヘッドをもたらします。
 チェックポイントの完了を早くするので、このパラメータを小さくするのはお勧めできません。
@@ -5167,7 +5167,7 @@ WALライタがWALを吐き出す頻度を量で指定します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Write a message to the server log if checkpoints caused by
         the filling of WAL segment files happen closer together
         than this amount of time (which suggests that
@@ -5179,7 +5179,7 @@ WALライタがWALを吐き出す頻度を量で指定します。
         is less than <varname>checkpoint_warning</varname>.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 WALセグメントファイルが溢れることが原因で起きるチェックポイントが、ここで指定した時間よりも短い間隔で発生したとき、サーバログにメッセージを書き出します
 （これは、<varname>max_wal_size</varname>を増やす必要があることを示唆しています）。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
@@ -5259,9 +5259,9 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
      </variablelist>
      </sect2>
      <sect2 id="runtime-config-wal-archiving">
-     <!--
+<!--
      <title>Archiving</title>
-     -->
+-->
      <title>アーカイビング</title>
 
     <variablelist>
@@ -5321,7 +5321,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The local shell command to execute to archive a completed WAL file
         segment.  Any <literal>%p</literal> in the string is
         replaced by the path name of the file to archive, and any
@@ -5332,7 +5332,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
         command.  It is important for the command to return a zero
         exit status only if it succeeds. For more information see
         <xref linkend="backup-archiving-wal"/>.
-       -->
+-->
 完了したWALファイルセグメントのアーカイブを実行するローカルのシェルコマンドです。
 文字列内のすべての<literal>%p</literal>は、格納されるファイルのパスで置き換えられ、そして、<literal>%f</literal>はファイル名のみ置換します。
 （このパス名はサーバの作業用ディレクトリ、つまり、クラスタのデータディレクトリからの相対パスです。）
@@ -5341,7 +5341,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
 詳しくは<xref linkend="backup-archiving-wal"/>を参照ください。
        </para>
        <para>
-       <!--
+<!--
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.  It is ignored unless
         <varname>archive_mode</varname> was enabled at server start.
@@ -5354,7 +5354,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
         Windows), effectively disables
         archiving, but also breaks the chain of WAL files needed for
         archive recovery, so it should only be used in unusual circumstances.
-       -->
+-->
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
 サーバ起動時に<varname>archive_mode</varname>が有効でなければ、これは無視されます。
 <varname>archive_command</varname>が空文字列（デフォルト）、かつ、<varname>archive_mode</varname>が有効な場合、WALアーカイブ処理は一時的に無効になりますが、コマンドが後で提供されることを見越して、サーバはWALセグメントの蓄積を続けます。
@@ -5374,7 +5374,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The <xref linkend="guc-archive-command"/> is only invoked for
         completed WAL segments. Hence, if your server generates little WAL
         traffic (or has slack periods where it does so), there could be a
@@ -5397,7 +5397,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
         If this value is specified without units, it is taken as seconds.
         This parameter can only be set in the
         <filename>postgresql.conf</filename> file or on the server command line.
-       -->
+-->
 <xref linkend="guc-archive-command"/>は完了したWALセグメントに対してのみ呼び出されます。
 従って、サーバのWAL転送量が少ししかない（あるいは処理が少ないなぎの期間がある）場合、トランザクションの完了とアーカイブ格納領域への安全な記録との間に長期にわたる遅延があることになります。
 データが未アーカイブのままでいられる期間を制限するために、<varname>archive_timeout</varname>を設定して、強制的にサーバを新しいWALセグメントに定期的に切り替えるようにすることができます。
@@ -6058,14 +6058,14 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <title>送出サーバ群</title>
 
      <para>
-     <!--
+<!--
       These parameters can be set on any server that is
       to send replication data to one or more standby servers.
       The primary is always a sending server, so these parameters must
       always be set on the primary.
       The role and meaning of these parameters does not change after a
       standby becomes the primary.
-      -->
+-->
 これらのパラメータはレプリケーションデータを１つ、またはそれ以上複数のスタンバイサーバに送るすべてのサーバ上で設定することができます。
 プライマリは常に送出サーバであるため、パラメータは常にプライマリ上に設定されなければなりません。
 これらのパラメータの役割と意味はスタンバイが後にプライマリに昇格しても変わりません。
@@ -6176,7 +6176,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
        </term>
        <listitem>
        <para>
-       <!--
+<!--
         Specifies the minimum size of past log file segments kept in the
         <filename>pg_wal</filename>
         directory, in case a standby server needs to fetch them for streaming
@@ -6188,14 +6188,14 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         will also eventually fail as a result.  (However, the standby
         server can recover by fetching the segment from archive, if WAL
         archiving is in use.)
-       -->
+-->
 ストリーミングレプリケーションにおいて、スタンバイサーバが過去のファイルセグメントを取得する必要がある場合に備え、<filename>pg_wal</filename>ディレクトリに保持しておくファイルセグメントの最小サイズを指定します。
 もし送出サーバに接続しているスタンバイサーバが<varname>wal_keep_size</varname>メガバイトを越えて遅延した場合、送出サーバはスタンバイサーバが今後とも必要とするWALセグメントを削除する可能性があります。
 この場合、レプリケーション接続は終了させられます。結果として下流に対する接続も結局は終了されることがあります。（しかし、WALアーカイブが使用されていれば、スタンバイサーバはアーカイブからセグメントを取り出し、復旧することができます。）
        </para>
 
        <para>
-       <!--
+<!--
         This sets only the minimum size of segments retained in
         <filename>pg_wal</filename>; the system might need to retain more segments
         for WAL archival or to recover from a checkpoint. If
@@ -6207,7 +6207,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         If this value is specified without units, it is taken as megabytes.
         This parameter can only be set in the
         <filename>postgresql.conf</filename> file or on the server command line.
-       -->
+-->
 <filename>pg_wal</filename>に保持され続けるセグメントの最小値のみを設定します。
 システムはWALアーカイブのため、またはチェックポイントからの復旧のため、より多くのセグメント保持が必要となることがあります。
 もし<varname>wal_keep_size</varname>が（デフォルトの）ゼロの場合、システムはスタンバイサーバのために追加セグメントを保持することはしません。
@@ -6326,7 +6326,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <title>プライマリサーバ</title>
 
      <para>
-      <!--
+<!--
       These parameters can be set on the primary server that is
       to send replication data to one or more standby servers.
       Note that in addition to these parameters,
@@ -6336,7 +6336,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
       The values of these parameters on standby servers are irrelevant,
       although you may wish to set them there in preparation for the
       possibility of a standby becoming the primary.
-      -->
+-->
 これらのパラメータはレプリケーションデータを１つ、またはそれ以上複数のスタンバイサーバに送るプライマリサーバ上で設定することができます。
 これらパラメータに加え、<xref linkend="guc-wal-level"/>はプライマリサーバ上で適切に設定される必要があり、オプションとしてWALアーカイブを有効にしてもかまいません（<xref linkend="runtime-config-wal-archiving"/>を参照してください）。
 スタンバイサーバがプライマリサーバになるかもしれない状況に備え、それらのパラメータをスタンバイサーバで設定したいと考えたとしても、スタンバイサーバ上でのパラメータの値は意味をなしません。
@@ -6517,7 +6517,7 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
         </para>
        </note>
        <para>
-       <!--
+<!--
         If no synchronous standby names are specified here, then synchronous
         replication is not enabled and transaction commits will not wait for
         replication.  This is the default configuration.  Even when
@@ -6525,15 +6525,15 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
         configured not to wait for replication by setting the
         <xref linkend="guc-synchronous-commit"/> parameter to
         <literal>local</literal> or <literal>off</literal>.
-       -->
-       ここに同期スタンバイ名が指定されていない場合、同期レプリケーションは有効とはならず、トランザクションコミットはレプリケーションを待機しません。これがデフォルトの設定です。同期レプリケーションが有効であっても、<xref linkend="guc-synchronous-commit"/>パラメータを<literal>local</literal> または <literal>off</literal>に設定することにより、個別のトランザクションをレプリケーションに対して待機しないように設定できます。
+-->
+ここに同期スタンバイ名が指定されていない場合、同期レプリケーションは有効とはならず、トランザクションコミットはレプリケーションを待機しません。これがデフォルトの設定です。同期レプリケーションが有効であっても、<xref linkend="guc-synchronous-commit"/>パラメータを<literal>local</literal> または <literal>off</literal>に設定することにより、個別のトランザクションをレプリケーションに対して待機しないように設定できます。
        </para>
        <para>
-       <!--
+<!--
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
-       このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+-->
+このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -6549,7 +6549,7 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the number of transactions by which <command>VACUUM</command> and
         <acronym>HOT</acronym> updates will defer cleanup of dead row versions. The
         default is zero transactions, meaning that dead row versions can be
@@ -6564,7 +6564,7 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
         grace time will be made available to standby queries.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 <command>VACUUM</command> および <acronym>HOT</acronym>更新が不要行バージョンの回収を決めるのを延期するトランザクションの数を指定します。
 デフォルトはゼロトランザクションで、つまり、開いている全てのトランザクションから不可視になった不要行バージョンは速やかに削除されうることを意味します。
 <xref linkend="hot-standby"/>に記載されているように、ホットスタンバイサーバをサポートしている場合、プライマリサーバ上で非ゼロ値に設定したい場合があります。
@@ -6573,10 +6573,10 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
 このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
        </para>
        <para>
-       <!--
+<!--
         You should also consider setting <varname>hot_standby_feedback</varname>
         on standby server(s) as an alternative to using this parameter.
-       -->
+-->
 このパラメータを使う代わりにスタンバイサーバ上に <varname>hot_standby_feedback</varname>の設定を考慮する必要もあります。
        </para>
        <para>
@@ -6593,19 +6593,19 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
     </sect2>
 
     <sect2 id="runtime-config-replication-standby">
-    <!--
+<!--
      <title>Standby Servers</title>
-    -->
+-->
      <title>スタンバイサーバ</title>
 
      <para>
-     <!--
+<!--
       These settings control the behavior of a
       <link linkend="standby-server-operation">standby server</link>
       that is
       to receive replication data.  Their values on the primary server
       are irrelevant.
-      -->
+-->
 これらの設定はレプリケーションデータを受け取る<link linkend="standby-server-operation">スタンバイサーバ</link>の動作を管理します。
 プライマリサーバ上のこれらの値は無意味です。
      </para>
@@ -6744,15 +6744,15 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies whether or not you can connect and run queries during
         recovery, as described in <xref linkend="hot-standby"/>.
         The default value is <literal>on</literal>.
         This parameter can only be set at server start. It only has effect
         during archive recovery or in standby mode.
-       -->
-       <xref linkend="hot-standby"/>に記載されている通り、リカバリの最中に接続し、そして問い合わせを実行できるか否かを設定します。デフォルト値は<literal>on</literal>です。
-       このパラメータはサーバ起動時のみ設定可能です。これは、アーカイブリカバリ期間、又はスタンバイモードにある場合にのみ効果をもたらします。
+-->
+<xref linkend="hot-standby"/>に記載されている通り、リカバリの最中に接続し、そして問い合わせを実行できるか否かを設定します。デフォルト値は<literal>on</literal>です。
+このパラメータはサーバ起動時のみ設定可能です。これは、アーカイブリカバリ期間、又はスタンバイモードにある場合にのみ効果をもたらします。
        </para>
       </listitem>
      </varlistentry>
@@ -6768,7 +6768,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When Hot Standby is active, this parameter determines how long the
         standby server should wait before canceling standby queries that
         conflict with about-to-be-applied WAL entries, as described in
@@ -6781,7 +6781,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
         queries to complete.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 ホットスタンバイが稼動している場合、このパラメータは<xref linkend="hot-standby-conflict"/>で記載されているように、まさに適用されようとしているWALエントリと衝突するスタンバイサーバの問い合わせをキャンセルするにはどれだけ待機しなければならないかを設定します。
 <varname>max_standby_archive_delay</varname>はWALデータをWALアーカイブ（すなわち最新ではありません）から読み込んでいる時に適用されます。
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
@@ -6790,14 +6790,14 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
 このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
        </para>
        <para>
-       <!--
+<!--
         Note that <varname>max_standby_archive_delay</varname> is not the same as the
         maximum length of time a query can run before cancellation; rather it
         is the maximum total time allowed to apply any one WAL segment's data.
         Thus, if one query has resulted in significant delay earlier in the
         WAL segment, subsequent conflicting queries will have much less grace
         time.
-       -->
+-->
 <varname>max_standby_archive_delay</varname>はキャンセル前に問い合わせが実行できる最大の時間の長さと同じでないことに注意してください。
 むしろ、任意の１つのWALセグメントのデータの適用のために許される最大合計時間です。
 従って、ある問い合わせによりWALセグメント内の前の部分で大幅な遅延となった場合、その後の衝突する問い合わせの猶予時間はずっと短くなります。
@@ -6816,7 +6816,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When Hot Standby is active, this parameter determines how long the
         standby server should wait before canceling standby queries that
         conflict with about-to-be-applied WAL entries, as described in
@@ -6829,7 +6829,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
         queries to complete.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 ホットスタンバイが稼動している場合、このパラメータは<xref linkend="hot-standby-conflict"/>で記載されているように、まさに適用されようとしているWALエントリと衝突するスタンバイサーバの問い合わせをキャンセルするにはどれだけ待機しなければならないかを設定します。
 <varname>max_standby_streaming_delay</varname>はWALデータをストリーミングレプリケーションから受け取っている時に適用されます。
 特に指定が無ければ単位はミリ秒です。
@@ -6838,7 +6838,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
 このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
        </para>
        <para>
-       <!--
+<!--
         Note that <varname>max_standby_streaming_delay</varname> is not the same as
         the maximum length of time a query can run before cancellation; rather
         it is the maximum total time allowed to apply WAL data once it has
@@ -6846,7 +6846,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
         resulted in significant delay, subsequent conflicting queries will
         have much less grace time until the standby server has caught up
         again.
-       -->
+-->
 <varname>max_standby_streaming_delay</varname>はキャンセル前に問い合わせが実行できる最大の時間の長さと同じでないことに注意してください。
 むしろ、プライマリサーバから一度受け取られたWALデータを適用するために許される最大合計時間です。
 従って、ある問い合わせが大幅な遅延を起こした場合、その後の衝突する問い合わせは、スタンバイサーバがふたたび遅れを取り戻すまでの間、猶予時間はずっと短くなります。
@@ -6893,7 +6893,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
       </term>
       <listitem>
       <para>
-      <!--
+<!--
        Specifies the minimum frequency for the WAL receiver
        process on the standby to send information about replication progress
        to the primary or upstream standby, where it can be seen using the
@@ -6914,7 +6914,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
        The default value is 10 seconds. This parameter can only be set in
        the <filename>postgresql.conf</filename> file or on the server
        command line.
-       -->
+-->
 スタンバイサーバ上のWAL受信プロセスがプライマリー、または上位サーバに対してレプリケーションの進捗情報を送信する最小頻度を指定します。
 送信された進捗情報は<link linkend="monitoring-pg-stat-replication-view"><structname>pg_stat_replication</structname></link>ビューにより確認することが可能です。
 スタンバイサーバは書き込みがされた直近の先行書き込みログ位置、ディスクにフラッシュされた直近のログ位置、およびリカバリ適用された直近のログ位置を報告します。
@@ -6941,7 +6941,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies whether or not a hot standby will send feedback to the primary
         or upstream standby
         about queries currently executing on the standby. This parameter can
@@ -6951,21 +6951,21 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
         <varname>wal_receiver_status_interval</varname>. The default value is
         <literal>off</literal>. This parameter can only be set in the
         <filename>postgresql.conf</filename> file or on the server command line.
-       -->
-       ホットスタンバイがスタンバイサーバ上で現在処理を行っている問い合わせについて、プライマリーまたは上位サーバにフィードバックを送るか否かを指定します。
-       このパラメータはレコードの回収に起因する問い合わせの取り消しを排除するために使用することができます。
-       しかし、いくつかのワークロードに対してはプライマリーサーバ上でのデータベース肥大の原因となります。
-       フィードバックメッセージは<varname>wal_receiver_status_interval</varname>毎に、2回以上送信されません。
-       デフォルトの値は<literal>off</literal>です。
-        このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+-->
+ホットスタンバイがスタンバイサーバ上で現在処理を行っている問い合わせについて、プライマリーまたは上位サーバにフィードバックを送るか否かを指定します。
+このパラメータはレコードの回収に起因する問い合わせの取り消しを排除するために使用することができます。
+しかし、いくつかのワークロードに対してはプライマリーサーバ上でのデータベース肥大の原因となります。
+フィードバックメッセージは<varname>wal_receiver_status_interval</varname>毎に、2回以上送信されません。
+デフォルトの値は<literal>off</literal>です。
+このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
        </para>
        <para>
-       <!--
+<!--
         If cascaded replication is in use the feedback is passed upstream
         until it eventually reaches the primary.  Standbys make no other use
         of feedback they receive other than to pass upstream.
-       -->
-       カスケードレプリケーションが使用されている場合、フィードバックは最終的にプライマリーに到達するまで上位サーバに転送されます。スタンバイは上位に転送する以外、受け取ったフィードバックを他に使用しません。
+-->
+カスケードレプリケーションが使用されている場合、フィードバックは最終的にプライマリーに到達するまで上位サーバに転送されます。スタンバイは上位に転送する以外、受け取ったフィードバックを他に使用しません。
        </para>
        <para>
 <!--
@@ -6997,7 +6997,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Terminate replication connections that are inactive for longer
         than this amount of time. This is useful for
         the receiving standby server to detect a primary node crash or network
@@ -7008,7 +7008,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
         This parameter can only be set in
         the <filename>postgresql.conf</filename> file or on the server
         command line.
-       -->
+-->
 指定された時間より長い間、活動していないレプリケーション接続は停止します。
 このことは受信するスタンバイサーバがプライマリノードの機能停止、またはネットワーク停止を検出するのに便利です。
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
@@ -7285,19 +7285,19 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
    </sect1>
 
    <sect1 id="runtime-config-query">
-   <!--
+<!--
     <title>Query Planning</title>
-    -->
+-->
     <title>問い合わせ計画</title>
 
     <sect2 id="runtime-config-query-enable">
-    <!--
+<!--
      <title>Planner Method Configuration</title>
-     -->
+-->
      <title>プランナメソッド設定</title>
 
       <para>
-      <!--
+<!--
        These configuration parameters provide a crude method of
        influencing the query plans chosen by the query optimizer. If
        the default plan chosen by the optimizer for a particular query
@@ -7313,7 +7313,7 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
        and increasing the amount of statistics collected for
        specific columns using <command>ALTER TABLE SET
        STATISTICS</command>.
-       -->
+-->
 以下の設定パラメータは、問い合わせオプティマイザが選択する問い合わせ計画に影響する大雑把な手法を提供します。
 ある問い合わせに対してオプティマイザが選択したデフォルト計画が最適でない場合、<emphasis>暫定的な</emphasis>解決策は、これらの設定パラメータの1つを使用し、オプティマイザに異なる計画を選択するように仕向けることです。
 オプティマイザが選択する計画の品質を改善するためのより良い方法には、プランナコスト定数を調節する（<xref linkend="runtime-config-query-constants"/>を参照）、<link linkend="sql-analyze"><command>ANALYZE</command></link>を手作業で実行する、<xref linkend="guc-default-statistics-target"/>設定パラメータの値を大きくする、<command>ALTER TABLE SET STATISTICS</command>を使用して、特定の列に対して収集される統計情報を増やす、などがあります。
@@ -7358,11 +7358,11 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables or disables the query planner's use of bitmap-scan plan
         types. The default is <literal>on</literal>.
-       -->
-       問い合わせプランナがビットマップスキャン計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</literal>です。
+-->
+問い合わせプランナがビットマップスキャン計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
      </varlistentry>
@@ -7399,10 +7399,10 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables or disables the query planner's use of hashed
         aggregation plan types. The default is <literal>on</literal>.
-       -->
+-->
 問い合わせプランナがハッシュ集約計画型を選択することを有効もしくは無効にします。
 デフォルトは<literal>on</literal>です。
        </para>
@@ -7420,11 +7420,11 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables or disables the query planner's use of hash-join plan
         types. The default is <literal>on</literal>.
-       -->
-       問い合わせプランナがハッシュ結合計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</literal>です。
+-->
+問い合わせプランナがハッシュ結合計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
      </varlistentry>
@@ -7467,11 +7467,11 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables or disables the query planner's use of index-scan plan
         types. The default is <literal>on</literal>.
-       -->
-       問い合わせプランナがインデックス走査計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</literal>です。
+-->
+問い合わせプランナがインデックス走査計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
      </varlistentry>
@@ -7510,15 +7510,15 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables or disables the query planner's use of materialization.
         It is impossible to suppress materialization entirely,
         but turning this variable off prevents the planner from inserting
         materialize nodes except in cases where it is required for correctness.
         The default is <literal>on</literal>.
-       -->
-       問い合わせプランナの具体化の使用を有効、または無効にします。
-       全体にわたって具体化を差し止めることはできませんが、この値をoffにすることにより、正確性が要求される場合を除いて、具体化ノードをプランナが挿入することを防止します。デフォルトは<literal>on</literal>です。
+-->
+問い合わせプランナの具体化の使用を有効、または無効にします。
+全体にわたって具体化を差し止めることはできませんが、この値をoffにすることにより、正確性が要求される場合を除いて、具体化ノードをプランナが挿入することを防止します。デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
      </varlistentry>
@@ -7562,11 +7562,11 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables or disables the query planner's use of merge-join plan
         types. The default is <literal>on</literal>.
-       -->
-       問い合わせプランナがマージ結合計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</literal>です。
+-->
+問い合わせプランナがマージ結合計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
      </varlistentry>
@@ -7582,16 +7582,16 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables or disables the query planner's use of nested-loop join
         plans. It is impossible to suppress nested-loop joins entirely,
         but turning this variable off discourages the planner from using
         one if there are other methods available. The default is
         <literal>on</literal>.
-       -->
-       問い合わせプランナがネステッドループ結合計画を選択することを有効もしくは無効にします。
-       ネステッドループ結合を完全に禁止することは不可能ですが、この変数をオフにすると、もし他の方法が利用できるのであれば、プランナはその使用を行わないようになります。
-       デフォルトは<literal>on</literal>です。
+-->
+問い合わせプランナがネステッドループ結合計画を選択することを有効もしくは無効にします。
+ネステッドループ結合を完全に禁止することは不可能ですが、この変数をオフにすると、もし他の方法が利用できるのであれば、プランナはその使用を行わないようになります。
+デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
      </varlistentry>
@@ -7804,13 +7804,13 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      </variablelist>
      </sect2>
      <sect2 id="runtime-config-query-constants">
-     <!--
+<!--
      <title>Planner Cost Constants</title>
-     -->
+-->
      <title>プランナコスト定数</title>
 
     <para>
-    <!--
+<!--
      The <firstterm>cost</firstterm> variables described in this section are measured
      on an arbitrary scale.  Only their relative values matter, hence
      scaling them all up or down by the same factor will result in no change
@@ -7820,7 +7820,7 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      and the other cost variables are set with reference to that.  But
      you can use a different scale if you prefer, such as actual execution
      times in milliseconds on a particular machine.
-     -->
+-->
 本節で扱う<firstterm>コスト</firstterm>変数は、任意の尺度で測られます。
 これらは相対的な値のみが意味を持つため、それらの値をすべて同じ係数で大きく、あるいは小さくしても、プランナの選択は結果として変わりません。
 デフォルトではこれらのコスト変数はシーケンシャルなページ取り込みに基づいています。
@@ -7830,13 +7830,13 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
 
    <note>
     <para>
-    <!--
+<!--
      Unfortunately, there is no well-defined method for determining ideal
      values for the cost variables.  They are best treated as averages over
      the entire mix of queries that a particular installation will receive.  This
      means that changing them on the basis of just a few experiments is very
      risky.
-     -->
+-->
 残念ながら、コスト変数に対する理想的な値を決定する、上手く定義された方法がありません。
 特定のインストレーションが受け取る問い合わせ全体を混在させたものの平均として扱うのが最善でしょう。
 数回の実験のみを根拠にこの値を変更することは危険であるといえます。
@@ -7856,13 +7856,13 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the planner's estimate of the cost of a disk page fetch
         that is part of a series of sequential fetches.  The default is 1.0.
         This value can be overridden for tables and indexes in a particular
         tablespace by setting the tablespace parameter of the same name
         (see <xref linkend="sql-altertablespace"/>).
-       -->
+-->
 シーケンシャルな一連の取り出しの一部となる、ディスクページ取り出しに関する、プランナの推定コストを設定します。
 デフォルトは1.0です。
 この値は同じ名前のテーブル空間パラメータを設定することで、特定のテーブル空間の中にあるテーブルとインデックスに対して上書きできます（<xref linkend="sql-altertablespace"/>を参照してください）。
@@ -7881,27 +7881,27 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the planner's estimate of the cost of a
         non-sequentially-fetched disk page.  The default is 4.0.
         This value can be overridden for tables and indexes in a particular
         tablespace by setting the tablespace parameter of the same name
         (see <xref linkend="sql-altertablespace"/>).
-       -->
+-->
 非シーケンシャル的に取り出されるディスクページのコストに対するプランナの推測を設定します。
 デフォルトは4です。
 この値は同じ名前のテーブル空間パラメータを設定することで、特定のテーブル空間の中にあるテーブルとインデックスに対して上書きできます（<xref linkend="sql-altertablespace"/>を参照してください）。
        </para>
 
        <para>
-       <!--
+<!--
         Reducing this value relative to <varname>seq_page_cost</varname>
         will cause the system to prefer index scans; raising it will
         make index scans look relatively more expensive.  You can raise
         or lower both values together to change the importance of disk I/O
         costs relative to CPU costs, which are described by the following
         parameters.
-       -->
+-->
 この値を<varname>seq_page_cost</varname>と比較して小さくすると、システムはなるべくインデックススキャンを使用するようになります。
 大きくすると、インデックススキャンが相対的に高価になります。
 両方の値を増減させることで、CPUコストに対するディスクI/Oコストの重要性を変更させることができます。
@@ -7909,21 +7909,21 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
        </para>
 
        <para>
-       <!--
+<!--
         Random access to mechanical disk storage is normally much more expensive
         than four times sequential access.  However, a lower default is used
         (4.0) because the majority of random accesses to disk, such as indexed
         reads, are assumed to be in cache.  The default value can be thought of
         as modeling random access as 40 times slower than sequential, while
         expecting 90% of random reads to be cached.
-       -->
+-->
 機械的ディスク記憶装置に対するランダムアクセスは通常はシーケンシャルアクセスの4倍よりもかなり高価です。
 しかし、より低いデフォルト（4.0）が使用されます。というのはインデックスのついた読み取りのようなディスクに対するランダムアクセスのほとんどはキャッシュにあると想定されるからです。
 このデフォルト値は、ランダムアクセスがシーケンシャルアクセスより40倍遅い一方で、ランダム読み込みの90%はキャッシュされていることが期待されるというモデルとして考えることができます。
        </para>
 
        <para>
-       <!--
+<!--
         If you believe a 90% cache rate is an incorrect assumption
         for your workload, you can increase random_page_cost to better
         reflect the true cost of random storage reads. Correspondingly,
@@ -7933,7 +7933,7 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
         read cost relative to sequential, e.g., solid-state drives, might
         also be better modeled with a lower value for random_page_cost,
         e.g., <literal>1.1</literal>.
-       -->
+-->
 自環境の作業負荷において、90％のキャッシュ率は誤った仮定と考えられるのであれば、ランダム記憶装置読み込みのコストをより良く反映するため random_page_cost を大きくすることができます。
 反対に、データが完全にキャッシュされていると思われるのであれば、random_page_cost を小さくすることが適切です。例えば、データベースの容量がサーバのメモリより小さい場合などです。
 例えばSSDのような、シーケンシャルアクセスに比べてランダム読み込みコストがあまり大きくない記憶装置の場合も、random_page_cost に対し<literal>1.1</literal>のようにより低い値のモデル化の方が良いでしょう。
@@ -7941,7 +7941,7 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
 
        <tip>
         <para>
-       <!--
+<!--
          Although the system will let you set <varname>random_page_cost</varname> to
          less than <varname>seq_page_cost</varname>, it is not physically sensible
          to do so.  However, setting them equal makes sense if the database
@@ -7950,7 +7950,7 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
          database you should lower both values relative to the CPU parameters,
          since the cost of fetching a page already in RAM is much smaller
          than it would normally be.
-        -->
+-->
 システムは<varname>random_page_cost</varname>を<varname>seq_page_cost</varname>よりも小さな値に設定することを許しますが、そのようにすることは物理的にはおかしなことです。
 しかし、データベースが完全にRAMにキャッシュされる場合、同じ値に設定することは意味を持ちます。
 この場合、順序通りではないページアクセスに対するペナルティが存在しないからです。
@@ -7972,11 +7972,11 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the planner's estimate of the cost of processing
         each row during a query.
         The default is 0.01.
-       -->
+-->
 問い合わせ時のそれぞれの行の処理コストに対するプランナの推測を設定します。
 デフォルトは0.01です。
        </para>
@@ -7994,11 +7994,11 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the planner's estimate of the cost of processing
         each index entry during an index scan.
         The default is 0.005.
-       -->
+-->
 インデックス走査時のそれぞれのインデックス行の処理コストに対するプランナの推測を設定します。
 デフォルトは0.005です。
        </para>
@@ -8016,12 +8016,12 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the planner's estimate of the cost of processing each
         operator or function executed during a query.
         The default is 0.0025.
-       -->
-       問い合わせ時に実行される各演算子や関数の処理コストに対するプランナの推測を設定します。デフォルトは0.0025です。
+-->
+問い合わせ時に実行される各演算子や関数の処理コストに対するプランナの推測を設定します。デフォルトは0.0025です。
        </para>
       </listitem>
      </varlistentry>
@@ -8273,23 +8273,23 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
 
     </sect2>
      <sect2 id="runtime-config-query-geqo">
-     <!--
+<!--
      <title>Genetic Query Optimizer</title>
-     -->
+-->
      <title>遺伝的問い合わせオプティマイザ</title>
 
      <para>
-     <!--
+<!--
       The genetic query optimizer (GEQO) is an algorithm that does query
       planning using heuristic searching.  This reduces planning time for
       complex queries (those joining many relations), at the cost of producing
       plans that are sometimes inferior to those found by the normal
       exhaustive-search algorithm.
       For more information see <xref linkend="geqo"/>.
-      -->
-      遺伝的問い合わせオプティマイザ（GEQO）はヒューリスティック（発見的）検索法を用いた問い合わせ計画を行なう演算手法です。
-      通常のしらみつぶしの検索演算手法で見いだされる計画よりも時として劣った計画を作成するという代償を払いますが、この手法は（多くのリレーションを結合するような）複雑な問い合わせに対し計画時間を軽減します。
-      より詳細は<xref linkend="geqo"/>を参照してください。
+-->
+遺伝的問い合わせオプティマイザ（GEQO）はヒューリスティック（発見的）検索法を用いた問い合わせ計画を行なう演算手法です。
+通常のしらみつぶしの検索演算手法で見いだされる計画よりも時として劣った計画を作成するという代償を払いますが、この手法は（多くのリレーションを結合するような）複雑な問い合わせに対し計画時間を軽減します。
+より詳細は<xref linkend="geqo"/>を参照してください。
      </para>
 
      <variablelist>
@@ -8304,9 +8304,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </indexterm>
       <indexterm>
        <primary>GEQO</primary>
-       <!--
+<!--
        <see>genetic query optimization</see>
-       -->
+-->
        <see>遺伝的問い合わせ最適化</see>
       </indexterm>
       <indexterm>
@@ -8318,14 +8318,14 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables or disables genetic query optimization.
         This is on by default.  It is usually best not to turn it off in
         production; the <varname>geqo_threshold</varname> variable provides
         more granular control of GEQO.
-       -->
-       遺伝的問い合わせ最適化を有効もしくは無効にします。デフォルトは有効です。
-       運用時には無効にしないことが通常最善です。<varname>geqo_threshold</varname>変数は、GEQOを制御するためよりきめ細かな方法を提供します。
+-->
+遺伝的問い合わせ最適化を有効もしくは無効にします。デフォルトは有効です。
+運用時には無効にしないことが通常最善です。<varname>geqo_threshold</varname>変数は、GEQOを制御するためよりきめ細かな方法を提供します。
        </para>
       </listitem>
      </varlistentry>
@@ -8341,7 +8341,7 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Use genetic query optimization to plan queries with at least
         this many <literal>FROM</literal> items involved. (Note that a
         <literal>FULL OUTER JOIN</literal> construct counts as only one <literal>FROM</literal>
@@ -8351,7 +8351,7 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
         longer than the penalty of executing a suboptimal plan.  Thus,
         a threshold on the size of the query is a convenient way to manage
         use of GEQO.
-       -->
+-->
 少なくともこれだけの数の<literal>FROM</literal>項目数があるときに、問い合わせを計画するのに遺伝的問い合わせ最適化を使用します。
 （<literal>FULL OUTER JOIN</literal>の生成子は、<literal>FROM</literal>項目が１つだけとして計算することに注意してください。）
 デフォルトは12です。
@@ -8372,27 +8372,27 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls the trade-off between planning time and query plan
         quality in GEQO. This variable must be an integer in the
         range from 1 to 10. The default value is five. Larger values
         increase the time spent doing query planning, but also
         increase the likelihood that an efficient query plan will be
         chosen.
-       -->
+-->
        GEQOにおける計画時間と問い合わせ計画の品質間のトレードオフを制御します。この変数は1から10までの範囲の整数でなければなりません。
-       デフォルトの値は5です。値を大きくすると、問い合わせ計画作成により多くの時間を費すことになりますが、より効率的な問い合わせ計画が選択される可能性が増加します。
+デフォルトの値は5です。値を大きくすると、問い合わせ計画作成により多くの時間を費すことになりますが、より効率的な問い合わせ計画が選択される可能性が増加します。
        </para>
 
        <para>
-       <!--
+<!--
         <varname>geqo_effort</varname> doesn't actually do anything
         directly; it is only used to compute the default values for
         the other variables that influence GEQO behavior (described
         below). If you prefer, you can set the other parameters by
         hand instead.
-       -->
-       実際<varname>geqo_effort</varname>は直接何も行いません。それはGEQOの動作に影響を与える他の変数に対し、デフォルトの値を計算するためにのみ使用されます（以下で説明します）。もしよければ、代わりに手作業で他のパラメータを設定できます。
+-->
+実際<varname>geqo_effort</varname>は直接何も行いません。それはGEQOの動作に影響を与える他の変数に対し、デフォルトの値を計算するためにのみ使用されます（以下で説明します）。もしよければ、代わりに手作業で他のパラメータを設定できます。
        </para>
       </listitem>
      </varlistentry>
@@ -8408,14 +8408,14 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls the pool size used by GEQO, that is the
         number of individuals in the genetic population.  It must be
         at least two, and useful values are typically 100 to 1000.  If
         it is set to zero (the default setting) then a suitable
         value is chosen based on <varname>geqo_effort</varname> and
         the number of tables in the query.
-       -->
+-->
        GEQOで使用されるプール容量を管理します。それは遺伝的個体群内の個体数です。最低でも2つはなければならず、よく100から1000までの値が使用されます。もし（デフォルトの設定である）零に設定されると、<varname>geqo_effort</varname>および問い合わせの中のテーブル数に基づいて、適切な値が選択されます。
        </para>
       </listitem>
@@ -8432,14 +8432,14 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls the number of generations used by GEQO, that is
         the number of iterations of the algorithm.  It must
         be at least one, and useful values are in the same range as
         the pool size.  If it is set to zero (the default setting)
         then a suitable value is chosen based on
         <varname>geqo_pool_size</varname>.
-       -->
+-->
        GEQOで使用される世代の数を管理します。それはアルゴリズムの反復数です。最低でも1はなければならず、よくプールサイズと同じ範囲の値が使用されます。これを0に設定（デフォルトの設定）すると、適切な値が<varname>geqo_pool_size</varname>に基づいて選択されます。
        </para>
       </listitem>
@@ -8456,11 +8456,11 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls the selection bias used by GEQO. The selection bias
         is the selective pressure within the population. Values can be
         from 1.50 to 2.00; the latter is the default.
-       -->
+-->
        GEQOで使用される淘汰の偏りを管理します。淘汰の偏りは個体群内の（遺伝的な）自然淘汰です。値は1.50から2.00で、2.00がデフォルトです。
        </para>
       </listitem>
@@ -8477,13 +8477,13 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls the initial value of the random number generator used
         by GEQO to select random paths through the join order search space.
         The value can range from zero (the default) to one.  Varying the
         value changes the set of join paths explored, and may result in a
         better or worse best path being found.
-       -->
+-->
 結合順序検索空間にわたって、GEQOが無作為のパスを選択するために使用される乱数発生器の初期値を制御します。
 値は0（デフォルト）から1までの範囲です。
 値を変動させると探査される結合パスの集合が変化するため、見つかる最善のパスが良くなる場合も悪くなる場合もあります。
@@ -8494,9 +8494,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      </variablelist>
     </sect2>
      <sect2 id="runtime-config-query-other">
-     <!--
+<!--
      <title>Other Planner Options</title>
-     -->
+-->
      <title>その他のプランナオプション</title>
 
      <variablelist>
@@ -8512,7 +8512,7 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the default statistics target for table columns without
         a column-specific target set via <command>ALTER TABLE
         SET STATISTICS</command>.  Larger values increase the time needed to
@@ -8520,8 +8520,8 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
         planner's estimates. The default is 100. For more information
         on the use of statistics by the <productname>PostgreSQL</productname>
         query planner, refer to <xref linkend="planner-stats"/>.
-       -->
-       <command>ALTER TABLE SET STATISTICS</command>で列特定の目的セットの無いテーブル列に対し、デフォルトの統計対象を設定します。
+-->
+<command>ALTER TABLE SET STATISTICS</command>で列特定の目的セットの無いテーブル列に対し、デフォルトの統計対象を設定します。
 より大きい値は<command>ANALYZE</command>に必要な時間を増加させますが、プランナの予測の品質を向上させます。
 デフォルトは100です。
 <productname>PostgreSQL</productname>の問い合わせプランナによる統計情報の使用方法に関するより詳細な情報は、<xref linkend="planner-stats"/>を参照してください。
@@ -8565,12 +8565,12 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </para>
 
        <para>
-       <!--
+<!--
         When this parameter allows it for a particular table, the planner
         compares query conditions with the table's <literal>CHECK</literal>
         constraints, and omits scanning tables for which the conditions
         contradict the constraints.  For example:
-       -->
+-->
 このパラメータが特定のテーブルに対して許される時、プランナはそのテーブルの<literal>CHECK</literal>制約で問い合わせ条件を比較し、制約と矛盾する条件のテーブルの走査を省きます。
 例えば以下のようになります。
 
@@ -8585,8 +8585,8 @@ SELECT * FROM parent WHERE key = 2400;
 <!--
         With constraint exclusion enabled, this <command>SELECT</command>
         will not scan <structname>child1000</structname> at all, improving performance.
-       -->
-       制約排除が有効であると、この<command>SELECT</command>は全く<structname>child1000</structname>を走査せず、性能を向上させます。
+-->
+制約排除が有効であると、この<command>SELECT</command>は全く<structname>child1000</structname>を走査せず、性能を向上させます。
        </para>
 
        <para>
@@ -8629,7 +8629,7 @@ SELECT * FROM parent WHERE key = 2400;
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the planner's estimate of the fraction of a cursor's rows that
         will be retrieved.  The default is 0.1.  Smaller values of this
         setting bias the planner towards using <quote>fast start</quote> plans
@@ -8639,14 +8639,14 @@ SELECT * FROM parent WHERE key = 2400;
         setting of 1.0, cursors are planned exactly like regular queries,
         considering only the total estimated time and not how soon the
         first rows might be delivered.
-       -->
-       検索されるカーソル行の割合のプランナの見積もりを設定します。
-       デフォルトは0.1です。
-       この設定をより小さくすると、プランナはカーソルに対し<quote>起動を高速にする</quote>計画を使用するようになりがちになります。
-       この場合先頭の数行の取り出しは高速になりますが、行全体を取り出す場合に時間がかかるようになる可能性があります。
-       この値をより大きくすると、推定時間全体がより強調されるようになります。
-       最大の設定である1.0の場合、カーソルは通常の問い合わせとまったく同様に計画されます。
-       つまり、推定時間全体のみが考慮され、先頭の行の取り出しにかかる時間は考慮されなくなります。
+-->
+検索されるカーソル行の割合のプランナの見積もりを設定します。
+デフォルトは0.1です。
+この設定をより小さくすると、プランナはカーソルに対し<quote>起動を高速にする</quote>計画を使用するようになりがちになります。
+この場合先頭の数行の取り出しは高速になりますが、行全体を取り出す場合に時間がかかるようになる可能性があります。
+この値をより大きくすると、推定時間全体がより強調されるようになります。
+最大の設定である1.0の場合、カーソルは通常の問い合わせとまったく同様に計画されます。
+つまり、推定時間全体のみが考慮され、先頭の行の取り出しにかかる時間は考慮されなくなります。
        </para>
       </listitem>
      </varlistentry>
@@ -8662,26 +8662,26 @@ SELECT * FROM parent WHERE key = 2400;
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The planner will merge sub-queries into upper queries if the
         resulting <literal>FROM</literal> list would have no more than
         this many items.  Smaller values reduce planning time but might
         yield inferior query plans.  The default is eight.
         For more information see <xref linkend="explicit-joins"/>.
-       -->
-       プランナは、<literal>FROM</literal>リストがこの数の項目より少ない結果の場合、副問い合わせを上位の問い合わせに併合します。
+-->
+プランナは、<literal>FROM</literal>リストがこの数の項目より少ない結果の場合、副問い合わせを上位の問い合わせに併合します。
 より小さい値は計画時間を縮小させますが、劣った問い合わせ計画をもたらす可能性があります。
 デフォルトは8です。
 詳細は<xref linkend="explicit-joins"/>を参照してください。
        </para>
 
        <para>
-       <!--
+<!--
         Setting this value to <xref linkend="guc-geqo-threshold"/> or more
         may trigger use of the GEQO planner, resulting in non-optimal
         plans.  See <xref linkend="runtime-config-query-geqo"/>.
-       -->
-       この値を<xref linkend="guc-geqo-threshold"/>か、それ以上に設定するとGEQOプランナ使用の誘引となり、最適ではない計画をもたらします。<xref linkend="runtime-config-query-geqo"/>を参照してください。
+-->
+この値を<xref linkend="guc-geqo-threshold"/>か、それ以上に設定するとGEQOプランナ使用の誘引となり、最適ではない計画をもたらします。<xref linkend="runtime-config-query-geqo"/>を参照してください。
        </para>
       </listitem>
      </varlistentry>
@@ -8722,19 +8722,19 @@ SELECT * FROM parent WHERE key = 2400;
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The planner will rewrite explicit <literal>JOIN</literal>
         constructs (except <literal>FULL JOIN</literal>s) into lists of
         <literal>FROM</literal> items whenever a list of no more than this many items
         would result.  Smaller values reduce planning time but might
         yield inferior query plans.
-       -->
-       最終的にリストがこの項目数以下になる時、プランナは、明示的な<literal>JOIN</literal>構文（<literal>FULL JOIN</literal>を除く）を<literal>FROM</literal>項目のリストに直します。
+-->
+最終的にリストがこの項目数以下になる時、プランナは、明示的な<literal>JOIN</literal>構文（<literal>FULL JOIN</literal>を除く）を<literal>FROM</literal>項目のリストに直します。
 この値を小さくすれば計画作成時間は減少しますが、劣った問い合わせ計画が作成される可能性があります。
        </para>
 
        <para>
-       <!--
+<!--
         By default, this variable is set the same as
         <varname>from_collapse_limit</varname>, which is appropriate
         for most uses. Setting it to 1 prevents any reordering of
@@ -8745,8 +8745,8 @@ SELECT * FROM parent WHERE key = 2400;
         temporarily set this variable to 1, and then specify the join
         order they desire explicitly.
         For more information see <xref linkend="explicit-joins"/>.
-       -->
-       デフォルトでは、この値は<varname>from_collapse_limit</varname>と同じ値に設定されており、殆どの場合に適切です。
+-->
+デフォルトでは、この値は<varname>from_collapse_limit</varname>と同じ値に設定されており、殆どの場合に適切です。
 これを1に設定すると明示的な<literal>JOIN</literal>の再順序付けは行われなくなります。
 したがって、問い合わせで指定された明示的結合順序は、関係（リレーション）が結合される実際の順序となります。
 問い合わせプランナは常に最適な結合順序を選択するとは限らないので、
@@ -8755,12 +8755,12 @@ SELECT * FROM parent WHERE key = 2400;
        </para>
 
        <para>
-       <!--
+<!--
         Setting this value to <xref linkend="guc-geqo-threshold"/> or more
         may trigger use of the GEQO planner, resulting in non-optimal
         plans.  See <xref linkend="runtime-config-query-geqo"/>.
-       -->
-       この値を<xref linkend="guc-geqo-threshold"/>か、それ以上に設定するとGEQOプランナ使用の誘引となり、最適ではない計画をもたらします。<xref linkend="runtime-config-query-geqo"/>を参照してください。
+-->
+この値を<xref linkend="guc-geqo-threshold"/>か、それ以上に設定するとGEQOプランナ使用の誘引となり、最適ではない計画をもたらします。<xref linkend="runtime-config-query-geqo"/>を参照してください。
        </para>
       </listitem>
      </varlistentry>
@@ -8811,9 +8811,9 @@ SELECT * FROM parent WHERE key = 2400;
    </sect1>
 
    <sect1 id="runtime-config-logging">
-   <!--
+<!--
     <title>Error Reporting and Logging</title>
-    -->
+-->
     <title>エラー報告とログ取得</title>
 
     <indexterm zone="runtime-config-logging">
@@ -8824,9 +8824,9 @@ SELECT * FROM parent WHERE key = 2400;
     </indexterm>
 
     <sect2 id="runtime-config-logging-where">
-    <!--
+<!--
      <title>Where to Log</title>
-     -->
+-->
      <title>ログの出力先</title>
 
      <indexterm zone="runtime-config-logging-where">
@@ -8858,7 +8858,7 @@ SELECT * FROM parent WHERE key = 2400;
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         <productname>PostgreSQL</productname> supports several methods
          for logging server messages, including
          <systemitem>stderr</systemitem>, <systemitem>csvlog</systemitem> and
@@ -8869,15 +8869,15 @@ SELECT * FROM parent WHERE key = 2400;
          only.
          This parameter can only be set in the <filename>postgresql.conf</filename>
          file or on the server command line.
-        -->
-        <productname>PostgreSQL</productname>は、<systemitem>stderr</systemitem>、<systemitem>csvlog</systemitem>および<systemitem>syslog</systemitem>を含めて、サーバメッセージのログ取得に対し数種類の方法を提供します。
+-->
+<productname>PostgreSQL</productname>は、<systemitem>stderr</systemitem>、<systemitem>csvlog</systemitem>および<systemitem>syslog</systemitem>を含めて、サーバメッセージのログ取得に対し数種類の方法を提供します。
 Windowsでは、<systemitem>eventlog</systemitem>も同時に提供します。
 このパラメータを設定するには、コンマ区切りでお好みのログ出力先を記載します。
 デフォルトでは、ログは<systemitem>stderr</systemitem>のみに出力されます。
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定されます。
        </para>
        <para>
-       <!--
+<!--
         If <systemitem>csvlog</systemitem> is included in <varname>log_destination</varname>,
         log entries are output in <quote>comma separated
         value</quote> (<acronym>CSV</acronym>) format, which is convenient for
@@ -8885,8 +8885,8 @@ Windowsでは、<systemitem>eventlog</systemitem>も同時に提供します。
         See <xref linkend="runtime-config-logging-csvlog"/> for details.
         <xref linkend="guc-logging-collector"/> must be enabled to generate
         CSV-format log output.
-       -->
-       <systemitem>csvlog</systemitem>が<varname>log_destination</varname>に含まれる場合、ログ項目はプログラムへの読み込みが簡便な<quote>カンマ区切り値</quote>書式（<acronym>CSV</acronym>）で出力されます。
+-->
+<systemitem>csvlog</systemitem>が<varname>log_destination</varname>に含まれる場合、ログ項目はプログラムへの読み込みが簡便な<quote>カンマ区切り値</quote>書式（<acronym>CSV</acronym>）で出力されます。
 詳細は<xref linkend="runtime-config-logging-csvlog"/>を参照してください。
 CSV書式のログ出力を生成するためには<xref linkend="guc-logging-collector"/>を有効にする必要があります。
        </para>
@@ -8923,7 +8923,7 @@ csvlog log/postgresql.csv
 
        <note>
         <para>
-       <!--
+<!--
          On most Unix systems, you will need to alter the configuration of
          your system's <application>syslog</application> daemon in order
          to make use of the <systemitem>syslog</systemitem> option for
@@ -8933,30 +8933,30 @@ csvlog log/postgresql.csv
          linkend="guc-syslog-facility"/>), but the default
          <application>syslog</application> configuration on most platforms
          will discard all such messages.  You will need to add something like:
-        -->
-        <varname>log_destination</varname>で<systemitem>syslog</systemitem>オプションを使用できるようにするために、ほとんどのUnixシステムではシステムの<application>syslog</application>デーモンの設定を変更しなければならないでしょう。
+-->
+<varname>log_destination</varname>で<systemitem>syslog</systemitem>オプションを使用できるようにするために、ほとんどのUnixシステムではシステムの<application>syslog</application>デーモンの設定を変更しなければならないでしょう。
 <productname>PostgreSQL</productname>ではログを<literal>LOCAL0</literal>から<literal>LOCAL7</literal>までの<application>syslog</application>ファシリティで記録することができます（<xref linkend="guc-syslog-facility"/>を参照してください）。
 しかし、ほとんどのプラットフォームのデフォルトの<application>syslog</application>設定ではこれらのメッセージはすべて破棄されます。
 うまく動作させるために<application>syslog</application>デーモンの設定に以下のようなものを追加しなければならないでしょう。
 <programlisting>
 local0.*    /var/log/postgresql
 </programlisting>
-        <!--
+<!--
          to the  <application>syslog</application> daemon's configuration file
          to make it work.
-        -->
+-->
         </para>
         <para>
-       <!--
+<!--
          On Windows, when you use the <literal>eventlog</literal>
          option for <varname>log_destination</varname>, you should
          register an event source and its library with the operating
          system so that the Windows Event Viewer can display event
          log messages cleanly.
          See <xref linkend="event-log-registration"/> for details.
-        -->
+-->
         Windowsで<varname>log_destination</varname>に対し<literal>eventlog</literal>オプションを使用する場合、Windows Event Viewer がイベントログメッセージを手際良く表示できるよう、オペレーティングシステムでイベントソースとそのライブラリを登録しなければなりません。
-        詳細は<xref linkend="event-log-registration"/>を参照ください。
+詳細は<xref linkend="event-log-registration"/>を参照ください。
         </para>
        </note>
       </listitem>
@@ -8973,7 +8973,7 @@ local0.*    /var/log/postgresql
       </term>
       <listitem>
        <para>
-       <!--
+<!--
          This parameter enables the <firstterm>logging collector</firstterm>, which
          is a background process that captures log messages
          sent to <systemitem>stderr</systemitem> and redirects them into log files.
@@ -8983,7 +8983,7 @@ local0.*    /var/log/postgresql
          example is dynamic-linker failure messages; another is error messages
          produced by scripts such as <varname>archive_command</varname>.)
          This parameter can only be set at server start.
-        -->
+-->
 このパラメータは<firstterm>ログ収集機構</firstterm>を有効にします。
 それは<systemitem>stderr</systemitem>に送られたログメッセージを捕捉し、ログファイルにリダイレクトするバックグラウンドプロセスです。
 この手法は<application>syslog</application>へのログよりもしばしば有用です。
@@ -8994,7 +8994,7 @@ local0.*    /var/log/postgresql
 
        <note>
         <para>
-       <!--
+<!--
          It is possible to log to <systemitem>stderr</systemitem> without using the
          logging collector; the log messages will just go to wherever the
          server's <systemitem>stderr</systemitem> is directed.  However, that method is
@@ -9003,17 +9003,17 @@ local0.*    /var/log/postgresql
          logging collector can result in lost or garbled log output, because
          multiple processes writing concurrently to the same log file can
          overwrite each other's output.
-        -->
-        ログ収集機構を使用せずに<systemitem>stderr</systemitem>のログを取ることは可能です。
-        ログメッセージはサーバの<systemitem>stderr</systemitem>が指し示すいかなる場所にも向かうだけです。
-        しかし、その方法はログファイルを巡回させる都合のよい方法を提供しないので、ログ容量が小さい場合のみに適しています。
-        同時に、ログ収集機構を使用しないいくつかのプラットフォームにおいては、ログ出力が失われたり、文字化けします。なぜなら、同一のログファイルに同時に書き込みを行うマルチプロセッサはそれぞれの出力を上書きできるからです。
+-->
+ログ収集機構を使用せずに<systemitem>stderr</systemitem>のログを取ることは可能です。
+ログメッセージはサーバの<systemitem>stderr</systemitem>が指し示すいかなる場所にも向かうだけです。
+しかし、その方法はログファイルを巡回させる都合のよい方法を提供しないので、ログ容量が小さい場合のみに適しています。
+同時に、ログ収集機構を使用しないいくつかのプラットフォームにおいては、ログ出力が失われたり、文字化けします。なぜなら、同一のログファイルに同時に書き込みを行うマルチプロセッサはそれぞれの出力を上書きできるからです。
         </para>
        </note>
 
        <note>
         <para>
-       <!--
+<!--
           The logging collector is designed to never lose messages.  This means
           that in case of extremely high load, server processes could be
           blocked while trying to send additional log messages when the
@@ -9021,7 +9021,7 @@ local0.*    /var/log/postgresql
           prefers to drop messages if it cannot write them, which means it
           may fail to log some messages in such cases but it will not block
           the rest of the system.
-         -->
+-->
 ログ収集機構はメッセージを決して失わないために設計されています。
 これは、極端に高い負荷の場合、サーバプロセスはコレクタが遅れをとった場合、追加のログメッセージを送信しようと試みる時に阻止される可能性があります。
 それとは対象的に<application>syslog</application>は、もし書き込みができなかったときメッセージの廃棄を選びます。
@@ -9043,7 +9043,7 @@ local0.*    /var/log/postgresql
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When <varname>logging_collector</varname> is enabled,
         this parameter determines the directory in which log files will be created.
         It can be specified as an absolute path, or relative to the
@@ -9051,10 +9051,10 @@ local0.*    /var/log/postgresql
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
         The default is <literal>log</literal>.
-       -->
-       <varname>logging_collector</varname>を有効と設定した場合、このパラメータはログファイルが作成されるディレクトリを確定します。
-        ディレクトリは、絶対パス、もしくはデータベースクラスタのディレクトリに対する相対パスで指定することができます。
-        このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバコマンドラインからのみ設定可能です。
+-->
+<varname>logging_collector</varname>を有効と設定した場合、このパラメータはログファイルが作成されるディレクトリを確定します。
+ディレクトリは、絶対パス、もしくはデータベースクラスタのディレクトリに対する相対パスで指定することができます。
+このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバコマンドラインからのみ設定可能です。
 デフォルトは<literal>log</literal>です。
        </para>
       </listitem>
@@ -9071,7 +9071,7 @@ local0.*    /var/log/postgresql
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When <varname>logging_collector</varname> is enabled,
         this parameter sets the file names of the created log files.  The value
         is treated as a <function>strftime</function> pattern,
@@ -9087,8 +9087,8 @@ local0.*    /var/log/postgresql
         Note that the system's <function>strftime</function> is not used
         directly, so platform-specific (nonstandard) extensions do not work.
         The default is <literal>postgresql-%Y-%m-%d_%H%M%S.log</literal>.
-       -->
-       <varname>logging_collector</varname>が有効な場合、このパラメータは作成されたログファイルのファイル名を設定します。
+-->
+<varname>logging_collector</varname>が有効な場合、このパラメータは作成されたログファイルのファイル名を設定します。
 値は<function>strftime</function>パターンとして扱われるため、<literal>%</literal>エスケープを使用して、時刻によって変動するファイル名を指定することができます。
 （時間帯に依存した<literal>%</literal>エスケープが存在する場合、<xref
 linkend="guc-log-timezone"/>で指定された時間帯で計算が行われます。）
@@ -9098,7 +9098,7 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
 デフォルトは<literal>postgresql-%Y-%m-%d_%H%M%S.log</literal>です。
        </para>
        <para>
-       <!--
+<!--
         If you specify a file name without escapes, you should plan to
         use a log rotation utility to avoid eventually filling the
         entire disk.  In releases prior to 8.4, if
@@ -9106,26 +9106,26 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
         present, <productname>PostgreSQL</productname> would append
         the epoch of the new log file's creation time, but this is no
         longer the case.
-       -->
-       エスケープすることなくファイル名を指定する場合、ディスク全体を使い切ってしまうことを防止するためにログローテーションを行うユーティリティを使用することを計画しなければなりません。
+-->
+エスケープすることなくファイル名を指定する場合、ディスク全体を使い切ってしまうことを防止するためにログローテーションを行うユーティリティを使用することを計画しなければなりません。
        8.4より前のリリースの<productname>PostgreSQL</productname>では、<literal>%</literal>エスケープがなければ、新しいログファイルの生成時のエポック時刻を付与しますが、これはもはや当てはまりません。
        </para>
        <para>
-       <!--
+<!--
         If CSV-format output is enabled in <varname>log_destination</varname>,
         <literal>.csv</literal> will be appended to the timestamped
         log file name to create the file name for CSV-format output.
         (If <varname>log_filename</varname> ends in <literal>.log</literal>, the suffix is
         replaced instead.)
-       -->
+-->
 CSV書式の出力が<varname>log_destination</varname>で有効な場合、タイムスタンプ付きのログファイル名に<literal>.csv</literal>を付与し、最終的なCSV書式出力用のファイル名が作成されます。
 （<varname>log_filename</varname>が<literal>.log</literal>で終わる場合は後置詞が置き換えられます。）
        </para>
        <para>
-       <!--
+<!--
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 このパラメータは<filename>postgresql.conf</filename>ファイルか、サーバコマンドラインのみ設定可能です。
        </para>
       </listitem>
@@ -9142,7 +9142,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         On Unix systems this parameter sets the permissions for log files
         when <varname>logging_collector</varname> is enabled. (On Microsoft
         Windows this parameter is ignored.)
@@ -9151,14 +9151,14 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         <function>chmod</function> and <function>umask</function>
         system calls.  (To use the customary octal format the number
         must start with a <literal>0</literal> (zero).)
-       -->
+-->
        Unixシステムにおいては、<varname>logging_collector</varname>が有効になっている場合、このパラメータはログファイルのパーミッションを設定します。
        （Microsoft Windowsではこのパラメータは無視されます。）
-       パラメータの値は<function>chmod</function> および <function>umask</function>システムコールで許容されるフォーマットで指定される数値モードであると期待されます。
+パラメータの値は<function>chmod</function> および <function>umask</function>システムコールで許容されるフォーマットで指定される数値モードであると期待されます。
        （慣例的な8進数フォーマットを使用する場合、番号は<literal>0</literal>（ゼロ）で始まらなければなりません。
        </para>
        <para>
-       <!--
+<!--
         The default permissions are <literal>0600</literal>, meaning only the
         server owner can read or write the log files.  The other commonly
         useful setting is <literal>0640</literal>, allowing members of the owner's
@@ -9167,17 +9167,17 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         store the files somewhere outside the cluster data directory.  In
         any case, it's unwise to make the log files world-readable, since
         they might contain sensitive data.
-       -->
-       デフォルトのパーミッションは<literal>0600</literal>で、意味するところはサーバの所有者のみログファイルの読み書きが可能です。
-       そのほか一般的に実用的な設定は<literal>0640</literal>で、所有者のグループはファイルを読み込めます。
-       しかし、これらの設定を活用するには<xref linkend="guc-log-directory"/>がクラスタデータディレクトリの外部のどこかにあるファイルを格納できるように変更する必要があります。
+-->
+デフォルトのパーミッションは<literal>0600</literal>で、意味するところはサーバの所有者のみログファイルの読み書きが可能です。
+そのほか一般的に実用的な設定は<literal>0640</literal>で、所有者のグループはファイルを読み込めます。
+しかし、これらの設定を活用するには<xref linkend="guc-log-directory"/>がクラスタデータディレクトリの外部のどこかにあるファイルを格納できるように変更する必要があります。
        </para>
        <para>
 <!--
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
-       このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバコマンドラインからのみ設定可能です。
+-->
+このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバコマンドラインからのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -9193,7 +9193,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When <varname>logging_collector</varname> is enabled,
         this parameter determines the maximum amount of time to use an
         individual log file, after which a new log file will be created.
@@ -9202,7 +9202,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         Set to zero to disable time-based creation of new log files.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 <varname>logging_collector</varname>が有効な場合、このパラメータは個々のログファイルの最大寿命を決定します。
 ここで指定した時間経過すると、新しいログファイルが生成されます。
 この値が単位なしで指定された場合は、分単位であるとみなします。
@@ -9224,7 +9224,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When <varname>logging_collector</varname> is enabled,
         this parameter determines the maximum size of an individual log file.
         After this amount of data has been emitted into a log file,
@@ -9234,7 +9234,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         Set to zero to disable size-based creation of new log files.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 <varname>logging_collector</varname>が有効な場合、このパラメータは個々のログファイルの最大容量を決定します。
 ここで指定したデータ量がログファイルに出力された後、新しいログファイルが生成されます。
 この値が単位なしで指定された場合は、キロバイト単位であるとみなします。
@@ -9256,7 +9256,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When <varname>logging_collector</varname> is enabled,
         this parameter will cause <productname>PostgreSQL</productname> to truncate (overwrite),
         rather than append to, any existing log file of the same name.
@@ -9269,8 +9269,8 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         cyclically overwriting them.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
-       <varname>logging_collector</varname>が有効な場合、このパラメータにより、<productname>PostgreSQL</productname>は既存の同名のファイルに追加するのではなく、そのファイルを切り詰める（上書きする）ようになります。
+-->
+<varname>logging_collector</varname>が有効な場合、このパラメータにより、<productname>PostgreSQL</productname>は既存の同名のファイルに追加するのではなく、そのファイルを切り詰める（上書きする）ようになります。
 しかし、切り詰めは時間を基にしたローテーションのために新規にファイルが開かれた時にのみ発生し、サーバ起動時やサイズを基にしたローテーションでは発生しません。
 偽の場合、全ての場合において既存のファイルは追記されます。
 例えば、この設定を<literal>postgresql-%H.log</literal>のような<varname>log_filename</varname>と組み合わせて使用すると、24個の時別のログファイルが生成され、それらは周期的に上書きされることになります。
@@ -9317,7 +9317,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When logging to <application>syslog</application> is enabled, this parameter
         determines the <application>syslog</application>
         <quote>facility</quote> to be used.  You can choose
@@ -9329,8 +9329,8 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         <application>syslog</application> daemon.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
-       <application>syslog</application>へのログ取得が有効な場合、このパラメータは<application>syslog</application>の<quote>facility</quote>が使われるように確定します。
+-->
+<application>syslog</application>へのログ取得が有効な場合、このパラメータは<application>syslog</application>の<quote>facility</quote>が使われるように確定します。
 <literal>LOCAL0</literal>、<literal>LOCAL1</literal>、<literal>LOCAL2</literal>、<literal>LOCAL3</literal>、<literal>LOCAL4</literal>、<literal>LOCAL5</literal>、<literal>LOCAL6</literal>、<literal>LOCAL7</literal>の中から選んでください。
 デフォルトは<literal>LOCAL0</literal>です。
 使用しているシステムの<application>syslog</application>デーモンの文書を同時に参照してください。
@@ -9350,7 +9350,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
        <listitem>
         <para>
-       <!--
+<!--
          When logging to <application>syslog</application> is enabled, this parameter
          determines the program name used to identify
          <productname>PostgreSQL</productname> messages in
@@ -9358,8 +9358,8 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
          <literal>postgres</literal>.
          This parameter can only be set in the <filename>postgresql.conf</filename>
          file or on the server command line.
-        -->
-        <application>syslog</application>にログ取得が有効な場合、このパラメータは<application>syslog</application>ログ内の<productname>PostgreSQL</productname>メッセージを特定するのに使用するプログラム名を確定します。デフォルトは<literal>postgres</literal>です。
+-->
+<application>syslog</application>にログ取得が有効な場合、このパラメータは<application>syslog</application>ログ内の<productname>PostgreSQL</productname>メッセージを特定するのに使用するプログラム名を確定します。デフォルトは<literal>postgres</literal>です。
 このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
         </para>
        </listitem>
@@ -9467,15 +9467,15 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When logging to <application>event log</application> is enabled, this parameter
         determines the program name used to identify
         <productname>PostgreSQL</productname> messages in
         the log. The default is <literal>PostgreSQL</literal>.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
-       <application>event log</application>へのログ取得が有効になっていると、このパラメータはログ中の<productname>PostgreSQL</productname>メッセージを特定するのに使用されるプログラム名を決定します。デフォルトは<literal>PostgreSQL</literal>です。このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+-->
+<application>event log</application>へのログ取得が有効になっていると、このパラメータはログ中の<productname>PostgreSQL</productname>メッセージを特定するのに使用されるプログラム名を決定します。デフォルトは<literal>PostgreSQL</literal>です。このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
        </para>
       </listitem>
      </varlistentry>
@@ -9483,9 +9483,9 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </variablelist>
     </sect2>
      <sect2 id="runtime-config-logging-when">
-     <!--
+<!--
      <title>When to Log</title>
-     -->
+-->
      <title>いつログを取得するか</title>
 
      <variablelist>
@@ -9514,7 +9514,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         <literal>LOG</literal> has a different rank here than in
         <xref linkend="guc-client-min-messages"/>.
         Only superusers can change this setting.
-       -->
+-->
 どの<link linkend="runtime-config-severity-levels">メッセージレベル</link>をサーバログに書き込むかを管理します。
 有効な値は<literal>DEBUG5</literal>、<literal>DEBUG4</literal>、<literal>DEBUG3</literal>、<literal>DEBUG2</literal>、<literal>DEBUG1</literal>、<literal>INFO</literal>、<literal>NOTICE</literal>、<literal>WARNING</literal>、<literal>ERROR</literal>、<literal>LOG</literal>、<literal>FATAL</literal>、および<literal>PANIC</literal>です。
 それぞれの階層はその下の全ての階層を含みます。階層を低くする程、より少ないメッセージがログに送られます。
@@ -9536,7 +9536,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls which SQL statements that cause an error
         condition are recorded in the server log.  The current
         SQL statement is included in the log entry for any message of
@@ -9555,7 +9555,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         To effectively turn off logging of failing statements,
         set this parameter to <literal>PANIC</literal>.
         Only superusers can change this setting.
-       -->
+-->
 エラー条件の原因となったどのSQL文をサーバログに記録するかを制御します。
 設定した<link linkend="runtime-config-severity-levels">レベル</link>以上のメッセージについては現在のSQL文がログに記録されます。
 有効な値は、<literal>DEBUG5</literal>、<literal>DEBUG4</literal>、<literal>DEBUG3</literal>、<literal>DEBUG2</literal>、<literal>DEBUG1</literal>、<literal>INFO</literal>、<literal>NOTICE</literal>、<literal>WARNING</literal>、<literal>ERROR</literal>、<literal>LOG</literal>、<literal>FATAL</literal>、<literal>PANIC</literal>です。
@@ -9578,7 +9578,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
        <listitem>
         <para>
-       <!--
+<!--
          Causes the duration of each completed statement to be logged
          if the statement ran for at least the specified amount of time.
          For example, if you set it to <literal>250ms</literal>
@@ -9589,7 +9589,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
          Setting this to zero prints all statement durations.
          <literal>-1</literal> (the default) disables logging statement
          durations. Only superusers can change this setting.
-        -->
+-->
 文の実行に少なくとも指定した時間かかった場合、それぞれの文の実行に要した時間をログに記録します。
 例えば、<literal>250ms</literal>と設定した場合、250msもしくはそれ以上長くかかった全てのSQL文がログとして残ります。
 このパラメータを有効にすることにより、アプリケーションで最適化されていない問い合わせを追跡するのが便利になります。
@@ -9609,16 +9609,16 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         </para>
 
         <para>
-       <!--
+<!--
          For clients using extended query protocol, durations of the Parse,
          Bind, and Execute steps are logged independently.
-        -->
-        拡張問い合わせプロトコルを使用するクライアントでは、Parse、Bind、Executeそれぞれの段階で要した時間が独立して記録されます。
+-->
+拡張問い合わせプロトコルを使用するクライアントでは、Parse、Bind、Executeそれぞれの段階で要した時間が独立して記録されます。
         </para>
 
        <note>
         <para>
-       <!--
+<!--
          When using this option together with
          <xref linkend="guc-log-statement"/>,
          the text of statements that are logged because of
@@ -9629,8 +9629,8 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
          <xref linkend="guc-log-line-prefix"/>
          so that you can link the statement message to the later
          duration message using the process ID or session ID.
-        -->
-        このオプションと<xref linkend="guc-log-statement"/>を一緒に使用する時、<varname>log_statement</varname>によってログされるテキスト文は、実行時間のログには重複されません。
+-->
+このオプションと<xref linkend="guc-log-statement"/>を一緒に使用する時、<varname>log_statement</varname>によってログされるテキスト文は、実行時間のログには重複されません。
 <application>syslog</application>を使用していなければ、プロセスIDとセッションIDを使用して、文メッセージと後の実行時間メッセージを関連付けできるように、<xref linkend="guc-log-line-prefix"/>を使用してPIDまたはセッションIDをログに記録することを勧めます。
         </para>
        </note>
@@ -9777,21 +9777,21 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
      </variablelist>
 
     <para>
-    <!--
+<!--
      <xref linkend="runtime-config-severity-levels"/> explains the message
      severity levels used by <productname>PostgreSQL</productname>.  If logging output
      is sent to <systemitem>syslog</systemitem> or Windows'
      <systemitem>eventlog</systemitem>, the severity levels are translated
      as shown in the table.
-     -->
-     <xref linkend="runtime-config-severity-levels"/>で、<productname>PostgreSQL</productname>で使用されるメッセージ深刻度レベルを説明します。
+-->
+<xref linkend="runtime-config-severity-levels"/>で、<productname>PostgreSQL</productname>で使用されるメッセージ深刻度レベルを説明します。
 ログ出力が<systemitem>syslog</systemitem>またはWindowsの<systemitem>eventlog</systemitem>に送られる場合、この深刻度レベルは表で示すように変換されます。
     </para>
 
     <table id="runtime-config-severity-levels">
-    <!--
+<!--
      <title>Message Severity Levels</title>
-     -->
+-->
      <title>メッセージ深刻度レベル</title>
      <tgroup cols="4">
       <colspec colname="col1" colwidth="1*"/>
@@ -9800,13 +9800,13 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       <colspec colname="col4" colwidth="1*"/>
       <thead>
        <row>
-       <!--
+<!--
         <entry>Severity</entry>
         <entry>Usage</entry>
         <entry><systemitem>syslog</systemitem></entry>
         <entry><systemitem>eventlog</systemitem></entry>
-       -->
-       <entry>深刻度</entry>
+-->
+        <entry>深刻度</entry>
         <entry>使用方法</entry>
         <entry><systemitem>syslog</systemitem></entry>
         <entry><systemitem>eventlog</systemitem></entry>
@@ -9816,10 +9816,10 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       <tbody>
        <row>
         <entry><literal>DEBUG1 .. DEBUG5</literal></entry>
-       <!--
+<!--
         <entry>Provides successively-more-detailed information for use by
          developers.</entry>
-        -->
+-->
         <entry>開発者が使用する連続的かつより詳細な情報を提供します。</entry>
         <entry><literal>DEBUG</literal></entry>
         <entry><literal>INFORMATION</literal></entry>
@@ -9827,46 +9827,46 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
 
        <row>
         <entry><literal>INFO</literal></entry>
-       <!--
+<!--
         <entry>Provides information implicitly requested by the user,
          e.g., output from <command>VACUUM VERBOSE</command>.</entry>
-        -->
+-->
         <entry><command>VACUUM VERBOSE</command>の出力などの、
-        ユーザによって暗黙的に要求された情報を提供します。</entry>
+ユーザによって暗黙的に要求された情報を提供します。</entry>
         <entry><literal>INFO</literal></entry>
         <entry><literal>INFORMATION</literal></entry>
        </row>
 
        <row>
         <entry><literal>NOTICE</literal></entry>
-       <!--
+<!--
         <entry>Provides information that might be helpful to users, e.g.,
          notice of truncation of long identifiers.</entry>
-        -->
+-->
         <entry>長い識別子の切り詰めに関する注意など、
-        ユーザの補助になる情報を提供します。</entry>
+ユーザの補助になる情報を提供します。</entry>
         <entry><literal>NOTICE</literal></entry>
         <entry><literal>INFORMATION</literal></entry>
        </row>
 
        <row>
         <entry><literal>WARNING</literal></entry>
-       <!--
+<!--
         <entry>Provides warnings of likely problems, e.g., <command>COMMIT</command>
          outside a transaction block.</entry>
-        -->
+-->
         <entry>トランザクションブロック外での<command>COMMIT</command>の様な、
-        ユーザへの警告を提供します。</entry>
+ユーザへの警告を提供します。</entry>
         <entry><literal>NOTICE</literal></entry>
         <entry><literal>WARNING</literal></entry>
        </row>
 
        <row>
         <entry><literal>ERROR</literal></entry>
-       <!--
+<!--
         <entry>Reports an error that caused the current command to
          abort.</entry>
-        -->
+-->
         <entry>現在のコマンドを中断させる原因となったエラーを報告します。</entry>
         <entry><literal>WARNING</literal></entry>
         <entry><literal>ERROR</literal></entry>
@@ -9874,22 +9874,22 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
 
        <row>
         <entry><literal>LOG</literal></entry>
-       <!--
+<!--
         <entry>Reports information of interest to administrators, e.g.,
          checkpoint activity.</entry>
-        -->
+-->
         <entry>チェックポイントの活動の様な、
-        管理者に関心のある情報を報告します。</entry>
+管理者に関心のある情報を報告します。</entry>
         <entry><literal>INFO</literal></entry>
         <entry><literal>INFORMATION</literal></entry>
        </row>
 
        <row>
         <entry><literal>FATAL</literal></entry>
-       <!--
+<!--
         <entry>Reports an error that caused the current session to
          abort.</entry>
-        -->
+-->
         <entry>現在のセッションを中断させる原因となったエラーを報告します。</entry>
         <entry><literal>ERR</literal></entry>
         <entry><literal>ERROR</literal></entry>
@@ -9897,10 +9897,10 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
 
        <row>
         <entry><literal>PANIC</literal></entry>
-       <!--
+<!--
         <entry>Reports an error that caused all database sessions to abort.</entry>
-       -->
-       <entry>全てのデータベースセッションを中断させる原因となったエラーを報告します。</entry>
+-->
+        <entry>全てのデータベースセッションを中断させる原因となったエラーを報告します。</entry>
         <entry><literal>CRIT</literal></entry>
         <entry><literal>ERROR</literal></entry>
        </row>
@@ -9910,9 +9910,9 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
 
     </sect2>
      <sect2 id="runtime-config-logging-what">
-     <!--
+<!--
      <title>What to Log</title>
-     -->
+-->
      <title>何をログに</title>
 
      <variablelist>
@@ -9928,7 +9928,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The <varname>application_name</varname> can be any string of less than
         <symbol>NAMEDATALEN</symbol> characters (64 characters in a standard build).
         It is typically set by an application upon connection to the server.
@@ -9938,7 +9938,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         Only printable ASCII characters may be used in the
         <varname>application_name</varname> value. Other characters will be
         replaced with question marks (<literal>?</literal>).
-       -->
+-->
 <varname>application_name</varname>は<symbol>NAMEDATALEN</symbol>（標準構築では64）文字以下の任意の文字列を指定できます。
 通常はサーバへの接続時にアプリケーションによって設定されます。
 この名前は <structname>pg_stat_activity</structname>ビューに表示され、CSVログに含まれます。
@@ -9975,7 +9975,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         These parameters enable various debugging output to be emitted.
         When set, they print the resulting parse tree, the query rewriter
         output, or the execution plan for each executed query.
@@ -9985,12 +9985,12 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         <xref linkend="guc-client-min-messages"/> and/or
         <xref linkend="guc-log-min-messages"/>.
         These parameters are off by default.
-       -->
-       これらのパラメータは生成される各種デバッグ出力を有効にします。
-       設定すると実行された問い合わせそれぞれに対し、最終的な解析ツリー、問い合わせリライタの出力、実行計画を出力します。
-       これらのメッセージは<literal>LOG</literal>メッセージレベルで出力されますので、デフォルトではサーバログに出力され、クライアントには渡されません。
-       <xref linkend="guc-client-min-messages"/>、<xref linkend="guc-log-min-messages"/>またはその両方を調整することで変更することができます。
-       デフォルトではこれらのパラメータは無効です。
+-->
+これらのパラメータは生成される各種デバッグ出力を有効にします。
+設定すると実行された問い合わせそれぞれに対し、最終的な解析ツリー、問い合わせリライタの出力、実行計画を出力します。
+これらのメッセージは<literal>LOG</literal>メッセージレベルで出力されますので、デフォルトではサーバログに出力され、クライアントには渡されません。
+<xref linkend="guc-client-min-messages"/>、<xref linkend="guc-log-min-messages"/>またはその両方を調整することで変更することができます。
+デフォルトではこれらのパラメータは無効です。
        </para>
       </listitem>
      </varlistentry>
@@ -10006,14 +10006,14 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When set, <varname>debug_pretty_print</varname> indents the messages
         produced by <varname>debug_print_parse</varname>,
         <varname>debug_print_rewritten</varname>, or
         <varname>debug_print_plan</varname>.  This results in more readable
         but much longer output than the <quote>compact</quote> format used when
         it is off.  It is on by default.
-       -->
+-->
 設定された場合、<varname>debug_pretty_print</varname>は<varname>debug_print_parse</varname>、<varname>debug_print_rewritten</varname>、または<varname>debug_print_plan</varname>で生成されたメッセージを字下げします。
 設定されない場合の<quote>コンパクト</quote>形式よりもより見やすく、しかしより長いものとなります。デフォルトは有効です。
        </para>
@@ -10073,15 +10073,15 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Causes checkpoints and restartpoints to be logged in the server log.
         Some statistics are included in the log messages, including the number
         of buffers written and the time spent writing them.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line. The default is off.
-       -->
-       チェックポイントおよびリスタートポイントをサーバログに記録するようにします。
-       書き出されたバッファ数や書き出しに要した時間など、いくつかの統計情報がこのログメッセージに含まれます。
+-->
+チェックポイントおよびリスタートポイントをサーバログに記録するようにします。
+書き出されたバッファ数や書き出しに要した時間など、いくつかの統計情報がこのログメッセージに含まれます。
 このパラメータは<filename>postgresql.conf</filename>ファイルまたはサーバのコマンドラインでのみ設定可能です。
 デフォルトはoffです。
        </para>
@@ -10099,14 +10099,14 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Causes each attempted connection to the server to be logged,
         as well as successful completion of both client authentication (if
         necessary) and authorization.
         Only superusers can change this parameter at session start,
         and it cannot be changed at all within a session.
         The default is <literal>off</literal>.
-       -->
+-->
 サーバへの接続試行とともに、クライアント認証の成功終了と（必要ならば）承認をログに残します。
 スーパーユーザだけがセッション開始時にこのパラメータを変更でき、セッションが開始された後は変更できません。
 デフォルトは<literal>off</literal>です。
@@ -10114,13 +10114,13 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
 
        <note>
         <para>
-       <!--
+<!--
          Some client programs, like <application>psql</application>, attempt
          to connect twice while determining if a password is required, so
          duplicate <quote>connection received</quote> messages do not
          necessarily indicate a problem.
-        -->
-        <application>psql</application>などクライアントプログラムは、パスワードが要求されているかどうか確認するまで2回接続を試みるので、二重の<quote>connection received</quote>メッセージは必ずしも問題を示すものではありません。
+-->
+<application>psql</application>などクライアントプログラムは、パスワードが要求されているかどうか確認するまで2回接続を試みるので、二重の<quote>connection received</quote>メッセージは必ずしも問題を示すものではありません。
         </para>
        </note>
       </listitem>
@@ -10137,14 +10137,14 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Causes session terminations to be logged.  The log output
         provides information similar to <varname>log_connections</varname>,
         plus the duration of the session.
         Only superusers can change this parameter at session start,
         and it cannot be changed at all within a session.
         The default is <literal>off</literal>.
-       -->
+-->
 セッションの終了をログします。
 ログ出力の情報は<varname>log_connections</varname>と同様で、更にセッションの経過時間が追加されます。
 スーパーユーザだけがセッション開始時にこのパラメータを変更でき、セッションが開始された後は変更できません。
@@ -10165,27 +10165,27 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Causes the duration of every completed statement to be logged.
         The default is <literal>off</literal>.
         Only superusers can change this setting.
-       -->
-       すべての完了した文について、その経過時間をログするようにします。
+-->
+すべての完了した文について、その経過時間をログするようにします。
 デフォルトは<literal>off</literal>です。
 スーパーユーザのみがこの設定を変更することができます。
        </para>
 
        <para>
-       <!--
+<!--
         For clients using extended query protocol, durations of the Parse,
         Bind, and Execute steps are logged independently.
-       -->
-       拡張問い合わせプロトコルを使用するクライアントでは、Parse、Bind、Executeそれぞれの段階で要した時間が独立して記録されます。
+-->
+拡張問い合わせプロトコルを使用するクライアントでは、Parse、Bind、Executeそれぞれの段階で要した時間が独立して記録されます。
        </para>
 
        <note>
         <para>
-       <!--
+<!--
          The difference between enabling <varname>log_duration</varname> and setting
          <xref linkend="guc-log-min-duration-statement"/> to zero is that
          exceeding <varname>log_min_duration_statement</varname> forces the text of
@@ -10195,7 +10195,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
          durations are logged but the query text is included only for
          statements exceeding the threshold.  This behavior can be useful for
          gathering statistics in high-load installations.
-        -->
+-->
 <varname>log_duration</varname>を有効にするのと<xref linkend="guc-log-min-duration-statement"/>を0に設定する方法との違いは、<varname>log_min_duration_statement</varname>を超えた場合、テキスト版の問い合わせが強制的に出力されるのに対して、このオプションでは出力されないという点です。
 したがって、<varname>log_duration</varname>が<literal>on</literal>、かつ、<varname>log_min_duration_statement</varname>が正の値を持つ場合、すべての経過時間がログに記録されますが、閾値を超えた文のみがテキスト版の問い合わせが含められるようになります。
 この動作は、高負荷なインストレーションで統計情報を収集する際に有用です。
@@ -10215,7 +10215,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls the amount of detail written in the server log for each
         message that is logged.  Valid values are <literal>TERSE</literal>,
         <literal>DEFAULT</literal>, and <literal>VERBOSE</literal>, each adding more
@@ -10226,12 +10226,12 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         code (see also <xref linkend="errcodes-appendix"/>) and the source code file name, function name,
         and line number that generated the error.
         Only superusers can change this setting.
-       -->
-       ログ取得されるそれぞれのメッセージに対し、サーバログに書き込まれる詳細の量を制御します。
-       有効な値は、<literal>TERSE</literal>、<literal>DEFAULT</literal>、および<literal>VERBOSE</literal>で、それぞれは表示されるメッセージにより多くのフィールドを追加します。
+-->
+ログ取得されるそれぞれのメッセージに対し、サーバログに書き込まれる詳細の量を制御します。
+有効な値は、<literal>TERSE</literal>、<literal>DEFAULT</literal>、および<literal>VERBOSE</literal>で、それぞれは表示されるメッセージにより多くのフィールドを追加します。
        <literal>TERSE</literal>は<literal>DETAIL</literal>、<literal>HINT</literal>、<literal>QUERY</literal>、および<literal>CONTEXT</literal>エラー情報を除外します。
        <literal>VERBOSE</literal>出力は、<symbol>SQLSTATE</symbol>エラーコード（<xref linkend="errcodes-appendix"/>も参照）、および、ソースコードファイル名、関数名、そしてエラーを生成した行番号を含みます。
-       スーパーユーザのみこの設定を変更できます。
+スーパーユーザのみこの設定を変更できます。
        </para>
       </listitem>
      </varlistentry>
@@ -10247,15 +10247,15 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         By default, connection log messages only show the IP address of the
         connecting host. Turning this parameter on causes logging of the
         host name as well.  Note that depending on your host name resolution
         setup this might impose a non-negligible performance penalty.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
-       デフォルトでは、接続ログメッセージは接続元ホストのIPアドレスのみを表示します。
+-->
+デフォルトでは、接続ログメッセージは接続元ホストのIPアドレスのみを表示します。
 このパラメータを有効にすると、ホスト名もログに残るようになります。
 ホスト名解決方法の設定に依存しますが、これが無視できないほどの性能劣化を起こす可能性があることに注意してください。
 このパラメータは<filename>postgresql.conf</filename>ファイル内またはサーバのコマンドラインでのみ設定可能です。
@@ -10274,7 +10274,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
          This is a <function>printf</function>-style string that is output at the
          beginning of each log line.
          <literal>%</literal> characters begin <quote>escape sequences</quote>
@@ -10289,7 +10289,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
          right with spaces to give it a minimum width, whereas a positive
          value will pad on the left. Padding can be useful to aid human
          readability in log files.
-         -->
+-->
 これは、各ログ行の先頭に出力する<function>printf</function>の書式文字列です。
 <literal>%</literal>から始まる<quote>エスケープシーケンス</quote>は、後述の通りのステータス情報で置き換えられます。
 この他のエスケープは無視されます。
@@ -10314,11 +10314,11 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
           <tgroup cols="3">
            <thead>
             <row>
-           <!--
+<!--
              <entry>Escape</entry>
              <entry>Effect</entry>
              <entry>Session only</entry>
-            -->
+-->
             <entry>エスケープ</entry>
              <entry>効果</entry>
              <entry>セッションのみ</entry>
@@ -10327,160 +10327,179 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
            <tbody>
             <row>
              <entry><literal>%a</literal></entry>
-            <!--
+<!--
              <entry>Application name</entry>
-            -->
-            <entry>アプリケーション名</entry>
-             <entry><!--yes-->○</entry>
+             <entry>yes</entry>
+-->
+             <entry>アプリケーション名</entry>
+             <entry>○</entry>
             </row>
             <row>
              <entry><literal>%u</literal></entry>
-            <!--
+<!--
              <entry>User name</entry>
-            -->
-            <entry>ユーザ名</entry>
-             <entry><!--yes-->○</entry>
+             <entry>yes</entry>
+-->
+             <entry>ユーザ名</entry>
+             <entry>○</entry>
             </row>
             <row>
              <entry><literal>%d</literal></entry>
-            <!--
+<!--
              <entry>Database name</entry>
-            -->
-            <entry>データベース名</entry>
-             <entry><!--yes-->○</entry>
+             <entry>yes</entry>
+-->
+             <entry>データベース名</entry>
+             <entry>○</entry>
             </row>
             <row>
              <entry><literal>%r</literal></entry>
-            <!--
+<!--
              <entry>Remote host name or IP address, and remote port</entry>
-            -->
-            <entry>遠隔ホスト名、またはIPアドレス、およびポート番号</entry>
-             <entry><!--yes-->○</entry>
+             <entry>yes</entry>
+-->
+             <entry>遠隔ホスト名、またはIPアドレス、およびポート番号</entry>
+             <entry>○</entry>
             </row>
             <row>
              <entry><literal>%h</literal></entry>
-            <!--
+<!--
              <entry>Remote host name or IP address</entry>
-            -->
-            <entry>遠隔ホスト名、またはIPアドレス</entry>
-             <entry><!--yes-->○</entry>
+             <entry>yes</entry>
+-->
+             <entry>遠隔ホスト名、またはIPアドレス</entry>
+             <entry>○</entry>
             </row>
             <row>
              <entry><literal>%b</literal></entry>
 <!--
              <entry>Backend type</entry>
+             <entry>no</entry>
 -->
              <entry>バックエンドタイプ</entry>
-             <entry><!--no-->×</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%p</literal></entry>
-            <!--
+<!--
              <entry>Process ID</entry>
-            -->
-            <entry>プロセス識別子</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>プロセス識別子</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%P</literal></entry>
 <!--
              <entry>Process ID of the parallel group leader, if this process
               is a parallel query worker</entry>
+             <entry>no</entry>
 -->
 <entry>このプロセスがパラレルクエリワーカである場合に、パラレルグループリーダのプロセス識別子</entry>
-             <entry><!--no-->×</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%t</literal></entry>
-            <!--
+<!--
              <entry>Time stamp without milliseconds</entry>
-            -->
-            <entry>ミリ秒無しのタイムスタンプ</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>ミリ秒無しのタイムスタンプ</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%m</literal></entry>
-            <!--
+<!--
              <entry>Time stamp with milliseconds</entry>
-            -->
-            <entry>ミリ秒付きタイムスタンプ</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>ミリ秒付きタイムスタンプ</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%n</literal></entry>
 <!--
              <entry>Time stamp with milliseconds (as a Unix epoch)</entry>
+             <entry>no</entry>
 -->
              <entry>ミリ秒付きタイムスタンプ（Unixエポックとして）</entry>
-             <entry><!--no-->×</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%i</literal></entry>
-            <!--
+<!--
              <entry>Command tag: type of session's current command</entry>
-            -->
-            <entry>コマンドタグ。セッションの現在のコマンド種類</entry>
-             <entry><!--yes-->○</entry>
+             <entry>yes</entry>
+-->
+             <entry>コマンドタグ。セッションの現在のコマンド種類</entry>
+             <entry>○</entry>
             </row>
             <row>
              <entry><literal>%e</literal></entry>
-            <!--
+<!--
              <entry>SQLSTATE error code</entry>
-            -->
-            <entry>SQLSTATE エラーコード</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>SQLSTATE エラーコード</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%c</literal></entry>
-            <!--
+<!--
              <entry>Session ID: see below</entry>
-            -->
-            <entry>セッションID。下記参照</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>セッションID。下記参照</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%l</literal></entry>
-            <!--
+<!--
              <entry>Number of the log line for each session or process, starting at 1</entry>
-            -->
-            <entry>各セッションまたは各プロセスのログ行の番号。1から始まります。</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>各セッションまたは各プロセスのログ行の番号。1から始まります。</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%s</literal></entry>
-            <!--
+<!--
              <entry>Process start time stamp</entry>
-            -->
-            <entry>プロセスの開始タイムスタンプ</entry>
-            <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>プロセスの開始タイムスタンプ</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%v</literal></entry>
-            <!--
+<!--
              <entry>Virtual transaction ID (backendID/localXID)</entry>
-            -->
-            <entry>仮想トランザクションID（backendID/localXID）</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>仮想トランザクションID（backendID/localXID）</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%x</literal></entry>
-            <!--
+<!--
              <entry>Transaction ID (0 if none is assigned)</entry>
-            -->
-            <entry>トランザクションID （未割り当ての場合は0）</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>トランザクションID （未割り当ての場合は0）</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%q</literal></entry>
-            <!--
+<!--
              <entry>Produces no output, but tells non-session
              processes to stop at this point in the string; ignored by
              session processes</entry>
-            -->
-            <entry>何も出力しません。
-            非セッションプロセスではこのエスケープ以降の出力を停止します。
-            セッションプロセスでは無視されます。</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>何も出力しません。
+非セッションプロセスではこのエスケープ以降の出力を停止します。
+セッションプロセスでは無視されます。</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%Q</literal></entry>
@@ -10490,18 +10509,20 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
              will be zero unless <xref linkend="guc-compute-query-id"/>
              parameter is enabled or a third-party module that computes
              query identifiers is configured.</entry>
+             <entry>yes</entry>
 -->
              <entry>現在の問い合わせの問い合わせ識別子。
-               問い合わせ識別子はデフォルトでは計算されません。ですから<xref linkend="guc-compute-query-id"/>パラメータが有効であるか、あるいは問い合わせ識別子を計算するサードパーティのモジュールが設定されていないければゼロとなります。</entry>
-             <entry><!--yes-->○</entry>
+問い合わせ識別子はデフォルトでは計算されません。ですから<xref linkend="guc-compute-query-id"/>パラメータが有効であるか、あるいは問い合わせ識別子を計算するサードパーティのモジュールが設定されていないければゼロとなります。</entry>
+             <entry>○</entry>
             </row>
             <row>
              <entry><literal>%%</literal></entry>
-            <!--
+<!--
              <entry>Literal <literal>%</literal></entry>
-            -->
-            <entry><literal>%</literal>文字そのもの</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry><literal>%</literal>文字そのもの</entry>
+             <entry>×</entry>
             </row>
            </tbody>
           </tgroup>
@@ -10520,15 +10541,15 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
          </para>
 
          <para>
-        <!--
+<!--
          The <literal>%c</literal> escape prints a quasi-unique session identifier,
          consisting of two 4-byte hexadecimal numbers (without leading zeros)
          separated by a dot.  The numbers are the process start time and the
          process ID, so <literal>%c</literal> can also be used as a space saving way
          of printing those items.  For example, to generate the session
          identifier from <literal>pg_stat_activity</literal>, use this query:
-        -->
-        <literal>%c</literal>エスケープは、2つの4バイトの16進数（先頭のゼロは省略）をドットで区切った構成の、準一意なセッション識別子を表示します。
+-->
+<literal>%c</literal>エスケープは、2つの4バイトの16進数（先頭のゼロは省略）をドットで区切った構成の、準一意なセッション識別子を表示します。
 この数値はプロセスの起動時間とそのプロセスIDです。
 したがって、<literal>%c</literal>を使用して、これらの項目を出力するための文字数を省略することができます。例として、<literal>pg_stat_activity</literal>からセッション識別子を生成するには以下の問い合わせを行ないます。
 <programlisting>
@@ -10541,25 +10562,25 @@ FROM pg_stat_activity;
 
        <tip>
         <para>
-       <!--
+<!--
          If you set a nonempty value for <varname>log_line_prefix</varname>,
          you should usually make its last character be a space, to provide
          visual separation from the rest of the log line.  A punctuation
          character can be used too.
-        -->
-        <varname>log_line_prefix</varname>に空白文字以外の値を設定する場合、通常、ログ行の残りとの区切りを明確にするために、その最後の文字を空白文字にすべきです。
+-->
+<varname>log_line_prefix</varname>に空白文字以外の値を設定する場合、通常、ログ行の残りとの区切りを明確にするために、その最後の文字を空白文字にすべきです。
 句読点用の文字も使用できます。
         </para>
        </tip>
 
        <tip>
         <para>
-       <!--
+<!--
          <application>Syslog</application> produces its own
          time stamp and process ID information, so you probably do not want to
          include those escapes if you are logging to <application>syslog</application>.
-        -->
-        <application>Syslog</application>は独自にタイムスタンプとプロセスID情報を生成します。
+-->
+<application>Syslog</application>は独自にタイムスタンプとプロセスID情報を生成します。
 ですのでおそらく、<application>Syslog</application>にログを保管する場合は、こうしたエスケープを含めるとは考えないでしょう。
         </para>
        </tip>
@@ -10605,13 +10626,13 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls whether a log message is produced when a session waits
         longer than <xref linkend="guc-deadlock-timeout"/> to acquire a
         lock.  This is useful in determining if lock waits are causing
         poor performance.  The default is <literal>off</literal>.
         Only superusers can change this setting.
-       -->
+-->
 セッションがロックの獲得までの間に<xref linkend="guc-deadlock-timeout"/>より長く待機する場合にログメッセージを生成するかどうかを制御します。
 これは、ロック待ちによって性能がでていないのかどうか確認する時に有用です。
 デフォルトは<literal>off</literal>です。
@@ -10749,7 +10770,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls which SQL statements are logged. Valid values are
         <literal>none</literal> (off), <literal>ddl</literal>, <literal>mod</literal>, and
         <literal>all</literal> (all statements). <literal>ddl</literal> logs all data definition
@@ -10765,7 +10786,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
         extended query protocol, logging occurs when an Execute message
         is received, and values of the Bind parameters are included
         (with any embedded single-quote marks doubled).
-       -->
+-->
 どのSQL文をログに記録するかを制御します。
 有効な値は、<literal>none</literal>（off）、<literal>ddl</literal>、<literal>mod</literal>、および<literal>all</literal>（全てのメッセージ）です。
 <literal>ddl</literal>は、<command>CREATE</command>、<command>ALTER</command>、および<command>DROP</command>文といった、データ定義文を全てログに記録します。
@@ -10775,16 +10796,16 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
        </para>
 
        <para>
-       <!--
+<!--
         The default is <literal>none</literal>. Only superusers can change this
         setting.
-       -->
-       デフォルトは<literal>none</literal>です。スーパーユーザのみこの設定を変更できます。
+-->
+デフォルトは<literal>none</literal>です。スーパーユーザのみこの設定を変更できます。
        </para>
 
        <note>
         <para>
-       <!--
+<!--
          Statements that contain simple syntax errors are not logged
          even by the <varname>log_statement</varname> = <literal>all</literal> setting,
          because the log message is emitted only after basic parsing has
@@ -10793,7 +10814,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
          fail before the Execute phase (i.e., during parse analysis or
          planning).  Set <varname>log_min_error_statement</varname> to
          <literal>ERROR</literal> (or lower) to log such statements.
-        -->
+-->
 ログメッセージの発行は、基本解析により文の種類が決まった後に行われますので、<varname>log_statement</varname> = <literal>all</literal>という設定を行ったとしても、単純な構文エラーを持つ文は記録されません。
 拡張問い合わせプロトコルの場合も同様に、この設定ではExecute段階以前（つまり、解析や計画作成期間）に失敗した文は記録されません。
 こうした文のログを記録するには、<varname>log_min_error_statement</varname>を<literal>ERROR</literal>（以下）に設定してください。
@@ -10838,7 +10859,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls logging of temporary file names and sizes.
         Temporary files can be
         created for sorts, hashes, and temporary query results.
@@ -10850,7 +10871,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
         If this value is specified without units, it is taken as kilobytes.
         The default setting is -1, which disables such logging.
         Only superusers can change this setting.
-       -->
+-->
 一時ファイルのファイル名とサイズのログ出力を制御します。
 一時ファイルはソート処理やハッシュ処理、一時的な問い合わせの結果のために作成されます。
 有効にすると、ログの項目はすべての一時ファイルそれぞれについて削除されたときに生成されます。
@@ -10874,7 +10895,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the time zone used for timestamps written in the server log.
         Unlike <xref linkend="guc-timezone"/>, this value is cluster-wide,
         so that all sessions will report timestamps consistently.
@@ -10884,7 +10905,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
         See <xref linkend="datatype-timezones"/> for more information.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 サーバログに書き出す際に使用される時間帯を設定します。
 <xref linkend="guc-timezone"/>と異なり、すべてのセッションで一貫性を持ってタイムスタンプが報告されるようにこの値はクラスタ全体に適用されます。
 組み込まれているデフォルトは<literal>GMT</literal>ですが、<filename>postgresql.conf</filename>により通常は上書きされます。<application>initdb</application>によりこれらと関連した設定をシステム環境にインストールされます。
@@ -10897,13 +10918,13 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      </variablelist>
     </sect2>
      <sect2 id="runtime-config-logging-csvlog">
-     <!--
+<!--
      <title>Using CSV-Format Log Output</title>
-     -->
+-->
      <title>CSV書式のログ出力の利用</title>
 
        <para>
-       <!--
+<!--
         Including <literal>csvlog</literal> in the <varname>log_destination</varname> list
         provides a convenient way to import log files into a database table.
         This option emits log lines in comma-separated-values
@@ -10936,29 +10957,29 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
         application name, backend type, process ID of parallel group leader,
         and query id.
         Here is a sample table definition for storing CSV-format log output:
-       -->
-       <varname>log_destination</varname>リストに<literal>csvlog</literal>を含めることは、ログファイルをデータベーステーブルにインポートする簡便な方法を提供します。このオプションはカンマ区切り値書式（<acronym>CSV</acronym>）で以下の列を含むログ行を生成します。
-        ミリ秒単位のtimestamp、
-        ユーザ名、
-        データベース名、
-        プロセス識別子、
-        クライアントホスト：ポート番号、
-        セッション識別子、
-        セッション前行番号、
-        コマンドタグ、
-        セッション開始時間、
-        仮想トランザクション識別子、
-        通常トランザクション識別子、
-        エラーの深刻度、
-        SQL状態コード、
-        エラーメッセージ、
-        詳細エラーメッセージ、
-        ヒント、
-        エラーとなった内部的な問い合わせ（もしあれば）、
-        内部問い合わせにおけるエラー位置の文字数、
-        エラーの文脈、
-        PostgreSQLソースコード上のエラー発生場所（<varname>log_error_verbosity</varname>が<literal>verbose</literal>に設定されているならば）
-        アプリケーション名、バックエンドタイプ、パラレルグループリーダのプロセスID、問い合わせID。
+-->
+<varname>log_destination</varname>リストに<literal>csvlog</literal>を含めることは、ログファイルをデータベーステーブルにインポートする簡便な方法を提供します。このオプションはカンマ区切り値書式（<acronym>CSV</acronym>）で以下の列を含むログ行を生成します。
+ミリ秒単位のtimestamp、
+ユーザ名、
+データベース名、
+プロセス識別子、
+クライアントホスト：ポート番号、
+セッション識別子、
+セッション前行番号、
+コマンドタグ、
+セッション開始時間、
+仮想トランザクション識別子、
+通常トランザクション識別子、
+エラーの深刻度、
+SQL状態コード、
+エラーメッセージ、
+詳細エラーメッセージ、
+ヒント、
+エラーとなった内部的な問い合わせ（もしあれば）、
+内部問い合わせにおけるエラー位置の文字数、
+エラーの文脈、
+PostgreSQLソースコード上のエラー発生場所（<varname>log_error_verbosity</varname>が<literal>verbose</literal>に設定されているならば）
+アプリケーション名、バックエンドタイプ、パラレルグループリーダのプロセスID、問い合わせID。
 以下にcsvlog出力を格納するためのテーブル定義のサンプルを示します。
 
 <programlisting>
@@ -10996,11 +11017,11 @@ CREATE TABLE postgres_log
        </para>
 
        <para>
-       <!--
+<!--
         To import a log file into this table, use the <command>COPY FROM</command>
         command:
-       -->
-       このテーブルにインポートするためには、<command>COPY FROM</command>コマンドを使用してください。
+-->
+このテーブルにインポートするためには、<command>COPY FROM</command>コマンドを使用してください。
 
 <programlisting>
 COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
@@ -11013,35 +11034,35 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
        </para>
 
        <para>
-       <!--
+<!--
        There are a few things you need to do to simplify importing CSV log
        files:
-       -->
+-->
        CSVログファイルをインポートする作業を単純にするためにいくつか必要な作業があります。
 
        <orderedlist>
          <listitem>
            <para>
-          <!--
+<!--
             Set <varname>log_filename</varname> and
             <varname>log_rotation_age</varname> to provide a consistent,
             predictable naming scheme for your log files.  This lets you
             predict what the file name will be and know when an individual log
             file is complete and therefore ready to be imported.
-           -->
-           一貫性があり、予測可能なログファイル命名機構を提供するために、<varname>log_filename</varname>および<varname>log_rotation_age</varname>を設定してください。
+-->
+一貫性があり、予測可能なログファイル命名機構を提供するために、<varname>log_filename</varname>および<varname>log_rotation_age</varname>を設定してください。
 これによりどのようなファイル名になると、個々のログファイルが完了しインポートする準備が整ったかが推測できるようになります。
          </para>
         </listitem>
 
         <listitem>
            <para>
-          <!--
+<!--
             Set <varname>log_rotation_size</varname> to 0 to disable
             size-based log rotation, as it makes the log file name difficult
             to predict.
-           -->
-           ログファイル名の予測が困難になりますので、<varname>log_rotation_size</varname>を0にして容量を基にしたログの回転を無効にしてください。
+-->
+ログファイル名の予測が困難になりますので、<varname>log_rotation_size</varname>を0にして容量を基にしたログの回転を無効にしてください。
            </para>
         </listitem>
 
@@ -11057,7 +11078,7 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
 
         <listitem>
           <para>
-         <!--
+<!--
            The table definition above includes a primary key specification.
            This is useful to protect against accidentally importing the same
            information twice.  The <command>COPY</command> command commits all of the
@@ -11068,8 +11089,8 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
            closed before importing.  This procedure will also protect against
            accidentally importing a partial line that hasn't been completely
            written, which would also cause <command>COPY</command> to fail.
-          -->
-          上のテーブル定義には主キーの指定が含まれています。
+-->
+上のテーブル定義には主キーの指定が含まれています。
 これにより、同じ情報が2回インポートされる事故を防止するために有用です。
 <command>COPY</command>コマンドは、一度にインポートするすべてのデータをコミットしますので、何か1つでもエラーがあればインポート全体が失敗します。
 ログファイルの一部をインポートし、そのファイルが完了した後に再度インポートしようとした場合、主キー違反によりインポートが失敗します。
@@ -11173,26 +11194,26 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
   </sect1>
 
    <sect1 id="runtime-config-statistics">
-   <!--
+<!--
     <title>Run-time Statistics</title>
-    -->
+-->
     <title>実行時統計情報</title>
 
     <sect2 id="runtime-config-statistics-collector">
-    <!--
+<!--
      <title>Query and Index Statistics Collector</title>
-     -->
+-->
      <title>問い合わせおよびインデックスに関する統計情報コレクタ</title>
 
      <para>
-     <!--
+<!--
       These parameters control server-wide statistics collection features.
       When statistics collection is enabled, the data that is produced can be
       accessed via the <structname>pg_stat</structname> and
       <structname>pg_statio</structname> family of system views.
       Refer to <xref linkend="monitoring"/> for more information.
-      -->
-      これらのパラメータは、サーバ全体の統計情報収集機能を制御します。
+-->
+これらのパラメータは、サーバ全体の統計情報収集機能を制御します。
 統計情報収集が有効ならば、生成されるデータは<structname>pg_stat</structname>と<structname>pg_statio</structname>系のシステムビュー経由でアクセス可能です。
 詳細は<xref linkend="monitoring"/>を参照してください。
      </para>
@@ -11210,7 +11231,7 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables the collection of information on the currently
         executing command of each session, along with its identifier and the
         time when that command began execution. This parameter is on by
@@ -11219,7 +11240,7 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
         the session being reported on, so it should not represent a
         security risk.
         Only superusers can change this setting.
-       -->
+-->
 各セッションで実行中のコマンドに関する情報と、そのコマンドの識別子および実行開始時刻の収集を有効にします。
 このパラメータはデフォルトで有効です。
 有効な場合であっても、すべてのユーザがこの情報を見ることができず、スーパーユーザと報告されたセッションの所有者のみから可視である点に注意してください。
@@ -11240,14 +11261,14 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
       </term>
       <listitem>
        <para>
-       <!--
+<!--
        Specifies the amount of memory reserved to store the text of the
        currently executing command for each active session, for the
        <structname>pg_stat_activity</structname>.<structfield>query</structfield> field.
        If this value is specified without units, it is taken as bytes.
        The default value is 1024 bytes.
        This parameter can only be set at server start.
-       -->
+-->
 <structname>pg_stat_activity</structname>.<structfield>query</structfield>フィールドに対し、それぞれの活動中のセッションで現在実行されているコマンドを追跡記録するため予約されるメモリ量を指定します。
 この値が単位なしで指定された場合は、バイト単位であるとみなします。
 デフォルトの値は1024バイトです。
@@ -11267,12 +11288,12 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables collection of statistics on database activity.
         This parameter is on by default, because the autovacuum
         daemon needs the collected information.
         Only superusers can change this setting.
-       -->
+-->
 データベースの活動についての統計情報の収集を有効にします。
 収集される情報を自動バキュームデーモンが必要とするため、このオプションはデフォルトで有効です。
 スーパーユーザのみがこの設定を変更することができます。
@@ -11358,28 +11379,28 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables tracking of function call counts and time used. Specify
         <literal>pl</literal> to track only procedural-language functions,
         <literal>all</literal> to also track SQL and C language functions.
         The default is <literal>none</literal>, which disables function
         statistics tracking.  Only superusers can change this setting.
-       -->
-       関数の呼び出し数と費やされた時間の追跡を有効にします。
-       手続き言語関数のみを追跡するためには<literal>pl</literal>と指定してください。
+-->
+関数の呼び出し数と費やされた時間の追跡を有効にします。
+手続き言語関数のみを追跡するためには<literal>pl</literal>と指定してください。
        SQL関数、C言語関数も追跡するためには<literal>all</literal>と指定してください。
-       デフォルトは、統計情報追跡機能を無効にする<literal>none</literal>です。
-       スーパーユーザのみがこの設定を変更できます。
+デフォルトは、統計情報追跡機能を無効にする<literal>none</literal>です。
+スーパーユーザのみがこの設定を変更できます。
        </para>
 
        <note>
         <para>
-       <!--
+<!--
          SQL-language functions that are simple enough to be <quote>inlined</quote>
          into the calling query will not be tracked, regardless of this
          setting.
-        -->
-        呼び出す問い合わせ内に<quote>インライン化</quote>できる位単純なSQL言語関数は、この設定と関係なく、追跡されません。
+-->
+呼び出す問い合わせ内に<quote>インライン化</quote>できる位単純なSQL言語関数は、この設定と関係なく、追跡されません。
         </para>
        </note>
       </listitem>
@@ -11396,7 +11417,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the directory to store temporary statistics data in. This can be
         a path relative to the data directory or an absolute path. The default
         is <filename>pg_stat_tmp</filename>. Pointing this at a RAM-based
@@ -11404,12 +11425,12 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         improved performance.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
-       統計情報データを一時的に格納するディレクトリを設定します。
-       これをデータディレクトリからの相対パスとすることも絶対パスとすることもできます。
-       デフォルトは<filename>pg_stat_tmp</filename>です。
-       これをRAMベースのファイルシステムを指し示すようにすることで物理I/O要求が減り、性能を向上させることができます。
-       このパラメータは、<filename>postgresql.conf</filename>ファイルまたはサーバのコマンドラインのみで設定可能です。
+-->
+統計情報データを一時的に格納するディレクトリを設定します。
+これをデータディレクトリからの相対パスとすることも絶対パスとすることもできます。
+デフォルトは<filename>pg_stat_tmp</filename>です。
+これをRAMベースのファイルシステムを指し示すようにすることで物理I/O要求が減り、性能を向上させることができます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルまたはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -11418,9 +11439,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
     </sect2>
 
     <sect2 id="runtime-config-statistics-monitor">
-    <!--
+<!--
      <title>Statistics Monitoring</title>
-     -->
+-->
      <title>統計情報の監視</title>
      <variablelist>
 
@@ -11508,7 +11529,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         For each query, output performance statistics of the respective
         module to the server log. This is a crude profiling
         instrument, similar to the Unix <function>getrusage()</function> operating
@@ -11517,8 +11538,8 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         <varname>log_statement_stats</varname> cannot be enabled together with
         any of the per-module options.  All of these options are disabled by
         default.   Only superusers can change these settings.
-       -->
-       各問い合わせに対し、対応するモジュールの性能に関する統計情報をサーバログに出力します。
+-->
+各問い合わせに対し、対応するモジュールの性能に関する統計情報をサーバログに出力します。
 これは、Unixの<function>getrusage()</function>オペレーティングシステム機能に類似した、雑なプロファイリング手段です。
 <varname>log_statement_stats</varname>は文に関する統計情報全体を、この他はモジュール毎の統計情報を報告します。
 <varname>log_statement_stats</varname>とモジュール毎のオプションを一緒に有効にすることはできません。
@@ -11534,26 +11555,26 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
    </sect1>
 
    <sect1 id="runtime-config-autovacuum">
-   <!--
+<!--
     <title>Automatic Vacuuming</title>
-    -->
+-->
     <title>自動Vacuum作業</title>
 
     <indexterm>
      <primary>autovacuum</primary>
-     <!--
+<!--
      <secondary>configuration parameters</secondary>
-     -->
+-->
      <secondary>設定パラメータ</secondary>
     </indexterm>
 
      <para>
-     <!--
+<!--
       These settings control the behavior of the <firstterm>autovacuum</firstterm>
       feature.  Refer to <xref linkend="autovacuum"/> for more information.
       Note that many of these settings can be overridden on a per-table
       basis; see <xref linkend="sql-createtable-storage-parameters"/>.
-      -->
+-->
 以下に示す設定は<firstterm>自動バキューム</firstterm>機能の動作を制御します。
 詳細は<xref linkend="autovacuum"/>を参照してください。
 これらの設定の多くは、テーブル単位で変更できることに注意してください。
@@ -11573,7 +11594,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls whether the server should run the
         autovacuum launcher daemon.  This is on by default; however,
         <xref linkend="guc-track-counts"/> must also be enabled for
@@ -11581,21 +11602,21 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line; however, autovacuuming can be
         disabled for individual tables by changing table storage parameters.
-       -->
-       サーバがautovacuumランチャデーモンを実行すべきかどうかを管理します。
+-->
+サーバがautovacuumランチャデーモンを実行すべきかどうかを管理します。
 デフォルトでは有効です。
 しかしautovacuumを作動させるためには<xref linkend="guc-track-counts"/>も有効でなければなりません。
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
 ただし、テーブルストレージパラメータを変更することにより、autovacuumは個々のテーブルに対して無効にできます。
        </para>
        <para>
-       <!--
+<!--
         Note that even when this parameter is disabled, the system
         will launch autovacuum processes if necessary to
         prevent transaction ID wraparound.  See <xref
         linkend="vacuum-for-wraparound"/> for more information.
-       -->
-       このパラメータが無効であったとしてもシステムは、トランザクションIDの周回を防止する必要があれば、autovacuumプロセスを起動することに注意してください。
+-->
+このパラメータが無効であったとしてもシステムは、トランザクションIDの周回を防止する必要があれば、autovacuumプロセスを起動することに注意してください。
 詳細は<xref linkend="vacuum-for-wraparound"/>を参照してください。
        </para>
       </listitem>
@@ -11612,11 +11633,11 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the maximum number of autovacuum processes (other than the
         autovacuum launcher) that may be running at any one time.  The default
         is three.  This parameter can only be set at server start.
-       -->
+-->
 同時に実行することができるautovacuumプロセス（autovacuumランチャ以外）の最大数を指定します。
 デフォルトは3です。
 サーバ起動時のみで設定可能です。
@@ -11635,7 +11656,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the minimum delay between autovacuum runs on any given
         database.  In each round the daemon examines the
         database and issues <command>VACUUM</command> and <command>ANALYZE</command> commands
@@ -11644,7 +11665,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         The default is one minute (<literal>1min</literal>).
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 あるデータベースについて実行されるautovacuumデーモンの最小遅延を指定します。
 それぞれの周期で、デーモンはそのデータベースを試験し、そしてそのデータベース内のテーブルで必要性が認められると、<command>VACUUM</command>および<command>ANALYZE</command>コマンドを発行します。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
@@ -11667,7 +11688,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the minimum number of updated or deleted tuples needed
         to trigger a <command>VACUUM</command> in any one table.
         The default is 50 tuples.
@@ -11675,7 +11696,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         file or on the server command line;
         but the setting can be overridden for individual tables by
         changing table storage parameters.
-       -->
+-->
 どのテーブルに対しても<command>VACUUM</command>を起動するために必要な、更新もしくは削除されたタプルの最小数を指定します。
 デフォルトは50タプルです。
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
@@ -11730,7 +11751,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the minimum number of inserted, updated or deleted tuples
         needed to trigger an <command>ANALYZE</command> in any one table.
         The default is 50 tuples.
@@ -11738,7 +11759,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         file or on the server command line;
         but the setting can be overridden for individual tables by
         changing table storage parameters.
-       -->
+-->
 どのテーブルに対しても<command>ANALYZE</command>を起動するのに必要な、挿入、更新、もしくは削除されたタプルの最小数を指定します。
 デフォルトは50タプルです。
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
@@ -11760,7 +11781,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies a fraction of the table size to add to
         <varname>autovacuum_vacuum_threshold</varname>
         when deciding whether to trigger a <command>VACUUM</command>.
@@ -11769,8 +11790,8 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         file or on the server command line;
         but the setting can be overridden for individual tables by
         changing table storage parameters.
-       -->
-       <command>VACUUM</command>を起動するか否かを決定するときに、<varname>autovacuum_vacuum_threshold</varname>に足し算するテーブル容量の割合を指定します。
+-->
+<command>VACUUM</command>を起動するか否かを決定するときに、<varname>autovacuum_vacuum_threshold</varname>に足し算するテーブル容量の割合を指定します。
 デフォルトは0.2（テーブルサイズの20%）です。
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されますが、テーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
@@ -11820,7 +11841,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies a fraction of the table size to add to
         <varname>autovacuum_analyze_threshold</varname>
         when deciding whether to trigger an <command>ANALYZE</command>.
@@ -11829,7 +11850,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         file or on the server command line;
         but the setting can be overridden for individual tables by
         changing table storage parameters.
-       -->
+-->
 <command>ANALYZE</command>を起動するか否かを決定するときに、<varname>autovacuum_analyze_threshold</varname>に足し算するテーブル容量の割合を指定します。
 デフォルトは0.1（テーブルサイズの10%）です。
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
@@ -11851,20 +11872,20 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the maximum age (in transactions) that a table's
         <structname>pg_class</structname>.<structfield>relfrozenxid</structfield> field can
         attain before a <command>VACUUM</command> operation is forced
         to prevent transaction ID wraparound within the table.
         Note that the system will launch autovacuum processes to
         prevent wraparound even when autovacuum is otherwise disabled.
-       -->
-       トランザクションID周回を防ぐために<command>VACUUM</command>操作が強制される前までにテーブルの<structname>pg_class</structname>.<structfield>relfrozenxid</structfield> フィールドが到達できる最大（トランザクションにおける）年代を指定します。
+-->
+トランザクションID周回を防ぐために<command>VACUUM</command>操作が強制される前までにテーブルの<structname>pg_class</structname>.<structfield>relfrozenxid</structfield> フィールドが到達できる最大（トランザクションにおける）年代を指定します。
 自動バキュームが無効であった時でも、システムは周回を防ぐために自動バキューム子プロセスを起動することに注意してください。
        </para>
 
        <para>
-       <!--
+<!--
         Vacuum also allows removal of old files from the
         <filename>pg_xact</filename> subdirectory, which is why the default
         is a relatively low 200 million transactions.
@@ -11872,10 +11893,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         can be reduced for individual tables by
         changing table storage parameters.
         For more information see <xref linkend="vacuum-for-wraparound"/>.
-       -->
+-->
        vacuumは同時に<filename>pg_xact</filename>サブディレクトリから古いファイルの削除を許可します。
-       これが、比較的低い2億トランザクションがデフォルトである理由です。
-       このパラメータはサーバ起動時にのみ設定可能です。
+これが、比較的低い2億トランザクションがデフォルトである理由です。
+このパラメータはサーバ起動時にのみ設定可能です。
 しかし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルで減らすことができます。
 詳細は<xref linkend="vacuum-for-wraparound"/>を参照してください。
        </para>
@@ -11903,7 +11924,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         Note that the system will launch autovacuum processes to
         prevent wraparound even when autovacuum is otherwise disabled.
 -->
-       トランザクションID周回を防ぐために<command>VACUUM</command>操作が強制される前までにテーブルの<structname>pg_class</structname>.<structfield>relminmxid</structfield> フィールドが到達できる最大（マルチトランザクションにおける）年代を指定します。
+トランザクションID周回を防ぐために<command>VACUUM</command>操作が強制される前までにテーブルの<structname>pg_class</structname>.<structfield>relminmxid</structfield> フィールドが到達できる最大（マルチトランザクションにおける）年代を指定します。
 自動バキュームが無効であった時でも、システムは周回を防ぐために自動バキューム子プロセスを起動することに注意してください。
        </para>
 
@@ -11917,9 +11938,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         be reduced for individual tables by changing table storage parameters.
         For more information see <xref linkend="vacuum-for-multixact-wraparound"/>.
 -->
-       またマルチトランザクションIDのvacuumは<filename>pg_multixact</filename>と<filename>pg_multixact/offsets</filename>サブディレクトリから古いファイルの削除します。
-       これがデフォルトが4億トランザクションをやや下回る理由です。
-       このパラメータはサーバ起動時にのみ設定可能です。
+またマルチトランザクションIDのvacuumは<filename>pg_multixact</filename>と<filename>pg_multixact/offsets</filename>サブディレクトリから古いファイルの削除します。
+これがデフォルトが4億トランザクションをやや下回る理由です。
+このパラメータはサーバ起動時にのみ設定可能です。
 しかし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルで減らすことができます。
 詳細は<xref linkend="vacuum-for-multixact-wraparound"/>を参照してください。
        </para>
@@ -11939,7 +11960,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the cost delay value that will be used in automatic
         <command>VACUUM</command> operations.  If -1 is specified, the regular
         <xref linkend="guc-vacuum-cost-delay"/> value will be used.
@@ -11949,7 +11970,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         file or on the server command line;
         but the setting can be overridden for individual tables by
         changing table storage parameters.
-       -->
+-->
 自動<command>VACUUM</command>操作に使用されるコスト遅延値を指定します。
 -1に指定されると、一定の <xref linkend="guc-vacuum-cost-delay"/>の値が使用されます。
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
@@ -11973,7 +11994,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the cost limit value that will be used in automatic
         <command>VACUUM</command> operations.  If -1 is specified (which is the
         default), the regular
@@ -11985,8 +12006,8 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         file or on the server command line;
         but the setting can be overridden for individual tables by
         changing table storage parameters.
-       -->
-       自動<command>VACUUM</command>操作に使用されるコスト限界値を指定します。
+-->
+自動<command>VACUUM</command>操作に使用されるコスト限界値を指定します。
 （デフォルトの）-1が指定されると、一定の <xref linkend="guc-vacuum-cost-limit"/>の値が使用されます。
 この値は、実行中の自動バキュームワーカが複数存在する場合ワーカすべてに比例分配されることに注意してください。
 したがって各ワーカの制限を足し合わせてもこの変数による制限を超えることはありません。
@@ -12000,15 +12021,15 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
    </sect1>
 
    <sect1 id="runtime-config-client">
-   <!--
+<!--
     <title>Client Connection Defaults</title>
-    -->
+-->
     <title>クライアント接続デフォルト</title>
 
     <sect2 id="runtime-config-client-statement">
-    <!--
+<!--
      <title>Statement Behavior</title>
-     -->
+-->
      <title>文の動作</title>
      <variablelist>
 
@@ -12064,7 +12085,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         This variable specifies the order in which schemas are searched
         when an object (table, data type, function, etc.) is referenced by a
         simple name with no schema specified.  When there are objects of
@@ -12072,44 +12093,44 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         in the search path is used.  An object that is not in any of the
         schemas in the search path can only be referenced by specifying
         its containing schema with a qualified (dotted) name.
-       -->
-       この変数は、オブジェクト（テーブル、データ型、関数など）がスキーマを指定されていない単純な名前で参照されている場合に、スキーマを検索する順番を指定します。
-       異なるスキーマに同じ名前のオブジェクトがある場合、検索パスで最初に見つかったものが使用されます。
-       検索パス内のどのスキーマにも存在しないオブジェクトを参照するには、修飾名（ドット付き）でそのオブジェクトが含まれるスキーマを指定する必要があります。
+-->
+この変数は、オブジェクト（テーブル、データ型、関数など）がスキーマを指定されていない単純な名前で参照されている場合に、スキーマを検索する順番を指定します。
+異なるスキーマに同じ名前のオブジェクトがある場合、検索パスで最初に見つかったものが使用されます。
+検索パス内のどのスキーマにも存在しないオブジェクトを参照するには、修飾名（ドット付き）でそのオブジェクトが含まれるスキーマを指定する必要があります。
        </para>
 
        <para>
-       <!--
+<!--
         The value for <varname>search_path</varname> must be a comma-separated
         list of schema names.  Any name that is not an existing schema, or is
         a schema for which the user does not have <literal>USAGE</literal>
         permission, is silently ignored.
-       -->
-       <varname>search_path</varname>の値は、スキーマの名前をカンマで区切った一覧でなければなりません。
-       存在していないスキーマ、またはユーザが<literal>USAGE</literal>権限を所有していないスキーマは警告なしに無視されます。
+-->
+<varname>search_path</varname>の値は、スキーマの名前をカンマで区切った一覧でなければなりません。
+存在していないスキーマ、またはユーザが<literal>USAGE</literal>権限を所有していないスキーマは警告なしに無視されます。
        </para>
 
        <para>
-       <!--
+<!--
         If one of the list items is the special name
         <literal>$user</literal>, then the schema having the name returned by
         <function>CURRENT_USER</function> is substituted, if there is such a schema
         and the user has <literal>USAGE</literal> permission for it.
         (If not, <literal>$user</literal> is ignored.)
-       -->
+-->
 もしそのようなスキーマが存在し、ユーザがそれにたいして<literal>USAGE</literal>権限を所有している場合、一覧内の項目の1つが特別な名前である<literal>$user</literal>の場合、<function>CURRENT_USER</function>と同じ名前を持つスキーマがあれば、そのスキーマが置換されます。
 （このような名前空間がない場合は<literal>$user</literal>は無視されます。）
        </para>
 
        <para>
-       <!--
+<!--
         The system catalog schema, <literal>pg_catalog</literal>, is always
         searched, whether it is mentioned in the path or not.  If it is
         mentioned in the path then it will be searched in the specified
         order.  If <literal>pg_catalog</literal> is not in the path then it will
         be searched <emphasis>before</emphasis> searching any of the path items.
-       -->
-       システムカタログのスキーマである<literal>pg_catalog</literal>は、パスでの指定の有無にかかわらず、常に検索されます。
+-->
+システムカタログのスキーマである<literal>pg_catalog</literal>は、パスでの指定の有無にかかわらず、常に検索されます。
 パスで指定されている場合は、指定された順序で検索されます。
 <literal>pg_catalog</literal>がパスに含まれていない場合、パスに含まれる項目を検索する<emphasis>前に</emphasis>検索が行われます
        </para>
@@ -12118,10 +12139,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
             schema, even when it considers typname='funcname'.  This paragraph
             refers to function names in a loose sense, "pg_proc.proname or
             func_name grammar production". -->
-      <!-- 細かい話ですが、typnameが'funcname'である場合でも、funcname('foo')は一時スキーマを使いません。
-この段落では、関数名とは「pg_proc.pronameあるいは文法生成物のfunc_name」のどちらでも良いという意味で使用しています。-->
+       <!-- 細かい話ですが、typnameが'funcname'である場合でも、funcname('foo')は一時スキーマを使いません。
+            この段落では、関数名とは「pg_proc.pronameあるいは文法生成物のfunc_name」のどちらでも良いという意味で使用しています。-->
        <para>
-       <!--
+<!--
         Likewise, the current session's temporary-table schema,
         <literal>pg_temp_<replaceable>nnn</replaceable></literal>, is always searched if it
         exists.  It can be explicitly listed in the path by using the
@@ -12130,8 +12151,8 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         the temporary schema is only searched for relation (table, view,
         sequence, etc) and data type names.  It is never searched for
         function or operator names.
-       -->
-       同様に、現在のセッションの一時テーブルスキーマ<literal>pg_temp_<replaceable>nnn</replaceable></literal>も、存在すれば常に検索されます。
+-->
+同様に、現在のセッションの一時テーブルスキーマ<literal>pg_temp_<replaceable>nnn</replaceable></literal>も、存在すれば常に検索されます。
 これは<literal>pg_temp</literal><indexterm><primary>pg_temp</primary></indexterm>という別名を使用してパスに明示的に列挙させることができます。
 パスに列挙されていない場合、最初に（<literal>pg_catalog</literal>よりも前であっても）検索されます。
 しかし、一時スキーマはリレーション（テーブル、ビュー、シーケンスなど）とデータ型名に対してのみ検索されます。
@@ -12139,18 +12160,18 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
        </para>
 
        <para>
-       <!--
+<!--
         When objects are created without specifying a particular target
         schema, they will be placed in the first valid schema named in
         <varname>search_path</varname>.  An error is reported if the search
         path is empty.
-       -->
-       対象となる特定のスキーマを指定せずにオブジェクトが作成された場合、それらのオブジェクトは<varname>search_path</varname>で名前を付けられた最初に有効となっているスキーマに配置されます。
+-->
+対象となる特定のスキーマを指定せずにオブジェクトが作成された場合、それらのオブジェクトは<varname>search_path</varname>で名前を付けられた最初に有効となっているスキーマに配置されます。
 検索パスが空の場合、エラーが報告されます。
        </para>
 
        <para>
-       <!--
+<!--
         The default value for this parameter is
         <literal>"$user", public</literal>.
         This setting supports shared use of a database (where no users
@@ -12158,8 +12179,8 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         private per-user schemas, and combinations of these.  Other
         effects can be obtained by altering the default search path
         setting, either globally or per-user.
-       -->
-       このパラメータのデフォルト値は<literal>"$user", public</literal>です。
+-->
+このパラメータのデフォルト値は<literal>"$user", public</literal>です。
 この設定はデータベースの共有（どのユーザも非公開のスキーマを持たず、全員が<literal>public</literal>を共有）、ユーザごとの非公開のスキーマ、およびこれらの組み合わせがサポートします。
 デフォルトの検索パスの設定を全体的またはユーザごとに変更することで、その他の効果を得ることもできます。
        </para>
@@ -12176,7 +12197,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
        </para>
 
        <para>
-       <!--
+<!--
         The current effective value of the search path can be examined
         via the <acronym>SQL</acronym> function
         <function>current_schemas</function>
@@ -12185,8 +12206,8 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         examining the value of <varname>search_path</varname>, since
         <function>current_schemas</function> shows how the items
         appearing in <varname>search_path</varname> were resolved.
-       -->
-       <acronym>SQL</acronym>関数の<function>current_schemas</function> によって、検索パスの現在の有効な値を調べることができます（<xref linkend="functions-info"/>を参照してください）。
+-->
+<acronym>SQL</acronym>関数の<function>current_schemas</function> によって、検索パスの現在の有効な値を調べることができます（<xref linkend="functions-info"/>を参照してください）。
 これは、<varname>search_path</varname> の値を調べるのとは異なります。
 <function>current_schemas</function>は、<varname>search_path</varname>に現れる項目がどのように解決されたかを表すからです。
        </para>
@@ -12273,16 +12294,16 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         This variable specifies the default tablespace in which to create
         objects (tables and indexes) when a <command>CREATE</command> command does
         not explicitly specify a tablespace.
-       -->
+-->
 この変数は、<command>CREATE</command>コマンドで明示的にテーブル空間を指定していない場合にオブジェクトの作成先となるデフォルトのテーブル空間を指定します。
        </para>
 
        <para>
-       <!--
+<!--
         The value is either the name of a tablespace, or an empty string
         to specify using the default tablespace of the current database.
         If the value does not match the name of any existing tablespace,
@@ -12290,28 +12311,28 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         tablespace of the current database.  If a nondefault tablespace
         is specified, the user must have <literal>CREATE</literal> privilege
         for it, or creation attempts will fail.
-       -->
-       値はテーブル空間名、もしくは現在のデータベースのデフォルトのテーブル空間を使用することを意味する空文字列です。
+-->
+値はテーブル空間名、もしくは現在のデータベースのデフォルトのテーブル空間を使用することを意味する空文字列です。
 この値が既存のテーブル空間名と一致しない場合、<productname>PostgreSQL</productname>は自動的に現在のデータベースのデフォルトのテーブル空間を使用します。
 デフォルト以外のテーブル空間が指定された場合、ユーザはそのテーブル空間で<literal>CREATE</literal>権限を持たなければなりません。
 さもなくば作成に失敗します。
        </para>
 
        <para>
-       <!--
+<!--
         This variable is not used for temporary tables; for them,
         <xref linkend="guc-temp-tablespaces"/> is consulted instead.
-       -->
+-->
 この変数は一時テーブル向けには使用されません。
 一時テーブル向けには代わりに<xref linkend="guc-temp-tablespaces"/>が考慮されます。
        </para>
 
        <para>
-       <!--
+<!--
         This variable is also not used when creating databases.
         By default, a new database inherits its tablespace setting from
         the template database it is copied from.
-       -->
+-->
 また、この変数はデータベース作成時には使用されません。
 デフォルトでは、新しいデータベースはコピー元のテンプレートデータベースからテーブル空間の設定を引き継ぎます。
        </para>
@@ -12328,11 +12349,11 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
        </para>
 
        <para>
-       <!--
+<!--
         For more information on tablespaces,
         see <xref linkend="manage-ag-tablespaces"/>.
-       -->
-       テーブル空間に付いてより詳細な情報は<xref linkend="manage-ag-tablespaces"/>を参照してください。
+-->
+テーブル空間に付いてより詳細な情報は<xref linkend="manage-ag-tablespaces"/>を参照してください。
        </para>
       </listitem>
      </varlistentry>
@@ -12382,19 +12403,19 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         This variable specifies tablespaces in which to create temporary
         objects (temp tables and indexes on temp tables) when a
         <command>CREATE</command> command does not explicitly specify a tablespace.
         Temporary files for purposes such as sorting large data sets
         are also created in these tablespaces.
-       -->
+-->
 この変数は、<command>CREATE</command>コマンドで明示的にテーブル空間が指定されない場合に、生成する一時オブジェクト（一時テーブルと一時テーブル上のインデックス）を格納するテーブル空間（複数可）を指定します。
 大規模データ集合のソートなどを目的とした一時ファイルもまた、このテーブル空間（複数可）に作成されます。
        </para>
 
        <para>
-       <!--
+<!--
         The value is a list of names of tablespaces.  When there is more than
         one name in the list, <productname>PostgreSQL</productname> chooses a random
         member of the list each time a temporary object is to be created;
@@ -12403,7 +12424,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         If the selected element of the list is an empty string,
         <productname>PostgreSQL</productname> will automatically use the default
         tablespace of the current database instead.
-       -->
+-->
 この値はテーブル空間名のリストです。
 リストに複数の名前が存在する場合、一時オブジェクトが作成される度に<productname>PostgreSQL</productname>は無作為にリストから要素を選択します。
 トランザクションの内側は例外で、連続して作成される一時オブジェクトはそのリストで連続するテーブル空間に格納されます。
@@ -12411,7 +12432,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
        </para>
 
        <para>
-       <!--
+<!--
         When <varname>temp_tablespaces</varname> is set interactively, specifying a
         nonexistent tablespace is an error, as is specifying a tablespace for
         which the user does not have <literal>CREATE</literal> privilege.  However,
@@ -12419,7 +12440,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         ignored, as are tablespaces for which the user lacks
         <literal>CREATE</literal> privilege.  In particular, this rule applies when
         using a value set in <filename>postgresql.conf</filename>.
-       -->
+-->
 <varname>temp_tablespaces</varname>を対話式に設定する場合、存在しないテーブル空間を指定するとエラーになります。
 ユーザが<literal>CREATE</literal>権限を持たないテーブル空間を指定した場合も同様です。
 しかし事前に設定された値を使用する場合、存在しないテーブル空間は無視されます。
@@ -12428,19 +12449,19 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
        </para>
 
        <para>
-       <!--
+<!--
         The default value is an empty string, which results in all temporary
         objects being created in the default tablespace of the current
         database.
-       -->
+-->
 デフォルト値は空文字列です。
 この結果、すべての一時オブジェクトは現在のデータベースのデフォルトのテーブル空間内に作成されます。
        </para>
 
        <para>
-       <!--
+<!--
         See also <xref linkend="guc-default-tablespace"/>.
-       -->
+-->
        <xref linkend="guc-default-tablespace"/>も参照してください
        </para>
       </listitem>
@@ -12480,13 +12501,13 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
      <varlistentry id="guc-default-transaction-isolation" xreflabel="default_transaction_isolation">
       <term><varname>default_transaction_isolation</varname> (<type>enum</type>)
       <indexterm>
-      <!--
+<!--
        <primary>transaction isolation level</primary>
-       -->
+-->
        <primary>トランザクション分離レベル</primary>
-       <!--
+<!--
        <secondary>setting default</secondary>
-       -->
+-->
        <secondary>デフォルト設定</secondary>
       </indexterm>
       <indexterm>
@@ -12498,25 +12519,25 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Each SQL transaction has an isolation level, which can be
         either <quote>read uncommitted</quote>, <quote>read
         committed</quote>, <quote>repeatable read</quote>, or
         <quote>serializable</quote>.  This parameter controls the
         default isolation level of each new transaction. The default
         is <quote>read committed</quote>.
-       -->
+-->
        SQLトランザクションはそれぞれ、<quote>read uncommitted</quote>、<quote>read committed</quote>、<quote>repeatable read</quote>、または<quote>serializable</quote>のいずれかの分離レベルを持ちます。
 このパラメータは各新規トランザクションのデフォルトの分離レベルを制御します。
 デフォルトは<quote>read committed</quote>です。
        </para>
 
        <para>
-       <!--
+<!--
         Consult <xref linkend="mvcc"/> and <xref
         linkend="sql-set-transaction"/> for more information.
-       -->
-       より詳細は <xref linkend="mvcc"/> および <xref
+-->
+より詳細は <xref linkend="mvcc"/> および <xref
         linkend="sql-set-transaction"/> を調べてください。
        </para>
       </listitem>
@@ -12528,13 +12549,13 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
      <varlistentry id="guc-default-transaction-read-only" xreflabel="default_transaction_read_only">
       <term><varname>default_transaction_read_only</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
+<!--
        <primary>read-only transaction</primary>
-       -->
+-->
        <primary>読み取り専用トランザクション</primary>
-       <!--
+<!--
        <secondary>setting default</secondary>
-       -->
+-->
        <secondary>デフォルト設定</secondary>
       </indexterm>
       <indexterm>
@@ -12546,21 +12567,21 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         A read-only SQL transaction cannot alter non-temporary tables.
         This parameter controls the default read-only status of each new
         transaction. The default is <literal>off</literal> (read/write).
-       -->
-       読み取り専用のSQLトランザクションでは、非一時的テーブルを変更することができません。
+-->
+読み取り専用のSQLトランザクションでは、非一時的テーブルを変更することができません。
 このパラメータは、各新規トランザクションのデフォルトの読み取りのみ状況を制御します。
 デフォルト<literal>off</literal>（読み書き）です。
        </para>
 
        <para>
-       <!--
+<!--
         Consult <xref linkend="sql-set-transaction"/> for more information.
-       -->
-       より詳細な情報は<xref linkend="sql-set-transaction"/>を調べてください。
+-->
+より詳細な情報は<xref linkend="sql-set-transaction"/>を調べてください。
        </para>
       </listitem>
      </varlistentry>
@@ -12568,10 +12589,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
      <varlistentry id="guc-default-transaction-deferrable" xreflabel="default_transaction_deferrable">
       <term><varname>default_transaction_deferrable</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
+<!--
        <primary>deferrable transaction</primary>
        <secondary>setting default</secondary>
-       -->
+-->
        <primary>遅延トランザクション</primary>
        <secondary>デフォルト設定</secondary>
       </indexterm>
@@ -12584,7 +12605,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When running at the <literal>serializable</literal> isolation level,
         a deferrable read-only SQL transaction may be delayed before
         it is allowed to proceed.  However, once it begins executing
@@ -12592,29 +12613,29 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         serializability; so serialization code will have no reason to
         force it to abort because of concurrent updates, making this
         option suitable for long-running read-only transactions.
-       -->
-       <literal>シリアライザブル</literal>分離レベルで運用されている場合、繰り延べ読み取り専用SQLトランザクションは、その処理の許可の前に遅延されることがあります。
-       しかし、ひとたび処理が開始されるとシリアライザブル可能性を保障するために必要ないかなるオーバヘッドも発生させません。
-       従って、シリアル化（直列化）のコードは、このオプションを長期間にわたる読み取り専用トランザクションに対して適切な処置と位置づけ、同時実行の更新の観点から中断を強制する理由はありません。
+-->
+<literal>シリアライザブル</literal>分離レベルで運用されている場合、繰り延べ読み取り専用SQLトランザクションは、その処理の許可の前に遅延されることがあります。
+しかし、ひとたび処理が開始されるとシリアライザブル可能性を保障するために必要ないかなるオーバヘッドも発生させません。
+従って、シリアル化（直列化）のコードは、このオプションを長期間にわたる読み取り専用トランザクションに対して適切な処置と位置づけ、同時実行の更新の観点から中断を強制する理由はありません。
         </para>
 
         <para>
-       <!--
+<!--
         This parameter controls the default deferrable status of each
         new transaction.  It currently has no effect on read-write
         transactions or those operating at isolation levels lower
         than <literal>serializable</literal>. The default is <literal>off</literal>.
-       -->
-       このパラメータはそれぞれの新規トランザクションのデフォルトでの繰り延べ状態を制御します。
-       現時点では、読み取り専用トランザクション、または<literal>シリアライザブル</literal>より低位の分離レベルの運用に対して効果はありません。
+-->
+このパラメータはそれぞれの新規トランザクションのデフォルトでの繰り延べ状態を制御します。
+現時点では、読み取り専用トランザクション、または<literal>シリアライザブル</literal>より低位の分離レベルの運用に対して効果はありません。
 デフォルトは<literal>off</literal>です。
        </para>
 
        <para>
-       <!--
+<!--
         Consult <xref linkend="sql-set-transaction"/> for more information.
-       -->
-       より詳細は<xref linkend="sql-set-transaction"/>を参照してください。
+-->
+より詳細は<xref linkend="sql-set-transaction"/>を参照してください。
        </para>
       </listitem>
      </varlistentry>
@@ -12722,7 +12743,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         query plans.  Possible values are <literal>origin</literal> (the default),
         <literal>replica</literal> and <literal>local</literal>.
 -->
-       現在のセッションでのレプリケーションに関連したトリガおよびルールの発行を制御します。
+現在のセッションでのレプリケーションに関連したトリガおよびルールの発行を制御します。
 この変数を設定するにはスーパーユーザ権限が必要で、かつ、これまでにキャッシュされた問い合わせ計画が破棄されることになります。
 取り得る値は、<literal>origin</literal>（デフォルト）、<literal>replica</literal>、<literal>local</literal>です。
        </para>
@@ -12810,11 +12831,11 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
        </para>
 
        <para>
-       <!--
+<!--
         Setting <varname>statement_timeout</varname> in
         <filename>postgresql.conf</filename> is not recommended because it would
         affect all sessions.
-       -->
+-->
 すべてのセッションに影響することがあるので、<filename>postgresql.conf</filename>内で<varname>statement_timeout</varname>を設定することは推奨されません。
        </para>
       </listitem>
@@ -12831,7 +12852,7 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Abort any statement that waits longer than the specified amount of
         time while attempting to acquire a lock on a table, index,
         row, or other database object.  The time limit applies separately to
@@ -12841,7 +12862,7 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
         locks.
         If this value is specified without units, it is taken as milliseconds.
         A value of zero (the default) disables the timeout.
-       -->
+-->
 テーブル、インデックス、行、またはその他のデータベースオブジェクトに対してロック獲得を試みている最中、指定された時間を超えて待機するいかなる命令も停止されます。
 時間制限はそれぞれのロック取得の試みに対し個別に適用されます。
 制限は明示的ロック要求（例えば<command>LOCK TABLE</command>、または<command>SELECT FOR UPDATE</command> without <literal>NOWAIT</literal>など）および暗黙的に取得されるロックに適用されます。
@@ -12850,7 +12871,7 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
        </para>
 
        <para>
-       <!--
+<!--
         Unlike <varname>statement_timeout</varname>, this timeout can only occur
         while waiting for locks.  Note that if <varname>statement_timeout</varname>
         is nonzero, it is rather pointless to set <varname>lock_timeout</varname> to
@@ -12858,19 +12879,19 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
         trigger first.  If <varname>log_min_error_statement</varname> is set to
         <literal>ERROR</literal> or lower, the statement that timed out will be
         logged.
-       -->
+-->
 <varname>statement_timeout</varname>と異なり、このタイムアウトはロックを待機しているときのみ発生します。
 命令によるタイムアウトは常に第一に起動されるため、もし<varname>statement_timeout</varname>が非ゼロであれば<varname>lock_timeout</varname>を同一、もしくはより大きい値に設定するのは的を射ていません。
 <varname>log_min_error_statement</varname>が<literal>ERROR</literal>またはそれより低く設定されると、時間制限を超えた命令はログに記録されます。
        </para>
 
        <para>
-       <!--
+<!--
         Setting <varname>lock_timeout</varname> in
         <filename>postgresql.conf</filename> is not recommended because it would
         affect all sessions.
-       -->
-       <varname>lock_timeout</varname>を<filename>postgresql.conf</filename>にて設定することは、すべてのセッションに影響を与える可能性があるため推奨されません。
+-->
+<varname>lock_timeout</varname>を<filename>postgresql.conf</filename>にて設定することは、すべてのセッションに影響を与える可能性があるため推奨されません。
        </para>
       </listitem>
      </varlistentry>
@@ -13010,7 +13031,7 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the cutoff age (in transactions) that <command>VACUUM</command>
         should use to decide whether to freeze row versions
         while scanning a table.
@@ -13021,8 +13042,8 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
         that there is not an unreasonably short time between forced
         autovacuums.  For more information see <xref
         linkend="vacuum-for-wraparound"/>.
-       -->
-       <command>VACUUM</command>がテーブルスキャン時に行バージョンをフリーズするかどうかを決定する際に使用する、カットオフ（トランザクション）年代を指定します。
+-->
+<command>VACUUM</command>がテーブルスキャン時に行バージョンをフリーズするかどうかを決定する際に使用する、カットオフ（トランザクション）年代を指定します。
 デフォルトは5千万トランザクションです。
 ユーザはこの値を0から10億までの間で任意の値に設定することができますが、<command>VACUUM</command>は警告なく<xref linkend="guc-autovacuum-freeze-max-age"/>の半分までの値に値を制限します。
 このため、強制的なautovacuumの間隔が不合理に短くなることはありません。
@@ -13206,17 +13227,17 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the output format for values of type <type>bytea</type>.
         Valid values are <literal>hex</literal> (the default)
         and <literal>escape</literal> (the traditional PostgreSQL
         format).  See <xref linkend="datatype-binary"/> for more
         information.  The <type>bytea</type> type always
         accepts both formats on input, regardless of this setting.
-       -->
-       <type>bytea</type>型の値の出力形式を設定します。
-       有効な値は<literal>hex</literal>（デフォルト）、および<literal>escape</literal>（PostgreSQLの伝統的な書式）です。
-       より詳細は<xref linkend="datatype-binary"/>を参照してください。
+-->
+<type>bytea</type>型の値の出力形式を設定します。
+有効な値は<literal>hex</literal>（デフォルト）、および<literal>escape</literal>（PostgreSQLの伝統的な書式）です。
+より詳細は<xref linkend="datatype-binary"/>を参照してください。
        <type>bytea</type>型は常にこの設定に係わらず、入力時に双方の書式を受け付けます。
        </para>
       </listitem>
@@ -13233,7 +13254,7 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets how binary values are to be encoded in XML.  This applies
         for example when <type>bytea</type> values are converted to
         XML by the functions <function>xmlelement</function> or
@@ -13242,8 +13263,8 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
         are both defined in the XML Schema standard.  The default is
         <literal>base64</literal>.  For further information about
         XML-related functions, see <xref linkend="functions-xml"/>.
-       -->
-       バイナリデータをXMLに符号化する方法を設定します。
+-->
+バイナリデータをXMLに符号化する方法を設定します。
 例えばこれは、<function>xmlelement</function>や<function>xmlforest</function>関数で<type>bytea</type>値をXMLに変換する際に適用されます。
 取り得る値は<literal>base64</literal>と<literal>hex</literal>です。
 どちらもXMLスキーマ標準で定義されています。
@@ -13252,14 +13273,14 @@ XMLに関連した関数については<xref linkend="functions-xml"/>を参照�
        </para>
 
        <para>
-       <!--
+<!--
         The actual choice here is mostly a matter of taste,
         constrained only by possible restrictions in client
         applications.  Both methods support all possible values,
         although the hex encoding will be somewhat larger than the
         base64 encoding.
-       -->
-       実のところこの選択はほとんど趣味の問題で、クライアントアプリケーションで起こり得る制限のみに制約されます。
+-->
+実のところこの選択はほとんど趣味の問題で、クライアントアプリケーションで起こり得る制限のみに制約されます。
 どちらの方法もすべての値をサポートしますが、hex符号化方式はbase64符号化方式より少し大きくなります。
        </para>
       </listitem>
@@ -13285,7 +13306,7 @@ XMLに関連した関数については<xref linkend="functions-xml"/>を参照�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets whether <literal>DOCUMENT</literal> or
         <literal>CONTENT</literal> is implicit when converting between
         XML and character string values.  See <xref
@@ -13293,25 +13314,25 @@ XMLに関連した関数については<xref linkend="functions-xml"/>を参照�
         values are <literal>DOCUMENT</literal> and
         <literal>CONTENT</literal>.  The default is
         <literal>CONTENT</literal>.
-       -->
-       XMLと文字列値との変換時に<literal>DOCUMENT</literal>とするか<literal>CONTENT</literal>とするかを設定します。
+-->
+XMLと文字列値との変換時に<literal>DOCUMENT</literal>とするか<literal>CONTENT</literal>とするかを設定します。
 この説明については<xref linkend="datatype-xml"/>を参照してください。
 有効な値は<literal>DOCUMENT</literal>と<literal>CONTENT</literal>です。
 デフォルトは<literal>CONTENT</literal>です。
        </para>
 
        <para>
-       <!--
+<!--
         According to the SQL standard, the command to set this option is
-       -->
-       標準SQLに従うと、このオプションを設定するコマンドは以下のようになります。
+-->
+標準SQLに従うと、このオプションを設定するコマンドは以下のようになります。
 <synopsis>
 SET XML OPTION { DOCUMENT | CONTENT };
 </synopsis>
-       <!--
+<!--
         This syntax is also available in PostgreSQL.
-       -->
-       この構文はPostgreSQLでも使用可能です。
+-->
+この構文はPostgreSQLでも使用可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -13354,9 +13375,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      </variablelist>
     </sect2>
      <sect2 id="runtime-config-client-format">
-     <!--
+<!--
      <title>Locale and Formatting</title>
-     -->
+-->
      <title>ロケールと書式設定</title>
 
      <variablelist>
@@ -13372,7 +13393,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the display format for date and time values, as well as the
         rules for interpreting ambiguous date input values. For
         historical reasons, this variable contains two independent
@@ -13389,8 +13410,8 @@ SET XML OPTION { DOCUMENT | CONTENT };
         <application>initdb</application> will initialize the
         configuration file with a setting that corresponds to the
         behavior of the chosen <varname>lc_time</varname> locale.
-       -->
-       日付時刻値の表示書式を設定し、曖昧な日付入力の解釈規則を設定します。
+-->
+日付時刻値の表示書式を設定し、曖昧な日付入力の解釈規則を設定します。
 歴史的な理由により、この変数には2つの独立した要素が含まれています。
 出力書式指定（<literal>ISO</literal>、<literal>Postgres</literal>、<literal>SQL</literal>、<literal>German</literal>）と年/月/日の順序の入出力指定（<literal>DMY</literal>、<literal>MDY</literal>、<literal>YMD</literal>）です。
 これらは分けて設定することもまとめて設定することもできます。
@@ -13412,7 +13433,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the display format for interval values.
         The value <literal>sql_standard</literal> will produce
         output matching <acronym>SQL</acronym> standard interval literals.
@@ -13427,20 +13448,20 @@ SET XML OPTION { DOCUMENT | CONTENT };
         The value <literal>iso_8601</literal> will produce output matching the time
         interval <quote>format with designators</quote> defined in section
         4.4.3.2 of ISO 8601.
-       -->
-       間隔の値の表示形式を設定します。<literal>sql_standard</literal>値は、<acronym>SQL</acronym>標準間隔リテラルに一致する出力を生成します。
-       （デフォルトの）値<literal>postgres</literal>は、<xref linkend="guc-datestyle"/>パラメータが<literal>ISO</literal>に設定されている場合、リリース8.4以前の<productname>PostgreSQL</productname>に一致する出力を生成します。
-       値<literal>postgres_verbose</literal>は、<varname>DateStyle</varname>パラメータが非<literal>ISO</literal>出力に設定されている場合、リリース8.4以前の<productname>PostgreSQL</productname>に一致する出力を生成します。
-       値<literal>iso_8601</literal>は、ISO 8601の4.4.3.2節で定義されている時間間隔<quote>format with designators</quote>に一致する出力を生成します。
+-->
+間隔の値の表示形式を設定します。<literal>sql_standard</literal>値は、<acronym>SQL</acronym>標準間隔リテラルに一致する出力を生成します。
+（デフォルトの）値<literal>postgres</literal>は、<xref linkend="guc-datestyle"/>パラメータが<literal>ISO</literal>に設定されている場合、リリース8.4以前の<productname>PostgreSQL</productname>に一致する出力を生成します。
+値<literal>postgres_verbose</literal>は、<varname>DateStyle</varname>パラメータが非<literal>ISO</literal>出力に設定されている場合、リリース8.4以前の<productname>PostgreSQL</productname>に一致する出力を生成します。
+値<literal>iso_8601</literal>は、ISO 8601の4.4.3.2節で定義されている時間間隔<quote>format with designators</quote>に一致する出力を生成します。
        </para>
        <para>
-       <!--
+<!--
         The <varname>IntervalStyle</varname> parameter also affects the
         interpretation of ambiguous interval input.  See
         <xref linkend="datatype-interval-input"/> for more information.
-       -->
-       また<varname>IntervalStyle</varname>パラメータはあいまいに入力された時間間隔の解釈に影響を与えます。
-       詳細については<xref linkend="datatype-interval-input"/>を参照してください。
+-->
+また<varname>IntervalStyle</varname>パラメータはあいまいに入力された時間間隔の解釈に影響を与えます。
+詳細については<xref linkend="datatype-interval-input"/>を参照してください。
        </para>
       </listitem>
      </varlistentry>
@@ -13458,16 +13479,16 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the time zone for displaying and interpreting time stamps.
         The built-in default is <literal>GMT</literal>, but that is typically
         overridden in <filename>postgresql.conf</filename>; <application>initdb</application>
         will install a setting there corresponding to its system environment.
         See <xref linkend="datatype-timezones"/> for more information.
-       -->
-       表示用およびタイムスタンプ解釈用の時間帯を設定します。
-       組み込まれているデフォルトは<literal>GMT</literal>ですが、通常は<filename>postgresql.conf</filename>により上書きされます。<application>initdb</application>によりこれらと関連した設定をシステム環境にインストールされます。
-        詳細は<xref linkend="datatype-timezones"/>を参照してください。
+-->
+表示用およびタイムスタンプ解釈用の時間帯を設定します。
+組み込まれているデフォルトは<literal>GMT</literal>ですが、通常は<filename>postgresql.conf</filename>により上書きされます。<application>initdb</application>によりこれらと関連した設定をシステム環境にインストールされます。
+詳細は<xref linkend="datatype-timezones"/>を参照してください。
        </para>
       </listitem>
      </varlistentry>
@@ -13485,15 +13506,15 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the collection of time zone abbreviations that will be accepted
         by the server for datetime input.  The default is <literal>'Default'</literal>,
         which is a collection that works in most of the world; there are
         also <literal>'Australia'</literal> and <literal>'India'</literal>,
         and other collections can be defined for a particular installation.
         See <xref linkend="datetime-config-files"/> for more information.
-       -->
-       サーバで日付時刻の入力として受付け可能となる時間帯省略形の集合を設定します。
+-->
+サーバで日付時刻の入力として受付け可能となる時間帯省略形の集合を設定します。
 デフォルトは<literal>'Default'</literal>です。
 これはほぼ全世界で通じる集合です。
 また、<literal>Australia</literal>、<literal>India</literal>、その他特定のインストレーションで定義可能な集合が存在します。
@@ -13511,13 +13532,11 @@ SET XML OPTION { DOCUMENT | CONTENT };
        <primary>有効数字</primary>
       </indexterm>
       <indexterm>
-      <!--
        <primary>floating-point</primary>
-       -->
-       <primary>浮動小数点</primary>
-       <!--
        <secondary>display</secondary>
-       -->
+      </indexterm>
+      <indexterm>
+       <primary>浮動小数点</primary>
        <secondary>表示</secondary>
       </indexterm>
       <indexterm>
@@ -13598,13 +13617,13 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the client-side encoding (character set).
         The default is to use the database encoding.
         The character sets supported by the <productname>PostgreSQL</productname>
         server are described in <xref linkend="multibyte-charset-supported"/>.
-       -->
-       クライアント側符号化方式（文字セット）を設定します。デフォルトはデータベース符号化方式を使用します。
+-->
+クライアント側符号化方式（文字セット）を設定します。デフォルトはデータベース符号化方式を使用します。
        <productname>PostgreSQL</productname>サーバでサポートされている文字セットは<xref linkend="multibyte-charset-supported"/>に記載されています。
        </para>
       </listitem>
@@ -13621,38 +13640,38 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the language in which messages are displayed.  Acceptable
         values are system-dependent; see <xref linkend="locale"/> for
         more information.  If this variable is set to the empty string
         (which is the default) then the value is inherited from the
         execution environment of the server in a system-dependent way.
-       -->
-       メッセージが表示される言語を設定します。使用可能な値はシステムに依存します。詳細については<xref linkend="locale"/>を参照してください。
-       この変数が空に設定された場合（これがデフォルトです）、値はシステムに依存する方法でサーバの実行環境から継承されます。
+-->
+メッセージが表示される言語を設定します。使用可能な値はシステムに依存します。詳細については<xref linkend="locale"/>を参照してください。
+この変数が空に設定された場合（これがデフォルトです）、値はシステムに依存する方法でサーバの実行環境から継承されます。
        </para>
 
        <para>
-       <!--
+<!--
         On some systems, this locale category does not exist.  Setting
         this variable will still work, but there will be no effect.
         Also, there is a chance that no translated messages for the
         desired language exist.  In that case you will continue to see
         the English messages.
-       -->
-       システムによっては、このロケールのカテゴリが存在しません。この変数を設定することはできますが、実効性はありません。
-       また、指定の言語に翻訳されたメッセージが存在しないこともあります。
-       その場合は、引き続き英語のメッセージが表示されます。
+-->
+システムによっては、このロケールのカテゴリが存在しません。この変数を設定することはできますが、実効性はありません。
+また、指定の言語に翻訳されたメッセージが存在しないこともあります。
+その場合は、引き続き英語のメッセージが表示されます。
        </para>
 
        <para>
-       <!--
+<!--
         Only superusers can change this setting, because it affects the
         messages sent to the server log as well as to the client, and
         an improper value might obscure the readability of the server
         logs.
-       -->
-       サーバログやクライアントに送信されるメッセージに影響するため、および、全ての不適切な値がサーバログの信頼性を損ねる可能性があるため、スーパーユーザのみがこの設定を変更することができます。
+-->
+サーバログやクライアントに送信されるメッセージに影響するため、および、全ての不適切な値がサーバログの信頼性を損ねる可能性があるため、スーパーユーザのみがこの設定を変更することができます。
        </para>
       </listitem>
      </varlistentry>
@@ -13668,7 +13687,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the locale to use for formatting monetary amounts, for
         example with the <function>to_char</function> family of
         functions.  Acceptable values are system-dependent; see <xref
@@ -13676,8 +13695,8 @@ SET XML OPTION { DOCUMENT | CONTENT };
         set to the empty string (which is the default) then the value
         is inherited from the execution environment of the server in a
         system-dependent way.
-       -->
-       通貨書式で使用するロケールを設定します。
+-->
+通貨書式で使用するロケールを設定します。
 例えば、<function>to_char()</function>系の関数で使用します。
 使用可能な値はシステムに依存します。
 詳細については<xref linkend="locale"/>を参照してください。
@@ -13697,7 +13716,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the locale to use for formatting numbers, for example
         with the <function>to_char</function> family of
         functions. Acceptable values are system-dependent; see <xref
@@ -13705,8 +13724,8 @@ SET XML OPTION { DOCUMENT | CONTENT };
         set to the empty string (which is the default) then the value
         is inherited from the execution environment of the server in a
         system-dependent way.
-       -->
-       数字の書式で使用するロケールを設定します。
+-->
+数字の書式で使用するロケールを設定します。
 例えば、<function>to_char</function>系の関数で使用します。
 使用可能な値はシステムに依存します。
 詳細については<xref linkend="locale"/>を参照してください。
@@ -13726,7 +13745,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the locale to use for formatting dates and times, for example
         with the <function>to_char</function> family of
         functions. Acceptable values are system-dependent; see <xref
@@ -13734,10 +13753,10 @@ SET XML OPTION { DOCUMENT | CONTENT };
         set to the empty string (which is the default) then the value
         is inherited from the execution environment of the server in a
         system-dependent way.
-       -->
-       例えば<function>to_char</function>系関数における、日付と時間の書式で使用するロケールを設定します。
-       使用可能な値はシステムに依存します。
-       詳細については<xref linkend="locale"/>を参照してください。
+-->
+例えば<function>to_char</function>系関数における、日付と時間の書式で使用するロケールを設定します。
+使用可能な値はシステムに依存します。
+詳細については<xref linkend="locale"/>を参照してください。
 この変数が空に設定された場合（これがデフォルトです）、値はシステムに依存する方法でサーバの実行環境から継承されます。
        </para>
       </listitem>
@@ -13754,7 +13773,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Selects the text search configuration that is used by those variants
         of the text search functions that do not have an explicit argument
         specifying the configuration.
@@ -13764,8 +13783,8 @@ SET XML OPTION { DOCUMENT | CONTENT };
         configuration file with a setting that corresponds to the
         chosen <varname>lc_ctype</varname> locale, if a configuration
         matching that locale can be identified.
-       -->
-       明示的な設定指定引数を持たないテキスト検索関数の亜種で使用される、テキスト検索設定を選択します。
+-->
+明示的な設定指定引数を持たないテキスト検索関数の亜種で使用される、テキスト検索設定を選択します。
 詳細は<xref linkend="textsearch"/>を参照してください。
 組み込みのデフォルトは<literal>pg_catalog.simple</literal>ですが、<application>initdb</application>は、ロケールに合う設定を認識することができれば、選択された<varname>lc_ctype</varname>ロケールに対応した設定で設定ファイルを初期化します。
        </para>
@@ -13793,7 +13812,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       library directory.  The differences between the settings are when they
       take effect and what privileges are required to change them.
 -->
-      追加機能や性能改良の目的で共有ライブラリをプリロードするいくつかの設定があります。
+追加機能や性能改良の目的で共有ライブラリをプリロードするいくつかの設定があります。
 たとえば<literal>'$libdir/mylib'</literal>を設定すると<literal>mylib.so</literal>(あるいは他のプラットフォームでは<literal>mylib.sl</literal>)を導入設定したの標準ディレクトリからプリロードします。
 各設定の違いは、設定変更を行うためにいつ、どのような権限が必要かにあります。
      </para>
@@ -13806,7 +13825,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       <literal>XXX</literal> is <literal>pgsql</literal>, <literal>perl</literal>,
       <literal>tcl</literal>, or <literal>python</literal>.
 -->
-      典型的には<literal>'$libdir/plXXX'</literal>のような構文を用いて<productname>PostgreSQL</productname>手続き言語ライブラリをこの方法でプリロードできます。
+典型的には<literal>'$libdir/plXXX'</literal>のような構文を用いて<productname>PostgreSQL</productname>手続き言語ライブラリをこの方法でプリロードできます。
 <literal>XXX</literal>は<literal>pgsql</literal>、<literal>perl</literal>、<literal>tcl</literal>、<literal>python</literal>です。
      </para>
 
@@ -13830,7 +13849,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       In general, refer to the documentation of a specific module for the
       recommended way to load that module.
 -->
-      一般的に言ってモジュールのドキュメントを参照し、推奨される方法でロードしてください。
+一般的に言ってモジュールのドキュメントを参照し、推奨される方法でロードしてください。
      </para>
 
      <variablelist>
@@ -13881,7 +13900,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
         the library name &mdash; <literal>mylib</literal> would have
         the same effect as <literal>$libdir/plugins/mylib</literal>.
 -->
-        このオプションはすべてのユーザが設定できます。
+このオプションはすべてのユーザが設定できます。
 この理由で、読み込み可能なライブラリはインストレーションの共有ライブラリディレクトリのサブディレクトリ<filename>plugins</filename>内にあるものに制限されています。
 （確実に<quote>安全</quote>なライブラリのみをここにインストールすることはデータベース管理者の責任です。）
  <varname>local_preload_libraries</varname>内の項目で、たとえば<literal>$libdir/plugins/mylib</literal>のようにこのディレクトリを明示的に指定することも、単にライブラリ名を指定することも可能です。
@@ -13961,7 +13980,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
         session is started), so it is easier to add new modules this way, even
         if they should apply to all sessions.
 -->
-        この機能は、デバッグや性能測定の目的で<command>LOAD</command>コマンドを使わずに特定のセッションでライブラリをロードする目的で使われます。
+この機能は、デバッグや性能測定の目的で<command>LOAD</command>コマンドを使わずに特定のセッションでライブラリをロードする目的で使われます。
 たとえば<command>ALTER ROLE SET</command>で設定することにより、特定のユーザが開始するすべてのセッションで<xref linkend="auto-explain"/>が有効になります。
 また、このパラメータはサーバを再起動せずに変更できます(しかし変更は新しいセッションが開始するときにのみ有効となります)。すべてのセッションで有効にしたいのであれば、この方法で新しいモジュールを容易に追加できます。
        </para>
@@ -13973,7 +13992,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
         when it is first used.  There is some advantage, however, when
         connection pooling is used.
 -->
-        <xref linkend="guc-shared-preload-libraries"/>と違って、ライブラリがはじめて使われるときにロードする方法と比べてセッションが開始するときにライブラリをロードする方法には大きな性能的な優位性はありません。
+<xref linkend="guc-shared-preload-libraries"/>と違って、ライブラリがはじめて使われるときにロードする方法と比べてセッションが開始するときにライブラリをロードする方法には大きな性能的な優位性はありません。
 しかし、コネクションプーリングを使うのであれば、いくらか優位性があります。
        </para>
       </listitem>
@@ -14015,7 +14034,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
         must be loaded at server start through this parameter.  See the
         documentation of each library for details.
 -->
-        ライブラリによってはpostmaster起動時にのみ可能な操作を実行する必要があるものがあります。
+ライブラリによってはpostmaster起動時にのみ可能な操作を実行する必要があるものがあります。
 たとえば、共有メモリの獲得、軽量ロックの予約、バックグラウンドワーカの起動などです。
 このようなライブラリはこのパラメータを使ってサーバ起動時にロードしなければなりません。
 詳細は各ライブラリのドキュメントを見てください。
@@ -14033,7 +14052,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
         say.  Use <xref linkend="guc-session-preload-libraries"/> for that
         instead.
 -->
-        これ以外のライブラリもプリロードできます。
+これ以外のライブラリもプリロードできます。
 共有ライブラリをプリロードすることにより、最初にライブラリが使われる際にライブラリが起動する時間を避けることができます。
 しかし、そのライブラリが使われないとしても、サーバプロセスが起動する時間がわずかに長くなる可能性があります。
 したがって、この方法は、ほとんどのセッションで使われるライブラリにのみ使用することを推奨します。
@@ -14098,9 +14117,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
    </sect2>
 
      <sect2 id="runtime-config-client-other">
-     <!--
+<!--
      <title>Other Defaults</title>
-     -->
+-->
      <title>その他のデフォルト</title>
 
      <variablelist>
@@ -14118,19 +14137,19 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If a dynamically loadable module needs to be opened and the
         file name specified in the <command>CREATE FUNCTION</command> or
         <command>LOAD</command> command
         does not have a directory component (i.e., the
         name does not contain a slash), the system will search this
         path for the required file.
-       -->
-       オープンする必要がある動的ロード可能なモジュールについて、その<command>CREATE FUNCTION</command>や<command>LOAD</command>コマンドで指定されたファイル名にディレクトリ要素がなく（つまり、名前にスラッシュが含まれずに）指定された場合、システムは必要なファイルをこのパスから検索します。
+-->
+オープンする必要がある動的ロード可能なモジュールについて、その<command>CREATE FUNCTION</command>や<command>LOAD</command>コマンドで指定されたファイル名にディレクトリ要素がなく（つまり、名前にスラッシュが含まれずに）指定された場合、システムは必要なファイルをこのパスから検索します。
        </para>
 
        <para>
-       <!--
+<!--
         The value for <varname>dynamic_library_path</varname> must be a
         list of absolute directory paths separated by colons (or semi-colons
         on Windows).  If a list element starts
@@ -14141,8 +14160,8 @@ SET XML OPTION { DOCUMENT | CONTENT };
         <productname>PostgreSQL</productname> distribution are installed.
         (Use <literal>pg_config &#045;-pkglibdir</literal> to find out the name of
         this directory.) For example:
-       -->
-       <varname>dynamic_library_path</varname>の値は、絶対パスのディレクトリ名をコロン（Windowsの場合はセミコロン）で区切った一覧です。
+-->
+<varname>dynamic_library_path</varname>の値は、絶対パスのディレクトリ名をコロン（Windowsの場合はセミコロン）で区切った一覧です。
 この一覧の要素が特別な<literal>$libdir</literal>という値から始まる場合、コンパイルされた<productname>PostgreSQL</productname>パッケージのライブラリディレクトリで<literal>$libdir</literal>は置換されます。
 ここには、<productname>PostgreSQL</productname>の標準配布物により提供されるモジュールがインストールされます
 （このディレクトリ名を表示するには、<literal>pg_config --pkglibdir</literal> を使用してください）。
@@ -14160,25 +14179,25 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
        </para>
 
        <para>
-       <!--
+<!--
         The default value for this parameter is
         <literal>'$libdir'</literal>. If the value is set to an empty
         string, the automatic path search is turned off.
-       -->
-       このパラメータのデフォルト値は<literal>'$libdir'</literal>です。
+-->
+このパラメータのデフォルト値は<literal>'$libdir'</literal>です。
 この値が空に設定された場合、自動的なパス検索は無効になります。
        </para>
 
        <para>
-       <!--
+<!--
         This parameter can be changed at run time by superusers, but a
         setting done that way will only persist until the end of the
         client connection, so this method should be reserved for
         development purposes. The recommended way to set this parameter
         is in the <filename>postgresql.conf</filename> configuration
         file.
-       -->
-       このパラメータはスーパーユーザによって実行時に変更することができますが、この方法での設定は、そのクライアント接続が終わるまでしか有効になりません。
+-->
+このパラメータはスーパーユーザによって実行時に変更することができますが、この方法での設定は、そのクライアント接続が終わるまでしか有効になりません。
 ですので、この方法は開発目的でのみ使用すべきです。
 推奨方法はこのパラメータを<filename>postgresql.conf</filename>設定ファイル内で設定することです。
        </para>
@@ -14196,10 +14215,10 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Soft upper limit of the size of the set returned by GIN index scans. For more
         information see <xref linkend="gin-tips"/>.
-       -->
+-->
        GINインデックス走査により返されるセットのソフトな上限サイズです。
 詳細は<xref linkend="gin-tips"/>を参照してください。
        </para>
@@ -14211,9 +14230,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
    </sect1>
 
    <sect1 id="runtime-config-locks">
-   <!--
+<!--
     <title>Lock Management</title>
-    -->
+-->
     <title>ロック管理</title>
 
      <variablelist>
@@ -14245,7 +14264,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         This is the amount of time to wait on a lock
         before checking to see if there is a deadlock condition. The
         check for deadlock is relatively expensive, so the server doesn't run
@@ -14277,13 +14296,13 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
        </para>
 
        <para>
-       <!--
+<!--
         When <xref linkend="guc-log-lock-waits"/> is set,
         this parameter also determines the amount of time to wait before
         a log message is issued about the lock wait.  If you are trying
         to investigate locking delays you might want to set a shorter than
         normal <varname>deadlock_timeout</varname>.
-       -->
+-->
 <xref linkend="guc-log-lock-waits"/>が設定された場合、このパラメータはロック待機に関するログメッセージを出力する前の待機時間を決定します。
 ロック遅延の調査を行う場合は、通常の<varname>deadlock_timeout</varname>よりも短い値を設定することを勧めます。
        </para>
@@ -14301,7 +14320,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The shared lock table tracks locks on
         <varname>max_locks_per_transaction</varname> * (<xref
         linkend="guc-max-connections"/> + <xref
@@ -14316,8 +14335,8 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         raise this value if you have queries that touch many different
         tables in a single transaction, e.g., query of a parent table with
         many children.  This parameter can only be set at server start.
-       -->
-       共有ロックテーブルは、<varname>max_locks_per_transaction</varname> * （<xref linkend="guc-max-connections"/> + <xref linkend="guc-max-prepared-transactions"/>）オブジェクト（例えばテーブル）上のロック追跡します。
+-->
+共有ロックテーブルは、<varname>max_locks_per_transaction</varname> * （<xref linkend="guc-max-connections"/> + <xref linkend="guc-max-prepared-transactions"/>）オブジェクト（例えばテーブル）上のロック追跡します。
 したがって、ある時点でこの数以上の個々のオブジェクトをロックすることはできません。
 このパラメータは各トランザクションで割り当てられるオブジェクトロックの平均値を制御します。
 個々のトランザクションでは、このロックテーブルにすべてのトランザクションのロックが収まる限りオブジェクトのロックを獲得できます。
@@ -14327,13 +14346,13 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
        </para>
 
        <para>
-       <!--
+<!--
         When running a standby server, you must set this parameter to the
         same or higher value than on the primary server. Otherwise, queries
         will not be allowed in the standby server.
-       -->
-       スタンバイサーバを稼動するとき、このパラメータをプライマリサーバと同じか、より高い値に設定しなければなりません。
-       そうしないと、問い合わせはスタンバイサーバでは許可されません。
+-->
+スタンバイサーバを稼動するとき、このパラメータをプライマリサーバと同じか、より高い値に設定しなければなりません。
+そうしないと、問い合わせはスタンバイサーバでは許可されません。
        </para>
       </listitem>
      </varlistentry>
@@ -14349,7 +14368,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The shared predicate lock table tracks locks on
         <varname>max_pred_locks_per_transaction</varname> * (<xref
         linkend="guc-max-connections"/> + <xref
@@ -14364,16 +14383,16 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         raise this value if you have clients that touch many different
         tables in a single serializable transaction. This parameter can
         only be set at server start.
-       -->
-       共有記述ロックテーブル（shared predicate lock table）は、<varname>max_pred_locks_per_transaction</varname> * (<xref
+-->
+共有記述ロックテーブル（shared predicate lock table）は、<varname>max_pred_locks_per_transaction</varname> * (<xref
         linkend="guc-max-connections"/> + <xref
         linkend="guc-max-prepared-transactions"/>)オブジェクト（例えば諸テーブル）のロックを追跡します。
-       従って、この数以上の明確なオブジェクトは同時にロックされません。
-       このパラメータはそれぞれのトランザクションに対して割り当てられたオブジェクトのロックの平均数を管理します。
-       個別のトランザクションはロックテーブル内の全てのトランザクションのロックが適合する限り、より多くのオブジェクトをロックできます。
-       これはロック可能な行数では<emphasis>ありません</emphasis>。その値は無制限です。
-       デフォルトは64で、テストでは一般的に充分ですが、単一のシリアライザブルトランザクションで数多くの異なるテーブルに触れるクライアントが存在する場合、この値を大きくする必要があることがあります。
-       このパラメータはサーバ起動時のみ設定可能です。
+従って、この数以上の明確なオブジェクトは同時にロックされません。
+このパラメータはそれぞれのトランザクションに対して割り当てられたオブジェクトのロックの平均数を管理します。
+個別のトランザクションはロックテーブル内の全てのトランザクションのロックが適合する限り、より多くのオブジェクトをロックできます。
+これはロック可能な行数では<emphasis>ありません</emphasis>。その値は無制限です。
+デフォルトは64で、テストでは一般的に充分ですが、単一のシリアライザブルトランザクションで数多くの異なるテーブルに触れるクライアントが存在する場合、この値を大きくする必要があることがあります。
+このパラメータはサーバ起動時のみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -14402,7 +14421,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
 -->
 リレーション全体をカバーするロックに昇格する前に、一つリレーションの中で述語ロックできるページ数あるいはタプル数を指定します。
 0以上の値は、絶対的な制限を表し、負の数は<xref linkend="guc-max-pred-locks-per-transaction"/>をその絶対値で割ったものを表します。
-  デフォルトは-2で、以前のバージョンの<productname>PostgreSQL</productname>の振る舞いを維持します。
+デフォルトは-2で、以前のバージョンの<productname>PostgreSQL</productname>の振る舞いを維持します。
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
@@ -14436,15 +14455,15 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
    </sect1>
 
    <sect1 id="runtime-config-compatible">
-   <!--
+<!--
     <title>Version and Platform Compatibility</title>
-    -->
+-->
     <title>バージョンとプラットフォーム互換性</title>
 
     <sect2 id="runtime-config-compatible-version">
-    <!--
+<!--
      <title>Previous PostgreSQL Versions</title>
-     -->
+-->
      <title>以前のPostgreSQLバージョン</title>
 
      <variablelist>
@@ -14460,7 +14479,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         This controls whether the array input parser recognizes
         unquoted <literal>NULL</literal> as specifying a null array element.
         By default, this is <literal>on</literal>, allowing array values containing
@@ -14470,19 +14489,19 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         the string value <quote>NULL</quote>.  For backward compatibility with
         applications that require the old behavior, this variable can be
         turned <literal>off</literal>.
-       -->
-       これは、配列入力パーサが引用符のない<literal>NULL</literal>をNULL配列要素として認識するかどうかを制御します。
+-->
+これは、配列入力パーサが引用符のない<literal>NULL</literal>をNULL配列要素として認識するかどうかを制御します。
 デフォルトでは、これは<literal>on</literal>で、NULL値を持つ配列値を入力することができます。
 しかし、8.2より前のバージョンの<productname>PostgreSQL</productname>では、配列内のNULL値をサポートしておらず、<literal>NULL</literal>を<quote>NULL</quote>という値の文字列を持つ通常の配列要素として扱っていました。
 古い動作を必要とするアプリケーションの後方互換性のため、この変数を<literal>off</literal>にすることができます。
        </para>
 
        <para>
-       <!--
+<!--
         Note that it is possible to create array values containing null values
         even when this variable is <literal>off</literal>.
-       -->
-       この変数が<literal>off</literal>であっても、NULL値を含む配列値を作成することができることに注意してください。
+-->
+この変数が<literal>off</literal>であっても、NULL値を含む配列値を作成することができることに注意してください。
        </para>
       </listitem>
      </varlistentry>
@@ -14500,7 +14519,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         This controls whether a quote mark can be represented by
         <literal>\'</literal> in a string literal.  The preferred, SQL-standard way
         to represent a quote mark is by doubling it (<literal>''</literal>) but
@@ -14518,12 +14537,12 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         <literal>safe_encoding</literal> (allow only if client encoding does not
         allow ASCII <literal>\</literal> within a multibyte character).
         <literal>safe_encoding</literal> is the default setting.
-       -->
-       文字列リテラルの中で引用符が<literal>\'</literal>で表現されるかどうかを管理します。
-       引用符の表現としてSQL準拠の方式では二重化（<literal>''</literal>）ですが、<productname>PostgreSQL</productname>は歴史的に<literal>\'</literal>も受け付けます。
-       とは言っても、いくつかのクライアント文字集合符号化方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
-       クライアント側のコードが事実上エスケープを正しく扱わない場合、SQLインジェクション攻撃が可能になります。この危険性の回避は、サーバが逆スラッシュでエスケープされた引用符を含む問い合わせを拒絶するようにします。
-       許可される<varname>backslash_quote</varname>の値は、
+-->
+文字列リテラルの中で引用符が<literal>\'</literal>で表現されるかどうかを管理します。
+引用符の表現としてSQL準拠の方式では二重化（<literal>''</literal>）ですが、<productname>PostgreSQL</productname>は歴史的に<literal>\'</literal>も受け付けます。
+とは言っても、いくつかのクライアント文字集合符号化方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
+クライアント側のコードが事実上エスケープを正しく扱わない場合、SQLインジェクション攻撃が可能になります。この危険性の回避は、サーバが逆スラッシュでエスケープされた引用符を含む問い合わせを拒絶するようにします。
+許可される<varname>backslash_quote</varname>の値は、
         <literal>on</literal> （常に <literal>\'</literal> を許可）,
         <literal>off</literal> （常に拒否）、および
         <literal>safe_encoding</literal> （クライアント符号化方式がASCIIの<literal>\</literal>を許可しないときのみ、マルチバイト文字内で許可）。
@@ -14531,13 +14550,13 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
        </para>
 
        <para>
-       <!--
+<!--
         Note that in a standard-conforming string literal, <literal>\</literal> just
         means <literal>\</literal> anyway.  This parameter only affects the handling of
         non-standard-conforming literals, including
         escape string syntax (<literal>E'...'</literal>).
-       -->
-       標準に従った文字列リテラルでは、<literal>\</literal>は単に<literal>\</literal>を意味するものです。
+-->
+標準に従った文字列リテラルでは、<literal>\</literal>は単に<literal>\</literal>を意味するものです。
 このパラメータのみが、エスケープ文字列構文（<literal>E'...'</literal>）を含む標準に従わないリテラルの取り扱いに影響します。
        </para>
       </listitem>
@@ -14556,25 +14575,25 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When on, a warning is issued if a backslash (<literal>\</literal>)
         appears in an ordinary string literal (<literal>'...'</literal>
         syntax) and <varname>standard_conforming_strings</varname> is off.
         The default is <literal>on</literal>.
-       -->
-       有効の場合、通常の文字列リテラル（<literal>'...'</literal>構文）にバックスラッシュ（<literal>\</literal>）があり、<varname>standard_conforming_strings</varname>が無効な場合、警告が発せられます。
+-->
+有効の場合、通常の文字列リテラル（<literal>'...'</literal>構文）にバックスラッシュ（<literal>\</literal>）があり、<varname>standard_conforming_strings</varname>が無効な場合、警告が発せられます。
 デフォルトは<literal>on</literal>です。
        </para>
        <para>
-       <!--
+<!--
         Applications that wish to use backslash as escape should be
         modified to use escape string syntax (<literal>E'...'</literal>),
         because the default behavior of ordinary strings is now to treat
         backslash as an ordinary character, per SQL standard.  This variable
         can be enabled to help locate code that needs to be changed.
-       -->
-       通常文字列のデフォルトの振る舞いは、SQL標準ではバックスラッシュを通常文字として取り扱うため、バックスラッシュをエスケープとして使用したいアプリケーションは、エスケープ文字列構文(<literal>E'...'</literal>)を使用するように変更すべきです。
-        この変数は変更すべきコードを突き止めるのに役立つよう、有効にすることができます。
+-->
+通常文字列のデフォルトの振る舞いは、SQL標準ではバックスラッシュを通常文字として取り扱うため、バックスラッシュをエスケープとして使用したいアプリケーションは、エスケープ文字列構文(<literal>E'...'</literal>)を使用するように変更すべきです。
+この変数は変更すべきコードを突き止めるのに役立つよう、有効にすることができます。
        </para>
       </listitem>
      </varlistentry>
@@ -14590,18 +14609,18 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         In <productname>PostgreSQL</productname> releases prior to 9.0, large objects
         did not have access privileges and were, therefore, always readable
         and writable by all users.  Setting this variable to <literal>on</literal>
         disables the new privilege checks, for compatibility with prior
         releases.  The default is <literal>off</literal>.
         Only superusers can change this setting.
-       -->
+-->
        9.0以前の<productname>PostgreSQL</productname>リリースでは、ラージオブジェクトはアクセス権限が無く、従って全てのユーザが常に読み込み、書き込みが可能でした。
-       この変数を<literal>on</literal>にすると、以前のリリースとの互換性のため、新規の権限チェックが無効になります。
-       デフォルトは<literal>off</literal>です。
-        スーパーユーザのみこの設定を変更できます。
+この変数を<literal>on</literal>にすると、以前のリリースとの互換性のため、新規の権限チェックが無効になります。
+デフォルトは<literal>off</literal>です。
+スーパーユーザのみこの設定を変更できます。
        </para>
        <para>
 <!--
@@ -14654,7 +14673,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         This controls whether ordinary string literals
         (<literal>'...'</literal>) treat backslashes literally, as specified in
         the SQL standard.
@@ -14667,10 +14686,10 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         Escape string syntax (<xref linkend="sql-syntax-strings-escape"/>)
         should be used if an application desires
         backslashes to be treated as escape characters.
-       -->
-       標準SQLで規定されたように、通常の文字列リテラル（<literal>'...'</literal>）がバックスラッシュをそのまま取り扱うか否かを制御します。
+-->
+標準SQLで規定されたように、通常の文字列リテラル（<literal>'...'</literal>）がバックスラッシュをそのまま取り扱うか否かを制御します。
        <productname>PostgreSQL</productname> 9.1からデフォルトは<literal>on</literal>になっています（それ以前のリリースでは<literal>off</literal>がデフォルトでした）。
-       どのように文字列リテラルが処理されるかを決めるこのパラメータを、アプリケーションで検査することができます。
+どのように文字列リテラルが処理されるかを決めるこのパラメータを、アプリケーションで検査することができます。
 このパラメータの存在は、エスケープ文字列構文（<literal>E'...'</literal>）がサポートされているかどうかを示すものとも考えられます。
 エスケープ文字列構文 (<xref linkend="sql-syntax-strings-escape"/>)は、アプリケーションでバックスラッシュをエスケープ文字として扱いたい場合に使用すべきです。
        </para>
@@ -14688,7 +14707,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         This allows sequential scans of large tables to synchronize with each
         other, so that concurrent scans read the same block at about the
         same time and hence share the I/O workload.  When this is enabled,
@@ -14700,8 +14719,8 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         <literal>off</literal> ensures the pre-8.3 behavior in which a sequential
         scan always starts from the beginning of the table.  The default
         is <literal>on</literal>.
-       -->
-       これにより、同時実行スキャンがほぼ同じ時間に同じブロックを読み取り、I/Oへの負荷を分散できるように、互いに同期して、大規模テーブルをシーケンシャルスキャンすることができます。
+-->
+これにより、同時実行スキャンがほぼ同じ時間に同じブロックを読み取り、I/Oへの負荷を分散できるように、互いに同期して、大規模テーブルをシーケンシャルスキャンすることができます。
 これが有効な場合、スキャンはテーブルの途中から始まり、進行中のスキャンの活動と同期するように、行全体を覆うように終端を<quote>巻き上げる</quote>可能性があります。
 これにより、<literal>ORDER BY</literal>句を持たない問い合わせが返す行の順序は予想できない程変わってしまいます。
 このパラメータを<literal>off</literal>にすることで、シーケンシャルスキャンが常にテーブルの先頭から始まるという、8.3より前の動作を保証します。
@@ -14714,9 +14733,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
     </sect2>
 
     <sect2 id="runtime-config-compatible-clients">
-    <!--
+<!--
      <title>Platform and Client Compatibility</title>
-     -->
+-->
      <title>プラットフォームとクライアント互換性</title>
      <variablelist>
 
@@ -14732,7 +14751,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When on, expressions of the form <literal><replaceable>expr</replaceable> =
         NULL</literal> (or <literal>NULL =
         <replaceable>expr</replaceable></literal>) are treated as
@@ -14742,8 +14761,8 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         <literal><replaceable>expr</replaceable> = NULL</literal> is to always
         return null (unknown). Therefore this parameter defaults to
         <literal>off</literal>.
-       -->
-       有効の場合、<literal><replaceable>expr</replaceable> = NULL</literal>（もしくは<literal>NULL = <replaceable>expr</replaceable></literal>）形式の式は<literal><replaceable>expr</replaceable> IS NULL</literal>として取り扱われ、それは、もし<replaceable>expr</replaceable>がNULL値と評価すれば真を返し、そうでなければ偽を返します。
+-->
+有効の場合、<literal><replaceable>expr</replaceable> = NULL</literal>（もしくは<literal>NULL = <replaceable>expr</replaceable></literal>）形式の式は<literal><replaceable>expr</replaceable> IS NULL</literal>として取り扱われ、それは、もし<replaceable>expr</replaceable>がNULL値と評価すれば真を返し、そうでなければ偽を返します。
 <literal><replaceable>expr</replaceable> = NULL</literal>の正しいSQL仕様準拠の動作は常にNULL（判らない）を返すことです。
 従って、このパラメータのデフォルトは<literal>off</literal>になっています。
        </para>
@@ -14769,23 +14788,23 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
        </para>
 
        <para>
-       <!--
+<!--
         Note that this option only affects the exact form <literal>= NULL</literal>,
         not other comparison operators or other expressions
         that are computationally equivalent to some expression
         involving the equals operator (such as <literal>IN</literal>).
         Thus, this option is not a general fix for bad programming.
-       -->
-       このオプションは<literal>= NULL</literal>という形式にのみ影響することに注意してください。
+-->
+このオプションは<literal>= NULL</literal>という形式にのみ影響することに注意してください。
 他の比較演算子や等価演算子を呼び出す他の（<literal>IN</literal>のような）式と計算する上で等価となる式には影響を与えません。
 したがって、このオプションは間違ったプログラミングの汎用的な問題解決を行いません。
        </para>
 
        <para>
-       <!--
+<!--
         Refer to <xref linkend="functions-comparison"/> for related information.
-       -->
-       関連する情報は<xref linkend="functions-comparison"/>を参照してください。
+-->
+関連する情報は<xref linkend="functions-comparison"/>を参照してください。
        </para>
       </listitem>
      </varlistentry>
@@ -14795,9 +14814,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
    </sect1>
 
    <sect1 id="runtime-config-error-handling">
-   <!--
+<!--
     <title>Error Handling</title>
-    -->
+-->
     <title>エラー処理</title>
 
     <variablelist>
@@ -14813,11 +14832,11 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If on, any error will terminate the current session.  By default,
         this is set to off, so that only FATAL errors will terminate the
         session.
-       -->
+-->
 onなら、全てのエラーは現在のセッションを中止させます。
 デフォルトではこれはoffに設定されているので、 FATALエラーのみがセッションを中止させます。
        </para>
@@ -14835,7 +14854,7 @@ onなら、全てのエラーは現在のセッションを中止させます。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When set to on, which is the default, <productname>PostgreSQL</productname>
         will automatically reinitialize after a backend crash.  Leaving this
         value set to on is normally the best way to maximize the availability
@@ -14843,7 +14862,7 @@ onなら、全てのエラーは現在のセッションを中止させます。
         <productname>PostgreSQL</productname> is being invoked by clusterware, it may be
         useful to disable the restart so that the clusterware can gain
         control and take any actions it deems appropriate.
-       -->
+-->
 デフォルトであるonの場合、<productname>PostgreSQL</productname>はバックエンドのクラッシュの後、自動的に再初期化を行います。
 この値を真のままにしておくことが、通常データベースの可用性を最大化する最適の方法です。
 しかし、 <productname>PostgreSQL</productname>がクラスタウェアにより起動された時のような状況では、クラスタウェアが制御を獲得して、適切とみなすいかなる振る舞いをも行えるように再起動を無効にすることが有益かもしれません。
@@ -14970,13 +14989,13 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
    </sect1>
 
    <sect1 id="runtime-config-preset">
-   <!--
+<!--
     <title>Preset Options</title>
-    -->
+-->
     <title>設定済みのオプション</title>
 
     <para>
-    <!--
+<!--
      The following <quote>parameters</quote> are read-only.
      As such, they have been excluded from the sample
      <filename>postgresql.conf</filename> file.  These options report
@@ -14985,7 +15004,7 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
      administrative front-ends.
      Most of them are determined when <productname>PostgreSQL</productname>
      is compiled or when it is installed.
-     -->
+-->
 以下の<quote>パラメータ</quote>は読み取り専用です。
 そのため、これらは<filename>postgresql.conf</filename>のサンプルから除かれています。
 このオプションは、特定のアプリケーション、特に管理用フロントエンドによって注目される可能性がある<productname>PostgreSQL</productname>の様々な部分の振舞いを報告します。
@@ -15005,18 +15024,18 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the size of a disk block.  It is determined by the value
         of <literal>BLCKSZ</literal> when building the server. The default
         value is 8192 bytes.  The meaning of some configuration
         variables (such as <xref linkend="guc-shared-buffers"/>) is
         influenced by <varname>block_size</varname>. See <xref
         linkend="runtime-config-resource"/> for information.
-       -->
-       ディスクブロックの容量を報告します。
-       サーバ構築の際に<literal>BLCKSZ</literal>の値で決定されます。デフォルトの値は8192バイトです。
+-->
+ディスクブロックの容量を報告します。
+サーバ構築の際に<literal>BLCKSZ</literal>の値で決定されます。デフォルトの値は8192バイトです。
        （<xref linkend="guc-shared-buffers"/>の様な）いくつかの構成変数の意味は<varname>block_size</varname>によって影響されます。
-       これに関しての情報は<xref
+これに関しての情報は<xref
         linkend="runtime-config-resource"/>を参照してください。
        </para>
       </listitem>
@@ -15037,8 +15056,8 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
         Reports whether data checksums are enabled for this cluster.
         See <xref linkend="app-initdb-data-checksums"/> for more information.
 -->
-        このクラスタでデータチェックサムが有効になっているかどうかを報告します。
-        詳細は<xref linkend="app-initdb-data-checksums"/>を見てください。
+このクラスタでデータチェックサムが有効になっているかどうかを報告します。
+詳細は<xref linkend="app-initdb-data-checksums"/>を見てください。
        </para>
       </listitem>
      </varlistentry>
@@ -15156,14 +15175,14 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the locale in which sorting of textual data is done.
         See <xref linkend="locale"/> for more information.
         This value is determined when a database is created.
-       -->
-       テキストデータの並び替えが行なわれるロケールを報告します。
-       詳細は<xref linkend="locale"/> を参照してください。
-       この値はデータベースが作成されたときに決定されます。
+-->
+テキストデータの並び替えが行なわれるロケールを報告します。
+詳細は<xref linkend="locale"/> を参照してください。
+この値はデータベースが作成されたときに決定されます。
        </para>
       </listitem>
      </varlistentry>
@@ -15179,17 +15198,17 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the locale that determines character classifications.
         See <xref linkend="locale"/> for more information.
         This value is determined when a database is created.
         Ordinarily this will be the same as <varname>lc_collate</varname>,
         but for special applications it might be set differently.
-       -->
-       文字分類を決定するロケールを報告します。
-       詳細は<xref linkend="locale"/>を参照してください。
-       この値はデータベースが作成されたときに決定されます。
-       通常、これは<varname>lc_collate</varname>と同一ですが、特殊なアプリケーションでは異なって設定されることがあります。
+-->
+文字分類を決定するロケールを報告します。
+詳細は<xref linkend="locale"/>を参照してください。
+この値はデータベースが作成されたときに決定されます。
+通常、これは<varname>lc_collate</varname>と同一ですが、特殊なアプリケーションでは異なって設定されることがあります。
        </para>
       </listitem>
      </varlistentry>
@@ -15205,12 +15224,12 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the maximum number of function arguments. It is determined by
         the value of <literal>FUNC_MAX_ARGS</literal> when building the server. The
         default value is 100 arguments.
-       -->
-       関数の引数の最大数を報告します。
+-->
+関数の引数の最大数を報告します。
 サーバを構築する時、<literal>FUNC_MAX_ARGS</literal>の値で決定されます。
 デフォルトの値は100引数です。
        </para>
@@ -15228,15 +15247,15 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the maximum identifier length. It is determined as one
         less than the value of <literal>NAMEDATALEN</literal> when building
         the server. The default value of <literal>NAMEDATALEN</literal> is
         64; therefore the default
         <varname>max_identifier_length</varname> is 63 bytes, which
         can be less than 63 characters when using multibyte encodings.
-       -->
-       最長の識別子の長さを報告します。
+-->
+最長の識別子の長さを報告します。
 サーバ構築時の<literal>NAMEDATALEN</literal>の値より一つ少なく設定されます。
 デフォルトの<literal>NAMEDATALEN</literal>の値は64ですので、デフォルトの<varname>max_identifier_length</varname>は63バイトで、マルチバイト符号化方式を使用している場合、63文字以下になることがあります。
        </para>
@@ -15254,12 +15273,12 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the maximum number of index keys. It is determined by
         the value of <literal>INDEX_MAX_KEYS</literal> when building the server. The
         default value is 32 keys.
-       -->
-       インデックスキーの最大数を報告します。サーバをビルドする際に<literal>INDEX_MAX_KEYS</literal>の値で決定されます。デフォルトの値は32キーです。
+-->
+インデックスキーの最大数を報告します。サーバをビルドする際に<literal>INDEX_MAX_KEYS</literal>の値で決定されます。デフォルトの値は32キーです。
        </para>
       </listitem>
      </varlistentry>
@@ -15275,16 +15294,16 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the number of blocks (pages) that can be stored within a file
         segment.  It is determined by the value of <literal>RELSEG_SIZE</literal>
         when building the server.  The maximum size of a segment file in bytes
         is equal to <varname>segment_size</varname> multiplied by
         <varname>block_size</varname>; by default this is 1GB.
-       -->
-       あるファイルセグメントの中に格納できるブロック数（ページ数）を報告します。
-       サーバ構築時に<literal>RELSEG_SIZE</literal>の値で決定されます。
-       バイト単位の一セグメントファイルの最大容量は、<varname>block_size</varname>倍の<varname>segment_size</varname>と等しくなります。デフォルトでは1GBです。
+-->
+あるファイルセグメントの中に格納できるブロック数（ページ数）を報告します。
+サーバ構築時に<literal>RELSEG_SIZE</literal>の値で決定されます。
+バイト単位の一セグメントファイルの最大容量は、<varname>block_size</varname>倍の<varname>segment_size</varname>と等しくなります。デフォルトでは1GBです。
        </para>
       </listitem>
      </varlistentry>
@@ -15302,14 +15321,14 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the database encoding (character set).
         It is determined when the database is created.  Ordinarily,
         clients need only be concerned with the value of <xref
         linkend="guc-client-encoding"/>.
-       -->
-       データベース符号化方式（文字セット）を報告します。
-       データベースが作成された時に決定されます。通常クライアントは<xref
+-->
+データベース符号化方式（文字セット）を報告します。
+データベースが作成された時に決定されます。通常クライアントは<xref
         linkend="guc-client-encoding"/>の値にのみ注意する必要があります。
        </para>
       </listitem>
@@ -15326,12 +15345,12 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the version number of the server. It is determined by the
         value of <literal>PG_VERSION</literal> when building the server.
-       -->
-       サーバのバージョン番号を報告します。
-       サーバ構築の際の<literal>PG_VERSION</literal>の値によって決定されます。
+-->
+サーバのバージョン番号を報告します。
+サーバ構築の際の<literal>PG_VERSION</literal>の値によって決定されます。
        </para>
       </listitem>
      </varlistentry>
@@ -15347,12 +15366,12 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the version number of the server as an integer. It is determined
         by the value of <literal>PG_VERSION_NUM</literal> when building the server.
-       -->
-       サーバのバージョン番号を整数として返します。
-       この値は、サーバ構築時の<literal>PG_VERSION_NUM</literal>の値により決まります。
+-->
+サーバのバージョン番号を整数として返します。
+この値は、サーバ構築時の<literal>PG_VERSION_NUM</literal>の値により決まります。
        </para>
       </listitem>
      </varlistentry>
@@ -15427,33 +15446,33 @@ WALディスクブロックの容量を報告します。
    </sect1>
 
    <sect1 id="runtime-config-custom">
-   <!--
+<!--
     <title>Customized Options</title>
-    -->
+-->
     <title>独自のオプション</title>
 
     <para>
-    <!--
+<!--
      This feature was designed to allow parameters not normally known to
      <productname>PostgreSQL</productname> to be added by add-on modules
      (such as procedural languages).  This allows extension modules to be
      configured in the standard ways.
-     -->
-     この機能は追加モジュール（手続き言語など）によって追加される<productname>PostgreSQL</productname>が識別できないパラメータを使えるように設計されたものです。
+-->
+この機能は追加モジュール（手続き言語など）によって追加される<productname>PostgreSQL</productname>が識別できないパラメータを使えるように設計されたものです。
 これにより拡張モジュールは標準の方法で構成されます。
     </para>
 
     <para>
-    <!--
+<!--
      Custom options have two-part names: an extension name, then a dot, then
      the parameter name proper, much like qualified names in SQL.  An example
      is <literal>plpgsql.variable_conflict</literal>.
-    -->
-    カスタムオプションには２つに分かれた名称があります。拡張名につづいてドット、そして特定のパラメータ名です。SQLの修飾名に良く似ています。例として<literal>plpgsql.variable_conflict</literal>が挙げられます。
+-->
+カスタムオプションには２つに分かれた名称があります。拡張名につづいてドット、そして特定のパラメータ名です。SQLの修飾名に良く似ています。例として<literal>plpgsql.variable_conflict</literal>が挙げられます。
     </para>
 
     <para>
-    <!--
+<!--
      Because custom options may need to be set in processes that have not
      loaded the relevant extension module, <productname>PostgreSQL</productname>
      will accept a setting for any two-part parameter name.  Such variables
@@ -15462,27 +15481,27 @@ WALディスクブロックの容量を報告します。
      its variable definitions, convert any placeholder values according to
      those definitions, and issue warnings for any unrecognized placeholders
      that begin with its extension name.
-     -->
-     カスタムオプションは読み込まれていない関連性のある拡張モジュールのプロセスに設定される必要がある場合があるので、<productname>PostgreSQL</productname>はどんな２つの部分のパラメータ名による設定を受け付けます。これらの変数は代替物として取り扱われ、それらを定義したモジュールが読み込まれるまで機能しません。
-     拡張モジュールが読み込まれた時、その変数定義が追加され、それら定義に基づいた代替値が変換され、そしてその拡張名の確認されない代替物に対して警告が発せられます。
+-->
+カスタムオプションは読み込まれていない関連性のある拡張モジュールのプロセスに設定される必要がある場合があるので、<productname>PostgreSQL</productname>はどんな２つの部分のパラメータ名による設定を受け付けます。これらの変数は代替物として取り扱われ、それらを定義したモジュールが読み込まれるまで機能しません。
+拡張モジュールが読み込まれた時、その変数定義が追加され、それら定義に基づいた代替値が変換され、そしてその拡張名の確認されない代替物に対して警告が発せられます。
     </para>
    </sect1>
 
    <sect1 id="runtime-config-developer">
-   <!--
+<!--
     <title>Developer Options</title>
-    -->
+-->
     <title>開発者向けのオプション</title>
 
     <para>
-    <!--
+<!--
      The following parameters are intended for developer testing, and
      should never be used on a production database.  However, some of
      them can be used to assist with the recovery of severely damaged
      databases.  As such, they have been excluded from the sample
      <filename>postgresql.conf</filename> file.  Note that many of these
      parameters require special source compilation flags to work at all.
-     -->
+-->
 以下のパラメータは、開発者のテスト用であり、決して実運用のデータベースに使わないでください。
 しかし、中には深刻な損傷を負ったデータベースの復旧に役立つものもあります。
 したがって、これらはサンプルの<filename>postgresql.conf</filename>からは除外されています。
@@ -15686,13 +15705,13 @@ WALディスクブロックの容量を報告します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Ignore system indexes when reading system tables (but still
         update the indexes when modifying the tables).  This is useful
         when recovering from damaged system indexes.
         This parameter cannot be changed after session start.
-       -->
-       システムテーブルの読み込み時にシステムインデックスを無視します（しかしテーブルが更新された時はインデックスを更新します）。
+-->
+システムテーブルの読み込み時にシステムインデックスを無視します（しかしテーブルが更新された時はインデックスを更新します）。
 障害があるシステムインデックスを復旧する時、これは有用です。
 セッションが始まった後に、このパラメータを変更することはできません。
        </para>
@@ -15710,7 +15729,7 @@ WALディスクブロックの容量を報告します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The amount of time to delay when a new
         server process is started, after it conducts the
         authentication procedure.  This is intended to give developers an
@@ -15718,7 +15737,7 @@ WALディスクブロックの容量を報告します。
         If this value is specified without units, it is taken as seconds.
         A value of zero (the default) disables the delay.
         This parameter cannot be changed after session start.
-       -->
+-->
 サーバプロセスが始まり認証手続きが終わった後の遅延時間です。
 これは、デバッガを使用してサーバプロセスに接続する機会を開発者に提供することを目的としています。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
@@ -15739,7 +15758,7 @@ WALディスクブロックの容量を報告します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The amount of time to delay just after a
         new server process is forked, before it conducts the
         authentication procedure.  This is intended to give developers an
@@ -15749,7 +15768,7 @@ WALディスクブロックの容量を報告します。
         A value of zero (the default) disables the delay.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 新しくサーバプロセスがforkした後、認証手続きに入る前の遅延時間です。
 これは、認証における誤動作を追跡するために、デバッガを使用してサーバプロセスに接続する機会を開発者に提供することを目的としたものです。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
@@ -15770,15 +15789,15 @@ WALディスクブロックの容量を報告します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Generates a great amount of debugging output for the
         <command>LISTEN</command> and <command>NOTIFY</command>
         commands.  <xref linkend="guc-client-min-messages"/> or
         <xref linkend="guc-log-min-messages"/> must be
         <literal>DEBUG1</literal> or lower to send this output to the
         client or server logs, respectively.
-       -->
-       <command>LISTEN</command>と<command>NOTIFY</command>コマンドのための大量なデバッグ出力を生成します。
+-->
+<command>LISTEN</command>と<command>NOTIFY</command>コマンドのための大量なデバッグ出力を生成します。
 この出力をクライアントもしくはサーバログに送信するためには、それぞれ、<xref linkend="guc-client-min-messages"/>もしくは<xref linkend="guc-log-min-messages"/>は<literal>DEBUG1</literal>以下でなければなりません。
        </para>
       </listitem>
@@ -15795,7 +15814,7 @@ WALディスクブロックの容量を報告します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables logging of recovery-related debugging output that otherwise
         would not be logged. This parameter allows the user to override the
         normal setting of <xref linkend="guc-log-min-messages"/>, but only for
@@ -15810,17 +15829,17 @@ WALディスクブロックの容量を報告します。
         them to the server log.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
-       復旧関連のデバッグ出力のログ取得を有効にします。さもないとログは取られません。
-       このパラメータはユーザに対し、<xref linkend="guc-log-min-messages"/>の通常設定を上書きすることを許可します。
-       しかし、特定のメッセージに対してのみです。これはホットスタンバイのデバッグを意図したものです。
-       有効な値は、<literal>DEBUG5</literal>、<literal>DEBUG4</literal>、
+-->
+復旧関連のデバッグ出力のログ取得を有効にします。さもないとログは取られません。
+このパラメータはユーザに対し、<xref linkend="guc-log-min-messages"/>の通常設定を上書きすることを許可します。
+しかし、特定のメッセージに対してのみです。これはホットスタンバイのデバッグを意図したものです。
+有効な値は、<literal>DEBUG5</literal>、<literal>DEBUG4</literal>、
         <literal>DEBUG3</literal>、<literal>DEBUG2</literal>、<literal>DEBUG1</literal>、および
         <literal>LOG</literal>です。
-       デフォルトの<literal>LOG</literal>は、ログ取得の決定に全く影響しません。
-       その他の値は、あたかも<literal>LOG</literal>優先度を所有しているごとく、それ、またはより高い優先度でログ取得される復旧関連デバッグメッセージの要因となります。
+デフォルトの<literal>LOG</literal>は、ログ取得の決定に全く影響しません。
+その他の値は、あたかも<literal>LOG</literal>優先度を所有しているごとく、それ、またはより高い優先度でログ取得される復旧関連デバッグメッセージの要因となります。
        <varname>log_min_messages</varname>の通常設定に対し、これは無条件にそれらをサーバログに送り込みます。
-       このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバコマンドラインでのみ設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -15836,13 +15855,13 @@ WALディスクブロックの容量を報告します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If on, emit information about resource usage during sort operations.
         This parameter is only available if the <symbol>TRACE_SORT</symbol> macro
         was defined when <productname>PostgreSQL</productname> was compiled.
         (However, <symbol>TRACE_SORT</symbol> is currently defined by default.)
-       -->
-       もしも有効であれば、並び替え操作の間のリソース使用についての情報を放出します。
+-->
+もしも有効であれば、並び替え操作の間のリソース使用についての情報を放出します。
 このパラメータは <productname>PostgreSQL</productname>がコンパイルされた時、<symbol>TRACE_SORT</symbol>マクロが定義されている場合にのみ有効です。
 （とは言っても、現在<symbol>TRACE_SORT</symbol>はデフォルトで定義されています。）
        </para>
@@ -15860,7 +15879,7 @@ WALディスクブロックの容量を報告します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If on, emit information about lock usage.  Information dumped
         includes the type of lock operation, the type of lock and the unique
         identifier of the object being locked or unlocked.  Also included
@@ -15869,12 +15888,12 @@ WALディスクブロックの容量を報告します。
         type a count of the number of granted locks and waiting locks is
         also dumped as well as the totals.  An example of the log file output
         is shown here:
-       -->
-       有効な場合、ロックの使用状況に関する情報を出力します。
-       出力される情報には、ロック操作の種類、ロックの種類、ロックまたはロック解除されているオブジェクトの一意な識別子が含まれます。
-       また、このオブジェクトに既に与えられているロック種類やこのオブジェクトで待機しているロック種類を表すビットマスクも含まれます。
-       ロック種類それぞれについて、与えられているロック数、待機中のロック数がその総数と共に出力されます。
-       ログファイル出力例を以下に示します。
+-->
+有効な場合、ロックの使用状況に関する情報を出力します。
+出力される情報には、ロック操作の種類、ロックの種類、ロックまたはロック解除されているオブジェクトの一意な識別子が含まれます。
+また、このオブジェクトに既に与えられているロック種類やこのオブジェクトで待機しているロック種類を表すビットマスクも含まれます。
+ロック種類それぞれについて、与えられているロック数、待機中のロック数がその総数と共に出力されます。
+ログファイル出力例を以下に示します。
 <screen>
 LOG:  LockAcquire: new: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       grantMask(0) req(0,0,0,0,0,0,0)=0 grant(0,0,0,0,0,0,0)=0
@@ -15889,19 +15908,19 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       grantMask(0) req(0,0,0,0,0,0,0)=0 grant(0,0,0,0,0,0,0)=0
       wait(0) type(INVALID)
 </screen>
-       <!--
+<!--
         Details of the structure being dumped may be found in
         <filename>src/include/storage/lock.h</filename>.
-       -->
-       ダンプされる構造の詳細は、<filename>src/include/storage/lock.h</filename> にあります。
+-->
+ダンプされる構造の詳細は、<filename>src/include/storage/lock.h</filename> にあります。
        </para>
        <para>
-       <!--
+<!--
         This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
         macro was defined when <productname>PostgreSQL</productname> was
         compiled.
-       -->
-       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+-->
+このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
        </para>
       </listitem>
      </varlistentry>
@@ -15917,21 +15936,21 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If on, emit information about lightweight lock usage.  Lightweight
         locks are intended primarily to provide mutual exclusion of access
         to shared-memory data structures.
-       -->
-       有効な場合、軽量ロックの使用状況に関する情報を出力します。
-       軽量ロックは主に、共有メモリ上のデータ構造へのアクセスに関する排他制御機能を提供することを意図したものです。
+-->
+有効な場合、軽量ロックの使用状況に関する情報を出力します。
+軽量ロックは主に、共有メモリ上のデータ構造へのアクセスに関する排他制御機能を提供することを意図したものです。
        </para>
        <para>
-       <!--
+<!--
         This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
         macro was defined when <productname>PostgreSQL</productname> was
         compiled.
-       -->
-       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+-->
+このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
        </para>
       </listitem>
      </varlistentry>
@@ -15947,20 +15966,20 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If on, emit information about user lock usage.  Output is the same
         as for <symbol>trace_locks</symbol>, only for advisory locks.
-       -->
-       有効な場合、ユーザロックの使用状況に関する情報を出力します。
-       出力は<symbol>trace_locks</symbol>と同じですが、勧告的ロックに関するもののみを出力します。
+-->
+有効な場合、ユーザロックの使用状況に関する情報を出力します。
+出力は<symbol>trace_locks</symbol>と同じですが、勧告的ロックに関するもののみを出力します。
        </para>
        <para>
-       <!--
+<!--
         This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
         macro was defined when <productname>PostgreSQL</productname> was
         compiled.
-       -->
-       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+-->
+このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
        </para>
       </listitem>
      </varlistentry>
@@ -15980,16 +15999,16 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
         If set, do not trace locks for tables below this OID (used to avoid
         output on system tables).
 -->
-       設定すると、このOID未満のテーブルに関するロックの追跡を行いません。
+設定すると、このOID未満のテーブルに関するロックの追跡を行いません。
        （システムテーブルに関する出力を抑えるために使用します。）
        </para>
        <para>
-       <!--
+<!--
         This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
         macro was defined when <productname>PostgreSQL</productname> was
         compiled.
-       -->
-       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+-->
+このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
        </para>
       </listitem>
      </varlistentry>
@@ -16005,18 +16024,18 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Unconditionally trace locks on this table (OID).
-       -->
-       このテーブル（OID）に対し無条件でロックを追跡します。
+-->
+このテーブル（OID）に対し無条件でロックを追跡します。
        </para>
        <para>
-       <!--
+<!--
         This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
         macro was defined when <productname>PostgreSQL</productname> was
         compiled.
-       -->
-       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+-->
+このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
        </para>
       </listitem>
      </varlistentry>
@@ -16032,19 +16051,19 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If set, dumps information about all current locks when a
         deadlock timeout occurs.
-       -->
-       設定すると、デッドロックタイムアウトが発生した時全ての進行中のロックについての情報がダンプされます。
+-->
+設定すると、デッドロックタイムアウトが発生した時全ての進行中のロックについての情報がダンプされます。
        </para>
        <para>
-       <!--
+<!--
         This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
         macro was defined when <productname>PostgreSQL</productname> was
         compiled.
-       -->
-       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+-->
+このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
        </para>
       </listitem>
      </varlistentry>
@@ -16060,19 +16079,19 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If set, logs system resource usage statistics (memory and CPU) on
         various B-tree operations.
-       -->
-       設定すると、各種B-tree操作に関するシステムリソース（メモリとCPU）の使用についての統計情報をログに出力します。
+-->
+設定すると、各種B-tree操作に関するシステムリソース（メモリとCPU）の使用についての統計情報をログに出力します。
        </para>
        <para>
-       <!--
+<!--
         This parameter is only available if the <symbol>BTREE_BUILD_STATS</symbol>
         macro was defined when <productname>PostgreSQL</productname> was
         compiled.
-       -->
-       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>BTREE_BUILD_STATS</symbol>マクロが定義された場合のみ有効です。
+-->
+このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>BTREE_BUILD_STATS</symbol>マクロが定義された場合のみ有効です。
        </para>
       </listitem>
      </varlistentry>
@@ -16137,13 +16156,13 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If on, emit WAL-related debugging output. This parameter is
         only available if the <symbol>WAL_DEBUG</symbol> macro was
         defined when <productname>PostgreSQL</productname> was
         compiled.
-       -->
-       もしonであれば、WALに関連したデバッグ出力が有効になります。このパラメータは<symbol>WAL_DEBUG</symbol>マクロが <productname>PostgreSQL</productname>のコンパイルの時に定義された場合にのみ有効です。
+-->
+もしonであれば、WALに関連したデバッグ出力が有効になります。このパラメータは<symbol>WAL_DEBUG</symbol>マクロが <productname>PostgreSQL</productname>のコンパイルの時に定義された場合にのみ有効です。
        </para>
       </listitem>
      </varlistentry>
@@ -16159,13 +16178,13 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Only has effect if <xref linkend="app-initdb-data-checksums"/> are enabled.
-       -->
+-->
        <xref linkend="app-initdb-data-checksums"/>が有効の時のみ効果があります。
        </para>
        <para>
-       <!--
+<!--
         Detection of a checksum failure during a read normally causes
         <productname>PostgreSQL</productname> to report an error, aborting the current
         transaction.  Setting <varname>ignore_checksum_failure</varname> to on causes
@@ -16176,13 +16195,13 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
         present in the table if the block header is still sane. If the header is
         corrupt an error will be reported even if this option is enabled. The
         default setting is <literal>off</literal>, and it can only be changed by a superuser.
-       -->
-       読み込み過程でチェックサム障害が検出されると、通常<productname>PostgreSQL</productname>はエラーを報告し、現時点のトランザクションを停止します。
+-->
+読み込み過程でチェックサム障害が検出されると、通常<productname>PostgreSQL</productname>はエラーを報告し、現時点のトランザクションを停止します。
        <varname>ignore_checksum_failure</varname>を有効（on）に設定するとシステムはその障害を無視し（しかし警告は報告をします）、処理を継続します。
-       この振る舞いはたぶん<emphasis>クラッシュの原因、破損の伝播や隠ぺい、もしくはその他の深刻な問題</emphasis>の原因になることがあります。
-       とは言っても、エラーを切り抜け、ブロックヘッダが健全に存在するテーブルにある障害を受けていないタプルの回収は行えます。
-       もしヘッダーが破損されたら、オプションが有効になっていたとしても報告はなされます。
-       デフォルトの設定は<literal>off</literal>で、スーパーユーザのみが変更可能です。
+この振る舞いはたぶん<emphasis>クラッシュの原因、破損の伝播や隠ぺい、もしくはその他の深刻な問題</emphasis>の原因になることがあります。
+とは言っても、エラーを切り抜け、ブロックヘッダが健全に存在するテーブルにある障害を受けていないタプルの回収は行えます。
+もしヘッダーが破損されたら、オプションが有効になっていたとしても報告はなされます。
+デフォルトの設定は<literal>off</literal>で、スーパーユーザのみが変更可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -16198,7 +16217,7 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Detection of a damaged page header normally causes
         <productname>PostgreSQL</productname> to report an error, aborting the current
         transaction.  Setting <varname>zero_damaged_pages</varname> to on causes
@@ -16214,15 +16233,15 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
         the index before turning this parameter off again.  The
         default setting is <literal>off</literal>, and it can only be changed
         by a superuser.
-       -->
-       ページヘッダの障害がわかると、通常<productname>PostgreSQL</productname>はエラーの報告を行い、現在のトランザクションを中断させます。
+-->
+ページヘッダの障害がわかると、通常<productname>PostgreSQL</productname>はエラーの報告を行い、現在のトランザクションを中断させます。
 <varname>zero_damaged_pages</varname>をonに設定することにより、システムは代わりに警告を報告し、障害のあるメモリ内のページをゼロで埋め、処理を継続します。
 この動作により、障害のあったページ上にある全ての行の<emphasis>データが破壊</emphasis>されます。
 しかし、これによりエラーを確実に無視し、正常なページに存在するテーブル内の行を取り出すことができます。
-        ハードウェアまたはソフトウェアのエラーによって破損が発生した場合のデータの復旧時に有用です。
+ハードウェアまたはソフトウェアのエラーによって破損が発生した場合のデータの復旧時に有用です。
 障害のあるページからのテーブルのデータの復旧をあきらめた場合を除き、通常はこれをonにしてはいけません。
-        ゼロで埋められたページはディスクに書き込みを強要されないため、このパラメータを再び無効にする以前にテーブル、またはインデックスを再作成することを勧めます。
-        デフォルトは<literal>off</literal>であり、スーパーユーザのみ変更可能です。
+ゼロで埋められたページはディスクに書き込みを強要されないため、このパラメータを再び無効にする以前にテーブル、またはインデックスを再作成することを勧めます。
+デフォルトは<literal>off</literal>であり、スーパーユーザのみ変更可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -16418,44 +16437,44 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
     </variablelist>
   </sect1>
   <sect1 id="runtime-config-short">
-  <!--
+<!--
    <title>Short Options</title>
-   -->
+-->
    <title>短いオプション</title>
 
    <para>
-   <!--
+<!--
     For convenience there are also single letter command-line option
     switches available for some parameters.  They are described in
     <xref linkend="runtime-config-short-table"/>.  Some of these
     options exist for historical reasons, and their presence as a
     single-letter option does not necessarily indicate an endorsement
     to use the option heavily.
-    -->
-    簡便性のために、一文字のコマンドラインオプションスイッチも、幾つかのパラメータのために用意されています。
+-->
+簡便性のために、一文字のコマンドラインオプションスイッチも、幾つかのパラメータのために用意されています。
 それらは<xref linkend="runtime-config-short-table"/>に解説されています。
 一部のオプションは歴史的な理由のために存在します。
 また、この一文字オプションが存在することが、このオプションを多く使用することを支持することを示しているわけではありません。
    </para>
 
     <table id="runtime-config-short-table">
-    <!--
+<!--
      <title>Short Option Key</title>
-     -->
+-->
      <title>短いオプションキー</title>
      <tgroup cols="2">
       <colspec colname="col1" colwidth="1*"/>
       <colspec colname="col2" colwidth="2*"/>
       <thead>
        <row>
-       <!--
+<!--
         <entry>Short Option</entry>
-       -->
-       <entry>短いオプション</entry>
-       <!--
+-->
+        <entry>短いオプション</entry>
+<!--
         <entry>Equivalent</entry>
-       -->
-       <entry>同義</entry>
+-->
+        <entry>同義</entry>
        </row>
       </thead>
 

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -1399,7 +1399,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
          On Windows, setting a value of 0 will set this parameter to 2 hours,
          since Windows does not provide a way to read the system default value.
 -->
-          Windowsでは0を指定するとこのパラメータを2時間に設定します。なぜなら、Windowsはシステムデフォルト値を読む手段を提供していないからです。
+Windowsでは0を指定するとこのパラメータを2時間に設定します。なぜなら、Windowsはシステムデフォルト値を読む手段を提供していないからです。
         </para>
        </note>
       </listitem>
@@ -1440,7 +1440,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
          On Windows, setting a value of 0 will set this parameter to 1 second,
          since Windows does not provide a way to read the system default value.
 -->
-         Windowsでは0を指定すると、このパラメータを1秒に設定します。なぜなら、Windowsはシステムデフォルト値を読む手段を提供していないからです。
+Windowsでは0を指定すると、このパラメータを1秒に設定します。なぜなら、Windowsはシステムデフォルト値を読む手段を提供していないからです。
         </para>
        </note>
       </listitem>
@@ -3419,7 +3419,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
 重要なロックを保有し可能なかぎり早急に完了しなければならないある種の操作があります。コストに基づいたvacuum遅延はこの様な操作では起こりません。
 したがって、コストの累計が指定された限度をかなり高く越える可能性があります。
 このような場合無駄な長い遅延を防止するため、実際の遅延は<varname>vacuum_cost_delay</varname> * 4 を上限として、以下のように計算されます。
-       <varname>vacuum_cost_delay</varname> * <varname>accumulated_balance</varname> / <varname>vacuum_cost_limit</varname>
+<varname>vacuum_cost_delay</varname> * <varname>accumulated_balance</varname> / <varname>vacuum_cost_limit</varname>
       </para>
      </note>
     </sect2>
@@ -3520,7 +3520,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
 -->
 それぞれの周期で、この数以上のバッファはバックグラウンドライタにより書き込まれません。
 ゼロに設定することでバックグラウンド書き込みは無効になります。
-        （分離し、そして専用の補助プロセスにより管理されるチェックポイントは影響を受けません。）
+（分離し、そして専用の補助プロセスにより管理されるチェックポイントは影響を受けません。）
 デフォルト値は100バッファです。
 このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみで設定可能です。
         </para>
@@ -4531,7 +4531,8 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
         since WAL file updates will not be forced out at all.
         Possible values are:
 -->
-       WALの更新をディスクへ強制するのに使用される方法です。<varname>fsync</varname>がオフの場合この設定は役に立ちません。と言うのはWALファイルの更新が全く強制されないからです。取り得る値は以下のものです。
+WALの更新をディスクへ強制するのに使用される方法です。
+<varname>fsync</varname>がオフの場合この設定は役に立ちません。と言うのはWALファイルの更新が全く強制されないからです。取り得る値は以下のものです。
        </para>
        <itemizedlist>
         <listitem>
@@ -4843,7 +4844,7 @@ COWファイルシステムでは、新しいファイルを作るほうが速�
         selected by the default setting of -1 should give reasonable
         results in most cases.
 -->
-       WALバッファの内容はトランザクションのコミット毎にディスクに書き込まれます。
+WALバッファの内容はトランザクションのコミット毎にディスクに書き込まれます。
 したがって、極端に大きな値は有意な効果を期待できません。
 しかし、この値を数メガバイトに設定することにより、多くのクライアントが同時にコミットするトラフィック量の多いサーバでは書き込み性能が向上します。
 デフォルト設定の-1で選択される自動チューニングによると、ほとんどの場合妥当な結果が得られます。
@@ -5006,9 +5007,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
         interval, while subsequent processes wait only until the leader
         completes the flush operation.
 -->
-        9.3より前の<productname>PostgreSQL</productname>では、<varname>commit_delay</varname>の振る舞いは異なっており、あまり効果がありませんでした。
+9.3より前の<productname>PostgreSQL</productname>では、<varname>commit_delay</varname>の振る舞いは異なっており、あまり効果がありませんでした。
 全てのWALフラッシュではなく、コミットだけに影響していました。また、そしてWALフラッシュが早めに完了しても設定された遅延分待機していました。
-       <productname>PostgreSQL</productname> 9.3以降では、フラッシュの準備が整った最初のプロセスが設定値分待機し、後続のプロセスは最初のプロセスがフラッシュ操作を完了するまでの間だけ待機をします。
+<productname>PostgreSQL</productname> 9.3以降では、フラッシュの準備が整った最初のプロセスが設定値分待機し、後続のプロセスは最初のプロセスがフラッシュ操作を完了するまでの間だけ待機をします。
        </para>
       </listitem>
      </varlistentry>
@@ -8380,7 +8381,7 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
         increase the likelihood that an efficient query plan will be
         chosen.
 -->
-       GEQOにおける計画時間と問い合わせ計画の品質間のトレードオフを制御します。この変数は1から10までの範囲の整数でなければなりません。
+GEQOにおける計画時間と問い合わせ計画の品質間のトレードオフを制御します。この変数は1から10までの範囲の整数でなければなりません。
 デフォルトの値は5です。値を大きくすると、問い合わせ計画作成により多くの時間を費すことになりますが、より効率的な問い合わせ計画が選択される可能性が増加します。
        </para>
 
@@ -8416,7 +8417,8 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
         value is chosen based on <varname>geqo_effort</varname> and
         the number of tables in the query.
 -->
-       GEQOで使用されるプール容量を管理します。それは遺伝的個体群内の個体数です。最低でも2つはなければならず、よく100から1000までの値が使用されます。もし（デフォルトの設定である）零に設定されると、<varname>geqo_effort</varname>および問い合わせの中のテーブル数に基づいて、適切な値が選択されます。
+GEQOで使用されるプール容量を管理します。それは遺伝的個体群内の個体数です。最低でも2つはなければならず、よく100から1000までの値が使用されます。
+もし（デフォルトの設定である）零に設定されると、<varname>geqo_effort</varname>および問い合わせの中のテーブル数に基づいて、適切な値が選択されます。
        </para>
       </listitem>
      </varlistentry>
@@ -8440,7 +8442,8 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
         then a suitable value is chosen based on
         <varname>geqo_pool_size</varname>.
 -->
-       GEQOで使用される世代の数を管理します。それはアルゴリズムの反復数です。最低でも1はなければならず、よくプールサイズと同じ範囲の値が使用されます。これを0に設定（デフォルトの設定）すると、適切な値が<varname>geqo_pool_size</varname>に基づいて選択されます。
+GEQOで使用される世代の数を管理します。それはアルゴリズムの反復数です。最低でも1はなければならず、よくプールサイズと同じ範囲の値が使用されます。
+これを0に設定（デフォルトの設定）すると、適切な値が<varname>geqo_pool_size</varname>に基づいて選択されます。
        </para>
       </listitem>
      </varlistentry>
@@ -8461,7 +8464,8 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
         is the selective pressure within the population. Values can be
         from 1.50 to 2.00; the latter is the default.
 -->
-       GEQOで使用される淘汰の偏りを管理します。淘汰の偏りは個体群内の（遺伝的な）自然淘汰です。値は1.50から2.00で、2.00がデフォルトです。
+GEQOで使用される淘汰の偏りを管理します。
+淘汰の偏りは個体群内の（遺伝的な）自然淘汰です。値は1.50から2.00で、2.00がデフォルトです。
        </para>
       </listitem>
      </varlistentry>
@@ -8955,7 +8959,7 @@ local0.*    /var/log/postgresql
          log messages cleanly.
          See <xref linkend="event-log-registration"/> for details.
 -->
-        Windowsで<varname>log_destination</varname>に対し<literal>eventlog</literal>オプションを使用する場合、Windows Event Viewer がイベントログメッセージを手際良く表示できるよう、オペレーティングシステムでイベントソースとそのライブラリを登録しなければなりません。
+Windowsで<varname>log_destination</varname>に対し<literal>eventlog</literal>オプションを使用する場合、Windows Event Viewer がイベントログメッセージを手際良く表示できるよう、オペレーティングシステムでイベントソースとそのライブラリを登録しなければなりません。
 詳細は<xref linkend="event-log-registration"/>を参照ください。
         </para>
        </note>
@@ -9092,8 +9096,7 @@ local0.*    /var/log/postgresql
 値は<function>strftime</function>パターンとして扱われるため、<literal>%</literal>エスケープを使用して、時刻によって変動するファイル名を指定することができます。
 （時間帯に依存した<literal>%</literal>エスケープが存在する場合、<xref
 linkend="guc-log-timezone"/>で指定された時間帯で計算が行われます。）
-サポートされている<literal>%</literal>-エスケープは<ulink
-        url="https://pubs.opengroup.org/onlinepubs/009695399/functions/strftime.html">strftime</ulink> 仕様によく似ています。
+サポートされている<literal>%</literal>-エスケープは<ulink url="https://pubs.opengroup.org/onlinepubs/009695399/functions/strftime.html">strftime</ulink> 仕様によく似ています。
 システムの<function>strftime</function>は直接使用されないので、プラットフォーム固有の（非標準）の拡張は動作しません。
 デフォルトは<literal>postgresql-%Y-%m-%d_%H%M%S.log</literal>です。
        </para>
@@ -9108,7 +9111,7 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
         longer the case.
 -->
 エスケープすることなくファイル名を指定する場合、ディスク全体を使い切ってしまうことを防止するためにログローテーションを行うユーティリティを使用することを計画しなければなりません。
-       8.4より前のリリースの<productname>PostgreSQL</productname>では、<literal>%</literal>エスケープがなければ、新しいログファイルの生成時のエポック時刻を付与しますが、これはもはや当てはまりません。
+8.4より前のリリースの<productname>PostgreSQL</productname>では、<literal>%</literal>エスケープがなければ、新しいログファイルの生成時のエポック時刻を付与しますが、これはもはや当てはまりません。
        </para>
        <para>
 <!--
@@ -9152,10 +9155,10 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         system calls.  (To use the customary octal format the number
         must start with a <literal>0</literal> (zero).)
 -->
-       Unixシステムにおいては、<varname>logging_collector</varname>が有効になっている場合、このパラメータはログファイルのパーミッションを設定します。
-       （Microsoft Windowsではこのパラメータは無視されます。）
+Unixシステムにおいては、<varname>logging_collector</varname>が有効になっている場合、このパラメータはログファイルのパーミッションを設定します。
+（Microsoft Windowsではこのパラメータは無視されます。）
 パラメータの値は<function>chmod</function> および <function>umask</function>システムコールで許容されるフォーマットで指定される数値モードであると期待されます。
-       （慣例的な8進数フォーマットを使用する場合、番号は<literal>0</literal>（ゼロ）で始まらなければなりません。
+（慣例的な8進数フォーマットを使用する場合、番号は<literal>0</literal>（ゼロ）で始まらなければなりません。
        </para>
        <para>
 <!--
@@ -9831,8 +9834,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         <entry>Provides information implicitly requested by the user,
          e.g., output from <command>VACUUM VERBOSE</command>.</entry>
 -->
-        <entry><command>VACUUM VERBOSE</command>の出力などの、
-ユーザによって暗黙的に要求された情報を提供します。</entry>
+        <entry><command>VACUUM VERBOSE</command>の出力などの、ユーザによって暗黙的に要求された情報を提供します。</entry>
         <entry><literal>INFO</literal></entry>
         <entry><literal>INFORMATION</literal></entry>
        </row>
@@ -9843,8 +9845,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         <entry>Provides information that might be helpful to users, e.g.,
          notice of truncation of long identifiers.</entry>
 -->
-        <entry>長い識別子の切り詰めに関する注意など、
-ユーザの補助になる情報を提供します。</entry>
+        <entry>長い識別子の切り詰めに関する注意など、ユーザの補助になる情報を提供します。</entry>
         <entry><literal>NOTICE</literal></entry>
         <entry><literal>INFORMATION</literal></entry>
        </row>
@@ -9855,8 +9856,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         <entry>Provides warnings of likely problems, e.g., <command>COMMIT</command>
          outside a transaction block.</entry>
 -->
-        <entry>トランザクションブロック外での<command>COMMIT</command>の様な、
-ユーザへの警告を提供します。</entry>
+        <entry>トランザクションブロック外での<command>COMMIT</command>の様な、ユーザへの警告を提供します。</entry>
         <entry><literal>NOTICE</literal></entry>
         <entry><literal>WARNING</literal></entry>
        </row>
@@ -9878,8 +9878,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         <entry>Reports information of interest to administrators, e.g.,
          checkpoint activity.</entry>
 -->
-        <entry>チェックポイントの活動の様な、
-管理者に関心のある情報を報告します。</entry>
+        <entry>チェックポイントの活動の様な、管理者に関心のある情報を報告します。</entry>
         <entry><literal>INFO</literal></entry>
         <entry><literal>INFORMATION</literal></entry>
        </row>
@@ -10229,8 +10228,8 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
 -->
 ログ取得されるそれぞれのメッセージに対し、サーバログに書き込まれる詳細の量を制御します。
 有効な値は、<literal>TERSE</literal>、<literal>DEFAULT</literal>、および<literal>VERBOSE</literal>で、それぞれは表示されるメッセージにより多くのフィールドを追加します。
-       <literal>TERSE</literal>は<literal>DETAIL</literal>、<literal>HINT</literal>、<literal>QUERY</literal>、および<literal>CONTEXT</literal>エラー情報を除外します。
-       <literal>VERBOSE</literal>出力は、<symbol>SQLSTATE</symbol>エラーコード（<xref linkend="errcodes-appendix"/>も参照）、および、ソースコードファイル名、関数名、そしてエラーを生成した行番号を含みます。
+<literal>TERSE</literal>は<literal>DETAIL</literal>、<literal>HINT</literal>、<literal>QUERY</literal>、および<literal>CONTEXT</literal>エラー情報を除外します。
+<literal>VERBOSE</literal>出力は、<symbol>SQLSTATE</symbol>エラーコード（<xref linkend="errcodes-appendix"/>も参照）、および、ソースコードファイル名、関数名、そしてエラーを生成した行番号を含みます。
 スーパーユーザのみこの設定を変更できます。
        </para>
       </listitem>
@@ -10319,7 +10318,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
              <entry>Effect</entry>
              <entry>Session only</entry>
 -->
-            <entry>エスケープ</entry>
+             <entry>エスケープ</entry>
              <entry>効果</entry>
              <entry>セッションのみ</entry>
              </row>
@@ -10395,7 +10394,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
               is a parallel query worker</entry>
              <entry>no</entry>
 -->
-<entry>このプロセスがパラレルクエリワーカである場合に、パラレルグループリーダのプロセス識別子</entry>
+             <entry>このプロセスがパラレルクエリワーカである場合に、パラレルグループリーダのプロセス識別子</entry>
              <entry>×</entry>
             </row>
             <row>
@@ -10497,8 +10496,8 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
              <entry>no</entry>
 -->
              <entry>何も出力しません。
-非セッションプロセスではこのエスケープ以降の出力を停止します。
-セッションプロセスでは無視されます。</entry>
+             非セッションプロセスではこのエスケープ以降の出力を停止します。
+             セッションプロセスでは無視されます。</entry>
              <entry>×</entry>
             </row>
             <row>
@@ -10511,8 +10510,8 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
              query identifiers is configured.</entry>
              <entry>yes</entry>
 -->
-             <entry>現在の問い合わせの問い合わせ識別子。
-問い合わせ識別子はデフォルトでは計算されません。ですから<xref linkend="guc-compute-query-id"/>パラメータが有効であるか、あるいは問い合わせ識別子を計算するサードパーティのモジュールが設定されていないければゼロとなります。</entry>
+             <entry>現在の問い合わせの問い合わせ識別子。問い合わせ識別子はデフォルトでは計算されません。
+             ですから<xref linkend="guc-compute-query-id"/>パラメータが有効であるか、あるいは問い合わせ識別子を計算するサードパーティのモジュールが設定されていないければゼロとなります。</entry>
              <entry>○</entry>
             </row>
             <row>
@@ -11038,7 +11037,7 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
        There are a few things you need to do to simplify importing CSV log
        files:
 -->
-       CSVログファイルをインポートする作業を単純にするためにいくつか必要な作業があります。
+CSVログファイルをインポートする作業を単純にするためにいくつか必要な作業があります。
 
        <orderedlist>
          <listitem>
@@ -11388,7 +11387,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
 -->
 関数の呼び出し数と費やされた時間の追跡を有効にします。
 手続き言語関数のみを追跡するためには<literal>pl</literal>と指定してください。
-       SQL関数、C言語関数も追跡するためには<literal>all</literal>と指定してください。
+SQL関数、C言語関数も追跡するためには<literal>all</literal>と指定してください。
 デフォルトは、統計情報追跡機能を無効にする<literal>none</literal>です。
 スーパーユーザのみがこの設定を変更できます。
        </para>
@@ -11894,7 +11893,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         changing table storage parameters.
         For more information see <xref linkend="vacuum-for-wraparound"/>.
 -->
-       vacuumは同時に<filename>pg_xact</filename>サブディレクトリから古いファイルの削除を許可します。
+vacuumは同時に<filename>pg_xact</filename>サブディレクトリから古いファイルの削除を許可します。
 これが、比較的低い2億トランザクションがデフォルトである理由です。
 このパラメータはサーバ起動時にのみ設定可能です。
 しかし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルで減らすことができます。
@@ -12462,7 +12461,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
 <!--
         See also <xref linkend="guc-default-tablespace"/>.
 -->
-       <xref linkend="guc-default-tablespace"/>も参照してください
+<xref linkend="guc-default-tablespace"/>も参照してください
        </para>
       </listitem>
      </varlistentry>
@@ -12527,7 +12526,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         default isolation level of each new transaction. The default
         is <quote>read committed</quote>.
 -->
-       SQLトランザクションはそれぞれ、<quote>read uncommitted</quote>、<quote>read committed</quote>、<quote>repeatable read</quote>、または<quote>serializable</quote>のいずれかの分離レベルを持ちます。
+SQLトランザクションはそれぞれ、<quote>read uncommitted</quote>、<quote>read committed</quote>、<quote>repeatable read</quote>、または<quote>serializable</quote>のいずれかの分離レベルを持ちます。
 このパラメータは各新規トランザクションのデフォルトの分離レベルを制御します。
 デフォルトは<quote>read committed</quote>です。
        </para>
@@ -12537,8 +12536,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         Consult <xref linkend="mvcc"/> and <xref
         linkend="sql-set-transaction"/> for more information.
 -->
-より詳細は <xref linkend="mvcc"/> および <xref
-        linkend="sql-set-transaction"/> を調べてください。
+より詳細は <xref linkend="mvcc"/> および <xref linkend="sql-set-transaction"/> を調べてください。
        </para>
       </listitem>
      </varlistentry>
@@ -13238,7 +13236,7 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
 <type>bytea</type>型の値の出力形式を設定します。
 有効な値は<literal>hex</literal>（デフォルト）、および<literal>escape</literal>（PostgreSQLの伝統的な書式）です。
 より詳細は<xref linkend="datatype-binary"/>を参照してください。
-       <type>bytea</type>型は常にこの設定に係わらず、入力時に双方の書式を受け付けます。
+<type>bytea</type>型は常にこの設定に係わらず、入力時に双方の書式を受け付けます。
        </para>
       </listitem>
      </varlistentry>
@@ -13624,7 +13622,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
         server are described in <xref linkend="multibyte-charset-supported"/>.
 -->
 クライアント側符号化方式（文字セット）を設定します。デフォルトはデータベース符号化方式を使用します。
-       <productname>PostgreSQL</productname>サーバでサポートされている文字セットは<xref linkend="multibyte-charset-supported"/>に記載されています。
+<productname>PostgreSQL</productname>サーバでサポートされている文字セットは<xref linkend="multibyte-charset-supported"/>に記載されています。
        </para>
       </listitem>
      </varlistentry>
@@ -13838,7 +13836,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       might be able to use operating-system facilities such
       as <envar>LD_PRELOAD</envar> for that.
 -->
-      PostgreSQLで使用することを意図したライブラリだけがこの方法でロードできます。
+PostgreSQLで使用することを意図したライブラリだけがこの方法でロードできます。
 すべてのPostgreSQL用のライブラリは<quote>magic block</quote>を持ち、互換性を保証するためにチェックされます。
 ですからPostgreSQL用ではないライブラリはこの方法ではロードできません。
 <envar>LD_PRELOAD</envar>のようなOSの機能を使えばあるいは使用できるかもしれません。
@@ -13903,7 +13901,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
 このオプションはすべてのユーザが設定できます。
 この理由で、読み込み可能なライブラリはインストレーションの共有ライブラリディレクトリのサブディレクトリ<filename>plugins</filename>内にあるものに制限されています。
 （確実に<quote>安全</quote>なライブラリのみをここにインストールすることはデータベース管理者の責任です。）
- <varname>local_preload_libraries</varname>内の項目で、たとえば<literal>$libdir/plugins/mylib</literal>のようにこのディレクトリを明示的に指定することも、単にライブラリ名を指定することも可能です。
+<varname>local_preload_libraries</varname>内の項目で、たとえば<literal>$libdir/plugins/mylib</literal>のようにこのディレクトリを明示的に指定することも、単にライブラリ名を指定することも可能です。
 <literal>mylib</literal> は<literal>$libdir/plugins/mylib</literal>と同じ効果です。
        </para>
 
@@ -14070,7 +14068,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
         </varname> is still useful on Windows hosts for libraries that need to
         perform operations at postmaster start time.
 -->
-        Windowsのホストでは、ライブラリのプリロードは、新しいサーバプロセスの起動に要する時間を短縮しません。
+Windowsのホストでは、ライブラリのプリロードは、新しいサーバプロセスの起動に要する時間を短縮しません。
 個々のサーバプロセスは、すべてのプリロードライブラリを再読み込みします。
 それでもpostmaster起動時に操作を実行しなければならないライブラリを使用するWindowsホストにとっては<varname>shared_preload_libraries</varname>は有用です。
        </para>
@@ -14219,7 +14217,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         Soft upper limit of the size of the set returned by GIN index scans. For more
         information see <xref linkend="gin-tips"/>.
 -->
-       GINインデックス走査により返されるセットのソフトな上限サイズです。
+GINインデックス走査により返されるセットのソフトな上限サイズです。
 詳細は<xref linkend="gin-tips"/>を参照してください。
        </para>
       </listitem>
@@ -14384,9 +14382,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         tables in a single serializable transaction. This parameter can
         only be set at server start.
 -->
-共有記述ロックテーブル（shared predicate lock table）は、<varname>max_pred_locks_per_transaction</varname> * (<xref
-        linkend="guc-max-connections"/> + <xref
-        linkend="guc-max-prepared-transactions"/>)オブジェクト（例えば諸テーブル）のロックを追跡します。
+共有記述ロックテーブル（shared predicate lock table）は、<varname>max_pred_locks_per_transaction</varname> * (<xref linkend="guc-max-connections"/> + <xref linkend="guc-max-prepared-transactions"/>)オブジェクト（例えば諸テーブル）のロックを追跡します。
 従って、この数以上の明確なオブジェクトは同時にロックされません。
 このパラメータはそれぞれのトランザクションに対して割り当てられたオブジェクトのロックの平均数を管理します。
 個別のトランザクションはロックテーブル内の全てのトランザクションのロックが適合する限り、より多くのオブジェクトをロックできます。
@@ -14542,11 +14538,8 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
 引用符の表現としてSQL準拠の方式では二重化（<literal>''</literal>）ですが、<productname>PostgreSQL</productname>は歴史的に<literal>\'</literal>も受け付けます。
 とは言っても、いくつかのクライアント文字集合符号化方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
 クライアント側のコードが事実上エスケープを正しく扱わない場合、SQLインジェクション攻撃が可能になります。この危険性の回避は、サーバが逆スラッシュでエスケープされた引用符を含む問い合わせを拒絶するようにします。
-許可される<varname>backslash_quote</varname>の値は、
-        <literal>on</literal> （常に <literal>\'</literal> を許可）,
-        <literal>off</literal> （常に拒否）、および
-        <literal>safe_encoding</literal> （クライアント符号化方式がASCIIの<literal>\</literal>を許可しないときのみ、マルチバイト文字内で許可）。
-        <literal>safe_encoding</literal> がデフォルトの設定。
+許可される<varname>backslash_quote</varname>の値は、<literal>on</literal> （常に <literal>\'</literal> を許可）,<literal>off</literal> （常に拒否）、および<literal>safe_encoding</literal> （クライアント符号化方式がASCIIの<literal>\</literal>を許可しないときのみ、マルチバイト文字内で許可）。
+<literal>safe_encoding</literal> がデフォルトの設定。
        </para>
 
        <para>
@@ -14617,7 +14610,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         releases.  The default is <literal>off</literal>.
         Only superusers can change this setting.
 -->
-       9.0以前の<productname>PostgreSQL</productname>リリースでは、ラージオブジェクトはアクセス権限が無く、従って全てのユーザが常に読み込み、書き込みが可能でした。
+9.0以前の<productname>PostgreSQL</productname>リリースでは、ラージオブジェクトはアクセス権限が無く、従って全てのユーザが常に読み込み、書き込みが可能でした。
 この変数を<literal>on</literal>にすると、以前のリリースとの互換性のため、新規の権限チェックが無効になります。
 デフォルトは<literal>off</literal>です。
 スーパーユーザのみこの設定を変更できます。
@@ -14688,7 +14681,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         backslashes to be treated as escape characters.
 -->
 標準SQLで規定されたように、通常の文字列リテラル（<literal>'...'</literal>）がバックスラッシュをそのまま取り扱うか否かを制御します。
-       <productname>PostgreSQL</productname> 9.1からデフォルトは<literal>on</literal>になっています（それ以前のリリースでは<literal>off</literal>がデフォルトでした）。
+<productname>PostgreSQL</productname> 9.1からデフォルトは<literal>on</literal>になっています（それ以前のリリースでは<literal>off</literal>がデフォルトでした）。
 どのように文字列リテラルが処理されるかを決めるこのパラメータを、アプリケーションで検査することができます。
 このパラメータの存在は、エスケープ文字列構文（<literal>E'...'</literal>）がサポートされているかどうかを示すものとも考えられます。
 エスケープ文字列構文 (<xref linkend="sql-syntax-strings-escape"/>)は、アプリケーションでバックスラッシュをエスケープ文字として扱いたい場合に使用すべきです。
@@ -15034,9 +15027,8 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
 -->
 ディスクブロックの容量を報告します。
 サーバ構築の際に<literal>BLCKSZ</literal>の値で決定されます。デフォルトの値は8192バイトです。
-       （<xref linkend="guc-shared-buffers"/>の様な）いくつかの構成変数の意味は<varname>block_size</varname>によって影響されます。
-これに関しての情報は<xref
-        linkend="runtime-config-resource"/>を参照してください。
+（<xref linkend="guc-shared-buffers"/>の様な）いくつかの構成変数の意味は<varname>block_size</varname>によって影響されます。
+これに関しての情報は<xref linkend="runtime-config-resource"/>を参照してください。
        </para>
       </listitem>
      </varlistentry>
@@ -15328,8 +15320,7 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
         linkend="guc-client-encoding"/>.
 -->
 データベース符号化方式（文字セット）を報告します。
-データベースが作成された時に決定されます。通常クライアントは<xref
-        linkend="guc-client-encoding"/>の値にのみ注意する必要があります。
+データベースが作成された時に決定されます。通常クライアントは<xref linkend="guc-client-encoding"/>の値にのみ注意する必要があります。
        </para>
       </listitem>
      </varlistentry>
@@ -15833,12 +15824,10 @@ WALディスクブロックの容量を報告します。
 復旧関連のデバッグ出力のログ取得を有効にします。さもないとログは取られません。
 このパラメータはユーザに対し、<xref linkend="guc-log-min-messages"/>の通常設定を上書きすることを許可します。
 しかし、特定のメッセージに対してのみです。これはホットスタンバイのデバッグを意図したものです。
-有効な値は、<literal>DEBUG5</literal>、<literal>DEBUG4</literal>、
-        <literal>DEBUG3</literal>、<literal>DEBUG2</literal>、<literal>DEBUG1</literal>、および
-        <literal>LOG</literal>です。
+有効な値は、<literal>DEBUG5</literal>、<literal>DEBUG4</literal>、<literal>DEBUG3</literal>、<literal>DEBUG2</literal>、<literal>DEBUG1</literal>、および<literal>LOG</literal>です。
 デフォルトの<literal>LOG</literal>は、ログ取得の決定に全く影響しません。
 その他の値は、あたかも<literal>LOG</literal>優先度を所有しているごとく、それ、またはより高い優先度でログ取得される復旧関連デバッグメッセージの要因となります。
-       <varname>log_min_messages</varname>の通常設定に対し、これは無条件にそれらをサーバログに送り込みます。
+<varname>log_min_messages</varname>の通常設定に対し、これは無条件にそれらをサーバログに送り込みます。
 このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバコマンドラインでのみ設定可能です。
        </para>
       </listitem>
@@ -16000,7 +15989,7 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
         output on system tables).
 -->
 設定すると、このOID未満のテーブルに関するロックの追跡を行いません。
-       （システムテーブルに関する出力を抑えるために使用します。）
+（システムテーブルに関する出力を抑えるために使用します。）
        </para>
        <para>
 <!--
@@ -16181,7 +16170,7 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
 <!--
         Only has effect if <xref linkend="app-initdb-data-checksums"/> are enabled.
 -->
-       <xref linkend="app-initdb-data-checksums"/>が有効の時のみ効果があります。
+<xref linkend="app-initdb-data-checksums"/>が有効の時のみ効果があります。
        </para>
        <para>
 <!--
@@ -16197,7 +16186,7 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
         default setting is <literal>off</literal>, and it can only be changed by a superuser.
 -->
 読み込み過程でチェックサム障害が検出されると、通常<productname>PostgreSQL</productname>はエラーを報告し、現時点のトランザクションを停止します。
-       <varname>ignore_checksum_failure</varname>を有効（on）に設定するとシステムはその障害を無視し（しかし警告は報告をします）、処理を継続します。
+<varname>ignore_checksum_failure</varname>を有効（on）に設定するとシステムはその障害を無視し（しかし警告は報告をします）、処理を継続します。
 この振る舞いはたぶん<emphasis>クラッシュの原因、破損の伝播や隠ぺい、もしくはその他の深刻な問題</emphasis>の原因になることがあります。
 とは言っても、エラーを切り抜け、ブロックヘッダが健全に存在するテーブルにある障害を受けていないタプルの回収は行えます。
 もしヘッダーが破損されたら、オプションが有効になっていたとしても報告はなされます。

--- a/doc/src/sgml/config0.sgml
+++ b/doc/src/sgml/config0.sgml
@@ -11,7 +11,7 @@
 <chapter id="runtime-config">
 <!--
   <title>Server Configuration</title>
-  -->
+-->
   <title>サーバの設定</title>
 
   <indexterm>
@@ -24,38 +24,38 @@
   </indexterm>
 
   <para>
-  <!--
+<!--
    There are many configuration parameters that affect the behavior of
    the database system. In the first section of this chapter we
    describe how to interact with configuration parameters. The subsequent sections
    discuss each parameter in detail.
-   -->
-   データベースシステムの動作に影響を与える数多くのパラメータがあります。
-   この章の最初の節で、どのように設定パラメータを操作するのかについて説明します。
-   引き続く節で、それぞれのパラメータの詳細を説明します。
+-->
+データベースシステムの動作に影響を与える数多くのパラメータがあります。
+この章の最初の節で、どのように設定パラメータを操作するのかについて説明します。
+引き続く節で、それぞれのパラメータの詳細を説明します。
   </para>
 
   <sect1 id="config-setting">
-  <!--
+<!--
    <title>Setting Parameters</title>
-   -->
+-->
    <title>パラメータの設定</title>
 
    <sect2 id="config-setting-names-values">
-   <!--
+<!--
     <title>Parameter Names and Values</title>
-    -->
+-->
     <title>パラメータ名とその値</title>
 
     <para>
-    <!--
+<!--
      All parameter names are case-insensitive. Every parameter takes a
      value of one of five types: boolean, string, integer, floating point,
      or enumerated (enum).  The type determines the syntax for setting the
      parameter:
-    -->
-    全てのパラメータの名前は大文字と小文字を区別しません。
-    それぞれのパラメータは、論理値、整数、浮動小数点、文字列、またはenum（列挙型）の5つの型のいずれかの値を取ります。
+-->
+全てのパラメータの名前は大文字と小文字を区別しません。
+それぞれのパラメータは、論理値、整数、浮動小数点、文字列、またはenum（列挙型）の5つの型のいずれかの値を取ります。
 型はパラメータをセットするための記法を定義します。
     </para>
 
@@ -201,8 +201,8 @@
        <structname>pg_settings</structname>.<structfield>enumvals</structfield>.
        Enum parameter values are case-insensitive.
 -->
-       <emphasis>列挙型:</emphasis>
-       列挙型のパラメータは文字列パラメータと同じように記述します。
+<emphasis>列挙型:</emphasis>
+列挙型のパラメータは文字列パラメータと同じように記述します。
 ただ、使用できる文字列の種類が決まっているだけです。
 使用できる文字列は <structname>pg_settings</structname>.<structfield>enumvals</structfield> で定義されています。
 列挙型の値は大文字小文字を区別しません。
@@ -212,20 +212,20 @@
    </sect2>
 
    <sect2 id="config-setting-configuration-file">
-   <!--
+<!--
     <title>Parameter Interaction via the Configuration File</title>
-    -->
+-->
     <title>設定ファイルによるパラメータ操作</title>
 
     <para>
-   <!--
+<!--
      The most fundamental way to set these parameters is to edit the file
      <filename>postgresql.conf</filename><indexterm><primary>postgresql.conf</primary></indexterm>,
      which is normally kept in the data directory.  A default copy is
      installed when the database cluster directory is initialized.
      An example of what this file might look like is:
-    -->
-    これらのパラメータを設定する最も基本的な方法は、<filename>postgresql.conf</filename><indexterm><primary>postgresql.conf</primary></indexterm>ファイルを編集することで、これは通常 data ディレクトリに格納されています。
+-->
+これらのパラメータを設定する最も基本的な方法は、<filename>postgresql.conf</filename><indexterm><primary>postgresql.conf</primary></indexterm>ファイルを編集することで、これは通常 data ディレクトリに格納されています。
 デフォルトのコピーはデータベースクラスタディレクトリが初期化されるときそこにインストールされます。このファイルがどういったものかの例を示します。
 <programlisting>
 # This is a comment
@@ -245,7 +245,7 @@ shared_buffers = 128MB
      or backslash-quote.
      If the file contains multiple entries for the same parameter,
      all but the last one are ignored.
-    -->
+-->
 1つの行毎に1つのパラメータが指定されます。
 名前と値の間の等号は省略可能です。
 （引用符付きのパラメータ値内を除き）空白は特に意味を持たず、何もない行は無視されます。
@@ -271,7 +271,7 @@ shared_buffers = 128MB
      <indexterm>
       <primary>SIGHUP</primary>
      </indexterm>
-     <!--
+<!--
      The configuration file is reread whenever the main server process
      receives a <systemitem>SIGHUP</systemitem> signal; this signal is most easily
      sent by running <literal>pg_ctl reload</literal> from the command line or by
@@ -285,7 +285,7 @@ shared_buffers = 128MB
      configuration file will be ignored until the server is restarted.
      Invalid parameter settings in the configuration file are likewise
      ignored (but logged) during <systemitem>SIGHUP</systemitem> processing.
-    -->
+-->
 設定ファイルは、メインサーバプロセスが<systemitem>SIGHUP</systemitem>シグナルを受け取るたびに再読み込みされます。
 このシグナルを手っ取り早く送信するには、コマンドラインから<literal>pg_ctl reload</literal>を実行するか、SQL関数の<function>pg_reload_conf()</function>を呼び出します。
 メインサーバプロセスは同時にこのシグナルを、現存のセッションが同様に新しい値を入手できるように、全ての現在実行しているサーバプロセスに伝播します(これは現在実行中のクライアントコマンドの処理を完了してから行われます)。
@@ -357,8 +357,8 @@ shared_buffers = 128MB
       In addition, there are two commands that allow setting of defaults
       on a per-database or per-role basis:
 -->
-    <productname>PostgreSQL</productname>は3つのSQLコマンドでデフォルト値を設定します。
-    すでに説明した<command>ALTER SYSTEM</command>コマンドは、SQLによってグローバルな設定値を変更する方法を提供します; <filename>postgresql.conf</filename>を編集するのと等価です。これに加え、データベース単位あるいはロール単位で設定するためのコマンドがあります:
+<productname>PostgreSQL</productname>は3つのSQLコマンドでデフォルト値を設定します。
+すでに説明した<command>ALTER SYSTEM</command>コマンドは、SQLによってグローバルな設定値を変更する方法を提供します; <filename>postgresql.conf</filename>を編集するのと等価です。これに加え、データベース単位あるいはロール単位で設定するためのコマンドがあります:
      </para>
 
      <itemizedlist>
@@ -368,7 +368,7 @@ shared_buffers = 128MB
        The <link linkend="sql-alterdatabase"><command>ALTER DATABASE</command></link> command allows global
        settings to be overridden on a per-database basis.
 -->
-      <link linkend="sql-alterdatabase"><command>ALTER DATABASE</command></link>コマンドはデータベース単位でグローバルな設定値を上書きします。
+<link linkend="sql-alterdatabase"><command>ALTER DATABASE</command></link>コマンドはデータベース単位でグローバルな設定値を上書きします。
       </para>
      </listitem>
 
@@ -378,7 +378,7 @@ shared_buffers = 128MB
        The <link linkend="sql-alterrole"><command>ALTER ROLE</command></link> command allows both global and
        per-database settings to be overridden with user-specific values.
 -->
-      <link linkend="sql-alterrole"><command>ALTER ROLE</command></link>コマンドはグローバルと、データベース単位の両方をユーザ固有の設定値で上書きします。
+<link linkend="sql-alterrole"><command>ALTER ROLE</command></link>コマンドはグローバルと、データベース単位の両方をユーザ固有の設定値で上書きします。
       </para>
      </listitem>
     </itemizedlist>
@@ -392,7 +392,7 @@ shared_buffers = 128MB
       Note that some settings cannot be changed after server start, and
       so cannot be set with these commands (or the ones listed below).
 -->
-     <command>ALTER DATABASE</command>と<command>ALTER ROLE</command>による設定値は新しくデータベースセッションを開始した時にのみ適用されます。
+<command>ALTER DATABASE</command>と<command>ALTER ROLE</command>による設定値は新しくデータベースセッションを開始した時にのみ適用されます。
 これらのコマンドは設定ファイルやサーバへのコマンド引数による設定値を上書きし、セッションの以後の状態に適用します。なお、一部の設定はサーバを起動した後では変更できず、これらのコマンドを使っては設定できません(以下に記述するコマンドでも同じことが言えます)。
     </para>
 
@@ -414,7 +414,7 @@ shared_buffers = 128MB
       <function>current_setting(setting_name text)</function>
       (see <xref linkend="functions-admin-set"/>).
 -->
-     <link linkend="sql-show"><command>SHOW</command></link>コマンドを使ってすべてのパラメータの現在の値を調べることができます。
+<link linkend="sql-show"><command>SHOW</command></link>コマンドを使ってすべてのパラメータの現在の値を調べることができます。
 対応する関数は<function>current_setting(setting_name text)</function>です（<xref linkend="functions-admin-set"/>を参照してください）。
      </para>
      </listitem>
@@ -453,7 +453,7 @@ shared_buffers = 128MB
        provides more detail.  It is also more flexible, since it's possible
        to specify filter conditions or join against other relations.
 -->
-     このビューを問い合わせるのは、<command>SHOW ALL</command>を使うのと同じですが、更に詳細な情報を提供します。
+このビューを問い合わせるのは、<command>SHOW ALL</command>を使うのと同じですが、更に詳細な情報を提供します。
 フィルター条件を指定したり他のリレーションと結合ができるので、より柔軟です。
       </para>
      </listitem>
@@ -498,7 +498,7 @@ UPDATE pg_settings SET setting = reset_val WHERE name = 'configuration_parameter
       Both the server and <application>libpq</application> client library
       accept parameter values via the shell.
 -->
-      グローバルなデフォルト値を設定したりデータベース、ロール単位で上書きを行えるだけでなく、シェル機能を使って<productname>PostgreSQL</productname>に設定値を渡すことができます。
+グローバルなデフォルト値を設定したりデータベース、ロール単位で上書きを行えるだけでなく、シェル機能を使って<productname>PostgreSQL</productname>に設定値を渡すことができます。
 サーバも<application>libpq</application>クライアントライブラリもシェル経由でパラメータ値を受けとることができます。
      </para>
 
@@ -510,7 +510,7 @@ UPDATE pg_settings SET setting = reset_val WHERE name = 'configuration_parameter
        passed to the <command>postgres</command> command via the
        <option>-c</option> command-line parameter.  For example,
 -->
-      サーバ起動時に、<option>-c</option>コマンドラインパラメータを使ってパラメータ設定値を<command>postgres</command>に渡すことができます。たとえば、
+サーバ起動時に、<option>-c</option>コマンドラインパラメータを使ってパラメータ設定値を<command>postgres</command>に渡すことができます。たとえば、
 <programlisting>
 postgres -c log_connections=yes -c log_destination='syslog'
 </programlisting>
@@ -519,7 +519,7 @@ postgres -c log_connections=yes -c log_destination='syslog'
        <filename>postgresql.conf</filename> or <command>ALTER SYSTEM</command>,
        so they cannot be changed globally without restarting the server.
 -->
-       このようにして渡された設定値は、<filename>postgresql.conf</filename>や<command>ALTER SYSTEM</command>による設定を上書きします。
+このようにして渡された設定値は、<filename>postgresql.conf</filename>や<command>ALTER SYSTEM</command>による設定を上書きします。
 したがってサーバを再起動しない限りこれらの設定値をグローバルに変更することはできません。
      </para>
     </listitem>
@@ -537,7 +537,7 @@ postgres -c log_connections=yes -c log_destination='syslog'
       command; specifically, the <option>-c</option> flag must be specified.
       For example,
 -->
-      <application>libpq</application>を使ってクライアントセッションを開始するときに<envar>PGOPTIONS</envar>環境変数を使って設定値を指定できます。
+<application>libpq</application>を使ってクライアントセッションを開始するときに<envar>PGOPTIONS</envar>環境変数を使って設定値を指定できます。
 このようにして渡された設定値はセッションのデフォルトとなりますが、他のセッションには影響を与えません。
 歴史的な理由により、<envar>PGOPTIONS</envar>の形式は<command>postgres</command>を起動するときのものと似ています。たとえば、<option>-c</option>フラグを指定しなければならない点です。
 <programlisting>
@@ -551,7 +551,7 @@ env PGOPTIONS="-c geqo=off -c statement_timeout=5min" psql
       via the shell or otherwise, that allow the user to alter session
       settings without direct use of SQL commands.
 -->
-     他のクライアントやライブラリではそれぞれ固有の方法でシェルなどを経由して、SQLコマンドを直接使わずにセッションの設定を変更することができるかもしれません。
+他のクライアントやライブラリではそれぞれ固有の方法でシェルなどを経由して、SQLコマンドを直接使わずにセッションの設定を変更することができるかもしれません。
      </para>
     </listitem>
    </itemizedlist>
@@ -559,9 +559,9 @@ env PGOPTIONS="-c geqo=off -c statement_timeout=5min" psql
    </sect2>
 
    <sect2 id="config-includes">
-   <!--
+<!--
     <title>Managing Configuration File Contents</title>
-   -->
+-->
     <title>設定ファイルの内容の管理</title>
 
      <para>
@@ -571,7 +571,7 @@ env PGOPTIONS="-c geqo=off -c statement_timeout=5min" psql
       These features are especially useful when managing multiple servers
       with related, but not identical, configurations.
 -->
-      <productname>PostgreSQL</productname>は複雑な<filename>postgresql.conf</filename>ファイルを複数の小さなファイルに分割する複数の方法を提供しています。
+<productname>PostgreSQL</productname>は複雑な<filename>postgresql.conf</filename>ファイルを複数の小さなファイルに分割する複数の方法を提供しています。
 これは、とりわけお互いに関連しているものの設定が同じではない複数のサーバを管理する際に有用です。
      </para>
 
@@ -582,9 +582,9 @@ env PGOPTIONS="-c geqo=off -c statement_timeout=5min" psql
       </indexterm>
       <indexterm>
        <primary><literal>include</literal></primary>
-       <secondary>設定ファイルの中</secondary>
+       <secondary>設定ファイルにおける</secondary>
       </indexterm>
-      <!--
+<!--
       In addition to individual parameter settings,
       the <filename>postgresql.conf</filename> file can contain <firstterm>include
       directives</firstterm>, which specify another file to read and process as if
@@ -669,7 +669,7 @@ include_dir 'ディレクトリ名'
       files within an include directory are processed in file name order
       (according to C locale rules, i.e., numbers before letters, and
       uppercase letters before lowercase ones).
-       -->
+-->
 絶対パスではないディレクトリ名はその設定ファイルがあるディレクトリへの相対パスと見なされます。
 指定したディレクトリの中で、ディレクトリではないファイルで末尾が<literal>.conf</literal>で終わるファイルだけがincludeされます。
 また、文字<literal>.</literal> で開始するファイル名は一部のプラットフォームでは隠しファイルとされるので、間違いを防止するため無視されます。
@@ -678,7 +678,7 @@ includeされるディレクトリにある複数ファイルはファイル名�
      </para>
 
      <para>
-     <!--
+<!--
       Include files or directories can be used to logically separate portions
       of the database configuration, rather than having a single large
       <filename>postgresql.conf</filename> file.  Consider a company that has two
@@ -690,7 +690,7 @@ includeされるディレクトリにある複数ファイルはファイル名�
       configuration changes for your site into three files.  You could add
       this to the end of your <filename>postgresql.conf</filename> file to include
       them:
-      -->
+-->
 includeされるファイルもしくはディレクトリは、大きな単一の<filename>postgresql.conf</filename>ファイルを使う代わりに、データベース設定の一部分を論理的に分離するために使用することが可能です。
 異なるメモリー容量を持つ二つのデータベースサーバを所有する会社を考えてみてください。
 例えばログ取得のように、二つが共有する設定の要素があると思われます。
@@ -710,7 +710,7 @@ include 'server.conf'
       with 8GB of RAM, another for those having 16GB.  And
       finally <filename>server.conf</filename> could have truly server-specific
       configuration information in it.
-      -->
+-->
 全てのシステムは同一の<filename>shared.conf</filename>を所有する様になるでしょう。
 特定のメモリー容量を所有するそれぞれのサーバは同じ<filename>memory.conf</filename>を共有できます。
 RAMが8GBのすべてのサーバには共通の<filename>memory.conf</filename>を1つ使い、16GBのサーバ群には別のものを使う、ということもできるでしょう。
@@ -718,7 +718,7 @@ RAMが8GBのすべてのサーバには共通の<filename>memory.conf</filename>
      </para>
 
      <para>
-     <!--
+<!--
       Another possibility is to create a configuration file directory and
       put this information into files there. For example, a <filename>conf.d</filename>
       directory could be referenced at the end of <filename>postgresql.conf</filename>:
@@ -738,21 +738,21 @@ include_dir 'conf.d'
 01memory.conf
 02server.conf
 </programlisting>
- <!--
+<!--
        This naming convention establishes a clear order in which these
        files will be loaded.  This is important because only the last
        setting encountered for a particular parameter while the server is
        reading configuration files will be used.  In this example,
        something set in <filename>conf.d/02server.conf</filename> would override a
        value set in <filename>conf.d/01memory.conf</filename>.
-       -->
+-->
 この命名規則により、これらのファイルが読み込まれる順序が明確になります。
 サーバが設定を読み込んでいるときに各パラメータについて最後にあった設定だけが使用されるので、このことは重要です。
 この例では、<filename>conf.d/02server.conf</filename>でされた指定は<filename>conf.d/01memory.conf</filename>の設定値よりも優先します。
      </para>
 
      <para>
-     <!--
+<!--
       You might instead use this approach to naming the files
       descriptively:
 -->
@@ -762,13 +762,13 @@ include_dir 'conf.d'
 01memory-8GB.conf
 02server-foo.conf
 </programlisting>
- <!--
+<!--
       This sort of arrangement gives a unique name for each configuration file
       variation.  This can help eliminate ambiguity when several servers have
       their configurations all stored in one place, such as in a version
       control repository.  (Storing database configuration files under version
       control is another good practice to consider.)
-       -->
+-->
 こういった工夫で、設定ファイルのバリエーションに対して固有の名前を付与することができます。
 また、バージョン管理リポジトリのリポジトリに複数のサーバの設定ファイルを置く場合に生じる曖昧さを排除することができます。
 （データベース設定ファイルをバージョン管理することは、これもまた検討に値するやり方です）。
@@ -777,13 +777,13 @@ include_dir 'conf.d'
    </sect1>
 
    <sect1 id="runtime-config-file-locations">
-   <!--
+<!--
     <title>File Locations</title>
-    -->
+-->
     <title>ファイルの場所</title>
 
      <para>
-     <!--
+<!--
       In addition to the <filename>postgresql.conf</filename> file
       already mentioned, <productname>PostgreSQL</productname> uses
       two other manually-edited configuration files, which control
@@ -795,7 +795,7 @@ include_dir 'conf.d'
       administration.  In particular it is often easier to ensure that
       the configuration files are properly backed-up when they are
       kept separate.)
-      -->
+-->
 すでに説明した<filename>postgresql.conf</filename>ファイルに加え、<productname>PostgreSQL</productname>は、クライアント認証の管理を行うために、他の2つの手作業で編集される設定ファイルを使用します（これらの使用方法は<xref linkend="client-authentication"/>で説明します）。
 全ての3つの設定ファイルは、デフォルトではデータベースクラスタのdataディレクトリに格納されます。
 本節で説明するパラメータにより、設定ファイルを他の場所に置くことが可能になります。
@@ -815,12 +815,12 @@ include_dir 'conf.d'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
          Specifies the directory to use for data storage.
          This parameter can only be set at server start.
-        -->
-        データ格納に使用するディレクトリを指定します。
-        このパラメータはサーバ起動時のみ設定可能です
+-->
+データ格納に使用するディレクトリを指定します。
+このパラメータはサーバ起動時のみ設定可能です
        </para>
       </listitem>
      </varlistentry>
@@ -836,12 +836,12 @@ include_dir 'conf.d'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
          Specifies the main server configuration file
          (customarily called <filename>postgresql.conf</filename>).
          This parameter can only be set on the <command>postgres</command> command line.
-        -->
-        メインサーバ設定ファイルを指定します（通例<filename>postgresql.conf</filename>と呼ばれます）。
+-->
+メインサーバ設定ファイルを指定します（通例<filename>postgresql.conf</filename>と呼ばれます）。
 このパラメータは<command>postgres</command>コマンドライン上でのみ設定可能です。
        </para>
       </listitem>
@@ -858,12 +858,12 @@ include_dir 'conf.d'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
          Specifies the configuration file for host-based authentication
          (customarily called <filename>pg_hba.conf</filename>).
          This parameter can only be set at server start.
-        -->
-        ホストベース認証（HBA）用のファイルを指定します（通例<filename>pg_hba.conf</filename>と呼ばれます）。
+-->
+ホストベース認証（HBA）用のファイルを指定します（通例<filename>pg_hba.conf</filename>と呼ばれます）。
 このパラメータはサーバ起動時のみ設定可能です。
        </para>
       </listitem>
@@ -880,12 +880,12 @@ include_dir 'conf.d'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
          Specifies the configuration file for user name mapping
          (customarily called <filename>pg_ident.conf</filename>).
          This parameter can only be set at server start.
          See also <xref linkend="auth-username-maps"/>.
-        -->
+-->
 ユーザ名マッピングの設定ファイルを指定します（通例<filename>pg_ident.conf</filename>と呼ばれます）。
 このパラメータはサーバ起動時のみ設定可能です。
 <xref linkend="auth-username-maps"/>もご覧ください。
@@ -904,11 +904,11 @@ include_dir 'conf.d'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the name of an additional process-ID (PID) file that the
         server should create for use by server administration programs.
         This parameter can only be set at server start.
-       -->
+-->
 サーバ管理プログラムで使用するためにサーバが作成する、追加のプロセス識別子（PID)ファイルの名前を指定します。
 このパラメータはサーバ起動時のみ設定可能です。
        </para>
@@ -917,19 +917,19 @@ include_dir 'conf.d'
      </variablelist>
 
      <para>
-     <!--
+<!--
       In a default installation, none of the above parameters are set
       explicitly.  Instead, the
       data directory is specified by the <option>-D</option> command-line
       option or the <envar>PGDATA</envar> environment variable, and the
       configuration files are all found within the data directory.
-      -->
-      デフォルトのインストールでは、上記のいかなるパラメータも明示的に設定されません。
+-->
+デフォルトのインストールでは、上記のいかなるパラメータも明示的に設定されません。
 その代わり、data ディレクトリは<option>-D</option>コマンドラインオプション、または<envar>PGDATA</envar>環境変数で指定され、設定ファイル全てはその data ディレクトリ内に格納されます。
      </para>
 
      <para>
-     <!--
+<!--
       If you wish to keep the configuration files elsewhere than the
       data directory, the <command>postgres</command> <option>-D</option>
       command-line option or <envar>PGDATA</envar> environment variable
@@ -941,13 +941,13 @@ include_dir 'conf.d'
       <envar>PGDATA</envar> for the location
       of the data directory, but not for the location of the configuration
       files.
-      -->
-      dataディレクトリ以外の場所に設定ファイルを格納したいのであれば、<command>postgres</command>の<option>-D</option>コマンドラインオプション、または<envar>PGDATA</envar>環境変数で設定ファイルの場所を指し示し、そしてdataディレクトリが実際どこに存在するのかを示すため、<filename>postgresql.conf</filename>の（もしくはコマンドライン上で）<varname>data_directory</varname>パラメータを設定しなければなりません。
-      <varname>data_directory</varname>は、設定ファイルの場所ではなく、data ディレクトリの位置に関して、<option>-D</option>および<envar>PGDATA</envar>を上書きすることに注意してください。
+-->
+dataディレクトリ以外の場所に設定ファイルを格納したいのであれば、<command>postgres</command>の<option>-D</option>コマンドラインオプション、または<envar>PGDATA</envar>環境変数で設定ファイルの場所を指し示し、そしてdataディレクトリが実際どこに存在するのかを示すため、<filename>postgresql.conf</filename>の（もしくはコマンドライン上で）<varname>data_directory</varname>パラメータを設定しなければなりません。
+<varname>data_directory</varname>は、設定ファイルの場所ではなく、data ディレクトリの位置に関して、<option>-D</option>および<envar>PGDATA</envar>を上書きすることに注意してください。
      </para>
 
      <para>
-     <!--
+<!--
       If you wish, you can specify the configuration file names and locations
       individually using the parameters <varname>config_file</varname>,
       <varname>hba_file</varname> and/or <varname>ident_file</varname>.
@@ -956,32 +956,32 @@ include_dir 'conf.d'
       set within the main configuration file.  If all three parameters plus
       <varname>data_directory</varname> are explicitly set, then it is not necessary
       to specify <option>-D</option> or <envar>PGDATA</envar>.
-      -->
+-->
 必要に応じて、パラメータ<varname>config_file</varname>、<varname>hba_file</varname>、<varname>ident_file</varname>を使用し、設定ファイルの名前と場所を個別に指定することができます。
 <varname>config_file</varname>は<command>postgres</command>コマンドラインによってのみ指定されますが、その他は主設定ファイル内で設定できます。
 全ての3つのパラメータと<varname>data_directory</varname>が明示的に設定されていれば、<option>-D</option>または<envar>PGDATA</envar>を指定する必要はありません。
      </para>
 
      <para>
-     <!--
+<!--
       When setting any of these parameters, a relative path will be interpreted
       with respect to the directory in which <command>postgres</command>
       is started.
-      -->
+-->
 これらのパラメータのどれを設定する場合でも、相対パスは、<command>postgres</command>が起動されるディレクトリから見た相対パスとして解釈されます。
      </para>
    </sect1>
 
    <sect1 id="runtime-config-connection">
-   <!--
+<!--
     <title>Connections and Authentication</title>
-    -->
+-->
     <title>接続と認証</title>
 
     <sect2 id="runtime-config-connection-settings">
-    <!--
+<!--
      <title>Connection Settings</title>
-     -->
+-->
      <title>接続設定</title>
 
      <variablelist>
@@ -1042,14 +1042,14 @@ include_dir 'conf.d'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The TCP port the server listens on; 5432 by default.  Note that the
         same port number is used for all IP addresses the server listens on.
         This parameter can only be set at server start.
-       -->
-       サーバが監視するTCPポートで、デフォルトは 5432です。
-       サーバが監視する全てのIPアドレスに対し、同じポート番号が使用されることを覚えておいてください。
-       このパラメータはサーバ起動時のみ設定可能です。
+-->
+サーバが監視するTCPポートで、デフォルトは 5432です。
+サーバが監視する全てのIPアドレスに対し、同じポート番号が使用されることを覚えておいてください。
+このパラメータはサーバ起動時のみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1065,24 +1065,24 @@ include_dir 'conf.d'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Determines the maximum number of concurrent connections to the
         database server. The default is typically 100 connections, but
         might be less if your kernel settings will not support it (as
         determined during <application>initdb</application>).  This parameter can
         only be set at server start.
-       -->
+-->
 データベースサーバに同時接続する最大数を決定します。
 デフォルトは典型的に100接続ですが、カーネルの設定が（<application>initdb</application>の過程で）それをサポートしていない場合、もっと少なくなることがあります。
 このパラメータはサーバ起動時のみに設定可能です。
        </para>
 
        <para>
-       <!--
+<!--
         When running a standby server, you must set this parameter to the
         same or higher value than on the primary server. Otherwise, queries
         will not be allowed in the standby server.
-       -->
+-->
 スタンバイサーバを運用している場合、このパラメータはプライマリサーバでの設定と同じ、もしくはより高い値に設定しなければなりません。そうしないと問い合わせがスタンバイサーバ内で受け入れられません。
        </para>
       </listitem>
@@ -1101,7 +1101,7 @@ include_dir 'conf.d'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Determines the number of connection <quote>slots</quote> that
         are reserved for connections by <productname>PostgreSQL</productname>
         superusers.  At most <xref linkend="guc-max-connections"/>
@@ -1111,18 +1111,18 @@ include_dir 'conf.d'
         <varname>superuser_reserved_connections</varname>, new
         connections will be accepted only for superusers, and no
         new replication connections will be accepted.
-       -->
+-->
 <productname>PostgreSQL</productname>のスーパーユーザによる接続のために予約されている接続<quote>開口部（スロット）</quote>の数を決定します。
 最大、<xref linkend="guc-max-connections"/>の数までの接続を同時に有効にすることができます。
 有効な接続数が<varname>max_connections</varname>から<varname>superuser_reserved_connections</varname>を差し引いた数以上のときは、新規接続はスーパーユーザのみが許可され、新たなレプリケーション接続は受け入れられません。
        </para>
 
        <para>
-       <!--
+<!--
         The default value is three connections. The value must be less
         than <varname>max_connections</varname>.
         This parameter can only be set at server start.
-       -->
+-->
 デフォルトの値は3接続です。
 この値は <varname>max_connections</varname>より小さくなくてはなりません。
 このパラメータはサーバ起動時のみ設定可能です。
@@ -1218,7 +1218,7 @@ Windowsではデフォルトは空文字で、これはつまりUnixドメイン
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the owning group of the Unix-domain socket(s).  (The owning
         user of the sockets is always the user that starts the
         server.)  In combination with the parameter
@@ -1227,7 +1227,7 @@ Windowsではデフォルトは空文字で、これはつまりUnixドメイン
         By default this is the empty string, which uses the default
         group of the server user.  This parameter can only be set at
         server start.
-       -->
+-->
 Unixドメインソケット（複数も）を所有するグループを設定します（ソケットを所有するユーザは常にサーバを起動するユーザです）。
 <varname>unix_socket_permissions</varname>パラメータとの組合せで、Unixドメインソケット接続の追加的アクセス管理機構として使うことができます。
 デフォルトでは空文字列で、サーバユーザのデフォルトグループを使用します。
@@ -1258,7 +1258,7 @@ Unixドメインソケット（複数も）を所有するグループを設定�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the access permissions of the Unix-domain socket(s).  Unix-domain
         sockets use the usual Unix file system permission set.
         The parameter value is expected to be a numeric mode
@@ -1266,7 +1266,7 @@ Unixドメインソケット（複数も）を所有するグループを設定�
         <function>chmod</function> and <function>umask</function>
         system calls.  (To use the customary octal format the number
         must start with a <literal>0</literal> (zero).)
-       -->
+-->
 Unixドメインソケット（複数も）のアクセスパーミッションを設定します。
 Unixドメインソケットは通常のUnixファイルシステムパーミッション設定の一式を使用します。
 パラメータ値は、<function>chmod</function>および<function>umask</function>システムコールが受け付ける数値形式での指定を想定しています。
@@ -1289,27 +1289,27 @@ Unixドメインソケットは通常のUnixファイルシステムパーミッ
        </para>
 
        <para>
-       <!--
+<!--
         This access control mechanism is independent of the one
         described in <xref linkend="client-authentication"/>.
-       -->
+-->
 このアクセス制御機構は <xref linkend="client-authentication"/>で記述されたものとは別個のものです。
        </para>
 
        <para>
-       <!--
+<!--
         This parameter can only be set at server start.
-       -->
+-->
 このパラメータはサーバ起動時のみ設定可能です。
        </para>
 
        <para>
-       <!--
+<!--
         This parameter is irrelevant on systems, notably Solaris as of Solaris
         10, that ignore socket permissions entirely.  There, one can achieve a
         similar effect by pointing <varname>unix_socket_directories</varname> to a
         directory having search permission limited to the desired audience.
-       -->
+-->
 このパラメータはSolaris 10の時点でのSolarisなど、ソケットのパーミッションを完全に無視するシステムでは無関係です。
 こうしたシステムでは、許可したいユーザだけが検索パーミッションを持つディレクトリを<varname>unix_socket_directories</varname>で指すようにすることによって同じような効果を得ることができます。
        </para>
@@ -1335,12 +1335,12 @@ Unixドメインソケットは通常のUnixファイルシステムパーミッ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables advertising the server's existence via
         <productname>Bonjour</productname>.  The default is off.
         This parameter can only be set at server start.
-       -->
-       <productname>Bonjour</productname>によりサーバの存在を公表することを可能にします。デフォルトはoffです。このパラメータはサーバ起動時のみ設定可能です。
+-->
+<productname>Bonjour</productname>によりサーバの存在を公表することを可能にします。デフォルトはoffです。このパラメータはサーバ起動時のみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1356,15 +1356,15 @@ Unixドメインソケットは通常のUnixファイルシステムパーミッ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the <productname>Bonjour</productname> service
         name.  The computer name is used if this parameter is set to the
         empty string <literal>''</literal> (which is the default).  This parameter is
         ignored if the server was not compiled with
         <productname>Bonjour</productname> support.
         This parameter can only be set at server start.
-       -->
-       <productname>Bonjour</productname>サービス名を指定します。
+-->
+<productname>Bonjour</productname>サービス名を指定します。
 このパラメータが空文字列<literal>''</literal>（デフォルトです）に設定されていると、コンピュータ名が使用されます。
 サーバが<productname>Bonjour</productname>サポート付でコンパイルでされていない場合は無視されます。
 このオプションはサーバ起動時のみに設定可能です。
@@ -1383,7 +1383,7 @@ Unixドメインソケットは通常のUnixファイルシステムパーミッ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the amount of time with no network activity after which
         the operating system should send a TCP keepalive message to the client.
         If this value is specified without units, it is taken as seconds.
@@ -1393,7 +1393,7 @@ Unixドメインソケットは通常のUnixファイルシステムパーミッ
         Windows; on other systems, it must be zero.
         In sessions connected via a Unix-domain socket, this parameter is
         ignored and always reads as zero.
-       -->
+-->
 クライアントとのやり取りがなくなった後、オペレーティングシステムがTCPのkeepaliveパケットをクライアントに送信するまでの時間を指定します。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
 0（デフォルトです）の場合はオペレーティングシステムのデフォルト値を使用します。
@@ -1403,10 +1403,10 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
        </para>
        <note>
         <para>
-         <!--
+<!--
          On Windows, setting a value of 0 will set this parameter to 2 hours,
          since Windows does not provide a way to read the system default value.
-          -->
+-->
           Windowsでは0を指定するとこのパラメータを2時間に設定します。なぜなら、Windowsはシステムデフォルト値を読む手段を提供していないからです。
         </para>
        </note>
@@ -1424,7 +1424,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the amount of time after which a TCP keepalive message
         that has not been acknowledged by the client should be retransmitted.
         If this value is specified without units, it is taken as seconds.
@@ -1434,7 +1434,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
         Windows; on other systems, it must be zero.
         In sessions connected via a Unix-domain socket, this parameter is
         ignored and always reads as zero.
-       -->
+-->
 TCPのkeepaliveメッセージに対してクライアントから応答がない場合に、再送を行うまでの時間を指定します。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
 0（デフォルトです）の場合はシステムのデフォルト値を使用します。
@@ -1465,7 +1465,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the number of TCP keepalive messages that can be lost before
         the server's connection to the client is considered dead.
         A value of 0 (the default) selects the operating system's default.
@@ -1474,7 +1474,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
         on other systems, it must be zero.
         In sessions connected via a Unix-domain socket, this parameter is
         ignored and always reads as zero.
-       -->
+-->
 サーバのクライアントへの接続が切れたと判断されるまでのTCP keepaliveメッセージの数を指定します。
 0（デフォルトです）の場合はオペレーティングシステムのデフォルト値を使用します。
 このパラメータは<symbol>TCP_KEEPCNT</symbol>または同等のソケットオプションをサポートするシステムでのみサポートされます。
@@ -1483,9 +1483,9 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
        </para>
        <note>
         <para>
-         <!--
+<!--
          This parameter is not supported on Windows, and must be zero.
-          -->
+-->
 このパラメータはWindowsではサポートされておらず、ゼロでなければなりません。
         </para>
        </note>
@@ -1533,9 +1533,9 @@ UNIXドメインソケットで接続しているセッションではこのパ�
      <varlistentry id="guc-client-connection-check-interval" xreflabel="client_connection_check_interval">
       <term><varname>client_connection_check_interval</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>client_connection_check_interval</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>client_connection_check_interval</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1589,9 +1589,9 @@ UNIXドメインソケットで接続しているセッションではこのパ�
      </sect2>
 
      <sect2 id="runtime-config-connection-authentication">
-     <!--
+<!--
      <title>Authentication</title>
-     -->
+-->
      <title>認証</title>
 
      <variablelist>
@@ -1611,7 +1611,7 @@ UNIXドメインソケットで接続しているセッションではこのパ�
 
       <listitem>
        <para>
-       <!--
+<!--
         Maximum amount of time allowed to complete client authentication. If a
         would-be client has not completed the authentication protocol in
         this much time, the server closes the connection. This prevents
@@ -1620,7 +1620,7 @@ UNIXドメインソケットで接続しているセッションではこのパ�
         The default is one minute (<literal>1m</literal>).
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 クライアント認証を完了するまでの最大時間です。
 もし、この時間内に自称クライアントが認証プロトコルを完了しない場合、サーバは接続を閉じます。
 これはハングしたクライアントが接続を永久に占有することを防ぎます。
@@ -1879,13 +1879,13 @@ SSLサーバ認証局（CA）が入っているファイル名を設定します
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the name of the file containing the SSL server certificate.
         Relative paths are relative to the data directory.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
         The default is <filename>server.crt</filename>.
-       -->
+-->
 SSLサーバ証明書が入っているファイル名を設定します。
 相対パスの場合は、データディレクトリからの相対パスになります。
 このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
@@ -1925,9 +1925,9 @@ SSLサーバ証明書失効リスト（CRL）が入っているファイル名�
      <varlistentry id="guc-ssl-crl-dir" xreflabel="ssl_crl_dir">
       <term><varname>ssl_crl_dir</varname> (<type>string</type>)
       <indexterm>
-<!--
        <primary><varname>ssl_crl_dir</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>ssl_crl_dir</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -1986,13 +1986,13 @@ SSLサーバ証明書失効リスト（CRL）が入っているディレクト�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the name of the file containing the SSL server private key.
         Relative paths are relative to the data directory.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
         The default is <filename>server.key</filename>.
-       -->
+-->
 SSLサーバの秘密鍵が入っているファイル名を設定します。
 相対パスの場合は、データディレクトリからの相対パスになります。
 このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
@@ -2159,9 +2159,9 @@ TLSバージョン1.2あるいはそれ以下のバージョンを使用する�
         usually better because it is more likely that the server is appropriately
         configured.
 -->
-        古いバージョンのPostgreSQLにはこの設定がなく、常にクライアントの設定を使います。
-        この設定は、主に古いバージョンとの互換性のために設けられています。
-        通常サーバの設定に従うほうが良いです。大抵の場合、サーバはより適切に設定されているからです。
+古いバージョンのPostgreSQLにはこの設定がなく、常にクライアントの設定を使います。
+この設定は、主に古いバージョンとの互換性のために設けられています。
+通常サーバの設定に従うほうが良いです。大抵の場合、サーバはより適切に設定されているからです。
        </para>
       </listitem>
      </varlistentry>
@@ -2198,7 +2198,7 @@ TLSバージョン1.2あるいはそれ以下のバージョンを使用する�
         <productname>OpenSSL</productname> names for the most common curves
         are:
 -->
-        <productname>OpenSSL</productname>はよく使われる曲線に名前を付けています。
+<productname>OpenSSL</productname>はよく使われる曲線に名前を付けています。
         <literal>prime256v1</literal> (NIST P-256),
         <literal>secp384r1</literal> (NIST P-384),
         <literal>secp521r1</literal> (NIST P-521).
@@ -2207,7 +2207,7 @@ TLSバージョン1.2あるいはそれ以下のバージョンを使用する�
         <command>openssl ecparam -list_curves</command>.  Not all of them
         are usable in <acronym>TLS</acronym> though.
 -->
-        利用できる曲線の完全なリストは<command>openssl ecparam -list_curves</command>で得られます。ただし、<acronym>TLS</acronym>ではこのすべてが利用できるわけではありません。
+利用できる曲線の完全なリストは<command>openssl ecparam -list_curves</command>で得られます。ただし、<acronym>TLS</acronym>ではこのすべてが利用できるわけではありません。
        </para>
       </listitem>
      </varlistentry>
@@ -2427,15 +2427,15 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
    </sect1>
 
    <sect1 id="runtime-config-resource">
-   <!--
+<!--
     <title>Resource Consumption</title>
-    -->
+-->
     <title>資源の消費</title>
 
     <sect2 id="runtime-config-resource-memory">
-    <!--
+<!--
      <title>Memory</title>
-     -->
+-->
      <title>メモリ</title>
 
      <variablelist>
@@ -2450,7 +2450,7 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the amount of memory the database server uses for shared
         memory buffers.  The default is typically 128 megabytes
         (<literal>128MB</literal>), but might be less if your kernel settings will
@@ -2463,7 +2463,7 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
         (Non-default values of <symbol>BLCKSZ</symbol> change the minimum
         value.)
         This parameter can only be set at server start.
-       -->
+-->
 データベースサーバが共有メモリバッファのために使用するメモリ量を設定します。
 デフォルトは一般的に128メガバイト(<literal>128MB</literal>)です。
 しかし、稼働中のカーネルの設定がこの値をサポートしていない場合、より少なくなることがあります（<application>initdb</application>の過程で決定されます）。
@@ -2475,7 +2475,7 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
        </para>
 
        <para>
-       <!--
+<!--
         If you have a dedicated database server with 1GB or more of RAM, a
         reasonable starting value for <varname>shared_buffers</varname> is 25%
         of the memory in your system.  There are some workloads where even
@@ -2488,7 +2488,7 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
         <varname>max_wal_size</varname>, in order to spread out the
         process of writing large quantities of new or changed data over a
         longer period of time.
-       -->
+-->
 1GB以上のRAMを載せた専用データベースサーバを使用している場合、<varname>shared_buffers</varname>に対する妥当な初期値はシステムメモリの25%です。
 <varname>shared_buffers</varname>をこれよりも大きな値に設定することが有効なワークロードもあります。
 しかし、<productname>PostgreSQL</productname>はオペレーティングシステムキャッシュにも依存するため、<varname>shared_buffers</varname>にRAMの40%以上を割り当てても、それより小さい値の時より動作が良くなる見込みはありません。
@@ -2496,10 +2496,10 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
        </para>
 
        <para>
-       <!--
+<!--
         On systems with less than 1GB of RAM, a smaller percentage of RAM is
         appropriate, so as to leave adequate space for the operating system.
-       -->
+-->
 1GB未満のRAMのシステムでは、オペレーティングシステムに十分な余裕を残すために、RAMに対してより小さい割合を設定することが適切です。
        </para>
 
@@ -2540,8 +2540,8 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
         setting is ignored on other systems when set to
         <literal>try</literal>.
 -->
-        今のところこの機能はLinuxとWindowsでのみサポートされています。
-        他のシステムでは<literal>try</literal>と設定しても無視されます。
+今のところこの機能はLinuxとWindowsでのみサポートされています。
+他のシステムでは<literal>try</literal>と設定しても無視されます。
        </para>
 
        <para>
@@ -2600,9 +2600,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-huge-page-size" xreflabel="huge_page_size">
       <term><varname>huge_page_size</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>huge_page_size</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>huge_page_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2652,7 +2652,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the maximum amount of memory used for temporary buffers within
         each database session.  These are session-local buffers used only
         for access to temporary tables.
@@ -2665,7 +2665,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
         sessions, but only before the first use of temporary tables
         within the session; subsequent attempts to change the value will
         have no effect on that session.
-       -->
+-->
 それぞれのデータベースセッションが使用する一時バッファの最大メモリ量を設定します。
 一時バッファは、一時テーブルにアクセスする時にのみ使用されるセッションローカルのバッファです。
 この値が単位なしで指定された場合は、ブロック単位であるとみなします。すなわち、<symbol>BLCKSZ</symbol>バイト、一般的には8kBです。
@@ -2675,7 +2675,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
        </para>
 
        <para>
-       <!--
+<!--
         A session will allocate temporary buffers as needed up to the limit
         given by <varname>temp_buffers</varname>.  The cost of setting a large
         value in sessions that do not actually need many temporary
@@ -2683,7 +2683,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
         increment in <varname>temp_buffers</varname>.  However if a buffer is
         actually used an additional 8192 bytes will be consumed for it
         (or in general, <symbol>BLCKSZ</symbol> bytes).
-       -->
+-->
 セッションは、<varname>temp_buffers</varname>を上限として、必要に応じて一時バッファを確保します。
 多くの一時バッファを実際に必要としないセッションで大きな値を設定するコストとは、<varname>temp_buffers</varname>の増分毎に、1つのバッファ記述子、約64バイトだけです。
 しかし、バッファが実際に使用されると、それに対して追加の8192バイト（汎用的に言えば<symbol>BLCKSZ</symbol>バイト）が消費されます。
@@ -2702,39 +2702,39 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the maximum number of transactions that can be in the
         <quote>prepared</quote> state simultaneously (see <xref
         linkend="sql-prepare-transaction"/>).
         Setting this parameter to zero (which is the default)
         disables the prepared-transaction feature.
         This parameter can only be set at server start.
-       -->
+-->
 同時に<quote>プリペアド</quote>状態にできるトランザクションの最大数を設定します（<xref linkend="sql-prepare-transaction"/>を参照してください）。
 このパラメータをゼロ（これがデフォルトです）に設定すると、プリペアドトランザクション機能が無効になります。
 このパラメータはサーバ起動時にのみ設定可能です。
        </para>
 
        <para>
-       <!--
+<!--
         If you are not planning to use prepared transactions, this parameter
         should be set to zero to prevent accidental creation of prepared
         transactions.  If you are using prepared transactions, you will
         probably want <varname>max_prepared_transactions</varname> to be at
         least as large as <xref linkend="guc-max-connections"/>, so that every
         session can have a prepared transaction pending.
-       -->
+-->
 プリペアドトランザクションの使用を意図しないのであれば、このパラメータはプリペアドトランザクションが偶然に作成されないようゼロに設定すべきです。
 プリペアドトランザクションを使用する場合、全てのセッションがプリペアドトランザクションを保留できるように、<varname>max_prepared_transactions</varname>を少なくとも<xref linkend="guc-max-connections"/>と同じ大きさに設定するのが良いでしょう。
        </para>
 
        <para>
-       <!--
+<!--
         When running a standby server, you must set this parameter to the
         same or higher value than on the primary server. Otherwise, queries
         will not be allowed in the standby server.
-       -->
-       スタンバイサーバを運用している場合、このパラメータはプライマリサーバ上の設定よりも同等かもしくはより高水準に設定しなければなりません。そうしないと問い合わせがスタンバイサーバ内で受け入れられません。
+-->
+スタンバイサーバを運用している場合、このパラメータはプライマリサーバ上の設定よりも同等かもしくはより高水準に設定しなければなりません。そうしないと問い合わせがスタンバイサーバ内で受け入れられません。
        </para>
       </listitem>
      </varlistentry>
@@ -2750,7 +2750,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the base maximum amount of memory to be used by a query operation
         (such as a sort or hash table) before writing to temporary disk files.
         If this value is specified without units, it is taken as kilobytes.
@@ -2768,7 +2768,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
         Hash tables are used in hash joins, hash-based aggregation, result
         cache nodes and hash-based processing of <literal>IN</literal>
         subqueries.
-       -->
+-->
 一時ディスクファイルに書き込むようになる前に、問い合わせ操作（たとえば並べ替えとハッシュテーブル操作）が使用する基本的な最大のメモリ容量を指定します。
 この値が単位なしで指定された場合は、キロバイト単位であるとみなします。
 デフォルト値は4メガバイト（<literal>4MB</literal>）です。
@@ -2852,7 +2852,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the maximum amount of memory to be used by maintenance
         operations, such as <command>VACUUM</command>, <command>CREATE
         INDEX</command>, and <command>ALTER TABLE ADD FOREIGN KEY</command>.
@@ -2864,7 +2864,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
         concurrently, it's safe to set this value significantly larger
         than <varname>work_mem</varname>.  Larger settings might improve
         performance for vacuuming and for restoring database dumps.
-       -->
+-->
 <command>VACUUM</command>、<command>CREATE INDEX</command>、および<command>ALTER TABLE ADD FOREIGN KEY</command>の様な保守操作で使用されるメモリの最大容量を指定します。
 この値が単位なしで指定された場合は、キロバイト単位であるとみなします。
 デフォルト値は64メガバイト（<literal>64MB</literal>）です。
@@ -2872,7 +2872,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
 大きい値を設定することでvacuum処理と、ダンプしたデータベースのリストア性能が向上します。
        </para>
        <para>
-       <!--
+<!--
         Note that when autovacuum runs, up to
         <xref linkend="guc-autovacuum-max-workers"/> times this memory
         may be allocated, so be careful not to set the default value
@@ -2915,7 +2915,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
         This parameter can only be set in the
         <filename>postgresql.conf</filename> file or on the server command
         line.
-       -->
+-->
 個々の自動バキュームワーカプロセスが使用する最大のメモリ量を指定します。
 この値が単位なしで指定された場合は、キロバイト単位であるとみなします。
 デフォルトは-1で、<xref linkend="guc-maintenance-work-mem"/>が代わりに使われる設定になります。
@@ -2977,7 +2977,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the maximum safe depth of the server's execution stack.
         The ideal setting for this parameter is the actual stack size limit
         enforced by the kernel (as set by <literal>ulimit -s</literal> or local
@@ -2989,7 +2989,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
         is conservatively small and unlikely to risk crashes.  However,
         it might be too small to allow execution of complex functions.
         Only superusers can change this setting.
-       -->
+-->
 サーバの実行スタックの最大安全深度を指定します。
 このパラメータの理想的な設定はカーネルにより強要される実際のスタック容量の（<literal>ulimit -s</literal>もしくはそれと同等の機能で設定された）限界から、1メガバイト程度の安全余裕度を差し引いたものです。
 この安全余裕度は、サーバがすべてのルーチンではスタック深度を検査をせず、再帰を行う可能性のある重要なルーチンでのみ検査をするために必要となるものです。
@@ -3000,7 +3000,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
        </para>
 
        <para>
-       <!--
+<!--
         Setting <varname>max_stack_depth</varname> higher than
         the actual kernel limit will mean that a runaway recursive function
         can crash an individual backend process.  On platforms where
@@ -3008,7 +3008,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
         the server will not allow this variable to be set to an unsafe
         value.  However, not all platforms provide the information,
         so caution is recommended in selecting a value.
-       -->
+-->
 <varname>max_stack_depth</varname>を実際のカーネルの制限よりも高い値に設定した場合、暴走した再帰関数により、個々のバックエンドプロセスがクラッシュするかもしれません。
 <productname>PostgreSQL</productname>がカーネルの制限を決定することができるプラットフォームでは、この変数を危険な値に設定させません。
 しかし、すべてのプラットフォームがこの情報を提供できるわけではありません。
@@ -3094,9 +3094,9 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
      <varlistentry id="guc-min-dynamic-shared-memory" xreflabel="min_dynamic_shared_memory">
       <term><varname>min_dynamic_shared_memory</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>min_dynamic_shared_memory</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>min_dynamic_shared_memory</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3132,9 +3132,9 @@ huge pageを自動管理するオペレーティングシステム上でより�
      </sect2>
 
      <sect2 id="runtime-config-resource-disk">
-     <!--
+<!--
      <title>Disk</title>
-     -->
+-->
      <title>ディスク</title>
 
      <variablelist>
@@ -3149,7 +3149,7 @@ huge pageを自動管理するオペレーティングシステム上でより�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the maximum amount of disk space that a process can use
         for temporary files, such as sort and hash temporary files, or the
         storage file for a held cursor.  A transaction attempting to exceed
@@ -3157,7 +3157,7 @@ huge pageを自動管理するオペレーティングシステム上でより�
         If this value is specified without units, it is taken as kilobytes.
         <literal>-1</literal> (the default) means no limit.
         Only superusers can change this setting.
-       -->
+-->
 あるプロセスが一時ファイルとして使用できるディスクの最大容量を設定します。
 例えば、ソートやハッシュの一時ファイルであったり、カーソルを保持する格納ファイルです。
 この制限値を超えようとするトランザクションはキャンセルされます。
@@ -3166,15 +3166,15 @@ huge pageを自動管理するオペレーティングシステム上でより�
 この設定はスーパーユーザのみ変更可能です。
        </para>
        <para>
-       <!--
+<!--
         This setting constrains the total space used at any instant by all
         temporary files used by a given <productname>PostgreSQL</productname> process.
         It should be noted that disk space used for explicit temporary
         tables, as opposed to temporary files used behind-the-scenes in query
         execution, does <emphasis>not</emphasis> count against this limit.
-       -->
-       この設定により、ある <productname>PostgreSQL</productname> セッションによって使用される一時ファイルの合計の容量が常に制約されることになります。
-       なお、問い合わせの実行において暗黙的に使用される一時ファイルとは異なり、一時テーブルとして明示的に使用されるディスク容量は、この制限には<emphasis>含まれません</emphasis>。
+-->
+この設定により、ある <productname>PostgreSQL</productname> セッションによって使用される一時ファイルの合計の容量が常に制約されることになります。
+なお、問い合わせの実行において暗黙的に使用される一時ファイルとは異なり、一時テーブルとして明示的に使用されるディスク容量は、この制限には<emphasis>含まれません</emphasis>。
        </para>
       </listitem>
      </varlistentry>
@@ -3183,9 +3183,9 @@ huge pageを自動管理するオペレーティングシステム上でより�
      </sect2>
 
      <sect2 id="runtime-config-resource-kernel">
-     <!--
+<!--
      <title>Kernel Resource Usage</title>
-     -->
+-->
      <title>カーネル資源使用</title>
 
      <variablelist>
@@ -3200,7 +3200,7 @@ huge pageを自動管理するオペレーティングシステム上でより�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the maximum number of simultaneously open files allowed to each
         server subprocess. The default is one thousand files. If the kernel is enforcing
         a safe per-process limit, you don't need to worry about this setting.
@@ -3210,8 +3210,8 @@ huge pageを自動管理するオペレーティングシステム上でより�
         that many files. If you find yourself seeing <quote>Too many open
         files</quote> failures, try reducing this setting.
         This parameter can only be set at server start.
-       -->
-       それぞれのサーバ子プロセスが同時にオープンできるファイル数の最大値をセットします。
+-->
+それぞれのサーバ子プロセスが同時にオープンできるファイル数の最大値をセットします。
 デフォルトは1000ファイルです。
 もしもカーネルがプロセス毎の安全制限を強要している場合、この設定を気にかける必要はありません。
 しかし、いくつかのプラットフォーム（特にほとんどのBSDシステム）では、もし多くのプロセス全てがそれだけ多くのファイルを開くことを試みたとした場合、実際にサポートできるファイル数より多くのファイルを開くことを許しています。もしも<quote>Too many open files</quote>エラーが発生した場合、この設定を削減してみてください。
@@ -3223,13 +3223,13 @@ huge pageを自動管理するオペレーティングシステム上でより�
     </sect2>
 
     <sect2 id="runtime-config-resource-vacuum-cost">
-    <!--
+<!--
      <title>Cost-based Vacuum Delay</title>
-     -->
+-->
      <title>コストに基づくVacuum遅延</title>
 
      <para>
-     <!--
+<!--
       During the execution of <xref linkend="sql-vacuum"/>
       and <xref linkend="sql-analyze"/>
       commands, the system maintains an
@@ -3240,13 +3240,13 @@ huge pageを自動管理するオペレーティングシステム上でより�
       the operation will sleep for a short period of time, as specified by
       <varname>vacuum_cost_delay</varname>. Then it will reset the
       counter and continue execution.
-      -->
-      <xref linkend="sql-vacuum"/> および <xref linkend="sql-analyze"/> コマンドの実行中、実行される各種I/O操作の予測コストを追跡し続ける内部カウンタをシステムが保守します。
-      累積されたコストが（<varname>vacuum_cost_limit</varname>で指定された）限度に達すると、操作を実行しているプロセスは<varname>vacuum_cost_delay</varname>で指定されたちょっとの間スリープします。その後、カウンタをリセットし、実行を継続します。
+-->
+<xref linkend="sql-vacuum"/> および <xref linkend="sql-analyze"/> コマンドの実行中、実行される各種I/O操作の予測コストを追跡し続ける内部カウンタをシステムが保守します。
+累積されたコストが（<varname>vacuum_cost_limit</varname>で指定された）限度に達すると、操作を実行しているプロセスは<varname>vacuum_cost_delay</varname>で指定されたちょっとの間スリープします。その後、カウンタをリセットし、実行を継続します。
      </para>
 
      <para>
-     <!--
+<!--
       The intent of this feature is to allow administrators to reduce
       the I/O impact of these commands on concurrent database
       activity. There are many situations where it is not
@@ -3256,7 +3256,7 @@ huge pageを自動管理するオペレーティングシステム上でより�
       commands do not significantly interfere with the ability of the
       system to perform other database operations. Cost-based vacuum
       delay provides a way for administrators to achieve this.
-      -->
+-->
 この機能の目的は、同時に実行されているデータベースの活動に対するこれらコマンドによるI/Oへの影響を、管理者が軽減できるようにすることです。
 <command>VACUUM</command> および <command>ANALYZE</command>の様な保守用コマンドが即座に終了することが重要ではない事態が数多くあります。
 しかし、他のデータベースの操作を行うに当たって、これらのコマンドがシステムの能力に多大な阻害を与えないことは通常とても重要です。
@@ -3264,12 +3264,12 @@ huge pageを自動管理するオペレーティングシステム上でより�
      </para>
 
      <para>
-     <!--
+<!--
       This feature is disabled by default for manually issued
       <command>VACUUM</command> commands. To enable it, set the
       <varname>vacuum_cost_delay</varname> variable to a nonzero
       value.
-      -->
+-->
 手動で実行した<command>VACUUM</command>コマンドについては、デフォルトでこの機能は無効になっています。
 有効にするには、<varname>vacuum_cost_delay</varname>変数をゼロでない値に設定します。
      </para>
@@ -3286,13 +3286,13 @@ huge pageを自動管理するオペレーティングシステム上でより�
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          The amount of time that the process will sleep
          when the cost limit has been exceeded.
          If this value is specified without units, it is taken as milliseconds.
          The default value is zero, which disables the cost-based vacuum
          delay feature.  Positive values enable cost-based vacuuming.
-        -->
+-->
 コストの限度を越えた場合、プロセスがスリープする時間の長さです。
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
 デフォルトの値は0で、コストに基づいたvacuum遅延機能を無効にします。
@@ -3300,7 +3300,7 @@ huge pageを自動管理するオペレーティングシステム上でより�
         </para>
 
         <para>
-       <!--
+<!--
          When using cost-based vacuuming, appropriate values for
          <varname>vacuum_cost_delay</varname> are usually quite small, perhaps
          less than 1 millisecond.  While <varname>vacuum_cost_delay</varname>
@@ -3311,7 +3311,7 @@ huge pageを自動管理するオペレーティングシステム上でより�
          parameters.  You should, nonetheless,
          keep <varname>vacuum_cost_delay</varname> as small as your platform
          will consistently measure; large delays are not helpful.
-        -->
+-->
 コストに基づいたバキューム処理を使用する場合、<varname>vacuum_cost_delay</varname>の適切な値は通常かなり小さくなり、おそらく1ミリ秒以下になります。
 バキュームによるリソース消費の調整は、他のバキュームのコストパラメータを変更して行うことが最善です。
 <varname>vacuum_cost_delay</varname>を1ミリ秒以下に設定することは可能ですが、そうした遅延は古いプラットフォームでは正確には計測されないかも知れません。
@@ -3328,17 +3328,17 @@ huge pageを自動管理するオペレーティングシステム上でより�
         <primary><varname>vacuum_cost_page_hit</varname> configuration parameter</primary>
        </indexterm>
        <indexterm>
-       <primary><varname>vacuum_cost_page_hit</varname>設定パラメータ</primary>
+        <primary><varname>vacuum_cost_page_hit</varname>設定パラメータ</primary>
        </indexterm>
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          The estimated cost for vacuuming a buffer found in the shared buffer
          cache. It represents the cost to lock the buffer pool, lookup
          the shared hash table and scan the content of the page. The
          default value is one.
-        -->
+-->
 共有バッファキャッシュの中のバッファにvacuumを掛ける予測コストです。バッファプールのロック、共有ハッシュテーブルの検索、およびページ内容走査のコストを示します。デフォルトの値は1です。
         </para>
        </listitem>
@@ -3350,17 +3350,17 @@ huge pageを自動管理するオペレーティングシステム上でより�
         <primary><varname>vacuum_cost_page_miss</varname> configuration parameter</primary>
        </indexterm>
        <indexterm>
-       <primary><varname>vacuum_cost_page_miss</varname>設定パラメータ</primary>
+        <primary><varname>vacuum_cost_page_miss</varname>設定パラメータ</primary>
        </indexterm>
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          The estimated cost for vacuuming a buffer that has to be read from
          disk.  This represents the effort to lock the buffer pool,
          lookup the shared hash table, read the desired block in from
          the disk and scan its content. The default value is 2.
-        -->
+-->
 ディスクから読み込まれなければならないバッファにvacuumを掛ける予測コストです。これが示すものは、バッファプールロックの試み、共有ハッシュテーブルの参照、ディスクから目的ブロックの読み込み、そしてその内容走査です。デフォルトの値は2です。
         </para>
        </listitem>
@@ -3372,17 +3372,17 @@ huge pageを自動管理するオペレーティングシステム上でより�
         <primary><varname>vacuum_cost_page_dirty</varname> configuration parameter</primary>
        </indexterm>
        <indexterm>
-       <primary><varname>vacuum_cost_page_dirty</varname>設定パラメータ</primary>
+        <primary><varname>vacuum_cost_page_dirty</varname>設定パラメータ</primary>
        </indexterm>
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          The estimated cost charged when vacuum modifies a block that was
          previously clean. It represents the extra I/O required to
          flush the dirty block out to disk again. The default value is
          20.
-        -->
+-->
 vacuumが、先だって掃除したブロックを変更するのに必要な見積コストです。
 ダーティブロックを再度ディスクに吐き出すのに必要な余分なI/Oを表します。デフォルトの値は20です。
         </para>
@@ -3395,15 +3395,15 @@ vacuumが、先だって掃除したブロックを変更するのに必要な�
         <primary><varname>vacuum_cost_limit</varname> configuration parameter</primary>
        </indexterm>
        <indexterm>
-       <primary><varname>vacuum_cost_limit</varname>設定パラメータ</primary>
+        <primary><varname>vacuum_cost_limit</varname>設定パラメータ</primary>
        </indexterm>
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          The accumulated cost that will cause the vacuuming process to sleep.
          The default value is 200.
-        -->
+-->
 vacuumを掛けるプロセスをスリープさせることになる累計されたコストです。
 デフォルトの値は200です。
         </para>
@@ -3413,7 +3413,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
 
      <note>
       <para>
-      <!--
+<!--
        There are certain operations that hold critical locks and should
        therefore complete as quickly as possible.  Cost-based vacuum
        delays do not occur during such operations.  Therefore it is
@@ -3423,7 +3423,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
        <varname>accumulated_balance</varname> /
        <varname>vacuum_cost_limit</varname> with a maximum of
        <varname>vacuum_cost_delay</varname> * 4.
-       -->
+-->
 重要なロックを保有し可能なかぎり早急に完了しなければならないある種の操作があります。コストに基づいたvacuum遅延はこの様な操作では起こりません。
 したがって、コストの累計が指定された限度をかなり高く越える可能性があります。
 このような場合無駄な長い遅延を防止するため、実際の遅延は<varname>vacuum_cost_delay</varname> * 4 を上限として、以下のように計算されます。
@@ -3433,13 +3433,13 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
     </sect2>
 
     <sect2 id="runtime-config-resource-background-writer">
-    <!--
+<!--
      <title>Background Writer</title>
-     -->
+-->
      <title>バックグラウンドライタ</title>
 
      <para>
-     <!--
+<!--
       There is a separate server
       process called the <firstterm>background writer</firstterm>, whose function
       is to issue writes of <quote>dirty</quote> (new or modified) shared
@@ -3454,7 +3454,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
       background writer might write it several times as it is dirtied
       in the same interval.  The parameters discussed in this subsection
       can be used to tune the behavior for local needs.
-      -->
+-->
 <firstterm>バックグラウンドライタ</firstterm>と呼ばれる個別のサーバプロセスがあり、その機能は（新規または更新された）<quote>ダーティ</quote>な共有バッファの書き込みを行うことです。
 クリーンなバッファの数が足りないことが分かると、バックグラウンドライタはダーティバッファをファイルシステムに書き込み、それらのバッファにクリーンであるという印を付けます。
 これにより、ユーザの問い合わせを処理するサーバプロセスがクリーンなバッファを見つけることができず、ダーティなバッファを自分で書き込まなければならなくなる可能性を減らすことができます。
@@ -3470,12 +3470,12 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
         <primary><varname>bgwriter_delay</varname> configuration parameter</primary>
        </indexterm>
        <indexterm>
-       <primary><varname>bgwriter_delay</varname>設定パラメータ</primary>
+        <primary><varname>bgwriter_delay</varname>設定パラメータ</primary>
        </indexterm>
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          Specifies the delay between activity rounds for the
          background writer.  In each round the writer issues writes
          for some number of dirty buffers (controllable by the
@@ -3492,7 +3492,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
          might have the same results as setting it to the next higher multiple
          of 10.  This parameter can only be set in the
          <filename>postgresql.conf</filename> file or on the server command line.
-        -->
+-->
 バックグラウンドライタの動作周期間の遅延を指定します。
 それぞれの周期でライタは、（以下のパラメータで管理される）一部のダーティバッファの書き込みを行います。
 そして<varname>bgwriter_delay</varname>の長さスリープした後、これを繰りかえします。
@@ -3517,7 +3517,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          In each round, no more than this many buffers will be written
          by the background writer.  Setting this to zero disables
          background writing.  (Note that checkpoints, which are managed by
@@ -3525,12 +3525,12 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
          The default value is 100 buffers.
          This parameter can only be set in the <filename>postgresql.conf</filename>
          file or on the server command line.
-        -->
-        それぞれの周期で、この数以上のバッファはバックグラウンドライタにより書き込まれません。
-         ゼロに設定することでバックグラウンド書き込みは無効になります。
+-->
+それぞれの周期で、この数以上のバッファはバックグラウンドライタにより書き込まれません。
+ゼロに設定することでバックグラウンド書き込みは無効になります。
         （分離し、そして専用の補助プロセスにより管理されるチェックポイントは影響を受けません。）
-         デフォルト値は100バッファです。
-         このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみで設定可能です。
+デフォルト値は100バッファです。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみで設定可能です。
         </para>
        </listitem>
       </varlistentry>
@@ -3541,12 +3541,12 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
         <primary><varname>bgwriter_lru_multiplier</varname> configuration parameter</primary>
        </indexterm>
        <indexterm>
-       <primary><varname>bgwriter_lru_multiplier</varname>設定パラメータ</primary>
+        <primary><varname>bgwriter_lru_multiplier</varname>設定パラメータ</primary>
        </indexterm>
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          The number of dirty buffers written in each round is based on the
          number of new buffers that have been needed by server processes
          during recent rounds.  The average recent need is multiplied by
@@ -3563,8 +3563,8 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
          The default is 2.0.
          This parameter can only be set in the <filename>postgresql.conf</filename>
          file or on the server command line.
-        -->
-        各周期で書き出されるダーティバッファ数は、最近の周期でサーバプロセスが必要とした新しいバッファ数を基にします。
+-->
+各周期で書き出されるダーティバッファ数は、最近の周期でサーバプロセスが必要とした新しいバッファ数を基にします。
 次の周期で必要となるバッファ数を推定するために、最近必要とされた平均が<varname>bgwriter_lru_multiplier</varname>と掛け合わせられます。
 ダーティバッファの書き出しは、同数の整理済み、再利用可能なバッファが利用できるようになるまで行われます。
 （しかし1周期に<varname>bgwriter_lru_maxpages</varname>を越えるバッファ数を書き出しません。）
@@ -3625,30 +3625,30 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
      </variablelist>
 
      <para>
-     <!--
+<!--
       Smaller values of <varname>bgwriter_lru_maxpages</varname> and
       <varname>bgwriter_lru_multiplier</varname> reduce the extra I/O load
       caused by the background writer, but make it more likely that server
       processes will have to issue writes for themselves, delaying interactive
       queries.
-      -->
-      <varname>bgwriter_lru_maxpages</varname>および<varname>bgwriter_lru_multiplier</varname>の値がより少ないと、バックグラウンドライタで引き起こされる追加のI/O負荷を軽減しますが、サーバプロセスが自分自身で行わなければならない書き込みが増加することになり、会話型問い合わせを遅らせることになります。
+-->
+<varname>bgwriter_lru_maxpages</varname>および<varname>bgwriter_lru_multiplier</varname>の値がより少ないと、バックグラウンドライタで引き起こされる追加のI/O負荷を軽減しますが、サーバプロセスが自分自身で行わなければならない書き込みが増加することになり、会話型問い合わせを遅らせることになります。
      </para>
     </sect2>
 
     <sect2 id="runtime-config-resource-async-behavior">
-    <!--
+<!--
      <title>Asynchronous Behavior</title>
-     -->
+-->
      <title>非同期動作</title>
 
      <variablelist>
       <varlistentry id="guc-backend-flush-after" xreflabel="backend_flush_after">
        <term><varname>backend_flush_after</varname> (<type>integer</type>)
        <indexterm>
-<!--
         <primary><varname>backend_flush_after</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>backend_flush_after</varname>設定パラメータ</primary>
        </indexterm>
        </term>
@@ -3692,12 +3692,12 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
         <primary><varname>effective_io_concurrency</varname> configuration parameter</primary>
        </indexterm>
        <indexterm>
-       <primary><varname>effective_io_concurrency</varname>設定パラメータ</primary>
+        <primary><varname>effective_io_concurrency</varname>設定パラメータ</primary>
        </indexterm>
        </term>
        <listitem>
         <para>
-       <!--
+<!--
          Sets the number of concurrent disk I/O operations that
          <productname>PostgreSQL</productname> expects can be executed
          simultaneously.  Raising this value will increase the number of I/O
@@ -3705,7 +3705,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
          attempts to initiate in parallel.  The allowed range is 1 to 1000,
          or zero to disable issuance of asynchronous I/O requests. Currently,
          this setting only affects bitmap heap scans.
-        -->
+-->
 <productname>PostgreSQL</productname>が同時実行可能であると想定する同時ディスクI/O操作の数を設定します。
 この値を大きくすると、あらゆる個別の<productname>PostgreSQL</productname>セッションが並行して開始を試みるI/O操作の数が増加します。
 設定可能な範囲は1から1000まで、または非同期I/Oリクエストの発行を無効にするゼロです。
@@ -3713,7 +3713,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
         </para>
 
         <para>
-       <!--
+<!--
          For magnetic drives, a good starting point for this setting is the
          number of separate
          drives comprising a RAID 0 stripe or RAID 1 mirror being used for the
@@ -3732,17 +3732,17 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
         </para>
 
         <para>
-       <!--
+<!--
          Asynchronous I/O depends on an effective <function>posix_fadvise</function>
          function, which some operating systems lack.  If the function is not
          present then setting this parameter to anything but zero will result
          in an error.  On some operating systems (e.g., Solaris), the function
          is present but does not actually do anything.
-        -->
-        非同期I/Oは実質的に<function>posix_fadvise</function>関数に依存します。
-        これは一部のオペレーティングシステムには存在しません。
-        この関数が存在しない場合、この値をゼロ以外に設定するとエラーとなります。
-        一部のオペレーティングシステム（例えばSolaris）では存在するけれども、実際何も行わないものもあります。
+-->
+非同期I/Oは実質的に<function>posix_fadvise</function>関数に依存します。
+これは一部のオペレーティングシステムには存在しません。
+この関数が存在しない場合、この値をゼロ以外に設定するとエラーとなります。
+一部のオペレーティングシステム（例えばSolaris）では存在するけれども、実際何も行わないものもあります。
         </para>
 
         <para>
@@ -3892,7 +3892,7 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
          For more information on parallel query, see
          <xref linkend="parallel-query"/>.
 -->
-         パラレルクエリに関する更なる情報については、<xref linkend="parallel-query"/>をご覧ください。
+パラレルクエリに関する更なる情報については、<xref linkend="parallel-query"/>をご覧ください。
         </para>
        </listitem>
       </varlistentry>

--- a/doc/src/sgml/config0.sgml
+++ b/doc/src/sgml/config0.sgml
@@ -1407,7 +1407,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
          On Windows, setting a value of 0 will set this parameter to 2 hours,
          since Windows does not provide a way to read the system default value.
 -->
-          Windowsでは0を指定するとこのパラメータを2時間に設定します。なぜなら、Windowsはシステムデフォルト値を読む手段を提供していないからです。
+Windowsでは0を指定するとこのパラメータを2時間に設定します。なぜなら、Windowsはシステムデフォルト値を読む手段を提供していないからです。
         </para>
        </note>
       </listitem>
@@ -1448,7 +1448,7 @@ Unixドメインソケット経由で接続されたセッションでは、こ�
          On Windows, setting a value of 0 will set this parameter to 1 second,
          since Windows does not provide a way to read the system default value.
 -->
-         Windowsでは0を指定すると、このパラメータを1秒に設定します。なぜなら、Windowsはシステムデフォルト値を読む手段を提供していないからです。
+Windowsでは0を指定すると、このパラメータを1秒に設定します。なぜなら、Windowsはシステムデフォルト値を読む手段を提供していないからです。
         </para>
        </note>
       </listitem>
@@ -3427,7 +3427,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
 重要なロックを保有し可能なかぎり早急に完了しなければならないある種の操作があります。コストに基づいたvacuum遅延はこの様な操作では起こりません。
 したがって、コストの累計が指定された限度をかなり高く越える可能性があります。
 このような場合無駄な長い遅延を防止するため、実際の遅延は<varname>vacuum_cost_delay</varname> * 4 を上限として、以下のように計算されます。
-       <varname>vacuum_cost_delay</varname> * <varname>accumulated_balance</varname> / <varname>vacuum_cost_limit</varname>
+<varname>vacuum_cost_delay</varname> * <varname>accumulated_balance</varname> / <varname>vacuum_cost_limit</varname>
       </para>
      </note>
     </sect2>
@@ -3528,7 +3528,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
 -->
 それぞれの周期で、この数以上のバッファはバックグラウンドライタにより書き込まれません。
 ゼロに設定することでバックグラウンド書き込みは無効になります。
-        （分離し、そして専用の補助プロセスにより管理されるチェックポイントは影響を受けません。）
+（分離し、そして専用の補助プロセスにより管理されるチェックポイントは影響を受けません。）
 デフォルト値は100バッファです。
 このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみで設定可能です。
         </para>

--- a/doc/src/sgml/config1.sgml
+++ b/doc/src/sgml/config1.sgml
@@ -528,7 +528,8 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
         since WAL file updates will not be forced out at all.
         Possible values are:
 -->
-       WALの更新をディスクへ強制するのに使用される方法です。<varname>fsync</varname>がオフの場合この設定は役に立ちません。と言うのはWALファイルの更新が全く強制されないからです。取り得る値は以下のものです。
+WALの更新をディスクへ強制するのに使用される方法です。
+<varname>fsync</varname>がオフの場合この設定は役に立ちません。と言うのはWALファイルの更新が全く強制されないからです。取り得る値は以下のものです。
        </para>
        <itemizedlist>
         <listitem>
@@ -840,7 +841,7 @@ COWファイルシステムでは、新しいファイルを作るほうが速�
         selected by the default setting of -1 should give reasonable
         results in most cases.
 -->
-       WALバッファの内容はトランザクションのコミット毎にディスクに書き込まれます。
+WALバッファの内容はトランザクションのコミット毎にディスクに書き込まれます。
 したがって、極端に大きな値は有意な効果を期待できません。
 しかし、この値を数メガバイトに設定することにより、多くのクライアントが同時にコミットするトラフィック量の多いサーバでは書き込み性能が向上します。
 デフォルト設定の-1で選択される自動チューニングによると、ほとんどの場合妥当な結果が得られます。
@@ -1003,9 +1004,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
         interval, while subsequent processes wait only until the leader
         completes the flush operation.
 -->
-        9.3より前の<productname>PostgreSQL</productname>では、<varname>commit_delay</varname>の振る舞いは異なっており、あまり効果がありませんでした。
+9.3より前の<productname>PostgreSQL</productname>では、<varname>commit_delay</varname>の振る舞いは異なっており、あまり効果がありませんでした。
 全てのWALフラッシュではなく、コミットだけに影響していました。また、そしてWALフラッシュが早めに完了しても設定された遅延分待機していました。
-       <productname>PostgreSQL</productname> 9.3以降では、フラッシュの準備が整った最初のプロセスが設定値分待機し、後続のプロセスは最初のプロセスがフラッシュ操作を完了するまでの間だけ待機をします。
+<productname>PostgreSQL</productname> 9.3以降では、フラッシュの準備が整った最初のプロセスが設定値分待機し、後続のプロセスは最初のプロセスがフラッシュ操作を完了するまでの間だけ待機をします。
        </para>
       </listitem>
      </varlistentry>
@@ -4377,7 +4378,7 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
         increase the likelihood that an efficient query plan will be
         chosen.
 -->
-       GEQOにおける計画時間と問い合わせ計画の品質間のトレードオフを制御します。この変数は1から10までの範囲の整数でなければなりません。
+GEQOにおける計画時間と問い合わせ計画の品質間のトレードオフを制御します。この変数は1から10までの範囲の整数でなければなりません。
 デフォルトの値は5です。値を大きくすると、問い合わせ計画作成により多くの時間を費すことになりますが、より効率的な問い合わせ計画が選択される可能性が増加します。
        </para>
 
@@ -4413,7 +4414,8 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
         value is chosen based on <varname>geqo_effort</varname> and
         the number of tables in the query.
 -->
-       GEQOで使用されるプール容量を管理します。それは遺伝的個体群内の個体数です。最低でも2つはなければならず、よく100から1000までの値が使用されます。もし（デフォルトの設定である）零に設定されると、<varname>geqo_effort</varname>および問い合わせの中のテーブル数に基づいて、適切な値が選択されます。
+GEQOで使用されるプール容量を管理します。それは遺伝的個体群内の個体数です。最低でも2つはなければならず、よく100から1000までの値が使用されます。
+もし（デフォルトの設定である）零に設定されると、<varname>geqo_effort</varname>および問い合わせの中のテーブル数に基づいて、適切な値が選択されます。
        </para>
       </listitem>
      </varlistentry>
@@ -4437,7 +4439,8 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
         then a suitable value is chosen based on
         <varname>geqo_pool_size</varname>.
 -->
-       GEQOで使用される世代の数を管理します。それはアルゴリズムの反復数です。最低でも1はなければならず、よくプールサイズと同じ範囲の値が使用されます。これを0に設定（デフォルトの設定）すると、適切な値が<varname>geqo_pool_size</varname>に基づいて選択されます。
+GEQOで使用される世代の数を管理します。それはアルゴリズムの反復数です。最低でも1はなければならず、よくプールサイズと同じ範囲の値が使用されます。
+これを0に設定（デフォルトの設定）すると、適切な値が<varname>geqo_pool_size</varname>に基づいて選択されます。
        </para>
       </listitem>
      </varlistentry>
@@ -4458,7 +4461,8 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
         is the selective pressure within the population. Values can be
         from 1.50 to 2.00; the latter is the default.
 -->
-       GEQOで使用される淘汰の偏りを管理します。淘汰の偏りは個体群内の（遺伝的な）自然淘汰です。値は1.50から2.00で、2.00がデフォルトです。
+GEQOで使用される淘汰の偏りを管理します。
+淘汰の偏りは個体群内の（遺伝的な）自然淘汰です。値は1.50から2.00で、2.00がデフォルトです。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/config1.sgml
+++ b/doc/src/sgml/config1.sgml
@@ -102,23 +102,23 @@
    </sect1>
 
    <sect1 id="runtime-config-wal">
-   <!--
+<!--
     <title>Write Ahead Log</title>
-    -->
+-->
     <title>ログ先行書き込み（WAL）</title>
 
    <para>
-   <!--
+<!--
     For additional information on tuning these settings,
     see <xref linkend="wal-configuration"/>.
-    -->
-    これらの設定をチューニングする追加情報は<xref linkend="wal-configuration"/>を参照してください。
+-->
+これらの設定をチューニングする追加情報は<xref linkend="wal-configuration"/>を参照してください。
    </para>
 
     <sect2 id="runtime-config-wal-settings">
-    <!--
+<!--
      <title>Settings</title>
-     -->
+-->
      <title>諸設定</title>
      <variablelist>
 
@@ -238,20 +238,20 @@
        </para>
 
        <para>
-       <!--
+<!--
         While turning off <varname>fsync</varname> is often a performance
         benefit, this can result in unrecoverable data corruption in
         the event of a power failure or system crash.  Thus it
         is only advisable to turn off <varname>fsync</varname> if
         you can easily recreate your entire database from external
         data.
-       -->
+-->
 <varname>fsync</varname>を停止することはしばしば性能上の利益になるとは言っても、停電やクラッシュの際に回復不可能なデータ破壊になることがあります。
 従って外部データから全てのデータベースを簡単に再構築できる場合のみ<varname>fsync</varname>を停止してください。
        </para>
 
        <para>
-       <!--
+<!--
         Examples of safe circumstances for turning off
         <varname>fsync</varname> include the initial loading of a new
         database cluster from a backup file, using a database cluster
@@ -261,7 +261,7 @@
         gets recreated frequently and is not used for failover.  High
         quality hardware alone is not a sufficient justification for
         turning off <varname>fsync</varname>.
-       -->
+-->
 <varname>fsync</varname>を停止しても安全な状況の例としては、以下があげられます。
 バックアップファイルから新しいデータベースクラスタにデータの初期読み込みを行う場合、バッチデータの処理のためにデータベースクラスタを使用し、その後データベースを削除して再構築する場合、読み込み専用のデータベースのクローンを頻繁に再作成するが、それをフェイルオーバーに使用しない場合、などです。
 高性能なハードウェアであるからと言って、<varname>fsync</varname>を停止することは正当性を主張する十分な理由とはなりません。
@@ -281,22 +281,22 @@
        </para>
 
        <para>
-       <!--
+<!--
         In many situations, turning off <xref linkend="guc-synchronous-commit"/>
         for noncritical transactions can provide much of the potential
         performance benefit of turning off <varname>fsync</varname>, without
         the attendant risks of data corruption.
-       -->
+-->
 多くの場合、重要でないトランザクションに対して<xref linkend="guc-synchronous-commit"/>を無効にすることにより、データ破壊という付随的危険性を伴うことなく、<varname>fsync</varname>を無効にすることで得られるであろう性能上のメリットの多くを得ることができます。
        </para>
 
        <para>
-       <!--
+<!--
         <varname>fsync</varname> can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
         If you turn this parameter off, also consider turning off
         <xref linkend="guc-full-page-writes"/>.
-       -->
+-->
 <varname>fsync</varname> は<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
 このパラメータを無効にする場合、<xref linkend="guc-full-page-writes"/>も同時に無効にすることを検討してください。
        </para>
@@ -411,7 +411,7 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
        </para>
 
        <para>
-       <!--
+<!--
         This parameter can be changed at any time; the behavior for any
         one transaction is determined by the setting in effect when it
         commits.  It is therefore possible, and useful, to have some
@@ -419,7 +419,7 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
         For example, to make a single multistatement transaction commit
         asynchronously when the default is the opposite, issue <command>SET
         LOCAL synchronous_commit TO OFF</command> within the transaction.
-       -->
+-->
 このパラメータはいつでも変更可能です。
 どのトランザクションの動作も、コミット時に有効であった設定によって決まります。
 したがって、一部のトランザクションのコミットを同期的に、その他を非同期的にすることが可能で、かつ、有用です。
@@ -522,58 +522,58 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Method used for forcing WAL updates out to disk.
         If <varname>fsync</varname> is off then this setting is irrelevant,
         since WAL file updates will not be forced out at all.
         Possible values are:
-       -->
+-->
        WALの更新をディスクへ強制するのに使用される方法です。<varname>fsync</varname>がオフの場合この設定は役に立ちません。と言うのはWALファイルの更新が全く強制されないからです。取り得る値は以下のものです。
        </para>
        <itemizedlist>
         <listitem>
         <para>
-       <!--
+<!--
          <literal>open_datasync</literal> (write WAL files with <function>open()</function> option <symbol>O_DSYNC</symbol>)
-        -->
-        <literal>open_datasync</literal>（<function>open()</function>のオプション<symbol>O_DSYNC</symbol>でWALファイルに書き込む）
+-->
+<literal>open_datasync</literal>（<function>open()</function>のオプション<symbol>O_DSYNC</symbol>でWALファイルに書き込む）
         </para>
         </listitem>
         <listitem>
         <para>
-       <!--
+<!--
          <literal>fdatasync</literal> (call <function>fdatasync()</function> at each commit)
-        -->
-        <literal>fdatasync</literal>（コミット毎に<function>fdatasync()</function>を呼び出す）
+-->
+<literal>fdatasync</literal>（コミット毎に<function>fdatasync()</function>を呼び出す）
         </para>
         </listitem>
         <listitem>
         <para>
-        <!--
+<!--
          <literal>fsync</literal> (call <function>fsync()</function> at each commit)
-        -->
-        <literal>fsync</literal>（コミット毎に<function>fsync()</function>を呼び出す）
+-->
+<literal>fsync</literal>（コミット毎に<function>fsync()</function>を呼び出す）
         </para>
         </listitem>
         <listitem>
         <para>
-       <!--
+<!--
          <literal>fsync_writethrough</literal> (call <function>fsync()</function> at each commit, forcing write-through of any disk write cache)
-        -->
-        <literal>fsync_writethrough</literal>（すべてのディスク書き込みキャッシュをライトスルーさせるため、コミット毎に<function>fsync()</function>を呼び出す）
+-->
+<literal>fsync_writethrough</literal>（すべてのディスク書き込みキャッシュをライトスルーさせるため、コミット毎に<function>fsync()</function>を呼び出す）
         </para>
         </listitem>
         <listitem>
         <para>
-       <!--
+<!--
          <literal>open_sync</literal> (write WAL files with <function>open()</function> option <symbol>O_SYNC</symbol>)
-        -->
-        <literal>open_sync</literal>（<function>open()</function>のオプション<symbol>O_SYNC</symbol>でWALファイルに書き込む）
+-->
+<literal>open_sync</literal>（<function>open()</function>のオプション<symbol>O_SYNC</symbol>でWALファイルに書き込む）
         </para>
         </listitem>
        </itemizedlist>
        <para>
-       <!--
+<!--
         The <literal>open_</literal>* options also use <literal>O_DIRECT</literal> if available.
         Not all of these choices are available on all platforms.
         The default is the first method in the above list that is supported
@@ -585,7 +585,7 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
         These aspects are discussed in <xref linkend="wal-reliability"/>.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 可能なら<literal>open_</literal>*オプションも<literal>O_DIRECT</literal>を使用します。
 全てのプラットフォームでこれら全ての選択肢が使えるわけではありません。
 デフォルトは、上のリストのプラットフォームでサポートされるものの最初に列挙されているものです。
@@ -609,7 +609,7 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When this parameter is on, the <productname>PostgreSQL</productname> server
         writes the entire content of each disk page to WAL during the
         first modification of that page after a checkpoint.
@@ -625,7 +625,7 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
         to do this during the first change of each page after a checkpoint.
         Therefore, one way to reduce the cost of full-page writes is to
         increase the checkpoint interval parameters.)
-       -->
+-->
 このパラメータが有効の場合、<productname>PostgreSQL</productname>サーバは、チェックポイントの後にそのページが最初に変更された過程で、ディスクページの全ての内容をWALに書き込みます。
 オペレーティングシステムがクラッシュした時に進行中のページ書き込みは途中までしか終わっていない可能性があり、ディスク上のページが古いデータと新しいデータが混在する状態になるため、この機能が必要です。
 通常WAL内に保存される行レベルの変更データは、クラッシュ後のリカバリ時にこうしたページを完全に復旧させるには不十分です。
@@ -635,33 +635,33 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
        </para>
 
        <para>
-       <!--
+<!--
         Turning this parameter off speeds normal operation, but
         might lead to either unrecoverable data corruption, or silent
         data corruption, after a system failure. The risks are similar to turning off
         <varname>fsync</varname>, though smaller, and it should be turned off
         only based on the same circumstances recommended for that parameter.
-       -->
-       このパラメータを無効にすると、通常の操作速度が上がりますが、システム障害後に、回復不能なデータ破損、あるいは警告なしのデータ損壊をもたらすかもしれません。
+-->
+このパラメータを無効にすると、通常の操作速度が上がりますが、システム障害後に、回復不能なデータ破損、あるいは警告なしのデータ損壊をもたらすかもしれません。
 このリスクは小さいながら<varname>fsync</varname>を無効にした場合と似ています。そしてその<varname>fsync</varname>に対して推奨されている同一の状況に基づく限りにおいて停止されなければなりません。
        </para>
 
        <para>
-       <!--
+<!--
         Turning off this parameter does not affect use of
         WAL archiving for point-in-time recovery (PITR)
         (see <xref linkend="continuous-archiving"/>).
-       -->
-       このパラメータを無効にしてもポイントインタイムリカバリ（PITR）用のWALアーカイブの使用に影響ありません（ <xref linkend="continuous-archiving"/>を参照してください）。
+-->
+このパラメータを無効にしてもポイントインタイムリカバリ（PITR）用のWALアーカイブの使用に影響ありません（ <xref linkend="continuous-archiving"/>を参照してください）。
        </para>
 
        <para>
-       <!--
+<!--
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
         The default is <literal>on</literal>.
-       -->
-       このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみ設定可能です。
+-->
+このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみ設定可能です。
 デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
@@ -684,7 +684,7 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
         first modification of that page after a checkpoint, even for
         non-critical modifications of so-called hint bits.
 -->
-        このパラメータが<literal>on</literal>の場合、<productname>PostgreSQL</productname>サーバはチェックポイント後にはじめてページを変更する際に、ディスクページの全内容をWALに書き出します。
+このパラメータが<literal>on</literal>の場合、<productname>PostgreSQL</productname>サーバはチェックポイント後にはじめてページを変更する際に、ディスクページの全内容をWALに書き出します。
 これは、あまり重要でない、ヒントビットと呼ばれるものに対する変更にさえ当てはまります。
        </para>
 
@@ -695,14 +695,14 @@ WALのリプレイを待つので、今までの設定に比べるとこの設�
         extra WAL-logging would occur if your database had data checksums
         enabled.
 -->
-        データチェックサムが有効であると、ヒントビットの更新は常にWALにログされ、この設定パラメータは無視されます。この設定パラメータを使って、データチェックサムが有効なときにどれだけのWALログは余計に書きだされるかをテストすることができます。
+データチェックサムが有効であると、ヒントビットの更新は常にWALにログされ、この設定パラメータは無視されます。この設定パラメータを使って、データチェックサムが有効なときにどれだけのWALログは余計に書きだされるかをテストすることができます。
        </para>
 
        <para>
 <!--
         This parameter can only be set at server start. The default value is <literal>off</literal>.
 -->
-       このパラメータはサーバ起動時のみ設定可能です。
+このパラメータはサーバ起動時のみ設定可能です。
 デフォルト値は<literal>off</literal>です。
        </para>
       </listitem>
@@ -808,7 +808,7 @@ COWファイルシステムでは、新しいファイルを作るほうが速�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The amount of shared memory used for WAL data that has not yet been
         written to disk.  The default setting of -1 selects a size equal to
         1/32nd (about 3%) of <xref linkend="guc-shared-buffers"/>, but not less
@@ -820,7 +820,7 @@ COWファイルシステムでは、新しいファイルを作るほうが速�
         If this value is specified without units, it is taken as WAL blocks,
         that is <symbol>XLOG_BLCKSZ</symbol> bytes, typically 8kB.
         This parameter can only be set at server start.
-       -->
+-->
 未だディスクに書き込まれていないWALデータに対して使用される共有メモリ容量です。
 デフォルトの設定である-1は、<xref linkend="guc-shared-buffers"/>の1/32（約3%）の容量に等しい大きさを選択します。
 しかし、<literal>64kB</literal>未満ではなく、かつ典型的に<literal>16MB</literal>であるWALセグメントの大きさを越えることはありません。
@@ -831,7 +831,7 @@ COWファイルシステムでは、新しいファイルを作るほうが速�
        </para>
 
        <para>
-       <!--
+<!--
         The contents of the WAL buffers are written out to disk at every
         transaction commit, so extremely large values are unlikely to
         provide a significant benefit.  However, setting this value to at
@@ -839,11 +839,11 @@ COWファイルシステムでは、新しいファイルを作るほうが速�
         server where many clients are committing at once.  The auto-tuning
         selected by the default setting of -1 should give reasonable
         results in most cases.
-       -->
+-->
        WALバッファの内容はトランザクションのコミット毎にディスクに書き込まれます。
-       したがって、極端に大きな値は有意な効果を期待できません。
-       しかし、この値を数メガバイトに設定することにより、多くのクライアントが同時にコミットするトラフィック量の多いサーバでは書き込み性能が向上します。
-       デフォルト設定の-1で選択される自動チューニングによると、ほとんどの場合妥当な結果が得られます。
+したがって、極端に大きな値は有意な効果を期待できません。
+しかし、この値を数メガバイトに設定することにより、多くのクライアントが同時にコミットするトラフィック量の多いサーバでは書き込み性能が向上します。
+デフォルト設定の-1で選択される自動チューニングによると、ほとんどの場合妥当な結果が得られます。
        </para>
 
       </listitem>
@@ -993,7 +993,7 @@ WALライタがWALを吐き出す頻度を量で指定します。
 この設定はスーパーユーザのみ変更可能です。
        </para>
        <para>
-       <!--
+<!--
         In <productname>PostgreSQL</productname> releases prior to 9.3,
         <varname>commit_delay</varname> behaved differently and was much
         less effective: it affected only commits, rather than all WAL flushes,
@@ -1002,9 +1002,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
         the first process that becomes ready to flush waits for the configured
         interval, while subsequent processes wait only until the leader
         completes the flush operation.
-       -->
+-->
         9.3より前の<productname>PostgreSQL</productname>では、<varname>commit_delay</varname>の振る舞いは異なっており、あまり効果がありませんでした。
-       全てのWALフラッシュではなく、コミットだけに影響していました。また、そしてWALフラッシュが早めに完了しても設定された遅延分待機していました。
+全てのWALフラッシュではなく、コミットだけに影響していました。また、そしてWALフラッシュが早めに完了しても設定された遅延分待機していました。
        <productname>PostgreSQL</productname> 9.3以降では、フラッシュの準備が整った最初のプロセスが設定値分待機し、後続のプロセスは最初のプロセスがフラッシュ操作を完了するまでの間だけ待機をします。
        </para>
       </listitem>
@@ -1021,13 +1021,13 @@ WALライタがWALを吐き出す頻度を量で指定します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Minimum number of concurrent open transactions to require
         before performing the <varname>commit_delay</varname> delay. A larger
         value makes it more probable that at least one other
         transaction will become ready to commit during the delay
         interval. The default is five transactions.
-       -->
+-->
 <varname>commit_delay</varname>の遅延を実行するときに必要とされる同時に開いているトランザクションの最小数です。
 より大きい値にすると、遅延周期の間に、少なくとも1つの他のトランザクションのコミットの準備が整う確率が高くなります。
 デフォルトは5トランザクションです。
@@ -1038,9 +1038,9 @@ WALライタがWALを吐き出す頻度を量で指定します。
      </variablelist>
      </sect2>
      <sect2 id="runtime-config-wal-checkpoints">
-     <!--
+<!--
      <title>Checkpoints</title>
-     -->
+-->
      <title>チェックポイント</title>
 
     <variablelist>
@@ -1055,7 +1055,7 @@ WALライタがWALを吐き出す頻度を量で指定します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Maximum time between automatic WAL checkpoints.
         If this value is specified without units, it is taken as seconds.
         The valid range is between 30 seconds and one day.
@@ -1064,7 +1064,7 @@ WALライタがWALを吐き出す頻度を量で指定します。
         for crash recovery.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 自動的WALチェックポイント間の最大間隔を指定します。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
 有効な範囲は、30秒から1日の間です。
@@ -1086,7 +1086,7 @@ WALライタがWALを吐き出す頻度を量で指定します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the target of checkpoint completion, as a fraction of
         total time between checkpoints. The default is 0.9, which spreads the
         checkpoint across almost all of the available interval, providing fairly
@@ -1097,7 +1097,7 @@ WALライタがWALを吐き出す頻度を量で指定します。
         the checkpoint completion and the next scheduled checkpoint.  This
         parameter can only be set in the <filename>postgresql.conf</filename> file
         or on the server command line.
-       -->
+-->
 チェックポイントの間の時間のうち、どの程度の割合を使うかをチェックポイントの完了目標として指定します。
 デフォルトは0.9で、可能な限りの間隔のほとんどにチェックポイントを拡散し、かなり一定のI/O負荷をもたらしますが、チェックポイントが完了するにあたってオーバヘッドをもたらします。
 チェックポイントの完了を早くするので、このパラメータを小さくするのはお勧めできません。
@@ -1164,7 +1164,7 @@ WALライタがWALを吐き出す頻度を量で指定します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Write a message to the server log if checkpoints caused by
         the filling of WAL segment files happen closer together
         than this amount of time (which suggests that
@@ -1176,7 +1176,7 @@ WALライタがWALを吐き出す頻度を量で指定します。
         is less than <varname>checkpoint_warning</varname>.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 WALセグメントファイルが溢れることが原因で起きるチェックポイントが、ここで指定した時間よりも短い間隔で発生したとき、サーバログにメッセージを書き出します
 （これは、<varname>max_wal_size</varname>を増やす必要があることを示唆しています）。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
@@ -1256,9 +1256,9 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
      </variablelist>
      </sect2>
      <sect2 id="runtime-config-wal-archiving">
-     <!--
+<!--
      <title>Archiving</title>
-     -->
+-->
      <title>アーカイビング</title>
 
     <variablelist>
@@ -1318,7 +1318,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The local shell command to execute to archive a completed WAL file
         segment.  Any <literal>%p</literal> in the string is
         replaced by the path name of the file to archive, and any
@@ -1329,7 +1329,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
         command.  It is important for the command to return a zero
         exit status only if it succeeds. For more information see
         <xref linkend="backup-archiving-wal"/>.
-       -->
+-->
 完了したWALファイルセグメントのアーカイブを実行するローカルのシェルコマンドです。
 文字列内のすべての<literal>%p</literal>は、格納されるファイルのパスで置き換えられ、そして、<literal>%f</literal>はファイル名のみ置換します。
 （このパス名はサーバの作業用ディレクトリ、つまり、クラスタのデータディレクトリからの相対パスです。）
@@ -1338,7 +1338,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
 詳しくは<xref linkend="backup-archiving-wal"/>を参照ください。
        </para>
        <para>
-       <!--
+<!--
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.  It is ignored unless
         <varname>archive_mode</varname> was enabled at server start.
@@ -1351,7 +1351,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
         Windows), effectively disables
         archiving, but also breaks the chain of WAL files needed for
         archive recovery, so it should only be used in unusual circumstances.
-       -->
+-->
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
 サーバ起動時に<varname>archive_mode</varname>が有効でなければ、これは無視されます。
 <varname>archive_command</varname>が空文字列（デフォルト）、かつ、<varname>archive_mode</varname>が有効な場合、WALアーカイブ処理は一時的に無効になりますが、コマンドが後で提供されることを見越して、サーバはWALセグメントの蓄積を続けます。
@@ -1371,7 +1371,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The <xref linkend="guc-archive-command"/> is only invoked for
         completed WAL segments. Hence, if your server generates little WAL
         traffic (or has slack periods where it does so), there could be a
@@ -1394,7 +1394,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
         If this value is specified without units, it is taken as seconds.
         This parameter can only be set in the
         <filename>postgresql.conf</filename> file or on the server command line.
-       -->
+-->
 <xref linkend="guc-archive-command"/>は完了したWALセグメントに対してのみ呼び出されます。
 従って、サーバのWAL転送量が少ししかない（あるいは処理が少ないなぎの期間がある）場合、トランザクションの完了とアーカイブ格納領域への安全な記録との間に長期にわたる遅延があることになります。
 データが未アーカイブのままでいられる期間を制限するために、<varname>archive_timeout</varname>を設定して、強制的にサーバを新しいWALセグメントに定期的に切り替えるようにすることができます。
@@ -2055,14 +2055,14 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <title>送出サーバ群</title>
 
      <para>
-     <!--
+<!--
       These parameters can be set on any server that is
       to send replication data to one or more standby servers.
       The primary is always a sending server, so these parameters must
       always be set on the primary.
       The role and meaning of these parameters does not change after a
       standby becomes the primary.
-      -->
+-->
 これらのパラメータはレプリケーションデータを１つ、またはそれ以上複数のスタンバイサーバに送るすべてのサーバ上で設定することができます。
 プライマリは常に送出サーバであるため、パラメータは常にプライマリ上に設定されなければなりません。
 これらのパラメータの役割と意味はスタンバイが後にプライマリに昇格しても変わりません。
@@ -2075,7 +2075,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         <primary><varname>max_wal_senders</varname> configuration parameter</primary>
        </indexterm>
        <indexterm>
-       <primary><varname>max_wal_senders</varname>設定パラメータ</primary>
+        <primary><varname>max_wal_senders</varname>設定パラメータ</primary>
        </indexterm>
        </term>
        <listitem>
@@ -2173,7 +2173,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
        </term>
        <listitem>
        <para>
-       <!--
+<!--
         Specifies the minimum size of past log file segments kept in the
         <filename>pg_wal</filename>
         directory, in case a standby server needs to fetch them for streaming
@@ -2185,14 +2185,14 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         will also eventually fail as a result.  (However, the standby
         server can recover by fetching the segment from archive, if WAL
         archiving is in use.)
-       -->
+-->
 ストリーミングレプリケーションにおいて、スタンバイサーバが過去のファイルセグメントを取得する必要がある場合に備え、<filename>pg_wal</filename>ディレクトリに保持しておくファイルセグメントの最小サイズを指定します。
 もし送出サーバに接続しているスタンバイサーバが<varname>wal_keep_size</varname>メガバイトを越えて遅延した場合、送出サーバはスタンバイサーバが今後とも必要とするWALセグメントを削除する可能性があります。
 この場合、レプリケーション接続は終了させられます。結果として下流に対する接続も結局は終了されることがあります。（しかし、WALアーカイブが使用されていれば、スタンバイサーバはアーカイブからセグメントを取り出し、復旧することができます。）
        </para>
 
        <para>
-       <!--
+<!--
         This sets only the minimum size of segments retained in
         <filename>pg_wal</filename>; the system might need to retain more segments
         for WAL archival or to recover from a checkpoint. If
@@ -2204,7 +2204,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         If this value is specified without units, it is taken as megabytes.
         This parameter can only be set in the
         <filename>postgresql.conf</filename> file or on the server command line.
-       -->
+-->
 <filename>pg_wal</filename>に保持され続けるセグメントの最小値のみを設定します。
 システムはWALアーカイブのため、またはチェックポイントからの復旧のため、より多くのセグメント保持が必要となることがあります。
 もし<varname>wal_keep_size</varname>が（デフォルトの）ゼロの場合、システムはスタンバイサーバのために追加セグメントを保持することはしません。
@@ -2323,7 +2323,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      <title>プライマリサーバ</title>
 
      <para>
-      <!--
+<!--
       These parameters can be set on the primary server that is
       to send replication data to one or more standby servers.
       Note that in addition to these parameters,
@@ -2333,7 +2333,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
       The values of these parameters on standby servers are irrelevant,
       although you may wish to set them there in preparation for the
       possibility of a standby becoming the primary.
-      -->
+-->
 これらのパラメータはレプリケーションデータを１つ、またはそれ以上複数のスタンバイサーバに送るプライマリサーバ上で設定することができます。
 これらパラメータに加え、<xref linkend="guc-wal-level"/>はプライマリサーバ上で適切に設定される必要があり、オプションとしてWALアーカイブを有効にしてもかまいません（<xref linkend="runtime-config-wal-archiving"/>を参照してください）。
 スタンバイサーバがプライマリサーバになるかもしれない状況に備え、それらのパラメータをスタンバイサーバで設定したいと考えたとしても、スタンバイサーバ上でのパラメータの値は意味をなしません。
@@ -2514,7 +2514,7 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
         </para>
        </note>
        <para>
-       <!--
+<!--
         If no synchronous standby names are specified here, then synchronous
         replication is not enabled and transaction commits will not wait for
         replication.  This is the default configuration.  Even when
@@ -2522,15 +2522,15 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
         configured not to wait for replication by setting the
         <xref linkend="guc-synchronous-commit"/> parameter to
         <literal>local</literal> or <literal>off</literal>.
-       -->
-       ここに同期スタンバイ名が指定されていない場合、同期レプリケーションは有効とはならず、トランザクションコミットはレプリケーションを待機しません。これがデフォルトの設定です。同期レプリケーションが有効であっても、<xref linkend="guc-synchronous-commit"/>パラメータを<literal>local</literal> または <literal>off</literal>に設定することにより、個別のトランザクションをレプリケーションに対して待機しないように設定できます。
+-->
+ここに同期スタンバイ名が指定されていない場合、同期レプリケーションは有効とはならず、トランザクションコミットはレプリケーションを待機しません。これがデフォルトの設定です。同期レプリケーションが有効であっても、<xref linkend="guc-synchronous-commit"/>パラメータを<literal>local</literal> または <literal>off</literal>に設定することにより、個別のトランザクションをレプリケーションに対して待機しないように設定できます。
        </para>
        <para>
-       <!--
+<!--
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
-       このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+-->
+このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -2546,7 +2546,7 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the number of transactions by which <command>VACUUM</command> and
         <acronym>HOT</acronym> updates will defer cleanup of dead row versions. The
         default is zero transactions, meaning that dead row versions can be
@@ -2561,7 +2561,7 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
         grace time will be made available to standby queries.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 <command>VACUUM</command> および <acronym>HOT</acronym>更新が不要行バージョンの回収を決めるのを延期するトランザクションの数を指定します。
 デフォルトはゼロトランザクションで、つまり、開いている全てのトランザクションから不可視になった不要行バージョンは速やかに削除されうることを意味します。
 <xref linkend="hot-standby"/>に記載されているように、ホットスタンバイサーバをサポートしている場合、プライマリサーバ上で非ゼロ値に設定したい場合があります。
@@ -2570,10 +2570,10 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
 このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
        </para>
        <para>
-       <!--
+<!--
         You should also consider setting <varname>hot_standby_feedback</varname>
         on standby server(s) as an alternative to using this parameter.
-       -->
+-->
 このパラメータを使う代わりにスタンバイサーバ上に <varname>hot_standby_feedback</varname>の設定を考慮する必要もあります。
        </para>
        <para>
@@ -2590,19 +2590,19 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
     </sect2>
 
     <sect2 id="runtime-config-replication-standby">
-    <!--
+<!--
      <title>Standby Servers</title>
-    -->
+-->
      <title>スタンバイサーバ</title>
 
      <para>
-     <!--
+<!--
       These settings control the behavior of a
       <link linkend="standby-server-operation">standby server</link>
       that is
       to receive replication data.  Their values on the primary server
       are irrelevant.
-      -->
+-->
 これらの設定はレプリケーションデータを受け取る<link linkend="standby-server-operation">スタンバイサーバ</link>の動作を管理します。
 プライマリサーバ上のこれらの値は無意味です。
      </para>
@@ -2741,15 +2741,15 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies whether or not you can connect and run queries during
         recovery, as described in <xref linkend="hot-standby"/>.
         The default value is <literal>on</literal>.
         This parameter can only be set at server start. It only has effect
         during archive recovery or in standby mode.
-       -->
-       <xref linkend="hot-standby"/>に記載されている通り、リカバリの最中に接続し、そして問い合わせを実行できるか否かを設定します。デフォルト値は<literal>on</literal>です。
-       このパラメータはサーバ起動時のみ設定可能です。これは、アーカイブリカバリ期間、又はスタンバイモードにある場合にのみ効果をもたらします。
+-->
+<xref linkend="hot-standby"/>に記載されている通り、リカバリの最中に接続し、そして問い合わせを実行できるか否かを設定します。デフォルト値は<literal>on</literal>です。
+このパラメータはサーバ起動時のみ設定可能です。これは、アーカイブリカバリ期間、又はスタンバイモードにある場合にのみ効果をもたらします。
        </para>
       </listitem>
      </varlistentry>
@@ -2765,7 +2765,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When Hot Standby is active, this parameter determines how long the
         standby server should wait before canceling standby queries that
         conflict with about-to-be-applied WAL entries, as described in
@@ -2778,7 +2778,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
         queries to complete.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 ホットスタンバイが稼動している場合、このパラメータは<xref linkend="hot-standby-conflict"/>で記載されているように、まさに適用されようとしているWALエントリと衝突するスタンバイサーバの問い合わせをキャンセルするにはどれだけ待機しなければならないかを設定します。
 <varname>max_standby_archive_delay</varname>はWALデータをWALアーカイブ（すなわち最新ではありません）から読み込んでいる時に適用されます。
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
@@ -2787,14 +2787,14 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
 このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
        </para>
        <para>
-       <!--
+<!--
         Note that <varname>max_standby_archive_delay</varname> is not the same as the
         maximum length of time a query can run before cancellation; rather it
         is the maximum total time allowed to apply any one WAL segment's data.
         Thus, if one query has resulted in significant delay earlier in the
         WAL segment, subsequent conflicting queries will have much less grace
         time.
-       -->
+-->
 <varname>max_standby_archive_delay</varname>はキャンセル前に問い合わせが実行できる最大の時間の長さと同じでないことに注意してください。
 むしろ、任意の１つのWALセグメントのデータの適用のために許される最大合計時間です。
 従って、ある問い合わせによりWALセグメント内の前の部分で大幅な遅延となった場合、その後の衝突する問い合わせの猶予時間はずっと短くなります。
@@ -2813,7 +2813,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When Hot Standby is active, this parameter determines how long the
         standby server should wait before canceling standby queries that
         conflict with about-to-be-applied WAL entries, as described in
@@ -2826,7 +2826,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
         queries to complete.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 ホットスタンバイが稼動している場合、このパラメータは<xref linkend="hot-standby-conflict"/>で記載されているように、まさに適用されようとしているWALエントリと衝突するスタンバイサーバの問い合わせをキャンセルするにはどれだけ待機しなければならないかを設定します。
 <varname>max_standby_streaming_delay</varname>はWALデータをストリーミングレプリケーションから受け取っている時に適用されます。
 特に指定が無ければ単位はミリ秒です。
@@ -2835,7 +2835,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
 このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
        </para>
        <para>
-       <!--
+<!--
         Note that <varname>max_standby_streaming_delay</varname> is not the same as
         the maximum length of time a query can run before cancellation; rather
         it is the maximum total time allowed to apply WAL data once it has
@@ -2843,7 +2843,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
         resulted in significant delay, subsequent conflicting queries will
         have much less grace time until the standby server has caught up
         again.
-       -->
+-->
 <varname>max_standby_streaming_delay</varname>はキャンセル前に問い合わせが実行できる最大の時間の長さと同じでないことに注意してください。
 むしろ、プライマリサーバから一度受け取られたWALデータを適用するために許される最大合計時間です。
 従って、ある問い合わせが大幅な遅延を起こした場合、その後の衝突する問い合わせは、スタンバイサーバがふたたび遅れを取り戻すまでの間、猶予時間はずっと短くなります。
@@ -2890,7 +2890,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
       </term>
       <listitem>
       <para>
-      <!--
+<!--
        Specifies the minimum frequency for the WAL receiver
        process on the standby to send information about replication progress
        to the primary or upstream standby, where it can be seen using the
@@ -2911,7 +2911,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
        The default value is 10 seconds. This parameter can only be set in
        the <filename>postgresql.conf</filename> file or on the server
        command line.
-       -->
+-->
 スタンバイサーバ上のWAL受信プロセスがプライマリー、または上位サーバに対してレプリケーションの進捗情報を送信する最小頻度を指定します。
 送信された進捗情報は<link linkend="monitoring-pg-stat-replication-view"><structname>pg_stat_replication</structname></link>ビューにより確認することが可能です。
 スタンバイサーバは書き込みがされた直近の先行書き込みログ位置、ディスクにフラッシュされた直近のログ位置、およびリカバリ適用された直近のログ位置を報告します。
@@ -2938,7 +2938,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies whether or not a hot standby will send feedback to the primary
         or upstream standby
         about queries currently executing on the standby. This parameter can
@@ -2948,21 +2948,21 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
         <varname>wal_receiver_status_interval</varname>. The default value is
         <literal>off</literal>. This parameter can only be set in the
         <filename>postgresql.conf</filename> file or on the server command line.
-       -->
-       ホットスタンバイがスタンバイサーバ上で現在処理を行っている問い合わせについて、プライマリーまたは上位サーバにフィードバックを送るか否かを指定します。
-       このパラメータはレコードの回収に起因する問い合わせの取り消しを排除するために使用することができます。
-       しかし、いくつかのワークロードに対してはプライマリーサーバ上でのデータベース肥大の原因となります。
-       フィードバックメッセージは<varname>wal_receiver_status_interval</varname>毎に、2回以上送信されません。
-       デフォルトの値は<literal>off</literal>です。
-        このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+-->
+ホットスタンバイがスタンバイサーバ上で現在処理を行っている問い合わせについて、プライマリーまたは上位サーバにフィードバックを送るか否かを指定します。
+このパラメータはレコードの回収に起因する問い合わせの取り消しを排除するために使用することができます。
+しかし、いくつかのワークロードに対してはプライマリーサーバ上でのデータベース肥大の原因となります。
+フィードバックメッセージは<varname>wal_receiver_status_interval</varname>毎に、2回以上送信されません。
+デフォルトの値は<literal>off</literal>です。
+このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
        </para>
        <para>
-       <!--
+<!--
         If cascaded replication is in use the feedback is passed upstream
         until it eventually reaches the primary.  Standbys make no other use
         of feedback they receive other than to pass upstream.
-       -->
-       カスケードレプリケーションが使用されている場合、フィードバックは最終的にプライマリーに到達するまで上位サーバに転送されます。スタンバイは上位に転送する以外、受け取ったフィードバックを他に使用しません。
+-->
+カスケードレプリケーションが使用されている場合、フィードバックは最終的にプライマリーに到達するまで上位サーバに転送されます。スタンバイは上位に転送する以外、受け取ったフィードバックを他に使用しません。
        </para>
        <para>
 <!--
@@ -2994,7 +2994,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Terminate replication connections that are inactive for longer
         than this amount of time. This is useful for
         the receiving standby server to detect a primary node crash or network
@@ -3005,7 +3005,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
         This parameter can only be set in
         the <filename>postgresql.conf</filename> file or on the server
         command line.
-       -->
+-->
 指定された時間より長い間、活動していないレプリケーション接続は停止します。
 このことは受信するスタンバイサーバがプライマリノードの機能停止、またはネットワーク停止を検出するのに便利です。
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
@@ -3282,19 +3282,19 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
    </sect1>
 
    <sect1 id="runtime-config-query">
-   <!--
+<!--
     <title>Query Planning</title>
-    -->
+-->
     <title>問い合わせ計画</title>
 
     <sect2 id="runtime-config-query-enable">
-    <!--
+<!--
      <title>Planner Method Configuration</title>
-     -->
+-->
      <title>プランナメソッド設定</title>
 
       <para>
-      <!--
+<!--
        These configuration parameters provide a crude method of
        influencing the query plans chosen by the query optimizer. If
        the default plan chosen by the optimizer for a particular query
@@ -3310,7 +3310,7 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
        and increasing the amount of statistics collected for
        specific columns using <command>ALTER TABLE SET
        STATISTICS</command>.
-       -->
+-->
 以下の設定パラメータは、問い合わせオプティマイザが選択する問い合わせ計画に影響する大雑把な手法を提供します。
 ある問い合わせに対してオプティマイザが選択したデフォルト計画が最適でない場合、<emphasis>暫定的な</emphasis>解決策は、これらの設定パラメータの1つを使用し、オプティマイザに異なる計画を選択するように仕向けることです。
 オプティマイザが選択する計画の品質を改善するためのより良い方法には、プランナコスト定数を調節する（<xref linkend="runtime-config-query-constants"/>を参照）、<link linkend="sql-analyze"><command>ANALYZE</command></link>を手作業で実行する、<xref linkend="guc-default-statistics-target"/>設定パラメータの値を大きくする、<command>ALTER TABLE SET STATISTICS</command>を使用して、特定の列に対して収集される統計情報を増やす、などがあります。
@@ -3320,9 +3320,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-async-append" xreflabel="enable_async_append">
       <term><varname>enable_async_append</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_async_append</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_async_append</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3355,11 +3355,11 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables or disables the query planner's use of bitmap-scan plan
         types. The default is <literal>on</literal>.
-       -->
-       問い合わせプランナがビットマップスキャン計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</literal>です。
+-->
+問い合わせプランナがビットマップスキャン計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
      </varlistentry>
@@ -3396,10 +3396,10 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables or disables the query planner's use of hashed
         aggregation plan types. The default is <literal>on</literal>.
-       -->
+-->
 問い合わせプランナがハッシュ集約計画型を選択することを有効もしくは無効にします。
 デフォルトは<literal>on</literal>です。
        </para>
@@ -3417,11 +3417,11 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables or disables the query planner's use of hash-join plan
         types. The default is <literal>on</literal>.
-       -->
-       問い合わせプランナがハッシュ結合計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</literal>です。
+-->
+問い合わせプランナがハッシュ結合計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
      </varlistentry>
@@ -3464,11 +3464,11 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables or disables the query planner's use of index-scan plan
         types. The default is <literal>on</literal>.
-       -->
-       問い合わせプランナがインデックス走査計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</literal>です。
+-->
+問い合わせプランナがインデックス走査計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
      </varlistentry>
@@ -3507,15 +3507,15 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables or disables the query planner's use of materialization.
         It is impossible to suppress materialization entirely,
         but turning this variable off prevents the planner from inserting
         materialize nodes except in cases where it is required for correctness.
         The default is <literal>on</literal>.
-       -->
-       問い合わせプランナの具体化の使用を有効、または無効にします。
-       全体にわたって具体化を差し止めることはできませんが、この値をoffにすることにより、正確性が要求される場合を除いて、具体化ノードをプランナが挿入することを防止します。デフォルトは<literal>on</literal>です。
+-->
+問い合わせプランナの具体化の使用を有効、または無効にします。
+全体にわたって具体化を差し止めることはできませんが、この値をoffにすることにより、正確性が要求される場合を除いて、具体化ノードをプランナが挿入することを防止します。デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
      </varlistentry>
@@ -3523,9 +3523,9 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      <varlistentry id="guc-enable-memoize" xreflabel="enable_memoize">
       <term><varname>enable_memoize</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>enable_memoize</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>enable_memoize</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3559,11 +3559,11 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables or disables the query planner's use of merge-join plan
         types. The default is <literal>on</literal>.
-       -->
-       問い合わせプランナがマージ結合計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</literal>です。
+-->
+問い合わせプランナがマージ結合計画型を選択することを有効もしくは無効にします。デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
      </varlistentry>
@@ -3579,16 +3579,16 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables or disables the query planner's use of nested-loop join
         plans. It is impossible to suppress nested-loop joins entirely,
         but turning this variable off discourages the planner from using
         one if there are other methods available. The default is
         <literal>on</literal>.
-       -->
-       問い合わせプランナがネステッドループ結合計画を選択することを有効もしくは無効にします。
-       ネステッドループ結合を完全に禁止することは不可能ですが、この変数をオフにすると、もし他の方法が利用できるのであれば、プランナはその使用を行わないようになります。
-       デフォルトは<literal>on</literal>です。
+-->
+問い合わせプランナがネステッドループ結合計画を選択することを有効もしくは無効にします。
+ネステッドループ結合を完全に禁止することは不可能ですが、この変数をオフにすると、もし他の方法が利用できるのであれば、プランナはその使用を行わないようになります。
+デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
      </varlistentry>
@@ -3801,13 +3801,13 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      </variablelist>
      </sect2>
      <sect2 id="runtime-config-query-constants">
-     <!--
+<!--
      <title>Planner Cost Constants</title>
-     -->
+-->
      <title>プランナコスト定数</title>
 
     <para>
-    <!--
+<!--
      The <firstterm>cost</firstterm> variables described in this section are measured
      on an arbitrary scale.  Only their relative values matter, hence
      scaling them all up or down by the same factor will result in no change
@@ -3817,7 +3817,7 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
      and the other cost variables are set with reference to that.  But
      you can use a different scale if you prefer, such as actual execution
      times in milliseconds on a particular machine.
-     -->
+-->
 本節で扱う<firstterm>コスト</firstterm>変数は、任意の尺度で測られます。
 これらは相対的な値のみが意味を持つため、それらの値をすべて同じ係数で大きく、あるいは小さくしても、プランナの選択は結果として変わりません。
 デフォルトではこれらのコスト変数はシーケンシャルなページ取り込みに基づいています。
@@ -3827,13 +3827,13 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
 
    <note>
     <para>
-    <!--
+<!--
      Unfortunately, there is no well-defined method for determining ideal
      values for the cost variables.  They are best treated as averages over
      the entire mix of queries that a particular installation will receive.  This
      means that changing them on the basis of just a few experiments is very
      risky.
-     -->
+-->
 残念ながら、コスト変数に対する理想的な値を決定する、上手く定義された方法がありません。
 特定のインストレーションが受け取る問い合わせ全体を混在させたものの平均として扱うのが最善でしょう。
 数回の実験のみを根拠にこの値を変更することは危険であるといえます。
@@ -3853,13 +3853,13 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the planner's estimate of the cost of a disk page fetch
         that is part of a series of sequential fetches.  The default is 1.0.
         This value can be overridden for tables and indexes in a particular
         tablespace by setting the tablespace parameter of the same name
         (see <xref linkend="sql-altertablespace"/>).
-       -->
+-->
 シーケンシャルな一連の取り出しの一部となる、ディスクページ取り出しに関する、プランナの推定コストを設定します。
 デフォルトは1.0です。
 この値は同じ名前のテーブル空間パラメータを設定することで、特定のテーブル空間の中にあるテーブルとインデックスに対して上書きできます（<xref linkend="sql-altertablespace"/>を参照してください）。
@@ -3878,27 +3878,27 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the planner's estimate of the cost of a
         non-sequentially-fetched disk page.  The default is 4.0.
         This value can be overridden for tables and indexes in a particular
         tablespace by setting the tablespace parameter of the same name
         (see <xref linkend="sql-altertablespace"/>).
-       -->
+-->
 非シーケンシャル的に取り出されるディスクページのコストに対するプランナの推測を設定します。
 デフォルトは4です。
 この値は同じ名前のテーブル空間パラメータを設定することで、特定のテーブル空間の中にあるテーブルとインデックスに対して上書きできます（<xref linkend="sql-altertablespace"/>を参照してください）。
        </para>
 
        <para>
-       <!--
+<!--
         Reducing this value relative to <varname>seq_page_cost</varname>
         will cause the system to prefer index scans; raising it will
         make index scans look relatively more expensive.  You can raise
         or lower both values together to change the importance of disk I/O
         costs relative to CPU costs, which are described by the following
         parameters.
-       -->
+-->
 この値を<varname>seq_page_cost</varname>と比較して小さくすると、システムはなるべくインデックススキャンを使用するようになります。
 大きくすると、インデックススキャンが相対的に高価になります。
 両方の値を増減させることで、CPUコストに対するディスクI/Oコストの重要性を変更させることができます。
@@ -3906,21 +3906,21 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
        </para>
 
        <para>
-       <!--
+<!--
         Random access to mechanical disk storage is normally much more expensive
         than four times sequential access.  However, a lower default is used
         (4.0) because the majority of random accesses to disk, such as indexed
         reads, are assumed to be in cache.  The default value can be thought of
         as modeling random access as 40 times slower than sequential, while
         expecting 90% of random reads to be cached.
-       -->
+-->
 機械的ディスク記憶装置に対するランダムアクセスは通常はシーケンシャルアクセスの4倍よりもかなり高価です。
 しかし、より低いデフォルト（4.0）が使用されます。というのはインデックスのついた読み取りのようなディスクに対するランダムアクセスのほとんどはキャッシュにあると想定されるからです。
 このデフォルト値は、ランダムアクセスがシーケンシャルアクセスより40倍遅い一方で、ランダム読み込みの90%はキャッシュされていることが期待されるというモデルとして考えることができます。
        </para>
 
        <para>
-       <!--
+<!--
         If you believe a 90% cache rate is an incorrect assumption
         for your workload, you can increase random_page_cost to better
         reflect the true cost of random storage reads. Correspondingly,
@@ -3930,7 +3930,7 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
         read cost relative to sequential, e.g., solid-state drives, might
         also be better modeled with a lower value for random_page_cost,
         e.g., <literal>1.1</literal>.
-       -->
+-->
 自環境の作業負荷において、90％のキャッシュ率は誤った仮定と考えられるのであれば、ランダム記憶装置読み込みのコストをより良く反映するため random_page_cost を大きくすることができます。
 反対に、データが完全にキャッシュされていると思われるのであれば、random_page_cost を小さくすることが適切です。例えば、データベースの容量がサーバのメモリより小さい場合などです。
 例えばSSDのような、シーケンシャルアクセスに比べてランダム読み込みコストがあまり大きくない記憶装置の場合も、random_page_cost に対し<literal>1.1</literal>のようにより低い値のモデル化の方が良いでしょう。
@@ -3938,7 +3938,7 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
 
        <tip>
         <para>
-       <!--
+<!--
          Although the system will let you set <varname>random_page_cost</varname> to
          less than <varname>seq_page_cost</varname>, it is not physically sensible
          to do so.  However, setting them equal makes sense if the database
@@ -3947,7 +3947,7 @@ WALの生成頻度が少ないシステムでは、この値を大きくする�
          database you should lower both values relative to the CPU parameters,
          since the cost of fetching a page already in RAM is much smaller
          than it would normally be.
-        -->
+-->
 システムは<varname>random_page_cost</varname>を<varname>seq_page_cost</varname>よりも小さな値に設定することを許しますが、そのようにすることは物理的にはおかしなことです。
 しかし、データベースが完全にRAMにキャッシュされる場合、同じ値に設定することは意味を持ちます。
 この場合、順序通りではないページアクセスに対するペナルティが存在しないからです。
@@ -3969,11 +3969,11 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the planner's estimate of the cost of processing
         each row during a query.
         The default is 0.01.
-       -->
+-->
 問い合わせ時のそれぞれの行の処理コストに対するプランナの推測を設定します。
 デフォルトは0.01です。
        </para>
@@ -3991,11 +3991,11 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the planner's estimate of the cost of processing
         each index entry during an index scan.
         The default is 0.005.
-       -->
+-->
 インデックス走査時のそれぞれのインデックス行の処理コストに対するプランナの推測を設定します。
 デフォルトは0.005です。
        </para>
@@ -4013,12 +4013,12 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the planner's estimate of the cost of processing each
         operator or function executed during a query.
         The default is 0.0025.
-       -->
-       問い合わせ時に実行される各演算子や関数の処理コストに対するプランナの推測を設定します。デフォルトは0.0025です。
+-->
+問い合わせ時に実行される各演算子や関数の処理コストに対するプランナの推測を設定します。デフォルトは0.0025です。
        </para>
       </listitem>
      </varlistentry>
@@ -4073,7 +4073,7 @@ RAM内に存在するページの取り出しコストは通常よりもかな�
        <primary><varname>min_parallel_table_scan_size</varname> configuration parameter</primary>
       </indexterm>
       <indexterm>
-       <primary><varname>min_parallel_relation_size</varname>設定パラメータ</primary>
+       <primary><varname>min_parallel_table_scan_size</varname>設定パラメータ</primary>
       </indexterm>
       </term>
       <listitem>
@@ -4270,23 +4270,23 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
 
     </sect2>
      <sect2 id="runtime-config-query-geqo">
-     <!--
+<!--
      <title>Genetic Query Optimizer</title>
-     -->
+-->
      <title>遺伝的問い合わせオプティマイザ</title>
 
      <para>
-     <!--
+<!--
       The genetic query optimizer (GEQO) is an algorithm that does query
       planning using heuristic searching.  This reduces planning time for
       complex queries (those joining many relations), at the cost of producing
       plans that are sometimes inferior to those found by the normal
       exhaustive-search algorithm.
       For more information see <xref linkend="geqo"/>.
-      -->
-      遺伝的問い合わせオプティマイザ（GEQO）はヒューリスティック（発見的）検索法を用いた問い合わせ計画を行なう演算手法です。
-      通常のしらみつぶしの検索演算手法で見いだされる計画よりも時として劣った計画を作成するという代償を払いますが、この手法は（多くのリレーションを結合するような）複雑な問い合わせに対し計画時間を軽減します。
-      より詳細は<xref linkend="geqo"/>を参照してください。
+-->
+遺伝的問い合わせオプティマイザ（GEQO）はヒューリスティック（発見的）検索法を用いた問い合わせ計画を行なう演算手法です。
+通常のしらみつぶしの検索演算手法で見いだされる計画よりも時として劣った計画を作成するという代償を払いますが、この手法は（多くのリレーションを結合するような）複雑な問い合わせに対し計画時間を軽減します。
+より詳細は<xref linkend="geqo"/>を参照してください。
      </para>
 
      <variablelist>
@@ -4301,9 +4301,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </indexterm>
       <indexterm>
        <primary>GEQO</primary>
-       <!--
+<!--
        <see>genetic query optimization</see>
-       -->
+-->
        <see>遺伝的問い合わせ最適化</see>
       </indexterm>
       <indexterm>
@@ -4315,14 +4315,14 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables or disables genetic query optimization.
         This is on by default.  It is usually best not to turn it off in
         production; the <varname>geqo_threshold</varname> variable provides
         more granular control of GEQO.
-       -->
-       遺伝的問い合わせ最適化を有効もしくは無効にします。デフォルトは有効です。
-       運用時には無効にしないことが通常最善です。<varname>geqo_threshold</varname>変数は、GEQOを制御するためよりきめ細かな方法を提供します。
+-->
+遺伝的問い合わせ最適化を有効もしくは無効にします。デフォルトは有効です。
+運用時には無効にしないことが通常最善です。<varname>geqo_threshold</varname>変数は、GEQOを制御するためよりきめ細かな方法を提供します。
        </para>
       </listitem>
      </varlistentry>
@@ -4338,7 +4338,7 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Use genetic query optimization to plan queries with at least
         this many <literal>FROM</literal> items involved. (Note that a
         <literal>FULL OUTER JOIN</literal> construct counts as only one <literal>FROM</literal>
@@ -4348,7 +4348,7 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
         longer than the penalty of executing a suboptimal plan.  Thus,
         a threshold on the size of the query is a convenient way to manage
         use of GEQO.
-       -->
+-->
 少なくともこれだけの数の<literal>FROM</literal>項目数があるときに、問い合わせを計画するのに遺伝的問い合わせ最適化を使用します。
 （<literal>FULL OUTER JOIN</literal>の生成子は、<literal>FROM</literal>項目が１つだけとして計算することに注意してください。）
 デフォルトは12です。
@@ -4369,27 +4369,27 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls the trade-off between planning time and query plan
         quality in GEQO. This variable must be an integer in the
         range from 1 to 10. The default value is five. Larger values
         increase the time spent doing query planning, but also
         increase the likelihood that an efficient query plan will be
         chosen.
-       -->
+-->
        GEQOにおける計画時間と問い合わせ計画の品質間のトレードオフを制御します。この変数は1から10までの範囲の整数でなければなりません。
-       デフォルトの値は5です。値を大きくすると、問い合わせ計画作成により多くの時間を費すことになりますが、より効率的な問い合わせ計画が選択される可能性が増加します。
+デフォルトの値は5です。値を大きくすると、問い合わせ計画作成により多くの時間を費すことになりますが、より効率的な問い合わせ計画が選択される可能性が増加します。
        </para>
 
        <para>
-       <!--
+<!--
         <varname>geqo_effort</varname> doesn't actually do anything
         directly; it is only used to compute the default values for
         the other variables that influence GEQO behavior (described
         below). If you prefer, you can set the other parameters by
         hand instead.
-       -->
-       実際<varname>geqo_effort</varname>は直接何も行いません。それはGEQOの動作に影響を与える他の変数に対し、デフォルトの値を計算するためにのみ使用されます（以下で説明します）。もしよければ、代わりに手作業で他のパラメータを設定できます。
+-->
+実際<varname>geqo_effort</varname>は直接何も行いません。それはGEQOの動作に影響を与える他の変数に対し、デフォルトの値を計算するためにのみ使用されます（以下で説明します）。もしよければ、代わりに手作業で他のパラメータを設定できます。
        </para>
       </listitem>
      </varlistentry>
@@ -4405,14 +4405,14 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls the pool size used by GEQO, that is the
         number of individuals in the genetic population.  It must be
         at least two, and useful values are typically 100 to 1000.  If
         it is set to zero (the default setting) then a suitable
         value is chosen based on <varname>geqo_effort</varname> and
         the number of tables in the query.
-       -->
+-->
        GEQOで使用されるプール容量を管理します。それは遺伝的個体群内の個体数です。最低でも2つはなければならず、よく100から1000までの値が使用されます。もし（デフォルトの設定である）零に設定されると、<varname>geqo_effort</varname>および問い合わせの中のテーブル数に基づいて、適切な値が選択されます。
        </para>
       </listitem>
@@ -4429,14 +4429,14 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls the number of generations used by GEQO, that is
         the number of iterations of the algorithm.  It must
         be at least one, and useful values are in the same range as
         the pool size.  If it is set to zero (the default setting)
         then a suitable value is chosen based on
         <varname>geqo_pool_size</varname>.
-       -->
+-->
        GEQOで使用される世代の数を管理します。それはアルゴリズムの反復数です。最低でも1はなければならず、よくプールサイズと同じ範囲の値が使用されます。これを0に設定（デフォルトの設定）すると、適切な値が<varname>geqo_pool_size</varname>に基づいて選択されます。
        </para>
       </listitem>
@@ -4453,11 +4453,11 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls the selection bias used by GEQO. The selection bias
         is the selective pressure within the population. Values can be
         from 1.50 to 2.00; the latter is the default.
-       -->
+-->
        GEQOで使用される淘汰の偏りを管理します。淘汰の偏りは個体群内の（遺伝的な）自然淘汰です。値は1.50から2.00で、2.00がデフォルトです。
        </para>
       </listitem>
@@ -4474,13 +4474,13 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls the initial value of the random number generator used
         by GEQO to select random paths through the join order search space.
         The value can range from zero (the default) to one.  Varying the
         value changes the set of join paths explored, and may result in a
         better or worse best path being found.
-       -->
+-->
 結合順序検索空間にわたって、GEQOが無作為のパスを選択するために使用される乱数発生器の初期値を制御します。
 値は0（デフォルト）から1までの範囲です。
 値を変動させると探査される結合パスの集合が変化するため、見つかる最善のパスが良くなる場合も悪くなる場合もあります。
@@ -4491,9 +4491,9 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
      </variablelist>
     </sect2>
      <sect2 id="runtime-config-query-other">
-     <!--
+<!--
      <title>Other Planner Options</title>
-     -->
+-->
      <title>その他のプランナオプション</title>
 
      <variablelist>
@@ -4509,7 +4509,7 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the default statistics target for table columns without
         a column-specific target set via <command>ALTER TABLE
         SET STATISTICS</command>.  Larger values increase the time needed to
@@ -4517,8 +4517,8 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
         planner's estimates. The default is 100. For more information
         on the use of statistics by the <productname>PostgreSQL</productname>
         query planner, refer to <xref linkend="planner-stats"/>.
-       -->
-       <command>ALTER TABLE SET STATISTICS</command>で列特定の目的セットの無いテーブル列に対し、デフォルトの統計対象を設定します。
+-->
+<command>ALTER TABLE SET STATISTICS</command>で列特定の目的セットの無いテーブル列に対し、デフォルトの統計対象を設定します。
 より大きい値は<command>ANALYZE</command>に必要な時間を増加させますが、プランナの予測の品質を向上させます。
 デフォルトは100です。
 <productname>PostgreSQL</productname>の問い合わせプランナによる統計情報の使用方法に関するより詳細な情報は、<xref linkend="planner-stats"/>を参照してください。
@@ -4562,12 +4562,12 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </para>
 
        <para>
-       <!--
+<!--
         When this parameter allows it for a particular table, the planner
         compares query conditions with the table's <literal>CHECK</literal>
         constraints, and omits scanning tables for which the conditions
         contradict the constraints.  For example:
-       -->
+-->
 このパラメータが特定のテーブルに対して許される時、プランナはそのテーブルの<literal>CHECK</literal>制約で問い合わせ条件を比較し、制約と矛盾する条件のテーブルの走査を省きます。
 例えば以下のようになります。
 
@@ -4582,8 +4582,8 @@ SELECT * FROM parent WHERE key = 2400;
 <!--
         With constraint exclusion enabled, this <command>SELECT</command>
         will not scan <structname>child1000</structname> at all, improving performance.
-       -->
-       制約排除が有効であると、この<command>SELECT</command>は全く<structname>child1000</structname>を走査せず、性能を向上させます。
+-->
+制約排除が有効であると、この<command>SELECT</command>は全く<structname>child1000</structname>を走査せず、性能を向上させます。
        </para>
 
        <para>
@@ -4626,7 +4626,7 @@ SELECT * FROM parent WHERE key = 2400;
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the planner's estimate of the fraction of a cursor's rows that
         will be retrieved.  The default is 0.1.  Smaller values of this
         setting bias the planner towards using <quote>fast start</quote> plans
@@ -4636,14 +4636,14 @@ SELECT * FROM parent WHERE key = 2400;
         setting of 1.0, cursors are planned exactly like regular queries,
         considering only the total estimated time and not how soon the
         first rows might be delivered.
-       -->
-       検索されるカーソル行の割合のプランナの見積もりを設定します。
-       デフォルトは0.1です。
-       この設定をより小さくすると、プランナはカーソルに対し<quote>起動を高速にする</quote>計画を使用するようになりがちになります。
-       この場合先頭の数行の取り出しは高速になりますが、行全体を取り出す場合に時間がかかるようになる可能性があります。
-       この値をより大きくすると、推定時間全体がより強調されるようになります。
-       最大の設定である1.0の場合、カーソルは通常の問い合わせとまったく同様に計画されます。
-       つまり、推定時間全体のみが考慮され、先頭の行の取り出しにかかる時間は考慮されなくなります。
+-->
+検索されるカーソル行の割合のプランナの見積もりを設定します。
+デフォルトは0.1です。
+この設定をより小さくすると、プランナはカーソルに対し<quote>起動を高速にする</quote>計画を使用するようになりがちになります。
+この場合先頭の数行の取り出しは高速になりますが、行全体を取り出す場合に時間がかかるようになる可能性があります。
+この値をより大きくすると、推定時間全体がより強調されるようになります。
+最大の設定である1.0の場合、カーソルは通常の問い合わせとまったく同様に計画されます。
+つまり、推定時間全体のみが考慮され、先頭の行の取り出しにかかる時間は考慮されなくなります。
        </para>
       </listitem>
      </varlistentry>
@@ -4659,26 +4659,26 @@ SELECT * FROM parent WHERE key = 2400;
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The planner will merge sub-queries into upper queries if the
         resulting <literal>FROM</literal> list would have no more than
         this many items.  Smaller values reduce planning time but might
         yield inferior query plans.  The default is eight.
         For more information see <xref linkend="explicit-joins"/>.
-       -->
-       プランナは、<literal>FROM</literal>リストがこの数の項目より少ない結果の場合、副問い合わせを上位の問い合わせに併合します。
+-->
+プランナは、<literal>FROM</literal>リストがこの数の項目より少ない結果の場合、副問い合わせを上位の問い合わせに併合します。
 より小さい値は計画時間を縮小させますが、劣った問い合わせ計画をもたらす可能性があります。
 デフォルトは8です。
 詳細は<xref linkend="explicit-joins"/>を参照してください。
        </para>
 
        <para>
-       <!--
+<!--
         Setting this value to <xref linkend="guc-geqo-threshold"/> or more
         may trigger use of the GEQO planner, resulting in non-optimal
         plans.  See <xref linkend="runtime-config-query-geqo"/>.
-       -->
-       この値を<xref linkend="guc-geqo-threshold"/>か、それ以上に設定するとGEQOプランナ使用の誘引となり、最適ではない計画をもたらします。<xref linkend="runtime-config-query-geqo"/>を参照してください。
+-->
+この値を<xref linkend="guc-geqo-threshold"/>か、それ以上に設定するとGEQOプランナ使用の誘引となり、最適ではない計画をもたらします。<xref linkend="runtime-config-query-geqo"/>を参照してください。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/config2.sgml
+++ b/doc/src/sgml/config2.sgml
@@ -252,7 +252,7 @@ local0.*    /var/log/postgresql
          log messages cleanly.
          See <xref linkend="event-log-registration"/> for details.
 -->
-        Windowsで<varname>log_destination</varname>に対し<literal>eventlog</literal>オプションを使用する場合、Windows Event Viewer がイベントログメッセージを手際良く表示できるよう、オペレーティングシステムでイベントソースとそのライブラリを登録しなければなりません。
+Windowsで<varname>log_destination</varname>に対し<literal>eventlog</literal>オプションを使用する場合、Windows Event Viewer がイベントログメッセージを手際良く表示できるよう、オペレーティングシステムでイベントソースとそのライブラリを登録しなければなりません。
 詳細は<xref linkend="event-log-registration"/>を参照ください。
         </para>
        </note>
@@ -389,8 +389,7 @@ local0.*    /var/log/postgresql
 値は<function>strftime</function>パターンとして扱われるため、<literal>%</literal>エスケープを使用して、時刻によって変動するファイル名を指定することができます。
 （時間帯に依存した<literal>%</literal>エスケープが存在する場合、<xref
 linkend="guc-log-timezone"/>で指定された時間帯で計算が行われます。）
-サポートされている<literal>%</literal>-エスケープは<ulink
-        url="https://pubs.opengroup.org/onlinepubs/009695399/functions/strftime.html">strftime</ulink> 仕様によく似ています。
+サポートされている<literal>%</literal>-エスケープは<ulink url="https://pubs.opengroup.org/onlinepubs/009695399/functions/strftime.html">strftime</ulink> 仕様によく似ています。
 システムの<function>strftime</function>は直接使用されないので、プラットフォーム固有の（非標準）の拡張は動作しません。
 デフォルトは<literal>postgresql-%Y-%m-%d_%H%M%S.log</literal>です。
        </para>
@@ -405,7 +404,7 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
         longer the case.
 -->
 エスケープすることなくファイル名を指定する場合、ディスク全体を使い切ってしまうことを防止するためにログローテーションを行うユーティリティを使用することを計画しなければなりません。
-       8.4より前のリリースの<productname>PostgreSQL</productname>では、<literal>%</literal>エスケープがなければ、新しいログファイルの生成時のエポック時刻を付与しますが、これはもはや当てはまりません。
+8.4より前のリリースの<productname>PostgreSQL</productname>では、<literal>%</literal>エスケープがなければ、新しいログファイルの生成時のエポック時刻を付与しますが、これはもはや当てはまりません。
        </para>
        <para>
 <!--
@@ -449,10 +448,10 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         system calls.  (To use the customary octal format the number
         must start with a <literal>0</literal> (zero).)
 -->
-       Unixシステムにおいては、<varname>logging_collector</varname>が有効になっている場合、このパラメータはログファイルのパーミッションを設定します。
-       （Microsoft Windowsではこのパラメータは無視されます。）
+Unixシステムにおいては、<varname>logging_collector</varname>が有効になっている場合、このパラメータはログファイルのパーミッションを設定します。
+（Microsoft Windowsではこのパラメータは無視されます。）
 パラメータの値は<function>chmod</function> および <function>umask</function>システムコールで許容されるフォーマットで指定される数値モードであると期待されます。
-       （慣例的な8進数フォーマットを使用する場合、番号は<literal>0</literal>（ゼロ）で始まらなければなりません。
+（慣例的な8進数フォーマットを使用する場合、番号は<literal>0</literal>（ゼロ）で始まらなければなりません。
        </para>
        <para>
 <!--
@@ -1128,8 +1127,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         <entry>Provides information implicitly requested by the user,
          e.g., output from <command>VACUUM VERBOSE</command>.</entry>
 -->
-        <entry><command>VACUUM VERBOSE</command>の出力などの、
-ユーザによって暗黙的に要求された情報を提供します。</entry>
+        <entry><command>VACUUM VERBOSE</command>の出力などの、ユーザによって暗黙的に要求された情報を提供します。</entry>
         <entry><literal>INFO</literal></entry>
         <entry><literal>INFORMATION</literal></entry>
        </row>
@@ -1140,8 +1138,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         <entry>Provides information that might be helpful to users, e.g.,
          notice of truncation of long identifiers.</entry>
 -->
-        <entry>長い識別子の切り詰めに関する注意など、
-ユーザの補助になる情報を提供します。</entry>
+        <entry>長い識別子の切り詰めに関する注意など、ユーザの補助になる情報を提供します。</entry>
         <entry><literal>NOTICE</literal></entry>
         <entry><literal>INFORMATION</literal></entry>
        </row>
@@ -1152,8 +1149,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         <entry>Provides warnings of likely problems, e.g., <command>COMMIT</command>
          outside a transaction block.</entry>
 -->
-        <entry>トランザクションブロック外での<command>COMMIT</command>の様な、
-ユーザへの警告を提供します。</entry>
+        <entry>トランザクションブロック外での<command>COMMIT</command>の様な、ユーザへの警告を提供します。</entry>
         <entry><literal>NOTICE</literal></entry>
         <entry><literal>WARNING</literal></entry>
        </row>
@@ -1175,8 +1171,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         <entry>Reports information of interest to administrators, e.g.,
          checkpoint activity.</entry>
 -->
-        <entry>チェックポイントの活動の様な、
-管理者に関心のある情報を報告します。</entry>
+        <entry>チェックポイントの活動の様な、管理者に関心のある情報を報告します。</entry>
         <entry><literal>INFO</literal></entry>
         <entry><literal>INFORMATION</literal></entry>
        </row>
@@ -1526,8 +1521,8 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
 -->
 ログ取得されるそれぞれのメッセージに対し、サーバログに書き込まれる詳細の量を制御します。
 有効な値は、<literal>TERSE</literal>、<literal>DEFAULT</literal>、および<literal>VERBOSE</literal>で、それぞれは表示されるメッセージにより多くのフィールドを追加します。
-       <literal>TERSE</literal>は<literal>DETAIL</literal>、<literal>HINT</literal>、<literal>QUERY</literal>、および<literal>CONTEXT</literal>エラー情報を除外します。
-       <literal>VERBOSE</literal>出力は、<symbol>SQLSTATE</symbol>エラーコード（<xref linkend="errcodes-appendix"/>も参照）、および、ソースコードファイル名、関数名、そしてエラーを生成した行番号を含みます。
+<literal>TERSE</literal>は<literal>DETAIL</literal>、<literal>HINT</literal>、<literal>QUERY</literal>、および<literal>CONTEXT</literal>エラー情報を除外します。
+<literal>VERBOSE</literal>出力は、<symbol>SQLSTATE</symbol>エラーコード（<xref linkend="errcodes-appendix"/>も参照）、および、ソースコードファイル名、関数名、そしてエラーを生成した行番号を含みます。
 スーパーユーザのみこの設定を変更できます。
        </para>
       </listitem>
@@ -1616,7 +1611,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
              <entry>Effect</entry>
              <entry>Session only</entry>
 -->
-            <entry>エスケープ</entry>
+             <entry>エスケープ</entry>
              <entry>効果</entry>
              <entry>セッションのみ</entry>
              </row>
@@ -1692,7 +1687,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
               is a parallel query worker</entry>
              <entry>no</entry>
 -->
-<entry>このプロセスがパラレルクエリワーカである場合に、パラレルグループリーダのプロセス識別子</entry>
+             <entry>このプロセスがパラレルクエリワーカである場合に、パラレルグループリーダのプロセス識別子</entry>
              <entry>×</entry>
             </row>
             <row>
@@ -1794,8 +1789,8 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
              <entry>no</entry>
 -->
              <entry>何も出力しません。
-非セッションプロセスではこのエスケープ以降の出力を停止します。
-セッションプロセスでは無視されます。</entry>
+             非セッションプロセスではこのエスケープ以降の出力を停止します。
+             セッションプロセスでは無視されます。</entry>
              <entry>×</entry>
             </row>
             <row>
@@ -1808,8 +1803,8 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
              query identifiers is configured.</entry>
              <entry>yes</entry>
 -->
-             <entry>現在の問い合わせの問い合わせ識別子。
-問い合わせ識別子はデフォルトでは計算されません。ですから<xref linkend="guc-compute-query-id"/>パラメータが有効であるか、あるいは問い合わせ識別子を計算するサードパーティのモジュールが設定されていないければゼロとなります。</entry>
+             <entry>現在の問い合わせの問い合わせ識別子。問い合わせ識別子はデフォルトでは計算されません。
+             ですから<xref linkend="guc-compute-query-id"/>パラメータが有効であるか、あるいは問い合わせ識別子を計算するサードパーティのモジュールが設定されていないければゼロとなります。</entry>
              <entry>○</entry>
             </row>
             <row>
@@ -2335,7 +2330,7 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
        There are a few things you need to do to simplify importing CSV log
        files:
 -->
-       CSVログファイルをインポートする作業を単純にするためにいくつか必要な作業があります。
+CSVログファイルをインポートする作業を単純にするためにいくつか必要な作業があります。
 
        <orderedlist>
          <listitem>
@@ -2685,7 +2680,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
 -->
 関数の呼び出し数と費やされた時間の追跡を有効にします。
 手続き言語関数のみを追跡するためには<literal>pl</literal>と指定してください。
-       SQL関数、C言語関数も追跡するためには<literal>all</literal>と指定してください。
+SQL関数、C言語関数も追跡するためには<literal>all</literal>と指定してください。
 デフォルトは、統計情報追跡機能を無効にする<literal>none</literal>です。
 スーパーユーザのみがこの設定を変更できます。
        </para>
@@ -3191,7 +3186,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         changing table storage parameters.
         For more information see <xref linkend="vacuum-for-wraparound"/>.
 -->
-       vacuumは同時に<filename>pg_xact</filename>サブディレクトリから古いファイルの削除を許可します。
+vacuumは同時に<filename>pg_xact</filename>サブディレクトリから古いファイルの削除を許可します。
 これが、比較的低い2億トランザクションがデフォルトである理由です。
 このパラメータはサーバ起動時にのみ設定可能です。
 しかし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルで減らすことができます。
@@ -3759,7 +3754,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
 <!--
         See also <xref linkend="guc-default-tablespace"/>.
 -->
-       <xref linkend="guc-default-tablespace"/>も参照してください
+<xref linkend="guc-default-tablespace"/>も参照してください
        </para>
       </listitem>
      </varlistentry>
@@ -3824,7 +3819,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         default isolation level of each new transaction. The default
         is <quote>read committed</quote>.
 -->
-       SQLトランザクションはそれぞれ、<quote>read uncommitted</quote>、<quote>read committed</quote>、<quote>repeatable read</quote>、または<quote>serializable</quote>のいずれかの分離レベルを持ちます。
+SQLトランザクションはそれぞれ、<quote>read uncommitted</quote>、<quote>read committed</quote>、<quote>repeatable read</quote>、または<quote>serializable</quote>のいずれかの分離レベルを持ちます。
 このパラメータは各新規トランザクションのデフォルトの分離レベルを制御します。
 デフォルトは<quote>read committed</quote>です。
        </para>
@@ -3834,8 +3829,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         Consult <xref linkend="mvcc"/> and <xref
         linkend="sql-set-transaction"/> for more information.
 -->
-より詳細は <xref linkend="mvcc"/> および <xref
-        linkend="sql-set-transaction"/> を調べてください。
+より詳細は <xref linkend="mvcc"/> および <xref linkend="sql-set-transaction"/> を調べてください。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/config2.sgml
+++ b/doc/src/sgml/config2.sgml
@@ -19,19 +19,19 @@
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The planner will rewrite explicit <literal>JOIN</literal>
         constructs (except <literal>FULL JOIN</literal>s) into lists of
         <literal>FROM</literal> items whenever a list of no more than this many items
         would result.  Smaller values reduce planning time but might
         yield inferior query plans.
-       -->
-       最終的にリストがこの項目数以下になる時、プランナは、明示的な<literal>JOIN</literal>構文（<literal>FULL JOIN</literal>を除く）を<literal>FROM</literal>項目のリストに直します。
+-->
+最終的にリストがこの項目数以下になる時、プランナは、明示的な<literal>JOIN</literal>構文（<literal>FULL JOIN</literal>を除く）を<literal>FROM</literal>項目のリストに直します。
 この値を小さくすれば計画作成時間は減少しますが、劣った問い合わせ計画が作成される可能性があります。
        </para>
 
        <para>
-       <!--
+<!--
         By default, this variable is set the same as
         <varname>from_collapse_limit</varname>, which is appropriate
         for most uses. Setting it to 1 prevents any reordering of
@@ -42,8 +42,8 @@
         temporarily set this variable to 1, and then specify the join
         order they desire explicitly.
         For more information see <xref linkend="explicit-joins"/>.
-       -->
-       デフォルトでは、この値は<varname>from_collapse_limit</varname>と同じ値に設定されており、殆どの場合に適切です。
+-->
+デフォルトでは、この値は<varname>from_collapse_limit</varname>と同じ値に設定されており、殆どの場合に適切です。
 これを1に設定すると明示的な<literal>JOIN</literal>の再順序付けは行われなくなります。
 したがって、問い合わせで指定された明示的結合順序は、関係（リレーション）が結合される実際の順序となります。
 問い合わせプランナは常に最適な結合順序を選択するとは限らないので、
@@ -52,12 +52,12 @@
        </para>
 
        <para>
-       <!--
+<!--
         Setting this value to <xref linkend="guc-geqo-threshold"/> or more
         may trigger use of the GEQO planner, resulting in non-optimal
         plans.  See <xref linkend="runtime-config-query-geqo"/>.
-       -->
-       この値を<xref linkend="guc-geqo-threshold"/>か、それ以上に設定するとGEQOプランナ使用の誘引となり、最適ではない計画をもたらします。<xref linkend="runtime-config-query-geqo"/>を参照してください。
+-->
+この値を<xref linkend="guc-geqo-threshold"/>か、それ以上に設定するとGEQOプランナ使用の誘引となり、最適ではない計画をもたらします。<xref linkend="runtime-config-query-geqo"/>を参照してください。
        </para>
       </listitem>
      </varlistentry>
@@ -108,9 +108,9 @@
    </sect1>
 
    <sect1 id="runtime-config-logging">
-   <!--
+<!--
     <title>Error Reporting and Logging</title>
-    -->
+-->
     <title>エラー報告とログ取得</title>
 
     <indexterm zone="runtime-config-logging">
@@ -121,9 +121,9 @@
     </indexterm>
 
     <sect2 id="runtime-config-logging-where">
-    <!--
+<!--
      <title>Where to Log</title>
-     -->
+-->
      <title>ログの出力先</title>
 
      <indexterm zone="runtime-config-logging-where">
@@ -155,7 +155,7 @@
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         <productname>PostgreSQL</productname> supports several methods
          for logging server messages, including
          <systemitem>stderr</systemitem>, <systemitem>csvlog</systemitem> and
@@ -166,15 +166,15 @@
          only.
          This parameter can only be set in the <filename>postgresql.conf</filename>
          file or on the server command line.
-        -->
-        <productname>PostgreSQL</productname>は、<systemitem>stderr</systemitem>、<systemitem>csvlog</systemitem>および<systemitem>syslog</systemitem>を含めて、サーバメッセージのログ取得に対し数種類の方法を提供します。
+-->
+<productname>PostgreSQL</productname>は、<systemitem>stderr</systemitem>、<systemitem>csvlog</systemitem>および<systemitem>syslog</systemitem>を含めて、サーバメッセージのログ取得に対し数種類の方法を提供します。
 Windowsでは、<systemitem>eventlog</systemitem>も同時に提供します。
 このパラメータを設定するには、コンマ区切りでお好みのログ出力先を記載します。
 デフォルトでは、ログは<systemitem>stderr</systemitem>のみに出力されます。
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定されます。
        </para>
        <para>
-       <!--
+<!--
         If <systemitem>csvlog</systemitem> is included in <varname>log_destination</varname>,
         log entries are output in <quote>comma separated
         value</quote> (<acronym>CSV</acronym>) format, which is convenient for
@@ -182,8 +182,8 @@ Windowsでは、<systemitem>eventlog</systemitem>も同時に提供します。
         See <xref linkend="runtime-config-logging-csvlog"/> for details.
         <xref linkend="guc-logging-collector"/> must be enabled to generate
         CSV-format log output.
-       -->
-       <systemitem>csvlog</systemitem>が<varname>log_destination</varname>に含まれる場合、ログ項目はプログラムへの読み込みが簡便な<quote>カンマ区切り値</quote>書式（<acronym>CSV</acronym>）で出力されます。
+-->
+<systemitem>csvlog</systemitem>が<varname>log_destination</varname>に含まれる場合、ログ項目はプログラムへの読み込みが簡便な<quote>カンマ区切り値</quote>書式（<acronym>CSV</acronym>）で出力されます。
 詳細は<xref linkend="runtime-config-logging-csvlog"/>を参照してください。
 CSV書式のログ出力を生成するためには<xref linkend="guc-logging-collector"/>を有効にする必要があります。
        </para>
@@ -220,7 +220,7 @@ csvlog log/postgresql.csv
 
        <note>
         <para>
-       <!--
+<!--
          On most Unix systems, you will need to alter the configuration of
          your system's <application>syslog</application> daemon in order
          to make use of the <systemitem>syslog</systemitem> option for
@@ -230,30 +230,30 @@ csvlog log/postgresql.csv
          linkend="guc-syslog-facility"/>), but the default
          <application>syslog</application> configuration on most platforms
          will discard all such messages.  You will need to add something like:
-        -->
-        <varname>log_destination</varname>で<systemitem>syslog</systemitem>オプションを使用できるようにするために、ほとんどのUnixシステムではシステムの<application>syslog</application>デーモンの設定を変更しなければならないでしょう。
+-->
+<varname>log_destination</varname>で<systemitem>syslog</systemitem>オプションを使用できるようにするために、ほとんどのUnixシステムではシステムの<application>syslog</application>デーモンの設定を変更しなければならないでしょう。
 <productname>PostgreSQL</productname>ではログを<literal>LOCAL0</literal>から<literal>LOCAL7</literal>までの<application>syslog</application>ファシリティで記録することができます（<xref linkend="guc-syslog-facility"/>を参照してください）。
 しかし、ほとんどのプラットフォームのデフォルトの<application>syslog</application>設定ではこれらのメッセージはすべて破棄されます。
 うまく動作させるために<application>syslog</application>デーモンの設定に以下のようなものを追加しなければならないでしょう。
 <programlisting>
 local0.*    /var/log/postgresql
 </programlisting>
-        <!--
+<!--
          to the  <application>syslog</application> daemon's configuration file
          to make it work.
-        -->
+-->
         </para>
         <para>
-       <!--
+<!--
          On Windows, when you use the <literal>eventlog</literal>
          option for <varname>log_destination</varname>, you should
          register an event source and its library with the operating
          system so that the Windows Event Viewer can display event
          log messages cleanly.
          See <xref linkend="event-log-registration"/> for details.
-        -->
+-->
         Windowsで<varname>log_destination</varname>に対し<literal>eventlog</literal>オプションを使用する場合、Windows Event Viewer がイベントログメッセージを手際良く表示できるよう、オペレーティングシステムでイベントソースとそのライブラリを登録しなければなりません。
-        詳細は<xref linkend="event-log-registration"/>を参照ください。
+詳細は<xref linkend="event-log-registration"/>を参照ください。
         </para>
        </note>
       </listitem>
@@ -270,7 +270,7 @@ local0.*    /var/log/postgresql
       </term>
       <listitem>
        <para>
-       <!--
+<!--
          This parameter enables the <firstterm>logging collector</firstterm>, which
          is a background process that captures log messages
          sent to <systemitem>stderr</systemitem> and redirects them into log files.
@@ -280,7 +280,7 @@ local0.*    /var/log/postgresql
          example is dynamic-linker failure messages; another is error messages
          produced by scripts such as <varname>archive_command</varname>.)
          This parameter can only be set at server start.
-        -->
+-->
 このパラメータは<firstterm>ログ収集機構</firstterm>を有効にします。
 それは<systemitem>stderr</systemitem>に送られたログメッセージを捕捉し、ログファイルにリダイレクトするバックグラウンドプロセスです。
 この手法は<application>syslog</application>へのログよりもしばしば有用です。
@@ -291,7 +291,7 @@ local0.*    /var/log/postgresql
 
        <note>
         <para>
-       <!--
+<!--
          It is possible to log to <systemitem>stderr</systemitem> without using the
          logging collector; the log messages will just go to wherever the
          server's <systemitem>stderr</systemitem> is directed.  However, that method is
@@ -300,17 +300,17 @@ local0.*    /var/log/postgresql
          logging collector can result in lost or garbled log output, because
          multiple processes writing concurrently to the same log file can
          overwrite each other's output.
-        -->
-        ログ収集機構を使用せずに<systemitem>stderr</systemitem>のログを取ることは可能です。
-        ログメッセージはサーバの<systemitem>stderr</systemitem>が指し示すいかなる場所にも向かうだけです。
-        しかし、その方法はログファイルを巡回させる都合のよい方法を提供しないので、ログ容量が小さい場合のみに適しています。
-        同時に、ログ収集機構を使用しないいくつかのプラットフォームにおいては、ログ出力が失われたり、文字化けします。なぜなら、同一のログファイルに同時に書き込みを行うマルチプロセッサはそれぞれの出力を上書きできるからです。
+-->
+ログ収集機構を使用せずに<systemitem>stderr</systemitem>のログを取ることは可能です。
+ログメッセージはサーバの<systemitem>stderr</systemitem>が指し示すいかなる場所にも向かうだけです。
+しかし、その方法はログファイルを巡回させる都合のよい方法を提供しないので、ログ容量が小さい場合のみに適しています。
+同時に、ログ収集機構を使用しないいくつかのプラットフォームにおいては、ログ出力が失われたり、文字化けします。なぜなら、同一のログファイルに同時に書き込みを行うマルチプロセッサはそれぞれの出力を上書きできるからです。
         </para>
        </note>
 
        <note>
         <para>
-       <!--
+<!--
           The logging collector is designed to never lose messages.  This means
           that in case of extremely high load, server processes could be
           blocked while trying to send additional log messages when the
@@ -318,7 +318,7 @@ local0.*    /var/log/postgresql
           prefers to drop messages if it cannot write them, which means it
           may fail to log some messages in such cases but it will not block
           the rest of the system.
-         -->
+-->
 ログ収集機構はメッセージを決して失わないために設計されています。
 これは、極端に高い負荷の場合、サーバプロセスはコレクタが遅れをとった場合、追加のログメッセージを送信しようと試みる時に阻止される可能性があります。
 それとは対象的に<application>syslog</application>は、もし書き込みができなかったときメッセージの廃棄を選びます。
@@ -340,7 +340,7 @@ local0.*    /var/log/postgresql
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When <varname>logging_collector</varname> is enabled,
         this parameter determines the directory in which log files will be created.
         It can be specified as an absolute path, or relative to the
@@ -348,10 +348,10 @@ local0.*    /var/log/postgresql
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
         The default is <literal>log</literal>.
-       -->
-       <varname>logging_collector</varname>を有効と設定した場合、このパラメータはログファイルが作成されるディレクトリを確定します。
-        ディレクトリは、絶対パス、もしくはデータベースクラスタのディレクトリに対する相対パスで指定することができます。
-        このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバコマンドラインからのみ設定可能です。
+-->
+<varname>logging_collector</varname>を有効と設定した場合、このパラメータはログファイルが作成されるディレクトリを確定します。
+ディレクトリは、絶対パス、もしくはデータベースクラスタのディレクトリに対する相対パスで指定することができます。
+このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバコマンドラインからのみ設定可能です。
 デフォルトは<literal>log</literal>です。
        </para>
       </listitem>
@@ -368,7 +368,7 @@ local0.*    /var/log/postgresql
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When <varname>logging_collector</varname> is enabled,
         this parameter sets the file names of the created log files.  The value
         is treated as a <function>strftime</function> pattern,
@@ -384,8 +384,8 @@ local0.*    /var/log/postgresql
         Note that the system's <function>strftime</function> is not used
         directly, so platform-specific (nonstandard) extensions do not work.
         The default is <literal>postgresql-%Y-%m-%d_%H%M%S.log</literal>.
-       -->
-       <varname>logging_collector</varname>が有効な場合、このパラメータは作成されたログファイルのファイル名を設定します。
+-->
+<varname>logging_collector</varname>が有効な場合、このパラメータは作成されたログファイルのファイル名を設定します。
 値は<function>strftime</function>パターンとして扱われるため、<literal>%</literal>エスケープを使用して、時刻によって変動するファイル名を指定することができます。
 （時間帯に依存した<literal>%</literal>エスケープが存在する場合、<xref
 linkend="guc-log-timezone"/>で指定された時間帯で計算が行われます。）
@@ -395,7 +395,7 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
 デフォルトは<literal>postgresql-%Y-%m-%d_%H%M%S.log</literal>です。
        </para>
        <para>
-       <!--
+<!--
         If you specify a file name without escapes, you should plan to
         use a log rotation utility to avoid eventually filling the
         entire disk.  In releases prior to 8.4, if
@@ -403,26 +403,26 @@ linkend="guc-log-timezone"/>で指定された時間帯で計算が行われま�
         present, <productname>PostgreSQL</productname> would append
         the epoch of the new log file's creation time, but this is no
         longer the case.
-       -->
-       エスケープすることなくファイル名を指定する場合、ディスク全体を使い切ってしまうことを防止するためにログローテーションを行うユーティリティを使用することを計画しなければなりません。
+-->
+エスケープすることなくファイル名を指定する場合、ディスク全体を使い切ってしまうことを防止するためにログローテーションを行うユーティリティを使用することを計画しなければなりません。
        8.4より前のリリースの<productname>PostgreSQL</productname>では、<literal>%</literal>エスケープがなければ、新しいログファイルの生成時のエポック時刻を付与しますが、これはもはや当てはまりません。
        </para>
        <para>
-       <!--
+<!--
         If CSV-format output is enabled in <varname>log_destination</varname>,
         <literal>.csv</literal> will be appended to the timestamped
         log file name to create the file name for CSV-format output.
         (If <varname>log_filename</varname> ends in <literal>.log</literal>, the suffix is
         replaced instead.)
-       -->
+-->
 CSV書式の出力が<varname>log_destination</varname>で有効な場合、タイムスタンプ付きのログファイル名に<literal>.csv</literal>を付与し、最終的なCSV書式出力用のファイル名が作成されます。
 （<varname>log_filename</varname>が<literal>.log</literal>で終わる場合は後置詞が置き換えられます。）
        </para>
        <para>
-       <!--
+<!--
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 このパラメータは<filename>postgresql.conf</filename>ファイルか、サーバコマンドラインのみ設定可能です。
        </para>
       </listitem>
@@ -439,7 +439,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         On Unix systems this parameter sets the permissions for log files
         when <varname>logging_collector</varname> is enabled. (On Microsoft
         Windows this parameter is ignored.)
@@ -448,14 +448,14 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         <function>chmod</function> and <function>umask</function>
         system calls.  (To use the customary octal format the number
         must start with a <literal>0</literal> (zero).)
-       -->
+-->
        Unixシステムにおいては、<varname>logging_collector</varname>が有効になっている場合、このパラメータはログファイルのパーミッションを設定します。
        （Microsoft Windowsではこのパラメータは無視されます。）
-       パラメータの値は<function>chmod</function> および <function>umask</function>システムコールで許容されるフォーマットで指定される数値モードであると期待されます。
+パラメータの値は<function>chmod</function> および <function>umask</function>システムコールで許容されるフォーマットで指定される数値モードであると期待されます。
        （慣例的な8進数フォーマットを使用する場合、番号は<literal>0</literal>（ゼロ）で始まらなければなりません。
        </para>
        <para>
-       <!--
+<!--
         The default permissions are <literal>0600</literal>, meaning only the
         server owner can read or write the log files.  The other commonly
         useful setting is <literal>0640</literal>, allowing members of the owner's
@@ -464,17 +464,17 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         store the files somewhere outside the cluster data directory.  In
         any case, it's unwise to make the log files world-readable, since
         they might contain sensitive data.
-       -->
-       デフォルトのパーミッションは<literal>0600</literal>で、意味するところはサーバの所有者のみログファイルの読み書きが可能です。
-       そのほか一般的に実用的な設定は<literal>0640</literal>で、所有者のグループはファイルを読み込めます。
-       しかし、これらの設定を活用するには<xref linkend="guc-log-directory"/>がクラスタデータディレクトリの外部のどこかにあるファイルを格納できるように変更する必要があります。
+-->
+デフォルトのパーミッションは<literal>0600</literal>で、意味するところはサーバの所有者のみログファイルの読み書きが可能です。
+そのほか一般的に実用的な設定は<literal>0640</literal>で、所有者のグループはファイルを読み込めます。
+しかし、これらの設定を活用するには<xref linkend="guc-log-directory"/>がクラスタデータディレクトリの外部のどこかにあるファイルを格納できるように変更する必要があります。
        </para>
        <para>
 <!--
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
-       このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバコマンドラインからのみ設定可能です。
+-->
+このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバコマンドラインからのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -490,7 +490,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When <varname>logging_collector</varname> is enabled,
         this parameter determines the maximum amount of time to use an
         individual log file, after which a new log file will be created.
@@ -499,7 +499,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         Set to zero to disable time-based creation of new log files.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 <varname>logging_collector</varname>が有効な場合、このパラメータは個々のログファイルの最大寿命を決定します。
 ここで指定した時間経過すると、新しいログファイルが生成されます。
 この値が単位なしで指定された場合は、分単位であるとみなします。
@@ -521,7 +521,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When <varname>logging_collector</varname> is enabled,
         this parameter determines the maximum size of an individual log file.
         After this amount of data has been emitted into a log file,
@@ -531,7 +531,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         Set to zero to disable size-based creation of new log files.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 <varname>logging_collector</varname>が有効な場合、このパラメータは個々のログファイルの最大容量を決定します。
 ここで指定したデータ量がログファイルに出力された後、新しいログファイルが生成されます。
 この値が単位なしで指定された場合は、キロバイト単位であるとみなします。
@@ -553,7 +553,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When <varname>logging_collector</varname> is enabled,
         this parameter will cause <productname>PostgreSQL</productname> to truncate (overwrite),
         rather than append to, any existing log file of the same name.
@@ -566,8 +566,8 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         cyclically overwriting them.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
-       <varname>logging_collector</varname>が有効な場合、このパラメータにより、<productname>PostgreSQL</productname>は既存の同名のファイルに追加するのではなく、そのファイルを切り詰める（上書きする）ようになります。
+-->
+<varname>logging_collector</varname>が有効な場合、このパラメータにより、<productname>PostgreSQL</productname>は既存の同名のファイルに追加するのではなく、そのファイルを切り詰める（上書きする）ようになります。
 しかし、切り詰めは時間を基にしたローテーションのために新規にファイルが開かれた時にのみ発生し、サーバ起動時やサイズを基にしたローテーションでは発生しません。
 偽の場合、全ての場合において既存のファイルは追記されます。
 例えば、この設定を<literal>postgresql-%H.log</literal>のような<varname>log_filename</varname>と組み合わせて使用すると、24個の時別のログファイルが生成され、それらは周期的に上書きされることになります。
@@ -614,7 +614,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When logging to <application>syslog</application> is enabled, this parameter
         determines the <application>syslog</application>
         <quote>facility</quote> to be used.  You can choose
@@ -626,8 +626,8 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         <application>syslog</application> daemon.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
-       <application>syslog</application>へのログ取得が有効な場合、このパラメータは<application>syslog</application>の<quote>facility</quote>が使われるように確定します。
+-->
+<application>syslog</application>へのログ取得が有効な場合、このパラメータは<application>syslog</application>の<quote>facility</quote>が使われるように確定します。
 <literal>LOCAL0</literal>、<literal>LOCAL1</literal>、<literal>LOCAL2</literal>、<literal>LOCAL3</literal>、<literal>LOCAL4</literal>、<literal>LOCAL5</literal>、<literal>LOCAL6</literal>、<literal>LOCAL7</literal>の中から選んでください。
 デフォルトは<literal>LOCAL0</literal>です。
 使用しているシステムの<application>syslog</application>デーモンの文書を同時に参照してください。
@@ -647,7 +647,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
        <listitem>
         <para>
-       <!--
+<!--
          When logging to <application>syslog</application> is enabled, this parameter
          determines the program name used to identify
          <productname>PostgreSQL</productname> messages in
@@ -655,8 +655,8 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
          <literal>postgres</literal>.
          This parameter can only be set in the <filename>postgresql.conf</filename>
          file or on the server command line.
-        -->
-        <application>syslog</application>にログ取得が有効な場合、このパラメータは<application>syslog</application>ログ内の<productname>PostgreSQL</productname>メッセージを特定するのに使用するプログラム名を確定します。デフォルトは<literal>postgres</literal>です。
+-->
+<application>syslog</application>にログ取得が有効な場合、このパラメータは<application>syslog</application>ログ内の<productname>PostgreSQL</productname>メッセージを特定するのに使用するプログラム名を確定します。デフォルトは<literal>postgres</literal>です。
 このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
         </para>
        </listitem>
@@ -764,15 +764,15 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When logging to <application>event log</application> is enabled, this parameter
         determines the program name used to identify
         <productname>PostgreSQL</productname> messages in
         the log. The default is <literal>PostgreSQL</literal>.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
-       <application>event log</application>へのログ取得が有効になっていると、このパラメータはログ中の<productname>PostgreSQL</productname>メッセージを特定するのに使用されるプログラム名を決定します。デフォルトは<literal>PostgreSQL</literal>です。このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+-->
+<application>event log</application>へのログ取得が有効になっていると、このパラメータはログ中の<productname>PostgreSQL</productname>メッセージを特定するのに使用されるプログラム名を決定します。デフォルトは<literal>PostgreSQL</literal>です。このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
        </para>
       </listitem>
      </varlistentry>
@@ -780,9 +780,9 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </variablelist>
     </sect2>
      <sect2 id="runtime-config-logging-when">
-     <!--
+<!--
      <title>When to Log</title>
-     -->
+-->
      <title>いつログを取得するか</title>
 
      <variablelist>
@@ -811,7 +811,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         <literal>LOG</literal> has a different rank here than in
         <xref linkend="guc-client-min-messages"/>.
         Only superusers can change this setting.
-       -->
+-->
 どの<link linkend="runtime-config-severity-levels">メッセージレベル</link>をサーバログに書き込むかを管理します。
 有効な値は<literal>DEBUG5</literal>、<literal>DEBUG4</literal>、<literal>DEBUG3</literal>、<literal>DEBUG2</literal>、<literal>DEBUG1</literal>、<literal>INFO</literal>、<literal>NOTICE</literal>、<literal>WARNING</literal>、<literal>ERROR</literal>、<literal>LOG</literal>、<literal>FATAL</literal>、および<literal>PANIC</literal>です。
 それぞれの階層はその下の全ての階層を含みます。階層を低くする程、より少ないメッセージがログに送られます。
@@ -833,7 +833,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls which SQL statements that cause an error
         condition are recorded in the server log.  The current
         SQL statement is included in the log entry for any message of
@@ -852,7 +852,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         To effectively turn off logging of failing statements,
         set this parameter to <literal>PANIC</literal>.
         Only superusers can change this setting.
-       -->
+-->
 エラー条件の原因となったどのSQL文をサーバログに記録するかを制御します。
 設定した<link linkend="runtime-config-severity-levels">レベル</link>以上のメッセージについては現在のSQL文がログに記録されます。
 有効な値は、<literal>DEBUG5</literal>、<literal>DEBUG4</literal>、<literal>DEBUG3</literal>、<literal>DEBUG2</literal>、<literal>DEBUG1</literal>、<literal>INFO</literal>、<literal>NOTICE</literal>、<literal>WARNING</literal>、<literal>ERROR</literal>、<literal>LOG</literal>、<literal>FATAL</literal>、<literal>PANIC</literal>です。
@@ -875,7 +875,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
        <listitem>
         <para>
-       <!--
+<!--
          Causes the duration of each completed statement to be logged
          if the statement ran for at least the specified amount of time.
          For example, if you set it to <literal>250ms</literal>
@@ -886,7 +886,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
          Setting this to zero prints all statement durations.
          <literal>-1</literal> (the default) disables logging statement
          durations. Only superusers can change this setting.
-        -->
+-->
 文の実行に少なくとも指定した時間かかった場合、それぞれの文の実行に要した時間をログに記録します。
 例えば、<literal>250ms</literal>と設定した場合、250msもしくはそれ以上長くかかった全てのSQL文がログとして残ります。
 このパラメータを有効にすることにより、アプリケーションで最適化されていない問い合わせを追跡するのが便利になります。
@@ -906,16 +906,16 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         </para>
 
         <para>
-       <!--
+<!--
          For clients using extended query protocol, durations of the Parse,
          Bind, and Execute steps are logged independently.
-        -->
-        拡張問い合わせプロトコルを使用するクライアントでは、Parse、Bind、Executeそれぞれの段階で要した時間が独立して記録されます。
+-->
+拡張問い合わせプロトコルを使用するクライアントでは、Parse、Bind、Executeそれぞれの段階で要した時間が独立して記録されます。
         </para>
 
        <note>
         <para>
-       <!--
+<!--
          When using this option together with
          <xref linkend="guc-log-statement"/>,
          the text of statements that are logged because of
@@ -926,8 +926,8 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
          <xref linkend="guc-log-line-prefix"/>
          so that you can link the statement message to the later
          duration message using the process ID or session ID.
-        -->
-        このオプションと<xref linkend="guc-log-statement"/>を一緒に使用する時、<varname>log_statement</varname>によってログされるテキスト文は、実行時間のログには重複されません。
+-->
+このオプションと<xref linkend="guc-log-statement"/>を一緒に使用する時、<varname>log_statement</varname>によってログされるテキスト文は、実行時間のログには重複されません。
 <application>syslog</application>を使用していなければ、プロセスIDとセッションIDを使用して、文メッセージと後の実行時間メッセージを関連付けできるように、<xref linkend="guc-log-line-prefix"/>を使用してPIDまたはセッションIDをログに記録することを勧めます。
         </para>
        </note>
@@ -1074,21 +1074,21 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
      </variablelist>
 
     <para>
-    <!--
+<!--
      <xref linkend="runtime-config-severity-levels"/> explains the message
      severity levels used by <productname>PostgreSQL</productname>.  If logging output
      is sent to <systemitem>syslog</systemitem> or Windows'
      <systemitem>eventlog</systemitem>, the severity levels are translated
      as shown in the table.
-     -->
-     <xref linkend="runtime-config-severity-levels"/>で、<productname>PostgreSQL</productname>で使用されるメッセージ深刻度レベルを説明します。
+-->
+<xref linkend="runtime-config-severity-levels"/>で、<productname>PostgreSQL</productname>で使用されるメッセージ深刻度レベルを説明します。
 ログ出力が<systemitem>syslog</systemitem>またはWindowsの<systemitem>eventlog</systemitem>に送られる場合、この深刻度レベルは表で示すように変換されます。
     </para>
 
     <table id="runtime-config-severity-levels">
-    <!--
+<!--
      <title>Message Severity Levels</title>
-     -->
+-->
      <title>メッセージ深刻度レベル</title>
      <tgroup cols="4">
       <colspec colname="col1" colwidth="1*"/>
@@ -1097,13 +1097,13 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       <colspec colname="col4" colwidth="1*"/>
       <thead>
        <row>
-       <!--
+<!--
         <entry>Severity</entry>
         <entry>Usage</entry>
         <entry><systemitem>syslog</systemitem></entry>
         <entry><systemitem>eventlog</systemitem></entry>
-       -->
-       <entry>深刻度</entry>
+-->
+        <entry>深刻度</entry>
         <entry>使用方法</entry>
         <entry><systemitem>syslog</systemitem></entry>
         <entry><systemitem>eventlog</systemitem></entry>
@@ -1113,10 +1113,10 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       <tbody>
        <row>
         <entry><literal>DEBUG1 .. DEBUG5</literal></entry>
-       <!--
+<!--
         <entry>Provides successively-more-detailed information for use by
          developers.</entry>
-        -->
+-->
         <entry>開発者が使用する連続的かつより詳細な情報を提供します。</entry>
         <entry><literal>DEBUG</literal></entry>
         <entry><literal>INFORMATION</literal></entry>
@@ -1124,46 +1124,46 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
 
        <row>
         <entry><literal>INFO</literal></entry>
-       <!--
+<!--
         <entry>Provides information implicitly requested by the user,
          e.g., output from <command>VACUUM VERBOSE</command>.</entry>
-        -->
+-->
         <entry><command>VACUUM VERBOSE</command>の出力などの、
-        ユーザによって暗黙的に要求された情報を提供します。</entry>
+ユーザによって暗黙的に要求された情報を提供します。</entry>
         <entry><literal>INFO</literal></entry>
         <entry><literal>INFORMATION</literal></entry>
        </row>
 
        <row>
         <entry><literal>NOTICE</literal></entry>
-       <!--
+<!--
         <entry>Provides information that might be helpful to users, e.g.,
          notice of truncation of long identifiers.</entry>
-        -->
+-->
         <entry>長い識別子の切り詰めに関する注意など、
-        ユーザの補助になる情報を提供します。</entry>
+ユーザの補助になる情報を提供します。</entry>
         <entry><literal>NOTICE</literal></entry>
         <entry><literal>INFORMATION</literal></entry>
        </row>
 
        <row>
         <entry><literal>WARNING</literal></entry>
-       <!--
+<!--
         <entry>Provides warnings of likely problems, e.g., <command>COMMIT</command>
          outside a transaction block.</entry>
-        -->
+-->
         <entry>トランザクションブロック外での<command>COMMIT</command>の様な、
-        ユーザへの警告を提供します。</entry>
+ユーザへの警告を提供します。</entry>
         <entry><literal>NOTICE</literal></entry>
         <entry><literal>WARNING</literal></entry>
        </row>
 
        <row>
         <entry><literal>ERROR</literal></entry>
-       <!--
+<!--
         <entry>Reports an error that caused the current command to
          abort.</entry>
-        -->
+-->
         <entry>現在のコマンドを中断させる原因となったエラーを報告します。</entry>
         <entry><literal>WARNING</literal></entry>
         <entry><literal>ERROR</literal></entry>
@@ -1171,22 +1171,22 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
 
        <row>
         <entry><literal>LOG</literal></entry>
-       <!--
+<!--
         <entry>Reports information of interest to administrators, e.g.,
          checkpoint activity.</entry>
-        -->
+-->
         <entry>チェックポイントの活動の様な、
-        管理者に関心のある情報を報告します。</entry>
+管理者に関心のある情報を報告します。</entry>
         <entry><literal>INFO</literal></entry>
         <entry><literal>INFORMATION</literal></entry>
        </row>
 
        <row>
         <entry><literal>FATAL</literal></entry>
-       <!--
+<!--
         <entry>Reports an error that caused the current session to
          abort.</entry>
-        -->
+-->
         <entry>現在のセッションを中断させる原因となったエラーを報告します。</entry>
         <entry><literal>ERR</literal></entry>
         <entry><literal>ERROR</literal></entry>
@@ -1194,10 +1194,10 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
 
        <row>
         <entry><literal>PANIC</literal></entry>
-       <!--
+<!--
         <entry>Reports an error that caused all database sessions to abort.</entry>
-       -->
-       <entry>全てのデータベースセッションを中断させる原因となったエラーを報告します。</entry>
+-->
+        <entry>全てのデータベースセッションを中断させる原因となったエラーを報告します。</entry>
         <entry><literal>CRIT</literal></entry>
         <entry><literal>ERROR</literal></entry>
        </row>
@@ -1207,9 +1207,9 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
 
     </sect2>
      <sect2 id="runtime-config-logging-what">
-     <!--
+<!--
      <title>What to Log</title>
-     -->
+-->
      <title>何をログに</title>
 
      <variablelist>
@@ -1225,7 +1225,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The <varname>application_name</varname> can be any string of less than
         <symbol>NAMEDATALEN</symbol> characters (64 characters in a standard build).
         It is typically set by an application upon connection to the server.
@@ -1235,7 +1235,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         Only printable ASCII characters may be used in the
         <varname>application_name</varname> value. Other characters will be
         replaced with question marks (<literal>?</literal>).
-       -->
+-->
 <varname>application_name</varname>は<symbol>NAMEDATALEN</symbol>（標準構築では64）文字以下の任意の文字列を指定できます。
 通常はサーバへの接続時にアプリケーションによって設定されます。
 この名前は <structname>pg_stat_activity</structname>ビューに表示され、CSVログに含まれます。
@@ -1272,7 +1272,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         These parameters enable various debugging output to be emitted.
         When set, they print the resulting parse tree, the query rewriter
         output, or the execution plan for each executed query.
@@ -1282,12 +1282,12 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         <xref linkend="guc-client-min-messages"/> and/or
         <xref linkend="guc-log-min-messages"/>.
         These parameters are off by default.
-       -->
-       これらのパラメータは生成される各種デバッグ出力を有効にします。
-       設定すると実行された問い合わせそれぞれに対し、最終的な解析ツリー、問い合わせリライタの出力、実行計画を出力します。
-       これらのメッセージは<literal>LOG</literal>メッセージレベルで出力されますので、デフォルトではサーバログに出力され、クライアントには渡されません。
-       <xref linkend="guc-client-min-messages"/>、<xref linkend="guc-log-min-messages"/>またはその両方を調整することで変更することができます。
-       デフォルトではこれらのパラメータは無効です。
+-->
+これらのパラメータは生成される各種デバッグ出力を有効にします。
+設定すると実行された問い合わせそれぞれに対し、最終的な解析ツリー、問い合わせリライタの出力、実行計画を出力します。
+これらのメッセージは<literal>LOG</literal>メッセージレベルで出力されますので、デフォルトではサーバログに出力され、クライアントには渡されません。
+<xref linkend="guc-client-min-messages"/>、<xref linkend="guc-log-min-messages"/>またはその両方を調整することで変更することができます。
+デフォルトではこれらのパラメータは無効です。
        </para>
       </listitem>
      </varlistentry>
@@ -1303,14 +1303,14 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When set, <varname>debug_pretty_print</varname> indents the messages
         produced by <varname>debug_print_parse</varname>,
         <varname>debug_print_rewritten</varname>, or
         <varname>debug_print_plan</varname>.  This results in more readable
         but much longer output than the <quote>compact</quote> format used when
         it is off.  It is on by default.
-       -->
+-->
 設定された場合、<varname>debug_pretty_print</varname>は<varname>debug_print_parse</varname>、<varname>debug_print_rewritten</varname>、または<varname>debug_print_plan</varname>で生成されたメッセージを字下げします。
 設定されない場合の<quote>コンパクト</quote>形式よりもより見やすく、しかしより長いものとなります。デフォルトは有効です。
        </para>
@@ -1370,15 +1370,15 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Causes checkpoints and restartpoints to be logged in the server log.
         Some statistics are included in the log messages, including the number
         of buffers written and the time spent writing them.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line. The default is off.
-       -->
-       チェックポイントおよびリスタートポイントをサーバログに記録するようにします。
-       書き出されたバッファ数や書き出しに要した時間など、いくつかの統計情報がこのログメッセージに含まれます。
+-->
+チェックポイントおよびリスタートポイントをサーバログに記録するようにします。
+書き出されたバッファ数や書き出しに要した時間など、いくつかの統計情報がこのログメッセージに含まれます。
 このパラメータは<filename>postgresql.conf</filename>ファイルまたはサーバのコマンドラインでのみ設定可能です。
 デフォルトはoffです。
        </para>
@@ -1396,14 +1396,14 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Causes each attempted connection to the server to be logged,
         as well as successful completion of both client authentication (if
         necessary) and authorization.
         Only superusers can change this parameter at session start,
         and it cannot be changed at all within a session.
         The default is <literal>off</literal>.
-       -->
+-->
 サーバへの接続試行とともに、クライアント認証の成功終了と（必要ならば）承認をログに残します。
 スーパーユーザだけがセッション開始時にこのパラメータを変更でき、セッションが開始された後は変更できません。
 デフォルトは<literal>off</literal>です。
@@ -1411,13 +1411,13 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
 
        <note>
         <para>
-       <!--
+<!--
          Some client programs, like <application>psql</application>, attempt
          to connect twice while determining if a password is required, so
          duplicate <quote>connection received</quote> messages do not
          necessarily indicate a problem.
-        -->
-        <application>psql</application>などクライアントプログラムは、パスワードが要求されているかどうか確認するまで2回接続を試みるので、二重の<quote>connection received</quote>メッセージは必ずしも問題を示すものではありません。
+-->
+<application>psql</application>などクライアントプログラムは、パスワードが要求されているかどうか確認するまで2回接続を試みるので、二重の<quote>connection received</quote>メッセージは必ずしも問題を示すものではありません。
         </para>
        </note>
       </listitem>
@@ -1434,14 +1434,14 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Causes session terminations to be logged.  The log output
         provides information similar to <varname>log_connections</varname>,
         plus the duration of the session.
         Only superusers can change this parameter at session start,
         and it cannot be changed at all within a session.
         The default is <literal>off</literal>.
-       -->
+-->
 セッションの終了をログします。
 ログ出力の情報は<varname>log_connections</varname>と同様で、更にセッションの経過時間が追加されます。
 スーパーユーザだけがセッション開始時にこのパラメータを変更でき、セッションが開始された後は変更できません。
@@ -1462,27 +1462,27 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Causes the duration of every completed statement to be logged.
         The default is <literal>off</literal>.
         Only superusers can change this setting.
-       -->
-       すべての完了した文について、その経過時間をログするようにします。
+-->
+すべての完了した文について、その経過時間をログするようにします。
 デフォルトは<literal>off</literal>です。
 スーパーユーザのみがこの設定を変更することができます。
        </para>
 
        <para>
-       <!--
+<!--
         For clients using extended query protocol, durations of the Parse,
         Bind, and Execute steps are logged independently.
-       -->
-       拡張問い合わせプロトコルを使用するクライアントでは、Parse、Bind、Executeそれぞれの段階で要した時間が独立して記録されます。
+-->
+拡張問い合わせプロトコルを使用するクライアントでは、Parse、Bind、Executeそれぞれの段階で要した時間が独立して記録されます。
        </para>
 
        <note>
         <para>
-       <!--
+<!--
          The difference between enabling <varname>log_duration</varname> and setting
          <xref linkend="guc-log-min-duration-statement"/> to zero is that
          exceeding <varname>log_min_duration_statement</varname> forces the text of
@@ -1492,7 +1492,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
          durations are logged but the query text is included only for
          statements exceeding the threshold.  This behavior can be useful for
          gathering statistics in high-load installations.
-        -->
+-->
 <varname>log_duration</varname>を有効にするのと<xref linkend="guc-log-min-duration-statement"/>を0に設定する方法との違いは、<varname>log_min_duration_statement</varname>を超えた場合、テキスト版の問い合わせが強制的に出力されるのに対して、このオプションでは出力されないという点です。
 したがって、<varname>log_duration</varname>が<literal>on</literal>、かつ、<varname>log_min_duration_statement</varname>が正の値を持つ場合、すべての経過時間がログに記録されますが、閾値を超えた文のみがテキスト版の問い合わせが含められるようになります。
 この動作は、高負荷なインストレーションで統計情報を収集する際に有用です。
@@ -1512,7 +1512,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls the amount of detail written in the server log for each
         message that is logged.  Valid values are <literal>TERSE</literal>,
         <literal>DEFAULT</literal>, and <literal>VERBOSE</literal>, each adding more
@@ -1523,12 +1523,12 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
         code (see also <xref linkend="errcodes-appendix"/>) and the source code file name, function name,
         and line number that generated the error.
         Only superusers can change this setting.
-       -->
-       ログ取得されるそれぞれのメッセージに対し、サーバログに書き込まれる詳細の量を制御します。
-       有効な値は、<literal>TERSE</literal>、<literal>DEFAULT</literal>、および<literal>VERBOSE</literal>で、それぞれは表示されるメッセージにより多くのフィールドを追加します。
+-->
+ログ取得されるそれぞれのメッセージに対し、サーバログに書き込まれる詳細の量を制御します。
+有効な値は、<literal>TERSE</literal>、<literal>DEFAULT</literal>、および<literal>VERBOSE</literal>で、それぞれは表示されるメッセージにより多くのフィールドを追加します。
        <literal>TERSE</literal>は<literal>DETAIL</literal>、<literal>HINT</literal>、<literal>QUERY</literal>、および<literal>CONTEXT</literal>エラー情報を除外します。
        <literal>VERBOSE</literal>出力は、<symbol>SQLSTATE</symbol>エラーコード（<xref linkend="errcodes-appendix"/>も参照）、および、ソースコードファイル名、関数名、そしてエラーを生成した行番号を含みます。
-       スーパーユーザのみこの設定を変更できます。
+スーパーユーザのみこの設定を変更できます。
        </para>
       </listitem>
      </varlistentry>
@@ -1544,15 +1544,15 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         By default, connection log messages only show the IP address of the
         connecting host. Turning this parameter on causes logging of the
         host name as well.  Note that depending on your host name resolution
         setup this might impose a non-negligible performance penalty.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
-       デフォルトでは、接続ログメッセージは接続元ホストのIPアドレスのみを表示します。
+-->
+デフォルトでは、接続ログメッセージは接続元ホストのIPアドレスのみを表示します。
 このパラメータを有効にすると、ホスト名もログに残るようになります。
 ホスト名解決方法の設定に依存しますが、これが無視できないほどの性能劣化を起こす可能性があることに注意してください。
 このパラメータは<filename>postgresql.conf</filename>ファイル内またはサーバのコマンドラインでのみ設定可能です。
@@ -1571,7 +1571,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
          This is a <function>printf</function>-style string that is output at the
          beginning of each log line.
          <literal>%</literal> characters begin <quote>escape sequences</quote>
@@ -1586,7 +1586,7 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
          right with spaces to give it a minimum width, whereas a positive
          value will pad on the left. Padding can be useful to aid human
          readability in log files.
-         -->
+-->
 これは、各ログ行の先頭に出力する<function>printf</function>の書式文字列です。
 <literal>%</literal>から始まる<quote>エスケープシーケンス</quote>は、後述の通りのステータス情報で置き換えられます。
 この他のエスケープは無視されます。
@@ -1611,11 +1611,11 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
           <tgroup cols="3">
            <thead>
             <row>
-           <!--
+<!--
              <entry>Escape</entry>
              <entry>Effect</entry>
              <entry>Session only</entry>
-            -->
+-->
             <entry>エスケープ</entry>
              <entry>効果</entry>
              <entry>セッションのみ</entry>
@@ -1624,160 +1624,179 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
            <tbody>
             <row>
              <entry><literal>%a</literal></entry>
-            <!--
+<!--
              <entry>Application name</entry>
-            -->
-            <entry>アプリケーション名</entry>
-             <entry><!--yes-->○</entry>
+             <entry>yes</entry>
+-->
+             <entry>アプリケーション名</entry>
+             <entry>○</entry>
             </row>
             <row>
              <entry><literal>%u</literal></entry>
-            <!--
+<!--
              <entry>User name</entry>
-            -->
-            <entry>ユーザ名</entry>
-             <entry><!--yes-->○</entry>
+             <entry>yes</entry>
+-->
+             <entry>ユーザ名</entry>
+             <entry>○</entry>
             </row>
             <row>
              <entry><literal>%d</literal></entry>
-            <!--
+<!--
              <entry>Database name</entry>
-            -->
-            <entry>データベース名</entry>
-             <entry><!--yes-->○</entry>
+             <entry>yes</entry>
+-->
+             <entry>データベース名</entry>
+             <entry>○</entry>
             </row>
             <row>
              <entry><literal>%r</literal></entry>
-            <!--
+<!--
              <entry>Remote host name or IP address, and remote port</entry>
-            -->
-            <entry>遠隔ホスト名、またはIPアドレス、およびポート番号</entry>
-             <entry><!--yes-->○</entry>
+             <entry>yes</entry>
+-->
+             <entry>遠隔ホスト名、またはIPアドレス、およびポート番号</entry>
+             <entry>○</entry>
             </row>
             <row>
              <entry><literal>%h</literal></entry>
-            <!--
+<!--
              <entry>Remote host name or IP address</entry>
-            -->
-            <entry>遠隔ホスト名、またはIPアドレス</entry>
-             <entry><!--yes-->○</entry>
+             <entry>yes</entry>
+-->
+             <entry>遠隔ホスト名、またはIPアドレス</entry>
+             <entry>○</entry>
             </row>
             <row>
              <entry><literal>%b</literal></entry>
 <!--
              <entry>Backend type</entry>
+             <entry>no</entry>
 -->
              <entry>バックエンドタイプ</entry>
-             <entry><!--no-->×</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%p</literal></entry>
-            <!--
+<!--
              <entry>Process ID</entry>
-            -->
-            <entry>プロセス識別子</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>プロセス識別子</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%P</literal></entry>
 <!--
              <entry>Process ID of the parallel group leader, if this process
               is a parallel query worker</entry>
+             <entry>no</entry>
 -->
 <entry>このプロセスがパラレルクエリワーカである場合に、パラレルグループリーダのプロセス識別子</entry>
-             <entry><!--no-->×</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%t</literal></entry>
-            <!--
+<!--
              <entry>Time stamp without milliseconds</entry>
-            -->
-            <entry>ミリ秒無しのタイムスタンプ</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>ミリ秒無しのタイムスタンプ</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%m</literal></entry>
-            <!--
+<!--
              <entry>Time stamp with milliseconds</entry>
-            -->
-            <entry>ミリ秒付きタイムスタンプ</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>ミリ秒付きタイムスタンプ</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%n</literal></entry>
 <!--
              <entry>Time stamp with milliseconds (as a Unix epoch)</entry>
+             <entry>no</entry>
 -->
              <entry>ミリ秒付きタイムスタンプ（Unixエポックとして）</entry>
-             <entry><!--no-->×</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%i</literal></entry>
-            <!--
+<!--
              <entry>Command tag: type of session's current command</entry>
-            -->
-            <entry>コマンドタグ。セッションの現在のコマンド種類</entry>
-             <entry><!--yes-->○</entry>
+             <entry>yes</entry>
+-->
+             <entry>コマンドタグ。セッションの現在のコマンド種類</entry>
+             <entry>○</entry>
             </row>
             <row>
              <entry><literal>%e</literal></entry>
-            <!--
+<!--
              <entry>SQLSTATE error code</entry>
-            -->
-            <entry>SQLSTATE エラーコード</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>SQLSTATE エラーコード</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%c</literal></entry>
-            <!--
+<!--
              <entry>Session ID: see below</entry>
-            -->
-            <entry>セッションID。下記参照</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>セッションID。下記参照</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%l</literal></entry>
-            <!--
+<!--
              <entry>Number of the log line for each session or process, starting at 1</entry>
-            -->
-            <entry>各セッションまたは各プロセスのログ行の番号。1から始まります。</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>各セッションまたは各プロセスのログ行の番号。1から始まります。</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%s</literal></entry>
-            <!--
+<!--
              <entry>Process start time stamp</entry>
-            -->
-            <entry>プロセスの開始タイムスタンプ</entry>
-            <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>プロセスの開始タイムスタンプ</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%v</literal></entry>
-            <!--
+<!--
              <entry>Virtual transaction ID (backendID/localXID)</entry>
-            -->
-            <entry>仮想トランザクションID（backendID/localXID）</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>仮想トランザクションID（backendID/localXID）</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%x</literal></entry>
-            <!--
+<!--
              <entry>Transaction ID (0 if none is assigned)</entry>
-            -->
-            <entry>トランザクションID （未割り当ての場合は0）</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>トランザクションID （未割り当ての場合は0）</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%q</literal></entry>
-            <!--
+<!--
              <entry>Produces no output, but tells non-session
              processes to stop at this point in the string; ignored by
              session processes</entry>
-            -->
-            <entry>何も出力しません。
-            非セッションプロセスではこのエスケープ以降の出力を停止します。
-            セッションプロセスでは無視されます。</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry>何も出力しません。
+非セッションプロセスではこのエスケープ以降の出力を停止します。
+セッションプロセスでは無視されます。</entry>
+             <entry>×</entry>
             </row>
             <row>
              <entry><literal>%Q</literal></entry>
@@ -1787,18 +1806,20 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
              will be zero unless <xref linkend="guc-compute-query-id"/>
              parameter is enabled or a third-party module that computes
              query identifiers is configured.</entry>
+             <entry>yes</entry>
 -->
              <entry>現在の問い合わせの問い合わせ識別子。
-               問い合わせ識別子はデフォルトでは計算されません。ですから<xref linkend="guc-compute-query-id"/>パラメータが有効であるか、あるいは問い合わせ識別子を計算するサードパーティのモジュールが設定されていないければゼロとなります。</entry>
-             <entry><!--yes-->○</entry>
+問い合わせ識別子はデフォルトでは計算されません。ですから<xref linkend="guc-compute-query-id"/>パラメータが有効であるか、あるいは問い合わせ識別子を計算するサードパーティのモジュールが設定されていないければゼロとなります。</entry>
+             <entry>○</entry>
             </row>
             <row>
              <entry><literal>%%</literal></entry>
-            <!--
+<!--
              <entry>Literal <literal>%</literal></entry>
-            -->
-            <entry><literal>%</literal>文字そのもの</entry>
-             <entry><!--no-->×</entry>
+             <entry>no</entry>
+-->
+             <entry><literal>%</literal>文字そのもの</entry>
+             <entry>×</entry>
             </row>
            </tbody>
           </tgroup>
@@ -1817,15 +1838,15 @@ CSV書式の出力が<varname>log_destination</varname>で有効な場合、タ�
          </para>
 
          <para>
-        <!--
+<!--
          The <literal>%c</literal> escape prints a quasi-unique session identifier,
          consisting of two 4-byte hexadecimal numbers (without leading zeros)
          separated by a dot.  The numbers are the process start time and the
          process ID, so <literal>%c</literal> can also be used as a space saving way
          of printing those items.  For example, to generate the session
          identifier from <literal>pg_stat_activity</literal>, use this query:
-        -->
-        <literal>%c</literal>エスケープは、2つの4バイトの16進数（先頭のゼロは省略）をドットで区切った構成の、準一意なセッション識別子を表示します。
+-->
+<literal>%c</literal>エスケープは、2つの4バイトの16進数（先頭のゼロは省略）をドットで区切った構成の、準一意なセッション識別子を表示します。
 この数値はプロセスの起動時間とそのプロセスIDです。
 したがって、<literal>%c</literal>を使用して、これらの項目を出力するための文字数を省略することができます。例として、<literal>pg_stat_activity</literal>からセッション識別子を生成するには以下の問い合わせを行ないます。
 <programlisting>
@@ -1838,25 +1859,25 @@ FROM pg_stat_activity;
 
        <tip>
         <para>
-       <!--
+<!--
          If you set a nonempty value for <varname>log_line_prefix</varname>,
          you should usually make its last character be a space, to provide
          visual separation from the rest of the log line.  A punctuation
          character can be used too.
-        -->
-        <varname>log_line_prefix</varname>に空白文字以外の値を設定する場合、通常、ログ行の残りとの区切りを明確にするために、その最後の文字を空白文字にすべきです。
+-->
+<varname>log_line_prefix</varname>に空白文字以外の値を設定する場合、通常、ログ行の残りとの区切りを明確にするために、その最後の文字を空白文字にすべきです。
 句読点用の文字も使用できます。
         </para>
        </tip>
 
        <tip>
         <para>
-       <!--
+<!--
          <application>Syslog</application> produces its own
          time stamp and process ID information, so you probably do not want to
          include those escapes if you are logging to <application>syslog</application>.
-        -->
-        <application>Syslog</application>は独自にタイムスタンプとプロセスID情報を生成します。
+-->
+<application>Syslog</application>は独自にタイムスタンプとプロセスID情報を生成します。
 ですのでおそらく、<application>Syslog</application>にログを保管する場合は、こうしたエスケープを含めるとは考えないでしょう。
         </para>
        </tip>
@@ -1902,13 +1923,13 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls whether a log message is produced when a session waits
         longer than <xref linkend="guc-deadlock-timeout"/> to acquire a
         lock.  This is useful in determining if lock waits are causing
         poor performance.  The default is <literal>off</literal>.
         Only superusers can change this setting.
-       -->
+-->
 セッションがロックの獲得までの間に<xref linkend="guc-deadlock-timeout"/>より長く待機する場合にログメッセージを生成するかどうかを制御します。
 これは、ロック待ちによって性能がでていないのかどうか確認する時に有用です。
 デフォルトは<literal>off</literal>です。
@@ -1920,9 +1941,9 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      <varlistentry id="guc-log-recovery-conflict-waits" xreflabel="log_recovery_conflict_waits">
       <term><varname>log_recovery_conflict_waits</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>log_recovery_conflict_waits</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>log_recovery_conflict_waits</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2046,7 +2067,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls which SQL statements are logged. Valid values are
         <literal>none</literal> (off), <literal>ddl</literal>, <literal>mod</literal>, and
         <literal>all</literal> (all statements). <literal>ddl</literal> logs all data definition
@@ -2062,7 +2083,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
         extended query protocol, logging occurs when an Execute message
         is received, and values of the Bind parameters are included
         (with any embedded single-quote marks doubled).
-       -->
+-->
 どのSQL文をログに記録するかを制御します。
 有効な値は、<literal>none</literal>（off）、<literal>ddl</literal>、<literal>mod</literal>、および<literal>all</literal>（全てのメッセージ）です。
 <literal>ddl</literal>は、<command>CREATE</command>、<command>ALTER</command>、および<command>DROP</command>文といった、データ定義文を全てログに記録します。
@@ -2072,16 +2093,16 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
        </para>
 
        <para>
-       <!--
+<!--
         The default is <literal>none</literal>. Only superusers can change this
         setting.
-       -->
-       デフォルトは<literal>none</literal>です。スーパーユーザのみこの設定を変更できます。
+-->
+デフォルトは<literal>none</literal>です。スーパーユーザのみこの設定を変更できます。
        </para>
 
        <note>
         <para>
-       <!--
+<!--
          Statements that contain simple syntax errors are not logged
          even by the <varname>log_statement</varname> = <literal>all</literal> setting,
          because the log message is emitted only after basic parsing has
@@ -2090,7 +2111,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
          fail before the Execute phase (i.e., during parse analysis or
          planning).  Set <varname>log_min_error_statement</varname> to
          <literal>ERROR</literal> (or lower) to log such statements.
-        -->
+-->
 ログメッセージの発行は、基本解析により文の種類が決まった後に行われますので、<varname>log_statement</varname> = <literal>all</literal>という設定を行ったとしても、単純な構文エラーを持つ文は記録されません。
 拡張問い合わせプロトコルの場合も同様に、この設定ではExecute段階以前（つまり、解析や計画作成期間）に失敗した文は記録されません。
 こうした文のログを記録するには、<varname>log_min_error_statement</varname>を<literal>ERROR</literal>（以下）に設定してください。
@@ -2135,7 +2156,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls logging of temporary file names and sizes.
         Temporary files can be
         created for sorts, hashes, and temporary query results.
@@ -2147,7 +2168,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
         If this value is specified without units, it is taken as kilobytes.
         The default setting is -1, which disables such logging.
         Only superusers can change this setting.
-       -->
+-->
 一時ファイルのファイル名とサイズのログ出力を制御します。
 一時ファイルはソート処理やハッシュ処理、一時的な問い合わせの結果のために作成されます。
 有効にすると、ログの項目はすべての一時ファイルそれぞれについて削除されたときに生成されます。
@@ -2171,7 +2192,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the time zone used for timestamps written in the server log.
         Unlike <xref linkend="guc-timezone"/>, this value is cluster-wide,
         so that all sessions will report timestamps consistently.
@@ -2181,7 +2202,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
         See <xref linkend="datatype-timezones"/> for more information.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 サーバログに書き出す際に使用される時間帯を設定します。
 <xref linkend="guc-timezone"/>と異なり、すべてのセッションで一貫性を持ってタイムスタンプが報告されるようにこの値はクラスタ全体に適用されます。
 組み込まれているデフォルトは<literal>GMT</literal>ですが、<filename>postgresql.conf</filename>により通常は上書きされます。<application>initdb</application>によりこれらと関連した設定をシステム環境にインストールされます。
@@ -2194,13 +2215,13 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
      </variablelist>
     </sect2>
      <sect2 id="runtime-config-logging-csvlog">
-     <!--
+<!--
      <title>Using CSV-Format Log Output</title>
-     -->
+-->
      <title>CSV書式のログ出力の利用</title>
 
        <para>
-       <!--
+<!--
         Including <literal>csvlog</literal> in the <varname>log_destination</varname> list
         provides a convenient way to import log files into a database table.
         This option emits log lines in comma-separated-values
@@ -2233,29 +2254,29 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
         application name, backend type, process ID of parallel group leader,
         and query id.
         Here is a sample table definition for storing CSV-format log output:
-       -->
-       <varname>log_destination</varname>リストに<literal>csvlog</literal>を含めることは、ログファイルをデータベーステーブルにインポートする簡便な方法を提供します。このオプションはカンマ区切り値書式（<acronym>CSV</acronym>）で以下の列を含むログ行を生成します。
-        ミリ秒単位のtimestamp、
-        ユーザ名、
-        データベース名、
-        プロセス識別子、
-        クライアントホスト：ポート番号、
-        セッション識別子、
-        セッション前行番号、
-        コマンドタグ、
-        セッション開始時間、
-        仮想トランザクション識別子、
-        通常トランザクション識別子、
-        エラーの深刻度、
-        SQL状態コード、
-        エラーメッセージ、
-        詳細エラーメッセージ、
-        ヒント、
-        エラーとなった内部的な問い合わせ（もしあれば）、
-        内部問い合わせにおけるエラー位置の文字数、
-        エラーの文脈、
-        PostgreSQLソースコード上のエラー発生場所（<varname>log_error_verbosity</varname>が<literal>verbose</literal>に設定されているならば）
-        アプリケーション名、バックエンドタイプ、パラレルグループリーダのプロセスID、問い合わせID。
+-->
+<varname>log_destination</varname>リストに<literal>csvlog</literal>を含めることは、ログファイルをデータベーステーブルにインポートする簡便な方法を提供します。このオプションはカンマ区切り値書式（<acronym>CSV</acronym>）で以下の列を含むログ行を生成します。
+ミリ秒単位のtimestamp、
+ユーザ名、
+データベース名、
+プロセス識別子、
+クライアントホスト：ポート番号、
+セッション識別子、
+セッション前行番号、
+コマンドタグ、
+セッション開始時間、
+仮想トランザクション識別子、
+通常トランザクション識別子、
+エラーの深刻度、
+SQL状態コード、
+エラーメッセージ、
+詳細エラーメッセージ、
+ヒント、
+エラーとなった内部的な問い合わせ（もしあれば）、
+内部問い合わせにおけるエラー位置の文字数、
+エラーの文脈、
+PostgreSQLソースコード上のエラー発生場所（<varname>log_error_verbosity</varname>が<literal>verbose</literal>に設定されているならば）
+アプリケーション名、バックエンドタイプ、パラレルグループリーダのプロセスID、問い合わせID。
 以下にcsvlog出力を格納するためのテーブル定義のサンプルを示します。
 
 <programlisting>
@@ -2293,11 +2314,11 @@ CREATE TABLE postgres_log
        </para>
 
        <para>
-       <!--
+<!--
         To import a log file into this table, use the <command>COPY FROM</command>
         command:
-       -->
-       このテーブルにインポートするためには、<command>COPY FROM</command>コマンドを使用してください。
+-->
+このテーブルにインポートするためには、<command>COPY FROM</command>コマンドを使用してください。
 
 <programlisting>
 COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
@@ -2310,35 +2331,35 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
        </para>
 
        <para>
-       <!--
+<!--
        There are a few things you need to do to simplify importing CSV log
        files:
-       -->
+-->
        CSVログファイルをインポートする作業を単純にするためにいくつか必要な作業があります。
 
        <orderedlist>
          <listitem>
            <para>
-          <!--
+<!--
             Set <varname>log_filename</varname> and
             <varname>log_rotation_age</varname> to provide a consistent,
             predictable naming scheme for your log files.  This lets you
             predict what the file name will be and know when an individual log
             file is complete and therefore ready to be imported.
-           -->
-           一貫性があり、予測可能なログファイル命名機構を提供するために、<varname>log_filename</varname>および<varname>log_rotation_age</varname>を設定してください。
+-->
+一貫性があり、予測可能なログファイル命名機構を提供するために、<varname>log_filename</varname>および<varname>log_rotation_age</varname>を設定してください。
 これによりどのようなファイル名になると、個々のログファイルが完了しインポートする準備が整ったかが推測できるようになります。
          </para>
         </listitem>
 
         <listitem>
            <para>
-          <!--
+<!--
             Set <varname>log_rotation_size</varname> to 0 to disable
             size-based log rotation, as it makes the log file name difficult
             to predict.
-           -->
-           ログファイル名の予測が困難になりますので、<varname>log_rotation_size</varname>を0にして容量を基にしたログの回転を無効にしてください。
+-->
+ログファイル名の予測が困難になりますので、<varname>log_rotation_size</varname>を0にして容量を基にしたログの回転を無効にしてください。
            </para>
         </listitem>
 
@@ -2354,7 +2375,7 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
 
         <listitem>
           <para>
-         <!--
+<!--
            The table definition above includes a primary key specification.
            This is useful to protect against accidentally importing the same
            information twice.  The <command>COPY</command> command commits all of the
@@ -2365,8 +2386,8 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
            closed before importing.  This procedure will also protect against
            accidentally importing a partial line that hasn't been completely
            written, which would also cause <command>COPY</command> to fail.
-          -->
-          上のテーブル定義には主キーの指定が含まれています。
+-->
+上のテーブル定義には主キーの指定が含まれています。
 これにより、同じ情報が2回インポートされる事故を防止するために有用です。
 <command>COPY</command>コマンドは、一度にインポートするすべてのデータをコミットしますので、何か1つでもエラーがあればインポート全体が失敗します。
 ログファイルの一部をインポートし、そのファイルが完了した後に再度インポートしようとした場合、主キー違反によりインポートが失敗します。
@@ -2470,26 +2491,26 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
   </sect1>
 
    <sect1 id="runtime-config-statistics">
-   <!--
+<!--
     <title>Run-time Statistics</title>
-    -->
+-->
     <title>実行時統計情報</title>
 
     <sect2 id="runtime-config-statistics-collector">
-    <!--
+<!--
      <title>Query and Index Statistics Collector</title>
-     -->
+-->
      <title>問い合わせおよびインデックスに関する統計情報コレクタ</title>
 
      <para>
-     <!--
+<!--
       These parameters control server-wide statistics collection features.
       When statistics collection is enabled, the data that is produced can be
       accessed via the <structname>pg_stat</structname> and
       <structname>pg_statio</structname> family of system views.
       Refer to <xref linkend="monitoring"/> for more information.
-      -->
-      これらのパラメータは、サーバ全体の統計情報収集機能を制御します。
+-->
+これらのパラメータは、サーバ全体の統計情報収集機能を制御します。
 統計情報収集が有効ならば、生成されるデータは<structname>pg_stat</structname>と<structname>pg_statio</structname>系のシステムビュー経由でアクセス可能です。
 詳細は<xref linkend="monitoring"/>を参照してください。
      </para>
@@ -2507,7 +2528,7 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables the collection of information on the currently
         executing command of each session, along with its identifier and the
         time when that command began execution. This parameter is on by
@@ -2516,7 +2537,7 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
         the session being reported on, so it should not represent a
         security risk.
         Only superusers can change this setting.
-       -->
+-->
 各セッションで実行中のコマンドに関する情報と、そのコマンドの識別子および実行開始時刻の収集を有効にします。
 このパラメータはデフォルトで有効です。
 有効な場合であっても、すべてのユーザがこの情報を見ることができず、スーパーユーザと報告されたセッションの所有者のみから可視である点に注意してください。
@@ -2537,14 +2558,14 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
       </term>
       <listitem>
        <para>
-       <!--
+<!--
        Specifies the amount of memory reserved to store the text of the
        currently executing command for each active session, for the
        <structname>pg_stat_activity</structname>.<structfield>query</structfield> field.
        If this value is specified without units, it is taken as bytes.
        The default value is 1024 bytes.
        This parameter can only be set at server start.
-       -->
+-->
 <structname>pg_stat_activity</structname>.<structfield>query</structfield>フィールドに対し、それぞれの活動中のセッションで現在実行されているコマンドを追跡記録するため予約されるメモリ量を指定します。
 この値が単位なしで指定された場合は、バイト単位であるとみなします。
 デフォルトの値は1024バイトです。
@@ -2564,12 +2585,12 @@ COPY postgres_log FROM '/full/path/to/logfile.csv' WITH csv;
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables collection of statistics on database activity.
         This parameter is on by default, because the autovacuum
         daemon needs the collected information.
         Only superusers can change this setting.
-       -->
+-->
 データベースの活動についての統計情報の収集を有効にします。
 収集される情報を自動バキュームデーモンが必要とするため、このオプションはデフォルトで有効です。
 スーパーユーザのみがこの設定を変更することができます。
@@ -2618,6 +2639,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-database-view"><str
       <indexterm>
        <primary><varname>track_wal_io_timing</varname> configuration parameter</primary>
       </indexterm>
+      <indexterm>
+       <primary><varname>track_wal_io_timing</varname>設定パラメータ</primary>
+      </indexterm>
       </term>
       <listitem>
        <para>
@@ -2652,28 +2676,28 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables tracking of function call counts and time used. Specify
         <literal>pl</literal> to track only procedural-language functions,
         <literal>all</literal> to also track SQL and C language functions.
         The default is <literal>none</literal>, which disables function
         statistics tracking.  Only superusers can change this setting.
-       -->
-       関数の呼び出し数と費やされた時間の追跡を有効にします。
-       手続き言語関数のみを追跡するためには<literal>pl</literal>と指定してください。
+-->
+関数の呼び出し数と費やされた時間の追跡を有効にします。
+手続き言語関数のみを追跡するためには<literal>pl</literal>と指定してください。
        SQL関数、C言語関数も追跡するためには<literal>all</literal>と指定してください。
-       デフォルトは、統計情報追跡機能を無効にする<literal>none</literal>です。
-       スーパーユーザのみがこの設定を変更できます。
+デフォルトは、統計情報追跡機能を無効にする<literal>none</literal>です。
+スーパーユーザのみがこの設定を変更できます。
        </para>
 
        <note>
         <para>
-       <!--
+<!--
          SQL-language functions that are simple enough to be <quote>inlined</quote>
          into the calling query will not be tracked, regardless of this
          setting.
-        -->
-        呼び出す問い合わせ内に<quote>インライン化</quote>できる位単純なSQL言語関数は、この設定と関係なく、追跡されません。
+-->
+呼び出す問い合わせ内に<quote>インライン化</quote>できる位単純なSQL言語関数は、この設定と関係なく、追跡されません。
         </para>
        </note>
       </listitem>
@@ -2690,7 +2714,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the directory to store temporary statistics data in. This can be
         a path relative to the data directory or an absolute path. The default
         is <filename>pg_stat_tmp</filename>. Pointing this at a RAM-based
@@ -2698,12 +2722,12 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         improved performance.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
-       統計情報データを一時的に格納するディレクトリを設定します。
-       これをデータディレクトリからの相対パスとすることも絶対パスとすることもできます。
-       デフォルトは<filename>pg_stat_tmp</filename>です。
-       これをRAMベースのファイルシステムを指し示すようにすることで物理I/O要求が減り、性能を向上させることができます。
-       このパラメータは、<filename>postgresql.conf</filename>ファイルまたはサーバのコマンドラインのみで設定可能です。
+-->
+統計情報データを一時的に格納するディレクトリを設定します。
+これをデータディレクトリからの相対パスとすることも絶対パスとすることもできます。
+デフォルトは<filename>pg_stat_tmp</filename>です。
+これをRAMベースのファイルシステムを指し示すようにすることで物理I/O要求が減り、性能を向上させることができます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルまたはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -2712,18 +2736,18 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
     </sect2>
 
     <sect2 id="runtime-config-statistics-monitor">
-    <!--
+<!--
      <title>Statistics Monitoring</title>
-     -->
+-->
      <title>統計情報の監視</title>
      <variablelist>
 
      <varlistentry id="guc-compute-query-id" xreflabel="compute_query_id">
       <term><varname>compute_query_id</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>compute_query_id</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>compute_query_id</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2802,7 +2826,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         For each query, output performance statistics of the respective
         module to the server log. This is a crude profiling
         instrument, similar to the Unix <function>getrusage()</function> operating
@@ -2811,8 +2835,8 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         <varname>log_statement_stats</varname> cannot be enabled together with
         any of the per-module options.  All of these options are disabled by
         default.   Only superusers can change these settings.
-       -->
-       各問い合わせに対し、対応するモジュールの性能に関する統計情報をサーバログに出力します。
+-->
+各問い合わせに対し、対応するモジュールの性能に関する統計情報をサーバログに出力します。
 これは、Unixの<function>getrusage()</function>オペレーティングシステム機能に類似した、雑なプロファイリング手段です。
 <varname>log_statement_stats</varname>は文に関する統計情報全体を、この他はモジュール毎の統計情報を報告します。
 <varname>log_statement_stats</varname>とモジュール毎のオプションを一緒に有効にすることはできません。
@@ -2828,26 +2852,26 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
    </sect1>
 
    <sect1 id="runtime-config-autovacuum">
-   <!--
+<!--
     <title>Automatic Vacuuming</title>
-    -->
+-->
     <title>自動Vacuum作業</title>
 
     <indexterm>
      <primary>autovacuum</primary>
-     <!--
+<!--
      <secondary>configuration parameters</secondary>
-     -->
+-->
      <secondary>設定パラメータ</secondary>
     </indexterm>
 
      <para>
-     <!--
+<!--
       These settings control the behavior of the <firstterm>autovacuum</firstterm>
       feature.  Refer to <xref linkend="autovacuum"/> for more information.
       Note that many of these settings can be overridden on a per-table
       basis; see <xref linkend="sql-createtable-storage-parameters"/>.
-      -->
+-->
 以下に示す設定は<firstterm>自動バキューム</firstterm>機能の動作を制御します。
 詳細は<xref linkend="autovacuum"/>を参照してください。
 これらの設定の多くは、テーブル単位で変更できることに注意してください。
@@ -2867,7 +2891,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Controls whether the server should run the
         autovacuum launcher daemon.  This is on by default; however,
         <xref linkend="guc-track-counts"/> must also be enabled for
@@ -2875,21 +2899,21 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line; however, autovacuuming can be
         disabled for individual tables by changing table storage parameters.
-       -->
-       サーバがautovacuumランチャデーモンを実行すべきかどうかを管理します。
+-->
+サーバがautovacuumランチャデーモンを実行すべきかどうかを管理します。
 デフォルトでは有効です。
 しかしautovacuumを作動させるためには<xref linkend="guc-track-counts"/>も有効でなければなりません。
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
 ただし、テーブルストレージパラメータを変更することにより、autovacuumは個々のテーブルに対して無効にできます。
        </para>
        <para>
-       <!--
+<!--
         Note that even when this parameter is disabled, the system
         will launch autovacuum processes if necessary to
         prevent transaction ID wraparound.  See <xref
         linkend="vacuum-for-wraparound"/> for more information.
-       -->
-       このパラメータが無効であったとしてもシステムは、トランザクションIDの周回を防止する必要があれば、autovacuumプロセスを起動することに注意してください。
+-->
+このパラメータが無効であったとしてもシステムは、トランザクションIDの周回を防止する必要があれば、autovacuumプロセスを起動することに注意してください。
 詳細は<xref linkend="vacuum-for-wraparound"/>を参照してください。
        </para>
       </listitem>
@@ -2906,11 +2930,11 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the maximum number of autovacuum processes (other than the
         autovacuum launcher) that may be running at any one time.  The default
         is three.  This parameter can only be set at server start.
-       -->
+-->
 同時に実行することができるautovacuumプロセス（autovacuumランチャ以外）の最大数を指定します。
 デフォルトは3です。
 サーバ起動時のみで設定可能です。
@@ -2929,7 +2953,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the minimum delay between autovacuum runs on any given
         database.  In each round the daemon examines the
         database and issues <command>VACUUM</command> and <command>ANALYZE</command> commands
@@ -2938,7 +2962,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         The default is one minute (<literal>1min</literal>).
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 あるデータベースについて実行されるautovacuumデーモンの最小遅延を指定します。
 それぞれの周期で、デーモンはそのデータベースを試験し、そしてそのデータベース内のテーブルで必要性が認められると、<command>VACUUM</command>および<command>ANALYZE</command>コマンドを発行します。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
@@ -2961,7 +2985,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the minimum number of updated or deleted tuples needed
         to trigger a <command>VACUUM</command> in any one table.
         The default is 50 tuples.
@@ -2969,7 +2993,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         file or on the server command line;
         but the setting can be overridden for individual tables by
         changing table storage parameters.
-       -->
+-->
 どのテーブルに対しても<command>VACUUM</command>を起動するために必要な、更新もしくは削除されたタプルの最小数を指定します。
 デフォルトは50タプルです。
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
@@ -3024,7 +3048,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the minimum number of inserted, updated or deleted tuples
         needed to trigger an <command>ANALYZE</command> in any one table.
         The default is 50 tuples.
@@ -3032,7 +3056,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         file or on the server command line;
         but the setting can be overridden for individual tables by
         changing table storage parameters.
-       -->
+-->
 どのテーブルに対しても<command>ANALYZE</command>を起動するのに必要な、挿入、更新、もしくは削除されたタプルの最小数を指定します。
 デフォルトは50タプルです。
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
@@ -3054,7 +3078,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies a fraction of the table size to add to
         <varname>autovacuum_vacuum_threshold</varname>
         when deciding whether to trigger a <command>VACUUM</command>.
@@ -3063,8 +3087,8 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         file or on the server command line;
         but the setting can be overridden for individual tables by
         changing table storage parameters.
-       -->
-       <command>VACUUM</command>を起動するか否かを決定するときに、<varname>autovacuum_vacuum_threshold</varname>に足し算するテーブル容量の割合を指定します。
+-->
+<command>VACUUM</command>を起動するか否かを決定するときに、<varname>autovacuum_vacuum_threshold</varname>に足し算するテーブル容量の割合を指定します。
 デフォルトは0.2（テーブルサイズの20%）です。
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されますが、テーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
@@ -3079,7 +3103,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </indexterm>
       <indexterm>
        <primary><varname>autovacuum_vacuum_insert_scale_factor</varname></primary>
-       <secondary>>設定パラメータ</secondary>
+       <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
       <listitem>
@@ -3114,7 +3138,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies a fraction of the table size to add to
         <varname>autovacuum_analyze_threshold</varname>
         when deciding whether to trigger an <command>ANALYZE</command>.
@@ -3123,7 +3147,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         file or on the server command line;
         but the setting can be overridden for individual tables by
         changing table storage parameters.
-       -->
+-->
 <command>ANALYZE</command>を起動するか否かを決定するときに、<varname>autovacuum_analyze_threshold</varname>に足し算するテーブル容量の割合を指定します。
 デフォルトは0.1（テーブルサイズの10%）です。
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
@@ -3138,23 +3162,27 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
        <primary><varname>autovacuum_freeze_max_age</varname></primary>
        <secondary>configuration parameter</secondary>
       </indexterm>
+      <indexterm>
+       <primary><varname>autovacuum_freeze_max_age</varname></primary>
+       <secondary>設定パラメータ</secondary>
+      </indexterm>
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the maximum age (in transactions) that a table's
         <structname>pg_class</structname>.<structfield>relfrozenxid</structfield> field can
         attain before a <command>VACUUM</command> operation is forced
         to prevent transaction ID wraparound within the table.
         Note that the system will launch autovacuum processes to
         prevent wraparound even when autovacuum is otherwise disabled.
-       -->
-       トランザクションID周回を防ぐために<command>VACUUM</command>操作が強制される前までにテーブルの<structname>pg_class</structname>.<structfield>relfrozenxid</structfield> フィールドが到達できる最大（トランザクションにおける）年代を指定します。
+-->
+トランザクションID周回を防ぐために<command>VACUUM</command>操作が強制される前までにテーブルの<structname>pg_class</structname>.<structfield>relfrozenxid</structfield> フィールドが到達できる最大（トランザクションにおける）年代を指定します。
 自動バキュームが無効であった時でも、システムは周回を防ぐために自動バキューム子プロセスを起動することに注意してください。
        </para>
 
        <para>
-       <!--
+<!--
         Vacuum also allows removal of old files from the
         <filename>pg_xact</filename> subdirectory, which is why the default
         is a relatively low 200 million transactions.
@@ -3162,10 +3190,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         can be reduced for individual tables by
         changing table storage parameters.
         For more information see <xref linkend="vacuum-for-wraparound"/>.
-       -->
+-->
        vacuumは同時に<filename>pg_xact</filename>サブディレクトリから古いファイルの削除を許可します。
-       これが、比較的低い2億トランザクションがデフォルトである理由です。
-       このパラメータはサーバ起動時にのみ設定可能です。
+これが、比較的低い2億トランザクションがデフォルトである理由です。
+このパラメータはサーバ起動時にのみ設定可能です。
 しかし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルで減らすことができます。
 詳細は<xref linkend="vacuum-for-wraparound"/>を参照してください。
        </para>
@@ -3193,7 +3221,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         Note that the system will launch autovacuum processes to
         prevent wraparound even when autovacuum is otherwise disabled.
 -->
-       トランザクションID周回を防ぐために<command>VACUUM</command>操作が強制される前までにテーブルの<structname>pg_class</structname>.<structfield>relminmxid</structfield> フィールドが到達できる最大（マルチトランザクションにおける）年代を指定します。
+トランザクションID周回を防ぐために<command>VACUUM</command>操作が強制される前までにテーブルの<structname>pg_class</structname>.<structfield>relminmxid</structfield> フィールドが到達できる最大（マルチトランザクションにおける）年代を指定します。
 自動バキュームが無効であった時でも、システムは周回を防ぐために自動バキューム子プロセスを起動することに注意してください。
        </para>
 
@@ -3207,9 +3235,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         be reduced for individual tables by changing table storage parameters.
         For more information see <xref linkend="vacuum-for-multixact-wraparound"/>.
 -->
-       またマルチトランザクションIDのvacuumは<filename>pg_multixact</filename>と<filename>pg_multixact/offsets</filename>サブディレクトリから古いファイルの削除します。
-       これがデフォルトが4億トランザクションをやや下回る理由です。
-       このパラメータはサーバ起動時にのみ設定可能です。
+またマルチトランザクションIDのvacuumは<filename>pg_multixact</filename>と<filename>pg_multixact/offsets</filename>サブディレクトリから古いファイルの削除します。
+これがデフォルトが4億トランザクションをやや下回る理由です。
+このパラメータはサーバ起動時にのみ設定可能です。
 しかし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルで減らすことができます。
 詳細は<xref linkend="vacuum-for-multixact-wraparound"/>を参照してください。
        </para>
@@ -3229,7 +3257,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the cost delay value that will be used in automatic
         <command>VACUUM</command> operations.  If -1 is specified, the regular
         <xref linkend="guc-vacuum-cost-delay"/> value will be used.
@@ -3239,7 +3267,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         file or on the server command line;
         but the setting can be overridden for individual tables by
         changing table storage parameters.
-       -->
+-->
 自動<command>VACUUM</command>操作に使用されるコスト遅延値を指定します。
 -1に指定されると、一定の <xref linkend="guc-vacuum-cost-delay"/>の値が使用されます。
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
@@ -3263,7 +3291,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the cost limit value that will be used in automatic
         <command>VACUUM</command> operations.  If -1 is specified (which is the
         default), the regular
@@ -3275,8 +3303,8 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         file or on the server command line;
         but the setting can be overridden for individual tables by
         changing table storage parameters.
-       -->
-       自動<command>VACUUM</command>操作に使用されるコスト限界値を指定します。
+-->
+自動<command>VACUUM</command>操作に使用されるコスト限界値を指定します。
 （デフォルトの）-1が指定されると、一定の <xref linkend="guc-vacuum-cost-limit"/>の値が使用されます。
 この値は、実行中の自動バキュームワーカが複数存在する場合ワーカすべてに比例分配されることに注意してください。
 したがって各ワーカの制限を足し合わせてもこの変数による制限を超えることはありません。
@@ -3290,15 +3318,15 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
    </sect1>
 
    <sect1 id="runtime-config-client">
-   <!--
+<!--
     <title>Client Connection Defaults</title>
-    -->
+-->
     <title>クライアント接続デフォルト</title>
 
     <sect2 id="runtime-config-client-statement">
-    <!--
+<!--
      <title>Statement Behavior</title>
-     -->
+-->
      <title>文の動作</title>
      <variablelist>
 
@@ -3354,7 +3382,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         This variable specifies the order in which schemas are searched
         when an object (table, data type, function, etc.) is referenced by a
         simple name with no schema specified.  When there are objects of
@@ -3362,44 +3390,44 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         in the search path is used.  An object that is not in any of the
         schemas in the search path can only be referenced by specifying
         its containing schema with a qualified (dotted) name.
-       -->
-       この変数は、オブジェクト（テーブル、データ型、関数など）がスキーマを指定されていない単純な名前で参照されている場合に、スキーマを検索する順番を指定します。
-       異なるスキーマに同じ名前のオブジェクトがある場合、検索パスで最初に見つかったものが使用されます。
-       検索パス内のどのスキーマにも存在しないオブジェクトを参照するには、修飾名（ドット付き）でそのオブジェクトが含まれるスキーマを指定する必要があります。
+-->
+この変数は、オブジェクト（テーブル、データ型、関数など）がスキーマを指定されていない単純な名前で参照されている場合に、スキーマを検索する順番を指定します。
+異なるスキーマに同じ名前のオブジェクトがある場合、検索パスで最初に見つかったものが使用されます。
+検索パス内のどのスキーマにも存在しないオブジェクトを参照するには、修飾名（ドット付き）でそのオブジェクトが含まれるスキーマを指定する必要があります。
        </para>
 
        <para>
-       <!--
+<!--
         The value for <varname>search_path</varname> must be a comma-separated
         list of schema names.  Any name that is not an existing schema, or is
         a schema for which the user does not have <literal>USAGE</literal>
         permission, is silently ignored.
-       -->
-       <varname>search_path</varname>の値は、スキーマの名前をカンマで区切った一覧でなければなりません。
-       存在していないスキーマ、またはユーザが<literal>USAGE</literal>権限を所有していないスキーマは警告なしに無視されます。
+-->
+<varname>search_path</varname>の値は、スキーマの名前をカンマで区切った一覧でなければなりません。
+存在していないスキーマ、またはユーザが<literal>USAGE</literal>権限を所有していないスキーマは警告なしに無視されます。
        </para>
 
        <para>
-       <!--
+<!--
         If one of the list items is the special name
         <literal>$user</literal>, then the schema having the name returned by
         <function>CURRENT_USER</function> is substituted, if there is such a schema
         and the user has <literal>USAGE</literal> permission for it.
         (If not, <literal>$user</literal> is ignored.)
-       -->
+-->
 もしそのようなスキーマが存在し、ユーザがそれにたいして<literal>USAGE</literal>権限を所有している場合、一覧内の項目の1つが特別な名前である<literal>$user</literal>の場合、<function>CURRENT_USER</function>と同じ名前を持つスキーマがあれば、そのスキーマが置換されます。
 （このような名前空間がない場合は<literal>$user</literal>は無視されます。）
        </para>
 
        <para>
-       <!--
+<!--
         The system catalog schema, <literal>pg_catalog</literal>, is always
         searched, whether it is mentioned in the path or not.  If it is
         mentioned in the path then it will be searched in the specified
         order.  If <literal>pg_catalog</literal> is not in the path then it will
         be searched <emphasis>before</emphasis> searching any of the path items.
-       -->
-       システムカタログのスキーマである<literal>pg_catalog</literal>は、パスでの指定の有無にかかわらず、常に検索されます。
+-->
+システムカタログのスキーマである<literal>pg_catalog</literal>は、パスでの指定の有無にかかわらず、常に検索されます。
 パスで指定されている場合は、指定された順序で検索されます。
 <literal>pg_catalog</literal>がパスに含まれていない場合、パスに含まれる項目を検索する<emphasis>前に</emphasis>検索が行われます
        </para>
@@ -3408,10 +3436,10 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
             schema, even when it considers typname='funcname'.  This paragraph
             refers to function names in a loose sense, "pg_proc.proname or
             func_name grammar production". -->
-      <!-- 細かい話ですが、typnameが'funcname'である場合でも、funcname('foo')は一時スキーマを使いません。
-この段落では、関数名とは「pg_proc.pronameあるいは文法生成物のfunc_name」のどちらでも良いという意味で使用しています。-->
+       <!-- 細かい話ですが、typnameが'funcname'である場合でも、funcname('foo')は一時スキーマを使いません。
+            この段落では、関数名とは「pg_proc.pronameあるいは文法生成物のfunc_name」のどちらでも良いという意味で使用しています。-->
        <para>
-       <!--
+<!--
         Likewise, the current session's temporary-table schema,
         <literal>pg_temp_<replaceable>nnn</replaceable></literal>, is always searched if it
         exists.  It can be explicitly listed in the path by using the
@@ -3420,8 +3448,8 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         the temporary schema is only searched for relation (table, view,
         sequence, etc) and data type names.  It is never searched for
         function or operator names.
-       -->
-       同様に、現在のセッションの一時テーブルスキーマ<literal>pg_temp_<replaceable>nnn</replaceable></literal>も、存在すれば常に検索されます。
+-->
+同様に、現在のセッションの一時テーブルスキーマ<literal>pg_temp_<replaceable>nnn</replaceable></literal>も、存在すれば常に検索されます。
 これは<literal>pg_temp</literal><indexterm><primary>pg_temp</primary></indexterm>という別名を使用してパスに明示的に列挙させることができます。
 パスに列挙されていない場合、最初に（<literal>pg_catalog</literal>よりも前であっても）検索されます。
 しかし、一時スキーマはリレーション（テーブル、ビュー、シーケンスなど）とデータ型名に対してのみ検索されます。
@@ -3429,18 +3457,18 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
        </para>
 
        <para>
-       <!--
+<!--
         When objects are created without specifying a particular target
         schema, they will be placed in the first valid schema named in
         <varname>search_path</varname>.  An error is reported if the search
         path is empty.
-       -->
-       対象となる特定のスキーマを指定せずにオブジェクトが作成された場合、それらのオブジェクトは<varname>search_path</varname>で名前を付けられた最初に有効となっているスキーマに配置されます。
+-->
+対象となる特定のスキーマを指定せずにオブジェクトが作成された場合、それらのオブジェクトは<varname>search_path</varname>で名前を付けられた最初に有効となっているスキーマに配置されます。
 検索パスが空の場合、エラーが報告されます。
        </para>
 
        <para>
-       <!--
+<!--
         The default value for this parameter is
         <literal>"$user", public</literal>.
         This setting supports shared use of a database (where no users
@@ -3448,8 +3476,8 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         private per-user schemas, and combinations of these.  Other
         effects can be obtained by altering the default search path
         setting, either globally or per-user.
-       -->
-       このパラメータのデフォルト値は<literal>"$user", public</literal>です。
+-->
+このパラメータのデフォルト値は<literal>"$user", public</literal>です。
 この設定はデータベースの共有（どのユーザも非公開のスキーマを持たず、全員が<literal>public</literal>を共有）、ユーザごとの非公開のスキーマ、およびこれらの組み合わせがサポートします。
 デフォルトの検索パスの設定を全体的またはユーザごとに変更することで、その他の効果を得ることもできます。
        </para>
@@ -3466,7 +3494,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
        </para>
 
        <para>
-       <!--
+<!--
         The current effective value of the search path can be examined
         via the <acronym>SQL</acronym> function
         <function>current_schemas</function>
@@ -3475,8 +3503,8 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         examining the value of <varname>search_path</varname>, since
         <function>current_schemas</function> shows how the items
         appearing in <varname>search_path</varname> were resolved.
-       -->
-       <acronym>SQL</acronym>関数の<function>current_schemas</function> によって、検索パスの現在の有効な値を調べることができます（<xref linkend="functions-info"/>を参照してください）。
+-->
+<acronym>SQL</acronym>関数の<function>current_schemas</function> によって、検索パスの現在の有効な値を調べることができます（<xref linkend="functions-info"/>を参照してください）。
 これは、<varname>search_path</varname> の値を調べるのとは異なります。
 <function>current_schemas</function>は、<varname>search_path</varname>に現れる項目がどのように解決されたかを表すからです。
        </para>
@@ -3563,16 +3591,16 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         This variable specifies the default tablespace in which to create
         objects (tables and indexes) when a <command>CREATE</command> command does
         not explicitly specify a tablespace.
-       -->
+-->
 この変数は、<command>CREATE</command>コマンドで明示的にテーブル空間を指定していない場合にオブジェクトの作成先となるデフォルトのテーブル空間を指定します。
        </para>
 
        <para>
-       <!--
+<!--
         The value is either the name of a tablespace, or an empty string
         to specify using the default tablespace of the current database.
         If the value does not match the name of any existing tablespace,
@@ -3580,28 +3608,28 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         tablespace of the current database.  If a nondefault tablespace
         is specified, the user must have <literal>CREATE</literal> privilege
         for it, or creation attempts will fail.
-       -->
-       値はテーブル空間名、もしくは現在のデータベースのデフォルトのテーブル空間を使用することを意味する空文字列です。
+-->
+値はテーブル空間名、もしくは現在のデータベースのデフォルトのテーブル空間を使用することを意味する空文字列です。
 この値が既存のテーブル空間名と一致しない場合、<productname>PostgreSQL</productname>は自動的に現在のデータベースのデフォルトのテーブル空間を使用します。
 デフォルト以外のテーブル空間が指定された場合、ユーザはそのテーブル空間で<literal>CREATE</literal>権限を持たなければなりません。
 さもなくば作成に失敗します。
        </para>
 
        <para>
-       <!--
+<!--
         This variable is not used for temporary tables; for them,
         <xref linkend="guc-temp-tablespaces"/> is consulted instead.
-       -->
+-->
 この変数は一時テーブル向けには使用されません。
 一時テーブル向けには代わりに<xref linkend="guc-temp-tablespaces"/>が考慮されます。
        </para>
 
        <para>
-       <!--
+<!--
         This variable is also not used when creating databases.
         By default, a new database inherits its tablespace setting from
         the template database it is copied from.
-       -->
+-->
 また、この変数はデータベース作成時には使用されません。
 デフォルトでは、新しいデータベースはコピー元のテンプレートデータベースからテーブル空間の設定を引き継ぎます。
        </para>
@@ -3618,11 +3646,11 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
        </para>
 
        <para>
-       <!--
+<!--
         For more information on tablespaces,
         see <xref linkend="manage-ag-tablespaces"/>.
-       -->
-       テーブル空間に付いてより詳細な情報は<xref linkend="manage-ag-tablespaces"/>を参照してください。
+-->
+テーブル空間に付いてより詳細な情報は<xref linkend="manage-ag-tablespaces"/>を参照してください。
        </para>
       </listitem>
      </varlistentry>
@@ -3630,9 +3658,9 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
      <varlistentry id="guc-default-toast-compression" xreflabel="default_toast_compression">
       <term><varname>default_toast_compression</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>default_toast_compression</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>default_toast_compression</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3672,19 +3700,19 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         This variable specifies tablespaces in which to create temporary
         objects (temp tables and indexes on temp tables) when a
         <command>CREATE</command> command does not explicitly specify a tablespace.
         Temporary files for purposes such as sorting large data sets
         are also created in these tablespaces.
-       -->
+-->
 この変数は、<command>CREATE</command>コマンドで明示的にテーブル空間が指定されない場合に、生成する一時オブジェクト（一時テーブルと一時テーブル上のインデックス）を格納するテーブル空間（複数可）を指定します。
 大規模データ集合のソートなどを目的とした一時ファイルもまた、このテーブル空間（複数可）に作成されます。
        </para>
 
        <para>
-       <!--
+<!--
         The value is a list of names of tablespaces.  When there is more than
         one name in the list, <productname>PostgreSQL</productname> chooses a random
         member of the list each time a temporary object is to be created;
@@ -3693,7 +3721,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         If the selected element of the list is an empty string,
         <productname>PostgreSQL</productname> will automatically use the default
         tablespace of the current database instead.
-       -->
+-->
 この値はテーブル空間名のリストです。
 リストに複数の名前が存在する場合、一時オブジェクトが作成される度に<productname>PostgreSQL</productname>は無作為にリストから要素を選択します。
 トランザクションの内側は例外で、連続して作成される一時オブジェクトはそのリストで連続するテーブル空間に格納されます。
@@ -3701,7 +3729,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
        </para>
 
        <para>
-       <!--
+<!--
         When <varname>temp_tablespaces</varname> is set interactively, specifying a
         nonexistent tablespace is an error, as is specifying a tablespace for
         which the user does not have <literal>CREATE</literal> privilege.  However,
@@ -3709,7 +3737,7 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
         ignored, as are tablespaces for which the user lacks
         <literal>CREATE</literal> privilege.  In particular, this rule applies when
         using a value set in <filename>postgresql.conf</filename>.
-       -->
+-->
 <varname>temp_tablespaces</varname>を対話式に設定する場合、存在しないテーブル空間を指定するとエラーになります。
 ユーザが<literal>CREATE</literal>権限を持たないテーブル空間を指定した場合も同様です。
 しかし事前に設定された値を使用する場合、存在しないテーブル空間は無視されます。
@@ -3718,19 +3746,19 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
        </para>
 
        <para>
-       <!--
+<!--
         The default value is an empty string, which results in all temporary
         objects being created in the default tablespace of the current
         database.
-       -->
+-->
 デフォルト値は空文字列です。
 この結果、すべての一時オブジェクトは現在のデータベースのデフォルトのテーブル空間内に作成されます。
        </para>
 
        <para>
-       <!--
+<!--
         See also <xref linkend="guc-default-tablespace"/>.
-       -->
+-->
        <xref linkend="guc-default-tablespace"/>も参照してください
        </para>
       </listitem>
@@ -3770,13 +3798,13 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
      <varlistentry id="guc-default-transaction-isolation" xreflabel="default_transaction_isolation">
       <term><varname>default_transaction_isolation</varname> (<type>enum</type>)
       <indexterm>
-      <!--
+<!--
        <primary>transaction isolation level</primary>
-       -->
+-->
        <primary>トランザクション分離レベル</primary>
-       <!--
+<!--
        <secondary>setting default</secondary>
-       -->
+-->
        <secondary>デフォルト設定</secondary>
       </indexterm>
       <indexterm>
@@ -3788,25 +3816,25 @@ I/O呼び出し情報は、<link linkend="monitoring-pg-stat-wal-view"><structna
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Each SQL transaction has an isolation level, which can be
         either <quote>read uncommitted</quote>, <quote>read
         committed</quote>, <quote>repeatable read</quote>, or
         <quote>serializable</quote>.  This parameter controls the
         default isolation level of each new transaction. The default
         is <quote>read committed</quote>.
-       -->
+-->
        SQLトランザクションはそれぞれ、<quote>read uncommitted</quote>、<quote>read committed</quote>、<quote>repeatable read</quote>、または<quote>serializable</quote>のいずれかの分離レベルを持ちます。
 このパラメータは各新規トランザクションのデフォルトの分離レベルを制御します。
 デフォルトは<quote>read committed</quote>です。
        </para>
 
        <para>
-       <!--
+<!--
         Consult <xref linkend="mvcc"/> and <xref
         linkend="sql-set-transaction"/> for more information.
-       -->
-       より詳細は <xref linkend="mvcc"/> および <xref
+-->
+より詳細は <xref linkend="mvcc"/> および <xref
         linkend="sql-set-transaction"/> を調べてください。
        </para>
       </listitem>

--- a/doc/src/sgml/config3.sgml
+++ b/doc/src/sgml/config3.sgml
@@ -11,13 +11,13 @@
      <varlistentry id="guc-default-transaction-read-only" xreflabel="default_transaction_read_only">
       <term><varname>default_transaction_read_only</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
+<!--
        <primary>read-only transaction</primary>
-       -->
+-->
        <primary>読み取り専用トランザクション</primary>
-       <!--
+<!--
        <secondary>setting default</secondary>
-       -->
+-->
        <secondary>デフォルト設定</secondary>
       </indexterm>
       <indexterm>
@@ -29,21 +29,21 @@
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         A read-only SQL transaction cannot alter non-temporary tables.
         This parameter controls the default read-only status of each new
         transaction. The default is <literal>off</literal> (read/write).
-       -->
-       読み取り専用のSQLトランザクションでは、非一時的テーブルを変更することができません。
+-->
+読み取り専用のSQLトランザクションでは、非一時的テーブルを変更することができません。
 このパラメータは、各新規トランザクションのデフォルトの読み取りのみ状況を制御します。
 デフォルト<literal>off</literal>（読み書き）です。
        </para>
 
        <para>
-       <!--
+<!--
         Consult <xref linkend="sql-set-transaction"/> for more information.
-       -->
-       より詳細な情報は<xref linkend="sql-set-transaction"/>を調べてください。
+-->
+より詳細な情報は<xref linkend="sql-set-transaction"/>を調べてください。
        </para>
       </listitem>
      </varlistentry>
@@ -51,10 +51,10 @@
      <varlistentry id="guc-default-transaction-deferrable" xreflabel="default_transaction_deferrable">
       <term><varname>default_transaction_deferrable</varname> (<type>boolean</type>)
       <indexterm>
-      <!--
+<!--
        <primary>deferrable transaction</primary>
        <secondary>setting default</secondary>
-       -->
+-->
        <primary>遅延トランザクション</primary>
        <secondary>デフォルト設定</secondary>
       </indexterm>
@@ -67,7 +67,7 @@
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When running at the <literal>serializable</literal> isolation level,
         a deferrable read-only SQL transaction may be delayed before
         it is allowed to proceed.  However, once it begins executing
@@ -75,29 +75,29 @@
         serializability; so serialization code will have no reason to
         force it to abort because of concurrent updates, making this
         option suitable for long-running read-only transactions.
-       -->
-       <literal>シリアライザブル</literal>分離レベルで運用されている場合、繰り延べ読み取り専用SQLトランザクションは、その処理の許可の前に遅延されることがあります。
-       しかし、ひとたび処理が開始されるとシリアライザブル可能性を保障するために必要ないかなるオーバヘッドも発生させません。
-       従って、シリアル化（直列化）のコードは、このオプションを長期間にわたる読み取り専用トランザクションに対して適切な処置と位置づけ、同時実行の更新の観点から中断を強制する理由はありません。
+-->
+<literal>シリアライザブル</literal>分離レベルで運用されている場合、繰り延べ読み取り専用SQLトランザクションは、その処理の許可の前に遅延されることがあります。
+しかし、ひとたび処理が開始されるとシリアライザブル可能性を保障するために必要ないかなるオーバヘッドも発生させません。
+従って、シリアル化（直列化）のコードは、このオプションを長期間にわたる読み取り専用トランザクションに対して適切な処置と位置づけ、同時実行の更新の観点から中断を強制する理由はありません。
         </para>
 
         <para>
-       <!--
+<!--
         This parameter controls the default deferrable status of each
         new transaction.  It currently has no effect on read-write
         transactions or those operating at isolation levels lower
         than <literal>serializable</literal>. The default is <literal>off</literal>.
-       -->
-       このパラメータはそれぞれの新規トランザクションのデフォルトでの繰り延べ状態を制御します。
-       現時点では、読み取り専用トランザクション、または<literal>シリアライザブル</literal>より低位の分離レベルの運用に対して効果はありません。
+-->
+このパラメータはそれぞれの新規トランザクションのデフォルトでの繰り延べ状態を制御します。
+現時点では、読み取り専用トランザクション、または<literal>シリアライザブル</literal>より低位の分離レベルの運用に対して効果はありません。
 デフォルトは<literal>off</literal>です。
        </para>
 
        <para>
-       <!--
+<!--
         Consult <xref linkend="sql-set-transaction"/> for more information.
-       -->
-       より詳細は<xref linkend="sql-set-transaction"/>を参照してください。
+-->
+より詳細は<xref linkend="sql-set-transaction"/>を参照してください。
        </para>
       </listitem>
      </varlistentry>
@@ -108,9 +108,9 @@
        <primary>transaction isolation level</primary>
       </indexterm>
       <indexterm>
-<!--
        <primary><varname>transaction_isolation</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>transaction_isolation</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -136,9 +136,9 @@
        <primary>read-only transaction</primary>
       </indexterm>
       <indexterm>
-<!--
        <primary><varname>transaction_read_only</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>transaction_read_only</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -164,9 +164,9 @@
        <primary>deferrable transaction</primary>
       </indexterm>
       <indexterm>
-<!--
        <primary><varname>transaction_deferrable</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>transaction_deferrable</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -205,7 +205,7 @@
         query plans.  Possible values are <literal>origin</literal> (the default),
         <literal>replica</literal> and <literal>local</literal>.
 -->
-       現在のセッションでのレプリケーションに関連したトリガおよびルールの発行を制御します。
+現在のセッションでのレプリケーションに関連したトリガおよびルールの発行を制御します。
 この変数を設定するにはスーパーユーザ権限が必要で、かつ、これまでにキャッシュされた問い合わせ計画が破棄されることになります。
 取り得る値は、<literal>origin</literal>（デフォルト）、<literal>replica</literal>、<literal>local</literal>です。
        </para>
@@ -293,11 +293,11 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
        </para>
 
        <para>
-       <!--
+<!--
         Setting <varname>statement_timeout</varname> in
         <filename>postgresql.conf</filename> is not recommended because it would
         affect all sessions.
-       -->
+-->
 すべてのセッションに影響することがあるので、<filename>postgresql.conf</filename>内で<varname>statement_timeout</varname>を設定することは推奨されません。
        </para>
       </listitem>
@@ -314,7 +314,7 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Abort any statement that waits longer than the specified amount of
         time while attempting to acquire a lock on a table, index,
         row, or other database object.  The time limit applies separately to
@@ -324,7 +324,7 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
         locks.
         If this value is specified without units, it is taken as milliseconds.
         A value of zero (the default) disables the timeout.
-       -->
+-->
 テーブル、インデックス、行、またはその他のデータベースオブジェクトに対してロック獲得を試みている最中、指定された時間を超えて待機するいかなる命令も停止されます。
 時間制限はそれぞれのロック取得の試みに対し個別に適用されます。
 制限は明示的ロック要求（例えば<command>LOCK TABLE</command>、または<command>SELECT FOR UPDATE</command> without <literal>NOWAIT</literal>など）および暗黙的に取得されるロックに適用されます。
@@ -333,7 +333,7 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
        </para>
 
        <para>
-       <!--
+<!--
         Unlike <varname>statement_timeout</varname>, this timeout can only occur
         while waiting for locks.  Note that if <varname>statement_timeout</varname>
         is nonzero, it is rather pointless to set <varname>lock_timeout</varname> to
@@ -341,19 +341,19 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
         trigger first.  If <varname>log_min_error_statement</varname> is set to
         <literal>ERROR</literal> or lower, the statement that timed out will be
         logged.
-       -->
+-->
 <varname>statement_timeout</varname>と異なり、このタイムアウトはロックを待機しているときのみ発生します。
 命令によるタイムアウトは常に第一に起動されるため、もし<varname>statement_timeout</varname>が非ゼロであれば<varname>lock_timeout</varname>を同一、もしくはより大きい値に設定するのは的を射ていません。
 <varname>log_min_error_statement</varname>が<literal>ERROR</literal>またはそれより低く設定されると、時間制限を超えた命令はログに記録されます。
        </para>
 
        <para>
-       <!--
+<!--
         Setting <varname>lock_timeout</varname> in
         <filename>postgresql.conf</filename> is not recommended because it would
         affect all sessions.
-       -->
-       <varname>lock_timeout</varname>を<filename>postgresql.conf</filename>にて設定することは、すべてのセッションに影響を与える可能性があるため推奨されません。
+-->
+<varname>lock_timeout</varname>を<filename>postgresql.conf</filename>にて設定することは、すべてのセッションに影響を与える可能性があるため推奨されません。
        </para>
       </listitem>
      </varlistentry>
@@ -401,9 +401,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-idle-session-timeout" xreflabel="idle_session_timeout">
       <term><varname>idle_session_timeout</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>idle_session_timeout</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>idle_session_timeout</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -493,7 +493,7 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Specifies the cutoff age (in transactions) that <command>VACUUM</command>
         should use to decide whether to freeze row versions
         while scanning a table.
@@ -504,8 +504,8 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
         that there is not an unreasonably short time between forced
         autovacuums.  For more information see <xref
         linkend="vacuum-for-wraparound"/>.
-       -->
-       <command>VACUUM</command>がテーブルスキャン時に行バージョンをフリーズするかどうかを決定する際に使用する、カットオフ（トランザクション）年代を指定します。
+-->
+<command>VACUUM</command>がテーブルスキャン時に行バージョンをフリーズするかどうかを決定する際に使用する、カットオフ（トランザクション）年代を指定します。
 デフォルトは5千万トランザクションです。
 ユーザはこの値を0から10億までの間で任意の値に設定することができますが、<command>VACUUM</command>は警告なく<xref linkend="guc-autovacuum-freeze-max-age"/>の半分までの値に値を制限します。
 このため、強制的なautovacuumの間隔が不合理に短くなることはありません。
@@ -517,9 +517,9 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
      <varlistentry id="guc-vacuum-failsafe-age" xreflabel="vacuum_failsafe_age">
       <term><varname>vacuum_failsafe_age</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>vacuum_failsafe_age</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>vacuum_failsafe_age</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -689,17 +689,17 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the output format for values of type <type>bytea</type>.
         Valid values are <literal>hex</literal> (the default)
         and <literal>escape</literal> (the traditional PostgreSQL
         format).  See <xref linkend="datatype-binary"/> for more
         information.  The <type>bytea</type> type always
         accepts both formats on input, regardless of this setting.
-       -->
-       <type>bytea</type>型の値の出力形式を設定します。
-       有効な値は<literal>hex</literal>（デフォルト）、および<literal>escape</literal>（PostgreSQLの伝統的な書式）です。
-       より詳細は<xref linkend="datatype-binary"/>を参照してください。
+-->
+<type>bytea</type>型の値の出力形式を設定します。
+有効な値は<literal>hex</literal>（デフォルト）、および<literal>escape</literal>（PostgreSQLの伝統的な書式）です。
+より詳細は<xref linkend="datatype-binary"/>を参照してください。
        <type>bytea</type>型は常にこの設定に係わらず、入力時に双方の書式を受け付けます。
        </para>
       </listitem>
@@ -716,7 +716,7 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets how binary values are to be encoded in XML.  This applies
         for example when <type>bytea</type> values are converted to
         XML by the functions <function>xmlelement</function> or
@@ -725,8 +725,8 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
         are both defined in the XML Schema standard.  The default is
         <literal>base64</literal>.  For further information about
         XML-related functions, see <xref linkend="functions-xml"/>.
-       -->
-       バイナリデータをXMLに符号化する方法を設定します。
+-->
+バイナリデータをXMLに符号化する方法を設定します。
 例えばこれは、<function>xmlelement</function>や<function>xmlforest</function>関数で<type>bytea</type>値をXMLに変換する際に適用されます。
 取り得る値は<literal>base64</literal>と<literal>hex</literal>です。
 どちらもXMLスキーマ標準で定義されています。
@@ -735,14 +735,14 @@ XMLに関連した関数については<xref linkend="functions-xml"/>を参照�
        </para>
 
        <para>
-       <!--
+<!--
         The actual choice here is mostly a matter of taste,
         constrained only by possible restrictions in client
         applications.  Both methods support all possible values,
         although the hex encoding will be somewhat larger than the
         base64 encoding.
-       -->
-       実のところこの選択はほとんど趣味の問題で、クライアントアプリケーションで起こり得る制限のみに制約されます。
+-->
+実のところこの選択はほとんど趣味の問題で、クライアントアプリケーションで起こり得る制限のみに制約されます。
 どちらの方法もすべての値をサポートしますが、hex符号化方式はbase64符号化方式より少し大きくなります。
        </para>
       </listitem>
@@ -768,7 +768,7 @@ XMLに関連した関数については<xref linkend="functions-xml"/>を参照�
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets whether <literal>DOCUMENT</literal> or
         <literal>CONTENT</literal> is implicit when converting between
         XML and character string values.  See <xref
@@ -776,25 +776,25 @@ XMLに関連した関数については<xref linkend="functions-xml"/>を参照�
         values are <literal>DOCUMENT</literal> and
         <literal>CONTENT</literal>.  The default is
         <literal>CONTENT</literal>.
-       -->
-       XMLと文字列値との変換時に<literal>DOCUMENT</literal>とするか<literal>CONTENT</literal>とするかを設定します。
+-->
+XMLと文字列値との変換時に<literal>DOCUMENT</literal>とするか<literal>CONTENT</literal>とするかを設定します。
 この説明については<xref linkend="datatype-xml"/>を参照してください。
 有効な値は<literal>DOCUMENT</literal>と<literal>CONTENT</literal>です。
 デフォルトは<literal>CONTENT</literal>です。
        </para>
 
        <para>
-       <!--
+<!--
         According to the SQL standard, the command to set this option is
-       -->
-       標準SQLに従うと、このオプションを設定するコマンドは以下のようになります。
+-->
+標準SQLに従うと、このオプションを設定するコマンドは以下のようになります。
 <synopsis>
 SET XML OPTION { DOCUMENT | CONTENT };
 </synopsis>
-       <!--
+<!--
         This syntax is also available in PostgreSQL.
-       -->
-       この構文はPostgreSQLでも使用可能です。
+-->
+この構文はPostgreSQLでも使用可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -837,9 +837,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
      </variablelist>
     </sect2>
      <sect2 id="runtime-config-client-format">
-     <!--
+<!--
      <title>Locale and Formatting</title>
-     -->
+-->
      <title>ロケールと書式設定</title>
 
      <variablelist>
@@ -855,7 +855,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the display format for date and time values, as well as the
         rules for interpreting ambiguous date input values. For
         historical reasons, this variable contains two independent
@@ -872,8 +872,8 @@ SET XML OPTION { DOCUMENT | CONTENT };
         <application>initdb</application> will initialize the
         configuration file with a setting that corresponds to the
         behavior of the chosen <varname>lc_time</varname> locale.
-       -->
-       日付時刻値の表示書式を設定し、曖昧な日付入力の解釈規則を設定します。
+-->
+日付時刻値の表示書式を設定し、曖昧な日付入力の解釈規則を設定します。
 歴史的な理由により、この変数には2つの独立した要素が含まれています。
 出力書式指定（<literal>ISO</literal>、<literal>Postgres</literal>、<literal>SQL</literal>、<literal>German</literal>）と年/月/日の順序の入出力指定（<literal>DMY</literal>、<literal>MDY</literal>、<literal>YMD</literal>）です。
 これらは分けて設定することもまとめて設定することもできます。
@@ -895,7 +895,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the display format for interval values.
         The value <literal>sql_standard</literal> will produce
         output matching <acronym>SQL</acronym> standard interval literals.
@@ -910,20 +910,20 @@ SET XML OPTION { DOCUMENT | CONTENT };
         The value <literal>iso_8601</literal> will produce output matching the time
         interval <quote>format with designators</quote> defined in section
         4.4.3.2 of ISO 8601.
-       -->
-       間隔の値の表示形式を設定します。<literal>sql_standard</literal>値は、<acronym>SQL</acronym>標準間隔リテラルに一致する出力を生成します。
-       （デフォルトの）値<literal>postgres</literal>は、<xref linkend="guc-datestyle"/>パラメータが<literal>ISO</literal>に設定されている場合、リリース8.4以前の<productname>PostgreSQL</productname>に一致する出力を生成します。
-       値<literal>postgres_verbose</literal>は、<varname>DateStyle</varname>パラメータが非<literal>ISO</literal>出力に設定されている場合、リリース8.4以前の<productname>PostgreSQL</productname>に一致する出力を生成します。
-       値<literal>iso_8601</literal>は、ISO 8601の4.4.3.2節で定義されている時間間隔<quote>format with designators</quote>に一致する出力を生成します。
+-->
+間隔の値の表示形式を設定します。<literal>sql_standard</literal>値は、<acronym>SQL</acronym>標準間隔リテラルに一致する出力を生成します。
+（デフォルトの）値<literal>postgres</literal>は、<xref linkend="guc-datestyle"/>パラメータが<literal>ISO</literal>に設定されている場合、リリース8.4以前の<productname>PostgreSQL</productname>に一致する出力を生成します。
+値<literal>postgres_verbose</literal>は、<varname>DateStyle</varname>パラメータが非<literal>ISO</literal>出力に設定されている場合、リリース8.4以前の<productname>PostgreSQL</productname>に一致する出力を生成します。
+値<literal>iso_8601</literal>は、ISO 8601の4.4.3.2節で定義されている時間間隔<quote>format with designators</quote>に一致する出力を生成します。
        </para>
        <para>
-       <!--
+<!--
         The <varname>IntervalStyle</varname> parameter also affects the
         interpretation of ambiguous interval input.  See
         <xref linkend="datatype-interval-input"/> for more information.
-       -->
-       また<varname>IntervalStyle</varname>パラメータはあいまいに入力された時間間隔の解釈に影響を与えます。
-       詳細については<xref linkend="datatype-interval-input"/>を参照してください。
+-->
+また<varname>IntervalStyle</varname>パラメータはあいまいに入力された時間間隔の解釈に影響を与えます。
+詳細については<xref linkend="datatype-interval-input"/>を参照してください。
        </para>
       </listitem>
      </varlistentry>
@@ -941,16 +941,16 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the time zone for displaying and interpreting time stamps.
         The built-in default is <literal>GMT</literal>, but that is typically
         overridden in <filename>postgresql.conf</filename>; <application>initdb</application>
         will install a setting there corresponding to its system environment.
         See <xref linkend="datatype-timezones"/> for more information.
-       -->
-       表示用およびタイムスタンプ解釈用の時間帯を設定します。
-       組み込まれているデフォルトは<literal>GMT</literal>ですが、通常は<filename>postgresql.conf</filename>により上書きされます。<application>initdb</application>によりこれらと関連した設定をシステム環境にインストールされます。
-        詳細は<xref linkend="datatype-timezones"/>を参照してください。
+-->
+表示用およびタイムスタンプ解釈用の時間帯を設定します。
+組み込まれているデフォルトは<literal>GMT</literal>ですが、通常は<filename>postgresql.conf</filename>により上書きされます。<application>initdb</application>によりこれらと関連した設定をシステム環境にインストールされます。
+詳細は<xref linkend="datatype-timezones"/>を参照してください。
        </para>
       </listitem>
      </varlistentry>
@@ -968,15 +968,15 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the collection of time zone abbreviations that will be accepted
         by the server for datetime input.  The default is <literal>'Default'</literal>,
         which is a collection that works in most of the world; there are
         also <literal>'Australia'</literal> and <literal>'India'</literal>,
         and other collections can be defined for a particular installation.
         See <xref linkend="datetime-config-files"/> for more information.
-       -->
-       サーバで日付時刻の入力として受付け可能となる時間帯省略形の集合を設定します。
+-->
+サーバで日付時刻の入力として受付け可能となる時間帯省略形の集合を設定します。
 デフォルトは<literal>'Default'</literal>です。
 これはほぼ全世界で通じる集合です。
 また、<literal>Australia</literal>、<literal>India</literal>、その他特定のインストレーションで定義可能な集合が存在します。
@@ -994,13 +994,11 @@ SET XML OPTION { DOCUMENT | CONTENT };
        <primary>有効数字</primary>
       </indexterm>
       <indexterm>
-      <!--
        <primary>floating-point</primary>
-       -->
-       <primary>浮動小数点</primary>
-       <!--
        <secondary>display</secondary>
-       -->
+      </indexterm>
+      <indexterm>
+       <primary>浮動小数点</primary>
        <secondary>表示</secondary>
       </indexterm>
       <indexterm>
@@ -1081,13 +1079,13 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the client-side encoding (character set).
         The default is to use the database encoding.
         The character sets supported by the <productname>PostgreSQL</productname>
         server are described in <xref linkend="multibyte-charset-supported"/>.
-       -->
-       クライアント側符号化方式（文字セット）を設定します。デフォルトはデータベース符号化方式を使用します。
+-->
+クライアント側符号化方式（文字セット）を設定します。デフォルトはデータベース符号化方式を使用します。
        <productname>PostgreSQL</productname>サーバでサポートされている文字セットは<xref linkend="multibyte-charset-supported"/>に記載されています。
        </para>
       </listitem>
@@ -1104,38 +1102,38 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the language in which messages are displayed.  Acceptable
         values are system-dependent; see <xref linkend="locale"/> for
         more information.  If this variable is set to the empty string
         (which is the default) then the value is inherited from the
         execution environment of the server in a system-dependent way.
-       -->
-       メッセージが表示される言語を設定します。使用可能な値はシステムに依存します。詳細については<xref linkend="locale"/>を参照してください。
-       この変数が空に設定された場合（これがデフォルトです）、値はシステムに依存する方法でサーバの実行環境から継承されます。
+-->
+メッセージが表示される言語を設定します。使用可能な値はシステムに依存します。詳細については<xref linkend="locale"/>を参照してください。
+この変数が空に設定された場合（これがデフォルトです）、値はシステムに依存する方法でサーバの実行環境から継承されます。
        </para>
 
        <para>
-       <!--
+<!--
         On some systems, this locale category does not exist.  Setting
         this variable will still work, but there will be no effect.
         Also, there is a chance that no translated messages for the
         desired language exist.  In that case you will continue to see
         the English messages.
-       -->
-       システムによっては、このロケールのカテゴリが存在しません。この変数を設定することはできますが、実効性はありません。
-       また、指定の言語に翻訳されたメッセージが存在しないこともあります。
-       その場合は、引き続き英語のメッセージが表示されます。
+-->
+システムによっては、このロケールのカテゴリが存在しません。この変数を設定することはできますが、実効性はありません。
+また、指定の言語に翻訳されたメッセージが存在しないこともあります。
+その場合は、引き続き英語のメッセージが表示されます。
        </para>
 
        <para>
-       <!--
+<!--
         Only superusers can change this setting, because it affects the
         messages sent to the server log as well as to the client, and
         an improper value might obscure the readability of the server
         logs.
-       -->
-       サーバログやクライアントに送信されるメッセージに影響するため、および、全ての不適切な値がサーバログの信頼性を損ねる可能性があるため、スーパーユーザのみがこの設定を変更することができます。
+-->
+サーバログやクライアントに送信されるメッセージに影響するため、および、全ての不適切な値がサーバログの信頼性を損ねる可能性があるため、スーパーユーザのみがこの設定を変更することができます。
        </para>
       </listitem>
      </varlistentry>
@@ -1151,7 +1149,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the locale to use for formatting monetary amounts, for
         example with the <function>to_char</function> family of
         functions.  Acceptable values are system-dependent; see <xref
@@ -1159,8 +1157,8 @@ SET XML OPTION { DOCUMENT | CONTENT };
         set to the empty string (which is the default) then the value
         is inherited from the execution environment of the server in a
         system-dependent way.
-       -->
-       通貨書式で使用するロケールを設定します。
+-->
+通貨書式で使用するロケールを設定します。
 例えば、<function>to_char()</function>系の関数で使用します。
 使用可能な値はシステムに依存します。
 詳細については<xref linkend="locale"/>を参照してください。
@@ -1180,7 +1178,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the locale to use for formatting numbers, for example
         with the <function>to_char</function> family of
         functions. Acceptable values are system-dependent; see <xref
@@ -1188,8 +1186,8 @@ SET XML OPTION { DOCUMENT | CONTENT };
         set to the empty string (which is the default) then the value
         is inherited from the execution environment of the server in a
         system-dependent way.
-       -->
-       数字の書式で使用するロケールを設定します。
+-->
+数字の書式で使用するロケールを設定します。
 例えば、<function>to_char</function>系の関数で使用します。
 使用可能な値はシステムに依存します。
 詳細については<xref linkend="locale"/>を参照してください。
@@ -1209,7 +1207,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Sets the locale to use for formatting dates and times, for example
         with the <function>to_char</function> family of
         functions. Acceptable values are system-dependent; see <xref
@@ -1217,10 +1215,10 @@ SET XML OPTION { DOCUMENT | CONTENT };
         set to the empty string (which is the default) then the value
         is inherited from the execution environment of the server in a
         system-dependent way.
-       -->
-       例えば<function>to_char</function>系関数における、日付と時間の書式で使用するロケールを設定します。
-       使用可能な値はシステムに依存します。
-       詳細については<xref linkend="locale"/>を参照してください。
+-->
+例えば<function>to_char</function>系関数における、日付と時間の書式で使用するロケールを設定します。
+使用可能な値はシステムに依存します。
+詳細については<xref linkend="locale"/>を参照してください。
 この変数が空に設定された場合（これがデフォルトです）、値はシステムに依存する方法でサーバの実行環境から継承されます。
        </para>
       </listitem>
@@ -1237,7 +1235,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Selects the text search configuration that is used by those variants
         of the text search functions that do not have an explicit argument
         specifying the configuration.
@@ -1247,8 +1245,8 @@ SET XML OPTION { DOCUMENT | CONTENT };
         configuration file with a setting that corresponds to the
         chosen <varname>lc_ctype</varname> locale, if a configuration
         matching that locale can be identified.
-       -->
-       明示的な設定指定引数を持たないテキスト検索関数の亜種で使用される、テキスト検索設定を選択します。
+-->
+明示的な設定指定引数を持たないテキスト検索関数の亜種で使用される、テキスト検索設定を選択します。
 詳細は<xref linkend="textsearch"/>を参照してください。
 組み込みのデフォルトは<literal>pg_catalog.simple</literal>ですが、<application>initdb</application>は、ロケールに合う設定を認識することができれば、選択された<varname>lc_ctype</varname>ロケールに対応した設定で設定ファイルを初期化します。
        </para>
@@ -1276,7 +1274,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       library directory.  The differences between the settings are when they
       take effect and what privileges are required to change them.
 -->
-      追加機能や性能改良の目的で共有ライブラリをプリロードするいくつかの設定があります。
+追加機能や性能改良の目的で共有ライブラリをプリロードするいくつかの設定があります。
 たとえば<literal>'$libdir/mylib'</literal>を設定すると<literal>mylib.so</literal>(あるいは他のプラットフォームでは<literal>mylib.sl</literal>)を導入設定したの標準ディレクトリからプリロードします。
 各設定の違いは、設定変更を行うためにいつ、どのような権限が必要かにあります。
      </para>
@@ -1289,7 +1287,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       <literal>XXX</literal> is <literal>pgsql</literal>, <literal>perl</literal>,
       <literal>tcl</literal>, or <literal>python</literal>.
 -->
-      典型的には<literal>'$libdir/plXXX'</literal>のような構文を用いて<productname>PostgreSQL</productname>手続き言語ライブラリをこの方法でプリロードできます。
+典型的には<literal>'$libdir/plXXX'</literal>のような構文を用いて<productname>PostgreSQL</productname>手続き言語ライブラリをこの方法でプリロードできます。
 <literal>XXX</literal>は<literal>pgsql</literal>、<literal>perl</literal>、<literal>tcl</literal>、<literal>python</literal>です。
      </para>
 
@@ -1313,7 +1311,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       In general, refer to the documentation of a specific module for the
       recommended way to load that module.
 -->
-      一般的に言ってモジュールのドキュメントを参照し、推奨される方法でロードしてください。
+一般的に言ってモジュールのドキュメントを参照し、推奨される方法でロードしてください。
      </para>
 
      <variablelist>
@@ -1364,7 +1362,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
         the library name &mdash; <literal>mylib</literal> would have
         the same effect as <literal>$libdir/plugins/mylib</literal>.
 -->
-        このオプションはすべてのユーザが設定できます。
+このオプションはすべてのユーザが設定できます。
 この理由で、読み込み可能なライブラリはインストレーションの共有ライブラリディレクトリのサブディレクトリ<filename>plugins</filename>内にあるものに制限されています。
 （確実に<quote>安全</quote>なライブラリのみをここにインストールすることはデータベース管理者の責任です。）
  <varname>local_preload_libraries</varname>内の項目で、たとえば<literal>$libdir/plugins/mylib</literal>のようにこのディレクトリを明示的に指定することも、単にライブラリ名を指定することも可能です。
@@ -1444,7 +1442,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
         session is started), so it is easier to add new modules this way, even
         if they should apply to all sessions.
 -->
-        この機能は、デバッグや性能測定の目的で<command>LOAD</command>コマンドを使わずに特定のセッションでライブラリをロードする目的で使われます。
+この機能は、デバッグや性能測定の目的で<command>LOAD</command>コマンドを使わずに特定のセッションでライブラリをロードする目的で使われます。
 たとえば<command>ALTER ROLE SET</command>で設定することにより、特定のユーザが開始するすべてのセッションで<xref linkend="auto-explain"/>が有効になります。
 また、このパラメータはサーバを再起動せずに変更できます(しかし変更は新しいセッションが開始するときにのみ有効となります)。すべてのセッションで有効にしたいのであれば、この方法で新しいモジュールを容易に追加できます。
        </para>
@@ -1456,7 +1454,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
         when it is first used.  There is some advantage, however, when
         connection pooling is used.
 -->
-        <xref linkend="guc-shared-preload-libraries"/>と違って、ライブラリがはじめて使われるときにロードする方法と比べてセッションが開始するときにライブラリをロードする方法には大きな性能的な優位性はありません。
+<xref linkend="guc-shared-preload-libraries"/>と違って、ライブラリがはじめて使われるときにロードする方法と比べてセッションが開始するときにライブラリをロードする方法には大きな性能的な優位性はありません。
 しかし、コネクションプーリングを使うのであれば、いくらか優位性があります。
        </para>
       </listitem>
@@ -1498,7 +1496,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
         must be loaded at server start through this parameter.  See the
         documentation of each library for details.
 -->
-        ライブラリによってはpostmaster起動時にのみ可能な操作を実行する必要があるものがあります。
+ライブラリによってはpostmaster起動時にのみ可能な操作を実行する必要があるものがあります。
 たとえば、共有メモリの獲得、軽量ロックの予約、バックグラウンドワーカの起動などです。
 このようなライブラリはこのパラメータを使ってサーバ起動時にロードしなければなりません。
 詳細は各ライブラリのドキュメントを見てください。
@@ -1516,7 +1514,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
         say.  Use <xref linkend="guc-session-preload-libraries"/> for that
         instead.
 -->
-        これ以外のライブラリもプリロードできます。
+これ以外のライブラリもプリロードできます。
 共有ライブラリをプリロードすることにより、最初にライブラリが使われる際にライブラリが起動する時間を避けることができます。
 しかし、そのライブラリが使われないとしても、サーバプロセスが起動する時間がわずかに長くなる可能性があります。
 したがって、この方法は、ほとんどのセッションで使われるライブラリにのみ使用することを推奨します。
@@ -1581,9 +1579,9 @@ SET XML OPTION { DOCUMENT | CONTENT };
    </sect2>
 
      <sect2 id="runtime-config-client-other">
-     <!--
+<!--
      <title>Other Defaults</title>
-     -->
+-->
      <title>その他のデフォルト</title>
 
      <variablelist>
@@ -1601,19 +1599,19 @@ SET XML OPTION { DOCUMENT | CONTENT };
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If a dynamically loadable module needs to be opened and the
         file name specified in the <command>CREATE FUNCTION</command> or
         <command>LOAD</command> command
         does not have a directory component (i.e., the
         name does not contain a slash), the system will search this
         path for the required file.
-       -->
-       オープンする必要がある動的ロード可能なモジュールについて、その<command>CREATE FUNCTION</command>や<command>LOAD</command>コマンドで指定されたファイル名にディレクトリ要素がなく（つまり、名前にスラッシュが含まれずに）指定された場合、システムは必要なファイルをこのパスから検索します。
+-->
+オープンする必要がある動的ロード可能なモジュールについて、その<command>CREATE FUNCTION</command>や<command>LOAD</command>コマンドで指定されたファイル名にディレクトリ要素がなく（つまり、名前にスラッシュが含まれずに）指定された場合、システムは必要なファイルをこのパスから検索します。
        </para>
 
        <para>
-       <!--
+<!--
         The value for <varname>dynamic_library_path</varname> must be a
         list of absolute directory paths separated by colons (or semi-colons
         on Windows).  If a list element starts
@@ -1624,8 +1622,8 @@ SET XML OPTION { DOCUMENT | CONTENT };
         <productname>PostgreSQL</productname> distribution are installed.
         (Use <literal>pg_config &#045;-pkglibdir</literal> to find out the name of
         this directory.) For example:
-       -->
-       <varname>dynamic_library_path</varname>の値は、絶対パスのディレクトリ名をコロン（Windowsの場合はセミコロン）で区切った一覧です。
+-->
+<varname>dynamic_library_path</varname>の値は、絶対パスのディレクトリ名をコロン（Windowsの場合はセミコロン）で区切った一覧です。
 この一覧の要素が特別な<literal>$libdir</literal>という値から始まる場合、コンパイルされた<productname>PostgreSQL</productname>パッケージのライブラリディレクトリで<literal>$libdir</literal>は置換されます。
 ここには、<productname>PostgreSQL</productname>の標準配布物により提供されるモジュールがインストールされます
 （このディレクトリ名を表示するには、<literal>pg_config --pkglibdir</literal> を使用してください）。
@@ -1643,25 +1641,25 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
        </para>
 
        <para>
-       <!--
+<!--
         The default value for this parameter is
         <literal>'$libdir'</literal>. If the value is set to an empty
         string, the automatic path search is turned off.
-       -->
-       このパラメータのデフォルト値は<literal>'$libdir'</literal>です。
+-->
+このパラメータのデフォルト値は<literal>'$libdir'</literal>です。
 この値が空に設定された場合、自動的なパス検索は無効になります。
        </para>
 
        <para>
-       <!--
+<!--
         This parameter can be changed at run time by superusers, but a
         setting done that way will only persist until the end of the
         client connection, so this method should be reserved for
         development purposes. The recommended way to set this parameter
         is in the <filename>postgresql.conf</filename> configuration
         file.
-       -->
-       このパラメータはスーパーユーザによって実行時に変更することができますが、この方法での設定は、そのクライアント接続が終わるまでしか有効になりません。
+-->
+このパラメータはスーパーユーザによって実行時に変更することができますが、この方法での設定は、そのクライアント接続が終わるまでしか有効になりません。
 ですので、この方法は開発目的でのみ使用すべきです。
 推奨方法はこのパラメータを<filename>postgresql.conf</filename>設定ファイル内で設定することです。
        </para>
@@ -1679,10 +1677,10 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Soft upper limit of the size of the set returned by GIN index scans. For more
         information see <xref linkend="gin-tips"/>.
-       -->
+-->
        GINインデックス走査により返されるセットのソフトな上限サイズです。
 詳細は<xref linkend="gin-tips"/>を参照してください。
        </para>
@@ -1694,9 +1692,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
    </sect1>
 
    <sect1 id="runtime-config-locks">
-   <!--
+<!--
     <title>Lock Management</title>
-    -->
+-->
     <title>ロック管理</title>
 
      <variablelist>
@@ -1728,7 +1726,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         This is the amount of time to wait on a lock
         before checking to see if there is a deadlock condition. The
         check for deadlock is relatively expensive, so the server doesn't run
@@ -1760,13 +1758,13 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
        </para>
 
        <para>
-       <!--
+<!--
         When <xref linkend="guc-log-lock-waits"/> is set,
         this parameter also determines the amount of time to wait before
         a log message is issued about the lock wait.  If you are trying
         to investigate locking delays you might want to set a shorter than
         normal <varname>deadlock_timeout</varname>.
-       -->
+-->
 <xref linkend="guc-log-lock-waits"/>が設定された場合、このパラメータはロック待機に関するログメッセージを出力する前の待機時間を決定します。
 ロック遅延の調査を行う場合は、通常の<varname>deadlock_timeout</varname>よりも短い値を設定することを勧めます。
        </para>
@@ -1784,7 +1782,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The shared lock table tracks locks on
         <varname>max_locks_per_transaction</varname> * (<xref
         linkend="guc-max-connections"/> + <xref
@@ -1799,8 +1797,8 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         raise this value if you have queries that touch many different
         tables in a single transaction, e.g., query of a parent table with
         many children.  This parameter can only be set at server start.
-       -->
-       共有ロックテーブルは、<varname>max_locks_per_transaction</varname> * （<xref linkend="guc-max-connections"/> + <xref linkend="guc-max-prepared-transactions"/>）オブジェクト（例えばテーブル）上のロック追跡します。
+-->
+共有ロックテーブルは、<varname>max_locks_per_transaction</varname> * （<xref linkend="guc-max-connections"/> + <xref linkend="guc-max-prepared-transactions"/>）オブジェクト（例えばテーブル）上のロック追跡します。
 したがって、ある時点でこの数以上の個々のオブジェクトをロックすることはできません。
 このパラメータは各トランザクションで割り当てられるオブジェクトロックの平均値を制御します。
 個々のトランザクションでは、このロックテーブルにすべてのトランザクションのロックが収まる限りオブジェクトのロックを獲得できます。
@@ -1810,13 +1808,13 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
        </para>
 
        <para>
-       <!--
+<!--
         When running a standby server, you must set this parameter to the
         same or higher value than on the primary server. Otherwise, queries
         will not be allowed in the standby server.
-       -->
-       スタンバイサーバを稼動するとき、このパラメータをプライマリサーバと同じか、より高い値に設定しなければなりません。
-       そうしないと、問い合わせはスタンバイサーバでは許可されません。
+-->
+スタンバイサーバを稼動するとき、このパラメータをプライマリサーバと同じか、より高い値に設定しなければなりません。
+そうしないと、問い合わせはスタンバイサーバでは許可されません。
        </para>
       </listitem>
      </varlistentry>
@@ -1832,7 +1830,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The shared predicate lock table tracks locks on
         <varname>max_pred_locks_per_transaction</varname> * (<xref
         linkend="guc-max-connections"/> + <xref
@@ -1847,16 +1845,16 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         raise this value if you have clients that touch many different
         tables in a single serializable transaction. This parameter can
         only be set at server start.
-       -->
-       共有記述ロックテーブル（shared predicate lock table）は、<varname>max_pred_locks_per_transaction</varname> * (<xref
+-->
+共有記述ロックテーブル（shared predicate lock table）は、<varname>max_pred_locks_per_transaction</varname> * (<xref
         linkend="guc-max-connections"/> + <xref
         linkend="guc-max-prepared-transactions"/>)オブジェクト（例えば諸テーブル）のロックを追跡します。
-       従って、この数以上の明確なオブジェクトは同時にロックされません。
-       このパラメータはそれぞれのトランザクションに対して割り当てられたオブジェクトのロックの平均数を管理します。
-       個別のトランザクションはロックテーブル内の全てのトランザクションのロックが適合する限り、より多くのオブジェクトをロックできます。
-       これはロック可能な行数では<emphasis>ありません</emphasis>。その値は無制限です。
-       デフォルトは64で、テストでは一般的に充分ですが、単一のシリアライザブルトランザクションで数多くの異なるテーブルに触れるクライアントが存在する場合、この値を大きくする必要があることがあります。
-       このパラメータはサーバ起動時のみ設定可能です。
+従って、この数以上の明確なオブジェクトは同時にロックされません。
+このパラメータはそれぞれのトランザクションに対して割り当てられたオブジェクトのロックの平均数を管理します。
+個別のトランザクションはロックテーブル内の全てのトランザクションのロックが適合する限り、より多くのオブジェクトをロックできます。
+これはロック可能な行数では<emphasis>ありません</emphasis>。その値は無制限です。
+デフォルトは64で、テストでは一般的に充分ですが、単一のシリアライザブルトランザクションで数多くの異なるテーブルに触れるクライアントが存在する場合、この値を大きくする必要があることがあります。
+このパラメータはサーバ起動時のみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1885,7 +1883,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
 -->
 リレーション全体をカバーするロックに昇格する前に、一つリレーションの中で述語ロックできるページ数あるいはタプル数を指定します。
 0以上の値は、絶対的な制限を表し、負の数は<xref linkend="guc-max-pred-locks-per-transaction"/>をその絶対値で割ったものを表します。
-  デフォルトは-2で、以前のバージョンの<productname>PostgreSQL</productname>の振る舞いを維持します。
+デフォルトは-2で、以前のバージョンの<productname>PostgreSQL</productname>の振る舞いを維持します。
 このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
@@ -1919,15 +1917,15 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
    </sect1>
 
    <sect1 id="runtime-config-compatible">
-   <!--
+<!--
     <title>Version and Platform Compatibility</title>
-    -->
+-->
     <title>バージョンとプラットフォーム互換性</title>
 
     <sect2 id="runtime-config-compatible-version">
-    <!--
+<!--
      <title>Previous PostgreSQL Versions</title>
-     -->
+-->
      <title>以前のPostgreSQLバージョン</title>
 
      <variablelist>
@@ -1943,7 +1941,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         This controls whether the array input parser recognizes
         unquoted <literal>NULL</literal> as specifying a null array element.
         By default, this is <literal>on</literal>, allowing array values containing
@@ -1953,19 +1951,19 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         the string value <quote>NULL</quote>.  For backward compatibility with
         applications that require the old behavior, this variable can be
         turned <literal>off</literal>.
-       -->
-       これは、配列入力パーサが引用符のない<literal>NULL</literal>をNULL配列要素として認識するかどうかを制御します。
+-->
+これは、配列入力パーサが引用符のない<literal>NULL</literal>をNULL配列要素として認識するかどうかを制御します。
 デフォルトでは、これは<literal>on</literal>で、NULL値を持つ配列値を入力することができます。
 しかし、8.2より前のバージョンの<productname>PostgreSQL</productname>では、配列内のNULL値をサポートしておらず、<literal>NULL</literal>を<quote>NULL</quote>という値の文字列を持つ通常の配列要素として扱っていました。
 古い動作を必要とするアプリケーションの後方互換性のため、この変数を<literal>off</literal>にすることができます。
        </para>
 
        <para>
-       <!--
+<!--
         Note that it is possible to create array values containing null values
         even when this variable is <literal>off</literal>.
-       -->
-       この変数が<literal>off</literal>であっても、NULL値を含む配列値を作成することができることに注意してください。
+-->
+この変数が<literal>off</literal>であっても、NULL値を含む配列値を作成することができることに注意してください。
        </para>
       </listitem>
      </varlistentry>
@@ -1983,7 +1981,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         This controls whether a quote mark can be represented by
         <literal>\'</literal> in a string literal.  The preferred, SQL-standard way
         to represent a quote mark is by doubling it (<literal>''</literal>) but
@@ -2001,12 +1999,12 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         <literal>safe_encoding</literal> (allow only if client encoding does not
         allow ASCII <literal>\</literal> within a multibyte character).
         <literal>safe_encoding</literal> is the default setting.
-       -->
-       文字列リテラルの中で引用符が<literal>\'</literal>で表現されるかどうかを管理します。
-       引用符の表現としてSQL準拠の方式では二重化（<literal>''</literal>）ですが、<productname>PostgreSQL</productname>は歴史的に<literal>\'</literal>も受け付けます。
-       とは言っても、いくつかのクライアント文字集合符号化方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
-       クライアント側のコードが事実上エスケープを正しく扱わない場合、SQLインジェクション攻撃が可能になります。この危険性の回避は、サーバが逆スラッシュでエスケープされた引用符を含む問い合わせを拒絶するようにします。
-       許可される<varname>backslash_quote</varname>の値は、
+-->
+文字列リテラルの中で引用符が<literal>\'</literal>で表現されるかどうかを管理します。
+引用符の表現としてSQL準拠の方式では二重化（<literal>''</literal>）ですが、<productname>PostgreSQL</productname>は歴史的に<literal>\'</literal>も受け付けます。
+とは言っても、いくつかのクライアント文字集合符号化方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
+クライアント側のコードが事実上エスケープを正しく扱わない場合、SQLインジェクション攻撃が可能になります。この危険性の回避は、サーバが逆スラッシュでエスケープされた引用符を含む問い合わせを拒絶するようにします。
+許可される<varname>backslash_quote</varname>の値は、
         <literal>on</literal> （常に <literal>\'</literal> を許可）,
         <literal>off</literal> （常に拒否）、および
         <literal>safe_encoding</literal> （クライアント符号化方式がASCIIの<literal>\</literal>を許可しないときのみ、マルチバイト文字内で許可）。
@@ -2014,13 +2012,13 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
        </para>
 
        <para>
-       <!--
+<!--
         Note that in a standard-conforming string literal, <literal>\</literal> just
         means <literal>\</literal> anyway.  This parameter only affects the handling of
         non-standard-conforming literals, including
         escape string syntax (<literal>E'...'</literal>).
-       -->
-       標準に従った文字列リテラルでは、<literal>\</literal>は単に<literal>\</literal>を意味するものです。
+-->
+標準に従った文字列リテラルでは、<literal>\</literal>は単に<literal>\</literal>を意味するものです。
 このパラメータのみが、エスケープ文字列構文（<literal>E'...'</literal>）を含む標準に従わないリテラルの取り扱いに影響します。
        </para>
       </listitem>
@@ -2039,25 +2037,25 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When on, a warning is issued if a backslash (<literal>\</literal>)
         appears in an ordinary string literal (<literal>'...'</literal>
         syntax) and <varname>standard_conforming_strings</varname> is off.
         The default is <literal>on</literal>.
-       -->
-       有効の場合、通常の文字列リテラル（<literal>'...'</literal>構文）にバックスラッシュ（<literal>\</literal>）があり、<varname>standard_conforming_strings</varname>が無効な場合、警告が発せられます。
+-->
+有効の場合、通常の文字列リテラル（<literal>'...'</literal>構文）にバックスラッシュ（<literal>\</literal>）があり、<varname>standard_conforming_strings</varname>が無効な場合、警告が発せられます。
 デフォルトは<literal>on</literal>です。
        </para>
        <para>
-       <!--
+<!--
         Applications that wish to use backslash as escape should be
         modified to use escape string syntax (<literal>E'...'</literal>),
         because the default behavior of ordinary strings is now to treat
         backslash as an ordinary character, per SQL standard.  This variable
         can be enabled to help locate code that needs to be changed.
-       -->
-       通常文字列のデフォルトの振る舞いは、SQL標準ではバックスラッシュを通常文字として取り扱うため、バックスラッシュをエスケープとして使用したいアプリケーションは、エスケープ文字列構文(<literal>E'...'</literal>)を使用するように変更すべきです。
-        この変数は変更すべきコードを突き止めるのに役立つよう、有効にすることができます。
+-->
+通常文字列のデフォルトの振る舞いは、SQL標準ではバックスラッシュを通常文字として取り扱うため、バックスラッシュをエスケープとして使用したいアプリケーションは、エスケープ文字列構文(<literal>E'...'</literal>)を使用するように変更すべきです。
+この変数は変更すべきコードを突き止めるのに役立つよう、有効にすることができます。
        </para>
       </listitem>
      </varlistentry>
@@ -2068,23 +2066,23 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
        <primary><varname>lo_compat_privileges</varname> configuration parameter</primary>
       </indexterm>
       <indexterm>
-       <primary><varname>lo-compat-privileges</varname>設定パラメータ</primary>
+       <primary><varname>lo_compat_privileges</varname>設定パラメータ</primary>
       </indexterm>
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         In <productname>PostgreSQL</productname> releases prior to 9.0, large objects
         did not have access privileges and were, therefore, always readable
         and writable by all users.  Setting this variable to <literal>on</literal>
         disables the new privilege checks, for compatibility with prior
         releases.  The default is <literal>off</literal>.
         Only superusers can change this setting.
-       -->
+-->
        9.0以前の<productname>PostgreSQL</productname>リリースでは、ラージオブジェクトはアクセス権限が無く、従って全てのユーザが常に読み込み、書き込みが可能でした。
-       この変数を<literal>on</literal>にすると、以前のリリースとの互換性のため、新規の権限チェックが無効になります。
-       デフォルトは<literal>off</literal>です。
-        スーパーユーザのみこの設定を変更できます。
+この変数を<literal>on</literal>にすると、以前のリリースとの互換性のため、新規の権限チェックが無効になります。
+デフォルトは<literal>off</literal>です。
+スーパーユーザのみこの設定を変更できます。
        </para>
        <para>
 <!--
@@ -2137,7 +2135,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         This controls whether ordinary string literals
         (<literal>'...'</literal>) treat backslashes literally, as specified in
         the SQL standard.
@@ -2150,10 +2148,10 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         Escape string syntax (<xref linkend="sql-syntax-strings-escape"/>)
         should be used if an application desires
         backslashes to be treated as escape characters.
-       -->
-       標準SQLで規定されたように、通常の文字列リテラル（<literal>'...'</literal>）がバックスラッシュをそのまま取り扱うか否かを制御します。
+-->
+標準SQLで規定されたように、通常の文字列リテラル（<literal>'...'</literal>）がバックスラッシュをそのまま取り扱うか否かを制御します。
        <productname>PostgreSQL</productname> 9.1からデフォルトは<literal>on</literal>になっています（それ以前のリリースでは<literal>off</literal>がデフォルトでした）。
-       どのように文字列リテラルが処理されるかを決めるこのパラメータを、アプリケーションで検査することができます。
+どのように文字列リテラルが処理されるかを決めるこのパラメータを、アプリケーションで検査することができます。
 このパラメータの存在は、エスケープ文字列構文（<literal>E'...'</literal>）がサポートされているかどうかを示すものとも考えられます。
 エスケープ文字列構文 (<xref linkend="sql-syntax-strings-escape"/>)は、アプリケーションでバックスラッシュをエスケープ文字として扱いたい場合に使用すべきです。
        </para>
@@ -2171,7 +2169,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         This allows sequential scans of large tables to synchronize with each
         other, so that concurrent scans read the same block at about the
         same time and hence share the I/O workload.  When this is enabled,
@@ -2183,8 +2181,8 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         <literal>off</literal> ensures the pre-8.3 behavior in which a sequential
         scan always starts from the beginning of the table.  The default
         is <literal>on</literal>.
-       -->
-       これにより、同時実行スキャンがほぼ同じ時間に同じブロックを読み取り、I/Oへの負荷を分散できるように、互いに同期して、大規模テーブルをシーケンシャルスキャンすることができます。
+-->
+これにより、同時実行スキャンがほぼ同じ時間に同じブロックを読み取り、I/Oへの負荷を分散できるように、互いに同期して、大規模テーブルをシーケンシャルスキャンすることができます。
 これが有効な場合、スキャンはテーブルの途中から始まり、進行中のスキャンの活動と同期するように、行全体を覆うように終端を<quote>巻き上げる</quote>可能性があります。
 これにより、<literal>ORDER BY</literal>句を持たない問い合わせが返す行の順序は予想できない程変わってしまいます。
 このパラメータを<literal>off</literal>にすることで、シーケンシャルスキャンが常にテーブルの先頭から始まるという、8.3より前の動作を保証します。
@@ -2197,9 +2195,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
     </sect2>
 
     <sect2 id="runtime-config-compatible-clients">
-    <!--
+<!--
      <title>Platform and Client Compatibility</title>
-     -->
+-->
      <title>プラットフォームとクライアント互換性</title>
      <variablelist>
 
@@ -2215,7 +2213,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When on, expressions of the form <literal><replaceable>expr</replaceable> =
         NULL</literal> (or <literal>NULL =
         <replaceable>expr</replaceable></literal>) are treated as
@@ -2225,8 +2223,8 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         <literal><replaceable>expr</replaceable> = NULL</literal> is to always
         return null (unknown). Therefore this parameter defaults to
         <literal>off</literal>.
-       -->
-       有効の場合、<literal><replaceable>expr</replaceable> = NULL</literal>（もしくは<literal>NULL = <replaceable>expr</replaceable></literal>）形式の式は<literal><replaceable>expr</replaceable> IS NULL</literal>として取り扱われ、それは、もし<replaceable>expr</replaceable>がNULL値と評価すれば真を返し、そうでなければ偽を返します。
+-->
+有効の場合、<literal><replaceable>expr</replaceable> = NULL</literal>（もしくは<literal>NULL = <replaceable>expr</replaceable></literal>）形式の式は<literal><replaceable>expr</replaceable> IS NULL</literal>として取り扱われ、それは、もし<replaceable>expr</replaceable>がNULL値と評価すれば真を返し、そうでなければ偽を返します。
 <literal><replaceable>expr</replaceable> = NULL</literal>の正しいSQL仕様準拠の動作は常にNULL（判らない）を返すことです。
 従って、このパラメータのデフォルトは<literal>off</literal>になっています。
        </para>
@@ -2252,23 +2250,23 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
        </para>
 
        <para>
-       <!--
+<!--
         Note that this option only affects the exact form <literal>= NULL</literal>,
         not other comparison operators or other expressions
         that are computationally equivalent to some expression
         involving the equals operator (such as <literal>IN</literal>).
         Thus, this option is not a general fix for bad programming.
-       -->
-       このオプションは<literal>= NULL</literal>という形式にのみ影響することに注意してください。
+-->
+このオプションは<literal>= NULL</literal>という形式にのみ影響することに注意してください。
 他の比較演算子や等価演算子を呼び出す他の（<literal>IN</literal>のような）式と計算する上で等価となる式には影響を与えません。
 したがって、このオプションは間違ったプログラミングの汎用的な問題解決を行いません。
        </para>
 
        <para>
-       <!--
+<!--
         Refer to <xref linkend="functions-comparison"/> for related information.
-       -->
-       関連する情報は<xref linkend="functions-comparison"/>を参照してください。
+-->
+関連する情報は<xref linkend="functions-comparison"/>を参照してください。
        </para>
       </listitem>
      </varlistentry>
@@ -2278,9 +2276,9 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
    </sect1>
 
    <sect1 id="runtime-config-error-handling">
-   <!--
+<!--
     <title>Error Handling</title>
-    -->
+-->
     <title>エラー処理</title>
 
     <variablelist>
@@ -2296,11 +2294,11 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If on, any error will terminate the current session.  By default,
         this is set to off, so that only FATAL errors will terminate the
         session.
-       -->
+-->
 onなら、全てのエラーは現在のセッションを中止させます。
 デフォルトではこれはoffに設定されているので、 FATALエラーのみがセッションを中止させます。
        </para>
@@ -2318,7 +2316,7 @@ onなら、全てのエラーは現在のセッションを中止させます。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         When set to on, which is the default, <productname>PostgreSQL</productname>
         will automatically reinitialize after a backend crash.  Leaving this
         value set to on is normally the best way to maximize the availability
@@ -2326,7 +2324,7 @@ onなら、全てのエラーは現在のセッションを中止させます。
         <productname>PostgreSQL</productname> is being invoked by clusterware, it may be
         useful to disable the restart so that the clusterware can gain
         control and take any actions it deems appropriate.
-       -->
+-->
 デフォルトであるonの場合、<productname>PostgreSQL</productname>はバックエンドのクラッシュの後、自動的に再初期化を行います。
 この値を真のままにしておくことが、通常データベースの可用性を最大化する最適の方法です。
 しかし、 <productname>PostgreSQL</productname>がクラスタウェアにより起動された時のような状況では、クラスタウェアが制御を獲得して、適切とみなすいかなる振る舞いをも行えるように再起動を無効にすることが有益かもしれません。
@@ -2394,9 +2392,9 @@ onに設定すると、代わりに<productname>PostgreSQL</productname>はエ�
      <varlistentry id="guc-recovery-init-sync-method" xreflabel="recovery_init_sync_method">
       <term><varname>recovery_init_sync_method</varname> (<type>enum</type>)
        <indexterm>
-<!--
         <primary><varname>recovery_init_sync_method</varname> configuration parameter</primary>
--->
+       </indexterm>
+       <indexterm>
         <primary><varname>recovery_init_sync_method</varname>設定パラメータ</primary>
        </indexterm>
       </term>
@@ -2453,13 +2451,13 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
    </sect1>
 
    <sect1 id="runtime-config-preset">
-   <!--
+<!--
     <title>Preset Options</title>
-    -->
+-->
     <title>設定済みのオプション</title>
 
     <para>
-    <!--
+<!--
      The following <quote>parameters</quote> are read-only.
      As such, they have been excluded from the sample
      <filename>postgresql.conf</filename> file.  These options report
@@ -2468,7 +2466,7 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
      administrative front-ends.
      Most of them are determined when <productname>PostgreSQL</productname>
      is compiled or when it is installed.
-     -->
+-->
 以下の<quote>パラメータ</quote>は読み取り専用です。
 そのため、これらは<filename>postgresql.conf</filename>のサンプルから除かれています。
 このオプションは、特定のアプリケーション、特に管理用フロントエンドによって注目される可能性がある<productname>PostgreSQL</productname>の様々な部分の振舞いを報告します。
@@ -2488,18 +2486,18 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the size of a disk block.  It is determined by the value
         of <literal>BLCKSZ</literal> when building the server. The default
         value is 8192 bytes.  The meaning of some configuration
         variables (such as <xref linkend="guc-shared-buffers"/>) is
         influenced by <varname>block_size</varname>. See <xref
         linkend="runtime-config-resource"/> for information.
-       -->
-       ディスクブロックの容量を報告します。
-       サーバ構築の際に<literal>BLCKSZ</literal>の値で決定されます。デフォルトの値は8192バイトです。
+-->
+ディスクブロックの容量を報告します。
+サーバ構築の際に<literal>BLCKSZ</literal>の値で決定されます。デフォルトの値は8192バイトです。
        （<xref linkend="guc-shared-buffers"/>の様な）いくつかの構成変数の意味は<varname>block_size</varname>によって影響されます。
-       これに関しての情報は<xref
+これに関しての情報は<xref
         linkend="runtime-config-resource"/>を参照してください。
        </para>
       </listitem>
@@ -2520,8 +2518,8 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
         Reports whether data checksums are enabled for this cluster.
         See <xref linkend="app-initdb-data-checksums"/> for more information.
 -->
-        このクラスタでデータチェックサムが有効になっているかどうかを報告します。
-        詳細は<xref linkend="app-initdb-data-checksums"/>を見てください。
+このクラスタでデータチェックサムが有効になっているかどうかを報告します。
+詳細は<xref linkend="app-initdb-data-checksums"/>を見てください。
        </para>
       </listitem>
      </varlistentry>
@@ -2605,9 +2603,9 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
      <varlistentry id="guc-in-hot-standby" xreflabel="in_hot_standby">
       <term><varname>in_hot_standby</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>in_hot_standby</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>in_hot_standby</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -2639,14 +2637,14 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the locale in which sorting of textual data is done.
         See <xref linkend="locale"/> for more information.
         This value is determined when a database is created.
-       -->
-       テキストデータの並び替えが行なわれるロケールを報告します。
-       詳細は<xref linkend="locale"/> を参照してください。
-       この値はデータベースが作成されたときに決定されます。
+-->
+テキストデータの並び替えが行なわれるロケールを報告します。
+詳細は<xref linkend="locale"/> を参照してください。
+この値はデータベースが作成されたときに決定されます。
        </para>
       </listitem>
      </varlistentry>
@@ -2662,17 +2660,17 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the locale that determines character classifications.
         See <xref linkend="locale"/> for more information.
         This value is determined when a database is created.
         Ordinarily this will be the same as <varname>lc_collate</varname>,
         but for special applications it might be set differently.
-       -->
-       文字分類を決定するロケールを報告します。
-       詳細は<xref linkend="locale"/>を参照してください。
-       この値はデータベースが作成されたときに決定されます。
-       通常、これは<varname>lc_collate</varname>と同一ですが、特殊なアプリケーションでは異なって設定されることがあります。
+-->
+文字分類を決定するロケールを報告します。
+詳細は<xref linkend="locale"/>を参照してください。
+この値はデータベースが作成されたときに決定されます。
+通常、これは<varname>lc_collate</varname>と同一ですが、特殊なアプリケーションでは異なって設定されることがあります。
        </para>
       </listitem>
      </varlistentry>
@@ -2688,12 +2686,12 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the maximum number of function arguments. It is determined by
         the value of <literal>FUNC_MAX_ARGS</literal> when building the server. The
         default value is 100 arguments.
-       -->
-       関数の引数の最大数を報告します。
+-->
+関数の引数の最大数を報告します。
 サーバを構築する時、<literal>FUNC_MAX_ARGS</literal>の値で決定されます。
 デフォルトの値は100引数です。
        </para>
@@ -2711,15 +2709,15 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the maximum identifier length. It is determined as one
         less than the value of <literal>NAMEDATALEN</literal> when building
         the server. The default value of <literal>NAMEDATALEN</literal> is
         64; therefore the default
         <varname>max_identifier_length</varname> is 63 bytes, which
         can be less than 63 characters when using multibyte encodings.
-       -->
-       最長の識別子の長さを報告します。
+-->
+最長の識別子の長さを報告します。
 サーバ構築時の<literal>NAMEDATALEN</literal>の値より一つ少なく設定されます。
 デフォルトの<literal>NAMEDATALEN</literal>の値は64ですので、デフォルトの<varname>max_identifier_length</varname>は63バイトで、マルチバイト符号化方式を使用している場合、63文字以下になることがあります。
        </para>
@@ -2737,12 +2735,12 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the maximum number of index keys. It is determined by
         the value of <literal>INDEX_MAX_KEYS</literal> when building the server. The
         default value is 32 keys.
-       -->
-       インデックスキーの最大数を報告します。サーバをビルドする際に<literal>INDEX_MAX_KEYS</literal>の値で決定されます。デフォルトの値は32キーです。
+-->
+インデックスキーの最大数を報告します。サーバをビルドする際に<literal>INDEX_MAX_KEYS</literal>の値で決定されます。デフォルトの値は32キーです。
        </para>
       </listitem>
      </varlistentry>
@@ -2758,16 +2756,16 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the number of blocks (pages) that can be stored within a file
         segment.  It is determined by the value of <literal>RELSEG_SIZE</literal>
         when building the server.  The maximum size of a segment file in bytes
         is equal to <varname>segment_size</varname> multiplied by
         <varname>block_size</varname>; by default this is 1GB.
-       -->
-       あるファイルセグメントの中に格納できるブロック数（ページ数）を報告します。
-       サーバ構築時に<literal>RELSEG_SIZE</literal>の値で決定されます。
-       バイト単位の一セグメントファイルの最大容量は、<varname>block_size</varname>倍の<varname>segment_size</varname>と等しくなります。デフォルトでは1GBです。
+-->
+あるファイルセグメントの中に格納できるブロック数（ページ数）を報告します。
+サーバ構築時に<literal>RELSEG_SIZE</literal>の値で決定されます。
+バイト単位の一セグメントファイルの最大容量は、<varname>block_size</varname>倍の<varname>segment_size</varname>と等しくなります。デフォルトでは1GBです。
        </para>
       </listitem>
      </varlistentry>
@@ -2785,14 +2783,14 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the database encoding (character set).
         It is determined when the database is created.  Ordinarily,
         clients need only be concerned with the value of <xref
         linkend="guc-client-encoding"/>.
-       -->
-       データベース符号化方式（文字セット）を報告します。
-       データベースが作成された時に決定されます。通常クライアントは<xref
+-->
+データベース符号化方式（文字セット）を報告します。
+データベースが作成された時に決定されます。通常クライアントは<xref
         linkend="guc-client-encoding"/>の値にのみ注意する必要があります。
        </para>
       </listitem>
@@ -2809,12 +2807,12 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the version number of the server. It is determined by the
         value of <literal>PG_VERSION</literal> when building the server.
-       -->
-       サーバのバージョン番号を報告します。
-       サーバ構築の際の<literal>PG_VERSION</literal>の値によって決定されます。
+-->
+サーバのバージョン番号を報告します。
+サーバ構築の際の<literal>PG_VERSION</literal>の値によって決定されます。
        </para>
       </listitem>
      </varlistentry>
@@ -2830,12 +2828,12 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Reports the version number of the server as an integer. It is determined
         by the value of <literal>PG_VERSION_NUM</literal> when building the server.
-       -->
-       サーバのバージョン番号を整数として返します。
-       この値は、サーバ構築時の<literal>PG_VERSION_NUM</literal>の値により決まります。
+-->
+サーバのバージョン番号を整数として返します。
+この値は、サーバ構築時の<literal>PG_VERSION_NUM</literal>の値により決まります。
        </para>
       </listitem>
      </varlistentry>
@@ -2910,33 +2908,33 @@ WALディスクブロックの容量を報告します。
    </sect1>
 
    <sect1 id="runtime-config-custom">
-   <!--
+<!--
     <title>Customized Options</title>
-    -->
+-->
     <title>独自のオプション</title>
 
     <para>
-    <!--
+<!--
      This feature was designed to allow parameters not normally known to
      <productname>PostgreSQL</productname> to be added by add-on modules
      (such as procedural languages).  This allows extension modules to be
      configured in the standard ways.
-     -->
-     この機能は追加モジュール（手続き言語など）によって追加される<productname>PostgreSQL</productname>が識別できないパラメータを使えるように設計されたものです。
+-->
+この機能は追加モジュール（手続き言語など）によって追加される<productname>PostgreSQL</productname>が識別できないパラメータを使えるように設計されたものです。
 これにより拡張モジュールは標準の方法で構成されます。
     </para>
 
     <para>
-    <!--
+<!--
      Custom options have two-part names: an extension name, then a dot, then
      the parameter name proper, much like qualified names in SQL.  An example
      is <literal>plpgsql.variable_conflict</literal>.
-    -->
-    カスタムオプションには２つに分かれた名称があります。拡張名につづいてドット、そして特定のパラメータ名です。SQLの修飾名に良く似ています。例として<literal>plpgsql.variable_conflict</literal>が挙げられます。
+-->
+カスタムオプションには２つに分かれた名称があります。拡張名につづいてドット、そして特定のパラメータ名です。SQLの修飾名に良く似ています。例として<literal>plpgsql.variable_conflict</literal>が挙げられます。
     </para>
 
     <para>
-    <!--
+<!--
      Because custom options may need to be set in processes that have not
      loaded the relevant extension module, <productname>PostgreSQL</productname>
      will accept a setting for any two-part parameter name.  Such variables
@@ -2945,27 +2943,27 @@ WALディスクブロックの容量を報告します。
      its variable definitions, convert any placeholder values according to
      those definitions, and issue warnings for any unrecognized placeholders
      that begin with its extension name.
-     -->
-     カスタムオプションは読み込まれていない関連性のある拡張モジュールのプロセスに設定される必要がある場合があるので、<productname>PostgreSQL</productname>はどんな２つの部分のパラメータ名による設定を受け付けます。これらの変数は代替物として取り扱われ、それらを定義したモジュールが読み込まれるまで機能しません。
-     拡張モジュールが読み込まれた時、その変数定義が追加され、それら定義に基づいた代替値が変換され、そしてその拡張名の確認されない代替物に対して警告が発せられます。
+-->
+カスタムオプションは読み込まれていない関連性のある拡張モジュールのプロセスに設定される必要がある場合があるので、<productname>PostgreSQL</productname>はどんな２つの部分のパラメータ名による設定を受け付けます。これらの変数は代替物として取り扱われ、それらを定義したモジュールが読み込まれるまで機能しません。
+拡張モジュールが読み込まれた時、その変数定義が追加され、それら定義に基づいた代替値が変換され、そしてその拡張名の確認されない代替物に対して警告が発せられます。
     </para>
    </sect1>
 
    <sect1 id="runtime-config-developer">
-   <!--
+<!--
     <title>Developer Options</title>
-    -->
+-->
     <title>開発者向けのオプション</title>
 
     <para>
-    <!--
+<!--
      The following parameters are intended for developer testing, and
      should never be used on a production database.  However, some of
      them can be used to assist with the recovery of severely damaged
      databases.  As such, they have been excluded from the sample
      <filename>postgresql.conf</filename> file.  Note that many of these
      parameters require special source compilation flags to work at all.
-     -->
+-->
 以下のパラメータは、開発者のテスト用であり、決して実運用のデータベースに使わないでください。
 しかし、中には深刻な損傷を負ったデータベースの復旧に役立つものもあります。
 したがって、これらはサンプルの<filename>postgresql.conf</filename>からは除外されています。
@@ -3042,9 +3040,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-debug-discard-caches" xreflabel="debug_discard_caches">
       <term><varname>debug_discard_caches</varname> (<type>integer</type>)
       <indexterm>
-<!--
        <primary><varname>debug_discard_caches</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>debug_discard_caches</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3099,9 +3097,9 @@ WALディスクブロックの容量を報告します。
      <varlistentry id="guc-force-parallel-mode" xreflabel="force_parallel_mode">
       <term><varname>force_parallel_mode</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary><varname>force_parallel_mode</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>force_parallel_mode</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3169,13 +3167,13 @@ WALディスクブロックの容量を報告します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Ignore system indexes when reading system tables (but still
         update the indexes when modifying the tables).  This is useful
         when recovering from damaged system indexes.
         This parameter cannot be changed after session start.
-       -->
-       システムテーブルの読み込み時にシステムインデックスを無視します（しかしテーブルが更新された時はインデックスを更新します）。
+-->
+システムテーブルの読み込み時にシステムインデックスを無視します（しかしテーブルが更新された時はインデックスを更新します）。
 障害があるシステムインデックスを復旧する時、これは有用です。
 セッションが始まった後に、このパラメータを変更することはできません。
        </para>
@@ -3193,7 +3191,7 @@ WALディスクブロックの容量を報告します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The amount of time to delay when a new
         server process is started, after it conducts the
         authentication procedure.  This is intended to give developers an
@@ -3201,7 +3199,7 @@ WALディスクブロックの容量を報告します。
         If this value is specified without units, it is taken as seconds.
         A value of zero (the default) disables the delay.
         This parameter cannot be changed after session start.
-       -->
+-->
 サーバプロセスが始まり認証手続きが終わった後の遅延時間です。
 これは、デバッガを使用してサーバプロセスに接続する機会を開発者に提供することを目的としています。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
@@ -3222,7 +3220,7 @@ WALディスクブロックの容量を報告します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         The amount of time to delay just after a
         new server process is forked, before it conducts the
         authentication procedure.  This is intended to give developers an
@@ -3232,7 +3230,7 @@ WALディスクブロックの容量を報告します。
         A value of zero (the default) disables the delay.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
+-->
 新しくサーバプロセスがforkした後、認証手続きに入る前の遅延時間です。
 これは、認証における誤動作を追跡するために、デバッガを使用してサーバプロセスに接続する機会を開発者に提供することを目的としたものです。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
@@ -3253,15 +3251,15 @@ WALディスクブロックの容量を報告します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Generates a great amount of debugging output for the
         <command>LISTEN</command> and <command>NOTIFY</command>
         commands.  <xref linkend="guc-client-min-messages"/> or
         <xref linkend="guc-log-min-messages"/> must be
         <literal>DEBUG1</literal> or lower to send this output to the
         client or server logs, respectively.
-       -->
-       <command>LISTEN</command>と<command>NOTIFY</command>コマンドのための大量なデバッグ出力を生成します。
+-->
+<command>LISTEN</command>と<command>NOTIFY</command>コマンドのための大量なデバッグ出力を生成します。
 この出力をクライアントもしくはサーバログに送信するためには、それぞれ、<xref linkend="guc-client-min-messages"/>もしくは<xref linkend="guc-log-min-messages"/>は<literal>DEBUG1</literal>以下でなければなりません。
        </para>
       </listitem>
@@ -3278,7 +3276,7 @@ WALディスクブロックの容量を報告します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Enables logging of recovery-related debugging output that otherwise
         would not be logged. This parameter allows the user to override the
         normal setting of <xref linkend="guc-log-min-messages"/>, but only for
@@ -3293,17 +3291,17 @@ WALディスクブロックの容量を報告します。
         them to the server log.
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
-       -->
-       復旧関連のデバッグ出力のログ取得を有効にします。さもないとログは取られません。
-       このパラメータはユーザに対し、<xref linkend="guc-log-min-messages"/>の通常設定を上書きすることを許可します。
-       しかし、特定のメッセージに対してのみです。これはホットスタンバイのデバッグを意図したものです。
-       有効な値は、<literal>DEBUG5</literal>、<literal>DEBUG4</literal>、
+-->
+復旧関連のデバッグ出力のログ取得を有効にします。さもないとログは取られません。
+このパラメータはユーザに対し、<xref linkend="guc-log-min-messages"/>の通常設定を上書きすることを許可します。
+しかし、特定のメッセージに対してのみです。これはホットスタンバイのデバッグを意図したものです。
+有効な値は、<literal>DEBUG5</literal>、<literal>DEBUG4</literal>、
         <literal>DEBUG3</literal>、<literal>DEBUG2</literal>、<literal>DEBUG1</literal>、および
         <literal>LOG</literal>です。
-       デフォルトの<literal>LOG</literal>は、ログ取得の決定に全く影響しません。
-       その他の値は、あたかも<literal>LOG</literal>優先度を所有しているごとく、それ、またはより高い優先度でログ取得される復旧関連デバッグメッセージの要因となります。
+デフォルトの<literal>LOG</literal>は、ログ取得の決定に全く影響しません。
+その他の値は、あたかも<literal>LOG</literal>優先度を所有しているごとく、それ、またはより高い優先度でログ取得される復旧関連デバッグメッセージの要因となります。
        <varname>log_min_messages</varname>の通常設定に対し、これは無条件にそれらをサーバログに送り込みます。
-       このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバコマンドラインでのみ設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -3319,13 +3317,13 @@ WALディスクブロックの容量を報告します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If on, emit information about resource usage during sort operations.
         This parameter is only available if the <symbol>TRACE_SORT</symbol> macro
         was defined when <productname>PostgreSQL</productname> was compiled.
         (However, <symbol>TRACE_SORT</symbol> is currently defined by default.)
-       -->
-       もしも有効であれば、並び替え操作の間のリソース使用についての情報を放出します。
+-->
+もしも有効であれば、並び替え操作の間のリソース使用についての情報を放出します。
 このパラメータは <productname>PostgreSQL</productname>がコンパイルされた時、<symbol>TRACE_SORT</symbol>マクロが定義されている場合にのみ有効です。
 （とは言っても、現在<symbol>TRACE_SORT</symbol>はデフォルトで定義されています。）
        </para>
@@ -3343,7 +3341,7 @@ WALディスクブロックの容量を報告します。
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If on, emit information about lock usage.  Information dumped
         includes the type of lock operation, the type of lock and the unique
         identifier of the object being locked or unlocked.  Also included
@@ -3352,12 +3350,12 @@ WALディスクブロックの容量を報告します。
         type a count of the number of granted locks and waiting locks is
         also dumped as well as the totals.  An example of the log file output
         is shown here:
-       -->
-       有効な場合、ロックの使用状況に関する情報を出力します。
-       出力される情報には、ロック操作の種類、ロックの種類、ロックまたはロック解除されているオブジェクトの一意な識別子が含まれます。
-       また、このオブジェクトに既に与えられているロック種類やこのオブジェクトで待機しているロック種類を表すビットマスクも含まれます。
-       ロック種類それぞれについて、与えられているロック数、待機中のロック数がその総数と共に出力されます。
-       ログファイル出力例を以下に示します。
+-->
+有効な場合、ロックの使用状況に関する情報を出力します。
+出力される情報には、ロック操作の種類、ロックの種類、ロックまたはロック解除されているオブジェクトの一意な識別子が含まれます。
+また、このオブジェクトに既に与えられているロック種類やこのオブジェクトで待機しているロック種類を表すビットマスクも含まれます。
+ロック種類それぞれについて、与えられているロック数、待機中のロック数がその総数と共に出力されます。
+ログファイル出力例を以下に示します。
 <screen>
 LOG:  LockAcquire: new: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       grantMask(0) req(0,0,0,0,0,0,0)=0 grant(0,0,0,0,0,0,0)=0
@@ -3372,19 +3370,19 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       grantMask(0) req(0,0,0,0,0,0,0)=0 grant(0,0,0,0,0,0,0)=0
       wait(0) type(INVALID)
 </screen>
-       <!--
+<!--
         Details of the structure being dumped may be found in
         <filename>src/include/storage/lock.h</filename>.
-       -->
-       ダンプされる構造の詳細は、<filename>src/include/storage/lock.h</filename> にあります。
+-->
+ダンプされる構造の詳細は、<filename>src/include/storage/lock.h</filename> にあります。
        </para>
        <para>
-       <!--
+<!--
         This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
         macro was defined when <productname>PostgreSQL</productname> was
         compiled.
-       -->
-       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+-->
+このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
        </para>
       </listitem>
      </varlistentry>
@@ -3400,21 +3398,21 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If on, emit information about lightweight lock usage.  Lightweight
         locks are intended primarily to provide mutual exclusion of access
         to shared-memory data structures.
-       -->
-       有効な場合、軽量ロックの使用状況に関する情報を出力します。
-       軽量ロックは主に、共有メモリ上のデータ構造へのアクセスに関する排他制御機能を提供することを意図したものです。
+-->
+有効な場合、軽量ロックの使用状況に関する情報を出力します。
+軽量ロックは主に、共有メモリ上のデータ構造へのアクセスに関する排他制御機能を提供することを意図したものです。
        </para>
        <para>
-       <!--
+<!--
         This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
         macro was defined when <productname>PostgreSQL</productname> was
         compiled.
-       -->
-       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+-->
+このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
        </para>
       </listitem>
      </varlistentry>
@@ -3430,20 +3428,20 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If on, emit information about user lock usage.  Output is the same
         as for <symbol>trace_locks</symbol>, only for advisory locks.
-       -->
-       有効な場合、ユーザロックの使用状況に関する情報を出力します。
-       出力は<symbol>trace_locks</symbol>と同じですが、勧告的ロックに関するもののみを出力します。
+-->
+有効な場合、ユーザロックの使用状況に関する情報を出力します。
+出力は<symbol>trace_locks</symbol>と同じですが、勧告的ロックに関するもののみを出力します。
        </para>
        <para>
-       <!--
+<!--
         This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
         macro was defined when <productname>PostgreSQL</productname> was
         compiled.
-       -->
-       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+-->
+このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
        </para>
       </listitem>
      </varlistentry>
@@ -3463,16 +3461,16 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
         If set, do not trace locks for tables below this OID (used to avoid
         output on system tables).
 -->
-       設定すると、このOID未満のテーブルに関するロックの追跡を行いません。
+設定すると、このOID未満のテーブルに関するロックの追跡を行いません。
        （システムテーブルに関する出力を抑えるために使用します。）
        </para>
        <para>
-       <!--
+<!--
         This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
         macro was defined when <productname>PostgreSQL</productname> was
         compiled.
-       -->
-       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+-->
+このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
        </para>
       </listitem>
      </varlistentry>
@@ -3488,18 +3486,18 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Unconditionally trace locks on this table (OID).
-       -->
-       このテーブル（OID）に対し無条件でロックを追跡します。
+-->
+このテーブル（OID）に対し無条件でロックを追跡します。
        </para>
        <para>
-       <!--
+<!--
         This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
         macro was defined when <productname>PostgreSQL</productname> was
         compiled.
-       -->
-       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+-->
+このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
        </para>
       </listitem>
      </varlistentry>
@@ -3515,19 +3513,19 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If set, dumps information about all current locks when a
         deadlock timeout occurs.
-       -->
-       設定すると、デッドロックタイムアウトが発生した時全ての進行中のロックについての情報がダンプされます。
+-->
+設定すると、デッドロックタイムアウトが発生した時全ての進行中のロックについての情報がダンプされます。
        </para>
        <para>
-       <!--
+<!--
         This parameter is only available if the <symbol>LOCK_DEBUG</symbol>
         macro was defined when <productname>PostgreSQL</productname> was
         compiled.
-       -->
-       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
+-->
+このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>LOCK_DEBUG</symbol>マクロが定義された場合のみ有効です。
        </para>
       </listitem>
      </varlistentry>
@@ -3543,19 +3541,19 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If set, logs system resource usage statistics (memory and CPU) on
         various B-tree operations.
-       -->
-       設定すると、各種B-tree操作に関するシステムリソース（メモリとCPU）の使用についての統計情報をログに出力します。
+-->
+設定すると、各種B-tree操作に関するシステムリソース（メモリとCPU）の使用についての統計情報をログに出力します。
        </para>
        <para>
-       <!--
+<!--
         This parameter is only available if the <symbol>BTREE_BUILD_STATS</symbol>
         macro was defined when <productname>PostgreSQL</productname> was
         compiled.
-       -->
-       このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>BTREE_BUILD_STATS</symbol>マクロが定義された場合のみ有効です。
+-->
+このパラメータは<productname>PostgreSQL</productname>がコンパイル時に<symbol>BTREE_BUILD_STATS</symbol>マクロが定義された場合のみ有効です。
        </para>
       </listitem>
      </varlistentry>
@@ -3620,13 +3618,13 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         If on, emit WAL-related debugging output. This parameter is
         only available if the <symbol>WAL_DEBUG</symbol> macro was
         defined when <productname>PostgreSQL</productname> was
         compiled.
-       -->
-       もしonであれば、WALに関連したデバッグ出力が有効になります。このパラメータは<symbol>WAL_DEBUG</symbol>マクロが <productname>PostgreSQL</productname>のコンパイルの時に定義された場合にのみ有効です。
+-->
+もしonであれば、WALに関連したデバッグ出力が有効になります。このパラメータは<symbol>WAL_DEBUG</symbol>マクロが <productname>PostgreSQL</productname>のコンパイルの時に定義された場合にのみ有効です。
        </para>
       </listitem>
      </varlistentry>
@@ -3642,13 +3640,13 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Only has effect if <xref linkend="app-initdb-data-checksums"/> are enabled.
-       -->
+-->
        <xref linkend="app-initdb-data-checksums"/>が有効の時のみ効果があります。
        </para>
        <para>
-       <!--
+<!--
         Detection of a checksum failure during a read normally causes
         <productname>PostgreSQL</productname> to report an error, aborting the current
         transaction.  Setting <varname>ignore_checksum_failure</varname> to on causes
@@ -3659,13 +3657,13 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
         present in the table if the block header is still sane. If the header is
         corrupt an error will be reported even if this option is enabled. The
         default setting is <literal>off</literal>, and it can only be changed by a superuser.
-       -->
-       読み込み過程でチェックサム障害が検出されると、通常<productname>PostgreSQL</productname>はエラーを報告し、現時点のトランザクションを停止します。
+-->
+読み込み過程でチェックサム障害が検出されると、通常<productname>PostgreSQL</productname>はエラーを報告し、現時点のトランザクションを停止します。
        <varname>ignore_checksum_failure</varname>を有効（on）に設定するとシステムはその障害を無視し（しかし警告は報告をします）、処理を継続します。
-       この振る舞いはたぶん<emphasis>クラッシュの原因、破損の伝播や隠ぺい、もしくはその他の深刻な問題</emphasis>の原因になることがあります。
-       とは言っても、エラーを切り抜け、ブロックヘッダが健全に存在するテーブルにある障害を受けていないタプルの回収は行えます。
-       もしヘッダーが破損されたら、オプションが有効になっていたとしても報告はなされます。
-       デフォルトの設定は<literal>off</literal>で、スーパーユーザのみが変更可能です。
+この振る舞いはたぶん<emphasis>クラッシュの原因、破損の伝播や隠ぺい、もしくはその他の深刻な問題</emphasis>の原因になることがあります。
+とは言っても、エラーを切り抜け、ブロックヘッダが健全に存在するテーブルにある障害を受けていないタプルの回収は行えます。
+もしヘッダーが破損されたら、オプションが有効になっていたとしても報告はなされます。
+デフォルトの設定は<literal>off</literal>で、スーパーユーザのみが変更可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -3681,7 +3679,7 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
       </term>
       <listitem>
        <para>
-       <!--
+<!--
         Detection of a damaged page header normally causes
         <productname>PostgreSQL</productname> to report an error, aborting the current
         transaction.  Setting <varname>zero_damaged_pages</varname> to on causes
@@ -3697,15 +3695,15 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
         the index before turning this parameter off again.  The
         default setting is <literal>off</literal>, and it can only be changed
         by a superuser.
-       -->
-       ページヘッダの障害がわかると、通常<productname>PostgreSQL</productname>はエラーの報告を行い、現在のトランザクションを中断させます。
+-->
+ページヘッダの障害がわかると、通常<productname>PostgreSQL</productname>はエラーの報告を行い、現在のトランザクションを中断させます。
 <varname>zero_damaged_pages</varname>をonに設定することにより、システムは代わりに警告を報告し、障害のあるメモリ内のページをゼロで埋め、処理を継続します。
 この動作により、障害のあったページ上にある全ての行の<emphasis>データが破壊</emphasis>されます。
 しかし、これによりエラーを確実に無視し、正常なページに存在するテーブル内の行を取り出すことができます。
-        ハードウェアまたはソフトウェアのエラーによって破損が発生した場合のデータの復旧時に有用です。
+ハードウェアまたはソフトウェアのエラーによって破損が発生した場合のデータの復旧時に有用です。
 障害のあるページからのテーブルのデータの復旧をあきらめた場合を除き、通常はこれをonにしてはいけません。
-        ゼロで埋められたページはディスクに書き込みを強要されないため、このパラメータを再び無効にする以前にテーブル、またはインデックスを再作成することを勧めます。
-        デフォルトは<literal>off</literal>であり、スーパーユーザのみ変更可能です。
+ゼロで埋められたページはディスクに書き込みを強要されないため、このパラメータを再び無効にする以前にテーブル、またはインデックスを再作成することを勧めます。
+デフォルトは<literal>off</literal>であり、スーパーユーザのみ変更可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -3873,9 +3871,9 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
      <varlistentry id="guc-remove-temp-files-after-crash" xreflabel="remove_temp_files_after_crash">
       <term><varname>remove_temp_files_after_crash</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary><varname>remove_temp_files_after_crash</varname> configuration parameter</primary>
--->
+      </indexterm>
+      <indexterm>
        <primary><varname>remove_temp_files_after_crash</varname>設定パラメータ</primary>
       </indexterm>
       </term>
@@ -3901,44 +3899,44 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
     </variablelist>
   </sect1>
   <sect1 id="runtime-config-short">
-  <!--
+<!--
    <title>Short Options</title>
-   -->
+-->
    <title>短いオプション</title>
 
    <para>
-   <!--
+<!--
     For convenience there are also single letter command-line option
     switches available for some parameters.  They are described in
     <xref linkend="runtime-config-short-table"/>.  Some of these
     options exist for historical reasons, and their presence as a
     single-letter option does not necessarily indicate an endorsement
     to use the option heavily.
-    -->
-    簡便性のために、一文字のコマンドラインオプションスイッチも、幾つかのパラメータのために用意されています。
+-->
+簡便性のために、一文字のコマンドラインオプションスイッチも、幾つかのパラメータのために用意されています。
 それらは<xref linkend="runtime-config-short-table"/>に解説されています。
 一部のオプションは歴史的な理由のために存在します。
 また、この一文字オプションが存在することが、このオプションを多く使用することを支持することを示しているわけではありません。
    </para>
 
     <table id="runtime-config-short-table">
-    <!--
+<!--
      <title>Short Option Key</title>
-     -->
+-->
      <title>短いオプションキー</title>
      <tgroup cols="2">
       <colspec colname="col1" colwidth="1*"/>
       <colspec colname="col2" colwidth="2*"/>
       <thead>
        <row>
-       <!--
+<!--
         <entry>Short Option</entry>
-       -->
-       <entry>短いオプション</entry>
-       <!--
+-->
+        <entry>短いオプション</entry>
+<!--
         <entry>Equivalent</entry>
-       -->
-       <entry>同義</entry>
+-->
+        <entry>同義</entry>
        </row>
       </thead>
 

--- a/doc/src/sgml/config3.sgml
+++ b/doc/src/sgml/config3.sgml
@@ -700,7 +700,7 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
 <type>bytea</type>型の値の出力形式を設定します。
 有効な値は<literal>hex</literal>（デフォルト）、および<literal>escape</literal>（PostgreSQLの伝統的な書式）です。
 より詳細は<xref linkend="datatype-binary"/>を参照してください。
-       <type>bytea</type>型は常にこの設定に係わらず、入力時に双方の書式を受け付けます。
+<type>bytea</type>型は常にこの設定に係わらず、入力時に双方の書式を受け付けます。
        </para>
       </listitem>
      </varlistentry>
@@ -1086,7 +1086,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
         server are described in <xref linkend="multibyte-charset-supported"/>.
 -->
 クライアント側符号化方式（文字セット）を設定します。デフォルトはデータベース符号化方式を使用します。
-       <productname>PostgreSQL</productname>サーバでサポートされている文字セットは<xref linkend="multibyte-charset-supported"/>に記載されています。
+<productname>PostgreSQL</productname>サーバでサポートされている文字セットは<xref linkend="multibyte-charset-supported"/>に記載されています。
        </para>
       </listitem>
      </varlistentry>
@@ -1300,7 +1300,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
       might be able to use operating-system facilities such
       as <envar>LD_PRELOAD</envar> for that.
 -->
-      PostgreSQLで使用することを意図したライブラリだけがこの方法でロードできます。
+PostgreSQLで使用することを意図したライブラリだけがこの方法でロードできます。
 すべてのPostgreSQL用のライブラリは<quote>magic block</quote>を持ち、互換性を保証するためにチェックされます。
 ですからPostgreSQL用ではないライブラリはこの方法ではロードできません。
 <envar>LD_PRELOAD</envar>のようなOSの機能を使えばあるいは使用できるかもしれません。
@@ -1365,7 +1365,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
 このオプションはすべてのユーザが設定できます。
 この理由で、読み込み可能なライブラリはインストレーションの共有ライブラリディレクトリのサブディレクトリ<filename>plugins</filename>内にあるものに制限されています。
 （確実に<quote>安全</quote>なライブラリのみをここにインストールすることはデータベース管理者の責任です。）
- <varname>local_preload_libraries</varname>内の項目で、たとえば<literal>$libdir/plugins/mylib</literal>のようにこのディレクトリを明示的に指定することも、単にライブラリ名を指定することも可能です。
+<varname>local_preload_libraries</varname>内の項目で、たとえば<literal>$libdir/plugins/mylib</literal>のようにこのディレクトリを明示的に指定することも、単にライブラリ名を指定することも可能です。
 <literal>mylib</literal> は<literal>$libdir/plugins/mylib</literal>と同じ効果です。
        </para>
 
@@ -1532,7 +1532,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
         </varname> is still useful on Windows hosts for libraries that need to
         perform operations at postmaster start time.
 -->
-        Windowsのホストでは、ライブラリのプリロードは、新しいサーバプロセスの起動に要する時間を短縮しません。
+Windowsのホストでは、ライブラリのプリロードは、新しいサーバプロセスの起動に要する時間を短縮しません。
 個々のサーバプロセスは、すべてのプリロードライブラリを再読み込みします。
 それでもpostmaster起動時に操作を実行しなければならないライブラリを使用するWindowsホストにとっては<varname>shared_preload_libraries</varname>は有用です。
        </para>
@@ -1681,7 +1681,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         Soft upper limit of the size of the set returned by GIN index scans. For more
         information see <xref linkend="gin-tips"/>.
 -->
-       GINインデックス走査により返されるセットのソフトな上限サイズです。
+GINインデックス走査により返されるセットのソフトな上限サイズです。
 詳細は<xref linkend="gin-tips"/>を参照してください。
        </para>
       </listitem>
@@ -1846,9 +1846,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         tables in a single serializable transaction. This parameter can
         only be set at server start.
 -->
-共有記述ロックテーブル（shared predicate lock table）は、<varname>max_pred_locks_per_transaction</varname> * (<xref
-        linkend="guc-max-connections"/> + <xref
-        linkend="guc-max-prepared-transactions"/>)オブジェクト（例えば諸テーブル）のロックを追跡します。
+共有記述ロックテーブル（shared predicate lock table）は、<varname>max_pred_locks_per_transaction</varname> * (<xref linkend="guc-max-connections"/> + <xref linkend="guc-max-prepared-transactions"/>)オブジェクト（例えば諸テーブル）のロックを追跡します。
 従って、この数以上の明確なオブジェクトは同時にロックされません。
 このパラメータはそれぞれのトランザクションに対して割り当てられたオブジェクトのロックの平均数を管理します。
 個別のトランザクションはロックテーブル内の全てのトランザクションのロックが適合する限り、より多くのオブジェクトをロックできます。
@@ -2004,11 +2002,8 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
 引用符の表現としてSQL準拠の方式では二重化（<literal>''</literal>）ですが、<productname>PostgreSQL</productname>は歴史的に<literal>\'</literal>も受け付けます。
 とは言っても、いくつかのクライアント文字集合符号化方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
 クライアント側のコードが事実上エスケープを正しく扱わない場合、SQLインジェクション攻撃が可能になります。この危険性の回避は、サーバが逆スラッシュでエスケープされた引用符を含む問い合わせを拒絶するようにします。
-許可される<varname>backslash_quote</varname>の値は、
-        <literal>on</literal> （常に <literal>\'</literal> を許可）,
-        <literal>off</literal> （常に拒否）、および
-        <literal>safe_encoding</literal> （クライアント符号化方式がASCIIの<literal>\</literal>を許可しないときのみ、マルチバイト文字内で許可）。
-        <literal>safe_encoding</literal> がデフォルトの設定。
+許可される<varname>backslash_quote</varname>の値は、<literal>on</literal> （常に <literal>\'</literal> を許可）,<literal>off</literal> （常に拒否）、および<literal>safe_encoding</literal> （クライアント符号化方式がASCIIの<literal>\</literal>を許可しないときのみ、マルチバイト文字内で許可）。
+<literal>safe_encoding</literal> がデフォルトの設定。
        </para>
 
        <para>
@@ -2079,7 +2074,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         releases.  The default is <literal>off</literal>.
         Only superusers can change this setting.
 -->
-       9.0以前の<productname>PostgreSQL</productname>リリースでは、ラージオブジェクトはアクセス権限が無く、従って全てのユーザが常に読み込み、書き込みが可能でした。
+9.0以前の<productname>PostgreSQL</productname>リリースでは、ラージオブジェクトはアクセス権限が無く、従って全てのユーザが常に読み込み、書き込みが可能でした。
 この変数を<literal>on</literal>にすると、以前のリリースとの互換性のため、新規の権限チェックが無効になります。
 デフォルトは<literal>off</literal>です。
 スーパーユーザのみこの設定を変更できます。
@@ -2150,7 +2145,7 @@ dynamic_library_path = 'C:\tools\postgresql;H:\my_project\lib;$libdir'
         backslashes to be treated as escape characters.
 -->
 標準SQLで規定されたように、通常の文字列リテラル（<literal>'...'</literal>）がバックスラッシュをそのまま取り扱うか否かを制御します。
-       <productname>PostgreSQL</productname> 9.1からデフォルトは<literal>on</literal>になっています（それ以前のリリースでは<literal>off</literal>がデフォルトでした）。
+<productname>PostgreSQL</productname> 9.1からデフォルトは<literal>on</literal>になっています（それ以前のリリースでは<literal>off</literal>がデフォルトでした）。
 どのように文字列リテラルが処理されるかを決めるこのパラメータを、アプリケーションで検査することができます。
 このパラメータの存在は、エスケープ文字列構文（<literal>E'...'</literal>）がサポートされているかどうかを示すものとも考えられます。
 エスケープ文字列構文 (<xref linkend="sql-syntax-strings-escape"/>)は、アプリケーションでバックスラッシュをエスケープ文字として扱いたい場合に使用すべきです。
@@ -2496,9 +2491,8 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
 -->
 ディスクブロックの容量を報告します。
 サーバ構築の際に<literal>BLCKSZ</literal>の値で決定されます。デフォルトの値は8192バイトです。
-       （<xref linkend="guc-shared-buffers"/>の様な）いくつかの構成変数の意味は<varname>block_size</varname>によって影響されます。
-これに関しての情報は<xref
-        linkend="runtime-config-resource"/>を参照してください。
+（<xref linkend="guc-shared-buffers"/>の様な）いくつかの構成変数の意味は<varname>block_size</varname>によって影響されます。
+これに関しての情報は<xref linkend="runtime-config-resource"/>を参照してください。
        </para>
       </listitem>
      </varlistentry>
@@ -2790,8 +2784,7 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
         linkend="guc-client-encoding"/>.
 -->
 データベース符号化方式（文字セット）を報告します。
-データベースが作成された時に決定されます。通常クライアントは<xref
-        linkend="guc-client-encoding"/>の値にのみ注意する必要があります。
+データベースが作成された時に決定されます。通常クライアントは<xref linkend="guc-client-encoding"/>の値にのみ注意する必要があります。
        </para>
       </listitem>
      </varlistentry>
@@ -3295,12 +3288,10 @@ WALディスクブロックの容量を報告します。
 復旧関連のデバッグ出力のログ取得を有効にします。さもないとログは取られません。
 このパラメータはユーザに対し、<xref linkend="guc-log-min-messages"/>の通常設定を上書きすることを許可します。
 しかし、特定のメッセージに対してのみです。これはホットスタンバイのデバッグを意図したものです。
-有効な値は、<literal>DEBUG5</literal>、<literal>DEBUG4</literal>、
-        <literal>DEBUG3</literal>、<literal>DEBUG2</literal>、<literal>DEBUG1</literal>、および
-        <literal>LOG</literal>です。
+有効な値は、<literal>DEBUG5</literal>、<literal>DEBUG4</literal>、<literal>DEBUG3</literal>、<literal>DEBUG2</literal>、<literal>DEBUG1</literal>、および<literal>LOG</literal>です。
 デフォルトの<literal>LOG</literal>は、ログ取得の決定に全く影響しません。
 その他の値は、あたかも<literal>LOG</literal>優先度を所有しているごとく、それ、またはより高い優先度でログ取得される復旧関連デバッグメッセージの要因となります。
-       <varname>log_min_messages</varname>の通常設定に対し、これは無条件にそれらをサーバログに送り込みます。
+<varname>log_min_messages</varname>の通常設定に対し、これは無条件にそれらをサーバログに送り込みます。
 このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバコマンドラインでのみ設定可能です。
        </para>
       </listitem>
@@ -3462,7 +3453,7 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
         output on system tables).
 -->
 設定すると、このOID未満のテーブルに関するロックの追跡を行いません。
-       （システムテーブルに関する出力を抑えるために使用します。）
+（システムテーブルに関する出力を抑えるために使用します。）
        </para>
        <para>
 <!--
@@ -3643,7 +3634,7 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
 <!--
         Only has effect if <xref linkend="app-initdb-data-checksums"/> are enabled.
 -->
-       <xref linkend="app-initdb-data-checksums"/>が有効の時のみ効果があります。
+<xref linkend="app-initdb-data-checksums"/>が有効の時のみ効果があります。
        </para>
        <para>
 <!--
@@ -3659,7 +3650,7 @@ LOG:  CleanUpLock: deleting: lock(0xb7acd844) id(24688,24696,0,0,0,1)
         default setting is <literal>off</literal>, and it can only be changed by a superuser.
 -->
 読み込み過程でチェックサム障害が検出されると、通常<productname>PostgreSQL</productname>はエラーを報告し、現時点のトランザクションを停止します。
-       <varname>ignore_checksum_failure</varname>を有効（on）に設定するとシステムはその障害を無視し（しかし警告は報告をします）、処理を継続します。
+<varname>ignore_checksum_failure</varname>を有効（on）に設定するとシステムはその障害を無視し（しかし警告は報告をします）、処理を継続します。
 この振る舞いはたぶん<emphasis>クラッシュの原因、破損の伝播や隠ぺい、もしくはその他の深刻な問題</emphasis>の原因になることがあります。
 とは言っても、エラーを切り抜け、ブロックヘッダが健全に存在するテーブルにある障害を受けていないタプルの回収は行えます。
 もしヘッダーが破損されたら、オプションが有効になっていたとしても報告はなされます。


### PR DESCRIPTION
config.sgmlだけインデントが独特でチェックと自動置き換えの
障害になっていたため修正しました。
また、行内コメントも差分チェックに引っかかるため変更しました。
一部indextermの修正も含みます。