### PR TITLE
fix missing comment tags

### DIFF
--- a/doc/src/sgml/legal.sgml
+++ b/doc/src/sgml/legal.sgml
@@ -17,10 +17,11 @@
  <title>法的告知</title>
 
  <para>
+<!--
   <productname>PostgreSQL</productname> is Copyright &copy; 1996&ndash;2022
   by the PostgreSQL Global Development Group.
 -->
-Copyright &copy; 1996&ndash;2021 <productname>PostgreSQL</productname>はPostgreSQLグローバル開発チームが著作権を有します。
+Copyright &copy; 1996&ndash;2022 <productname>PostgreSQL</productname>はPostgreSQLグローバル開発チームが著作権を有します。
  </para>
 
  <para>

--- a/doc/src/sgml/xindex.sgml
+++ b/doc/src/sgml/xindex.sgml
@@ -1120,6 +1120,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
       <row>
        <entry><function>options</function></entry>
        <entry>
+<!--
         define options that are specific to this operator class
         (optional)
 -->
@@ -1205,6 +1206,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
       <row>
        <entry><function>options</function></entry>
        <entry>
+<!--
         define options that are specific to this operator class
         (optional)
 -->


### PR DESCRIPTION
14.5でコメントのタグが閉じていないことに気づきました。

訳の時に合わせてやればいいのですがその時には忘れてそうなので。