### PR TITLE
update ecpg for 14.5

### DIFF
--- a/doc/src/sgml/ecpg.sgml
+++ b/doc/src/sgml/ecpg.sgml
@@ -13887,7 +13887,7 @@ risnull(CINTTYPE, (char *) &i);
 <!--
    Specifically, this mode changes <command>ecpg</command> in three ways:
 -->
-特に、このモードは以下の3つ点ので<command>ecpg</command>を変更します。
+特に、このモードは以下の3つの点で<command>ecpg</command>を変更します。
 
    <itemizedlist>
     <listitem>

--- a/doc/src/sgml/ecpg.sgml
+++ b/doc/src/sgml/ecpg.sgml
@@ -1062,7 +1062,7 @@ EXEC SQL DEALLOCATE PREPARE <replaceable>name</replaceable>;
    applications is the use of SQL descriptors, described
    in <xref linkend="ecpg-descriptors"/>.
 -->
-   PostgreSQLバックエンドとECPGアプリケーションの間で値をやり取りするその他の方法は、 <xref linkend="ecpg-descriptors"/> で説明されているSQLデスクリプタを使う方法です。
+PostgreSQLバックエンドとECPGアプリケーションの間で値をやり取りするその他の方法は、 <xref linkend="ecpg-descriptors"/> で説明されているSQLデスクリプタを使う方法です。
   </para>
 
   <sect2 id="ecpg-variables-overview">
@@ -1465,7 +1465,7 @@ do
      of <type>char</type>, which is the most common way to handle
      character data in C.
 -->
-     ひとつは <type>char</type> の配列 <type>char[]</type> を使うことで、C言語において文字列データを扱うもっとも一般的な方法です。
+ひとつは <type>char</type> の配列 <type>char[]</type> を使うことで、C言語において文字列データを扱うもっとも一般的な方法です。
 <programlisting>
 EXEC SQL BEGIN DECLARE SECTION;
     char str[50];
@@ -1477,8 +1477,8 @@ EXEC SQL END DECLARE SECTION;
      returns a string with more than 49 characters, a buffer overflow
      occurs.
 -->
-     文字列の長さについて、自分自身で気を付けておく必要があります。
-     上記のホスト変数を49文字以上の文字列を返すクエリのターゲット変数として使った場合、バッファオーバーフローが発生します。
+文字列の長さについて、自分自身で気を付けておく必要があります。
+上記のホスト変数を49文字以上の文字列を返すクエリのターゲット変数として使った場合、バッファオーバーフローが発生します。
     </para>
 
     <para>
@@ -1488,16 +1488,16 @@ EXEC SQL END DECLARE SECTION;
      type <type>VARCHAR</type> is converted into a
      named <type>struct</type> for every variable. A declaration like:
 -->
-     その他の方法は、ECPGによって提供される特殊なデータ型 <type>VARCHAR</type> を使う方法です。
-     <type>VARCHAR</type> の配列の定義は、すべての変数が名前の付いた <type>struct</type> に変換されます。
-     以下のような宣言は:
+その他の方法は、ECPGによって提供される特殊なデータ型 <type>VARCHAR</type> を使う方法です。
+<type>VARCHAR</type> の配列の定義は、すべての変数が名前の付いた <type>struct</type> に変換されます。
+以下のような宣言は:
 <programlisting>
 VARCHAR var[180];
 </programlisting>
 <!--
      is converted into:
 -->
-     次のように変換されます:
+次のように変換されます:
 <programlisting>
 struct varchar_var { int len; char arr[180]; } var;
 </programlisting>
@@ -1645,9 +1645,9 @@ ts = 2010-06-27 18:03:56.949343
       <function>PGTYPESdate_to_asc()</function> function. For more details about the
       pgtypes library functions, see <xref linkend="ecpg-pgtypes"/>.
 -->
-      また、DATE型も同じ方法で扱うことができます。
-      プログラムは <filename>pgtypes_date.h</filename> をインクルードし、ホスト変数を date 型として宣言し、<function>PGTYPESdate_to_asc()</function> 関数によって DATE の値を text 形式に変換します。
-      pgtypesライブラリ関数についての詳細は、<xref linkend="ecpg-pgtypes"/> を参照してください。
+また、DATE型も同じ方法で扱うことができます。
+プログラムは <filename>pgtypes_date.h</filename> をインクルードし、ホスト変数を date 型として宣言し、<function>PGTYPESdate_to_asc()</function> 関数によって DATE の値を text 形式に変換します。
+pgtypesライブラリ関数についての詳細は、<xref linkend="ecpg-pgtypes"/> を参照してください。
      </para>
     </sect4>
 
@@ -1844,7 +1844,7 @@ struct bytea_var { int len; char arr[180]; } var;
      As a host variable you can also use arrays, typedefs, structs, and
      pointers.
 -->
-     ホスト変数として、配列、typedef、構造体およびポインタも使うことができます。
+ホスト変数として、配列、typedef、構造体およびポインタも使うことができます。
     </para>
 
     <sect4 id="ecpg-variables-arrays">
@@ -1867,12 +1867,12 @@ struct bytea_var { int len; char arr[180]; } var;
       the array has to be defined to be able to accommodate all rows,
       otherwise a buffer overflow will likely occur.
 -->
-      ホスト変数としての配列の使い方には二通りの利用方法があります。
-      一つ目の使い方は、<xref linkend="ecpg-char"/> で説明されたように <type>char[]</type> または <type>VARCHAR[]</type> の何らかのテキスト文字列を保持するための方法です。
-      二つ目の使い方は、カーソルを用いずに複数行を返却するクエリ結果を受け取るために使う方法です。
-      配列を使わない場合、複数行からなるクエリの実行結果を処理するには、カーソルと <command>FETCH</command> コマンドを使用する必要があります。
-      しかし、配列のホスト変数を使うと、複数行を一括して受け取ることができます。
-      配列の長さはすべての行を受け入れられるように定義されなければなりません。でなければバッファーオーバーフローが発生するでしょう。
+ホスト変数としての配列の使い方には二通りの利用方法があります。
+一つ目の使い方は、<xref linkend="ecpg-char"/> で説明されたように <type>char[]</type> または <type>VARCHAR[]</type> の何らかのテキスト文字列を保持するための方法です。
+二つ目の使い方は、カーソルを用いずに複数行を返却するクエリ結果を受け取るために使う方法です。
+配列を使わない場合、複数行からなるクエリの実行結果を処理するには、カーソルと <command>FETCH</command> コマンドを使用する必要があります。
+しかし、配列のホスト変数を使うと、複数行を一括して受け取ることができます。
+配列の長さはすべての行を受け入れられるように定義されなければなりません。でなければバッファーオーバーフローが発生するでしょう。
      </para>
 
      <para>
@@ -1881,7 +1881,7 @@ struct bytea_var { int len; char arr[180]; } var;
       system table and shows all OIDs and names of the available
       databases:
 -->
-      以下の例は <literal>pg_database</literal> システムテーブルをスキャンし、利用可能なデータベースのすべてのOIDとデータベース名を表示します:
+以下の例は <literal>pg_database</literal> システムテーブルをスキャンし、利用可能なデータベースのすべてのOIDとデータベース名を表示します:
 <programlisting>
 int
 main(void)
@@ -1917,7 +1917,7 @@ EXEC SQL END DECLARE SECTION;
     This example shows following result. (The exact values depend on
     local circumstances.)
 -->
-    この例は、以下の結果を表示します。（実際の値はローカルな環境に依存します）
+この例は、以下の結果を表示します。（実際の値はローカルな環境に依存します）
 <screen>
 oid=1, dbname=template1
 oid=11510, dbname=template0
@@ -1943,8 +1943,8 @@ oid=0, dbname=
       structure enables handling multiple column values in a single
       host variable.
 -->
-      メンバー変数の名前がクエリ結果のカラム名に合致する構造体は、複数のカラムを一括して受け取るために利用することができます。
-      構造体は複数のカラムの値を単一のホスト変数で扱うことを可能にします。
+メンバー変数の名前がクエリ結果のカラム名に合致する構造体は、複数のカラムを一括して受け取るために利用することができます。
+構造体は複数のカラムの値を単一のホスト変数で扱うことを可能にします。
      </para>
 
      <para>
@@ -2008,7 +2008,7 @@ EXEC SQL END DECLARE SECTION;
       This example shows following result. (The exact values depend on
       local circumstances.)
 -->
-      この例は、次の結果を示します（実際の値はローカルな環境に依存します）
+この例は、次の結果を示します（実際の値はローカルな環境に依存します）
 <screen>
 oid=1, datname=template1, size=4324580
 oid=11510, datname=template0, size=4243460
@@ -2025,9 +2025,9 @@ oid=313780, datname=testdb, size=8183012
       also be restructured like this, with the <varname>size</varname>
       variable outside the structure:
 -->
-      構造体のホスト変数は、多数のカラムを構造体のフィールドとして<quote>吸収</quote>します。
-      追加のカラムは他のホスト変数に割り当てることができます。
-      例えば、上記のプログラムは構造体に含まれない <varname>size</varname> 変数を使って以下のように書き換えることができます。
+構造体のホスト変数は、多数のカラムを構造体のフィールドとして<quote>吸収</quote>します。
+追加のカラムは他のホスト変数に割り当てることができます。
+例えば、上記のプログラムは構造体に含まれない <varname>size</varname> 変数を使って以下のように書き換えることができます。
 <programlisting>
 EXEC SQL BEGIN DECLARE SECTION;
     typedef struct
@@ -2082,7 +2082,7 @@ EXEC SQL END DECLARE SECTION;
       Use the <literal>typedef</literal> keyword to map new types to already
       existing types.
 -->
-      新しい型と既存の型を対応付けるためには <literal>typedef</literal> キーワードを使ってください。
+新しい型と既存の型を対応付けるためには <literal>typedef</literal> キーワードを使ってください。
 <programlisting>
 EXEC SQL BEGIN DECLARE SECTION;
     typedef char mychartype[40];
@@ -2092,14 +2092,14 @@ EXEC SQL END DECLARE SECTION;
 <!--
       Note that you could also use:
 -->
-      また、同様に以下を使うこともできます:
+また、同様に以下を使うこともできます:
 <programlisting>
 EXEC SQL TYPE serial_t IS long;
 </programlisting>
 <!--
       This declaration does not need to be part of a declare section.
 -->
-      この宣言は、宣言セクションの一部である必要はありません。
+この宣言は、宣言セクションの一部である必要はありません。
      </para>
     </sect4>
 
@@ -2116,9 +2116,9 @@ EXEC SQL TYPE serial_t IS long;
       without auto-allocation. See <xref linkend="ecpg-descriptors"/>
       for more information on auto-allocation.
 -->
-      ほとんどの一般的な型のポインタを宣言することができます。
-      但し、自動メモリ確保を使わずにクエリのターゲット変数として使うことはできません。
-      自動メモリ確保については <xref linkend="ecpg-descriptors"/> を参照してください。
+ほとんどの一般的な型のポインタを宣言することができます。
+但し、自動メモリ確保を使わずにクエリのターゲット変数として使うことはできません。
+自動メモリ確保については <xref linkend="ecpg-descriptors"/> を参照してください。
      </para>
 
      <para>
@@ -2146,8 +2146,8 @@ EXEC SQL END DECLARE SECTION;
     this is distinct from the handling of host variables of
     nonprimitive types, described in the previous section.
 -->
-    本節では、非スカラー型およびユーザ定義のSQLデータ型をECPGアプリケーションで扱う方法を示します。
-    この内容は、前の説で説明した非プリミティブ型のホスト変数の扱い方とは別のものです。
+本節では、非スカラー型およびユーザ定義のSQLデータ型をECPGアプリケーションで扱う方法を示します。
+この内容は、前の説で説明した非プリミティブ型のホスト変数の扱い方とは別のものです。
    </para>
 
    <sect3>
@@ -2631,10 +2631,15 @@ EXEC SQL END DECLARE SECTION:
 
 EXEC SQL SELECT b INTO :val :val_ind FROM test1;
 </programlisting>
+<!--
     The indicator variable <varname>val_ind</varname> will be zero if
     the value was not null, and it will be negative if the value was
     null.  (See <xref linkend="ecpg-oracle-compat"/> to enable
     Oracle-specific behavior.)
+-->
+値がNULLでなければ、指示子変数<varname>val_ind</varname>は0となります。
+値がNULLならば負の値となります。
+(Oracle特有の振舞いを有効にするには<xref linkend="ecpg-oracle-compat"/>を参照してください。)
    </para>
 
    <para>
@@ -13864,35 +13869,54 @@ risnull(CINTTYPE, (char *) &i);
  </sect1>
 
  <sect1 id="ecpg-oracle-compat">
+<!--
   <title><productname>Oracle</productname> Compatibility Mode</title>
+-->
+  <title><productname>Oracle</productname>互換モード</title>
   <para>
+<!--
    <command>ecpg</command> can be run in a so-called <firstterm>Oracle
    compatibility mode</firstterm>. If this mode is active, it tries to
    behave as if it were Oracle <productname>Pro*C</productname>.
+-->
+<command>ecpg</command>はいわゆる<firstterm>Oracle互換モード</firstterm>で実行できます。
+このモードが有効であれば、Oracle <productname>Pro*C</productname>であるかのように振る舞おうとします。
   </para>
 
   <para>
+<!--
    Specifically, this mode changes <command>ecpg</command> in three ways:
+-->
+特に、このモードは以下の3つ点ので<command>ecpg</command>を変更します。
 
    <itemizedlist>
     <listitem>
      <para>
+<!--
       Pad character arrays receiving character string types with
       trailing spaces to the specified length
+-->
+文字列型を受け取る文字配列の末尾に、指定された長さまで空白を詰めます。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Zero byte terminate these character arrays, and set the indicator
       variable if truncation occurs
+-->
+ゼロバイトでこの文字配列を終端し、切り詰められた場合には指示子変数を設定します。
      </para>
     </listitem>
 
     <listitem>
      <para>
+<!--
       Set the null indicator to <literal>-1</literal> when character
       arrays receive empty character string types
+-->
+文字配列が空の文字列型を受け取った場合には、NULL指示子を<literal>-1</literal>に設定します。
      </para>
     </listitem>
    </itemizedlist>


### PR DESCRIPTION
ecpg.sgml の14.5対応です。

が、初めの方は気がついてしまったのでついでに行頭の空白を削除しただけで、ラスボスは2631行以降です。