### PR TITLE
plpgsql.sgmlを再修正

### DIFF
--- a/doc/src/sgml/plpgsql.sgml
+++ b/doc/src/sgml/plpgsql.sgml
@@ -3174,7 +3174,6 @@ END IF;
 そして関連した文が実行され、その後<literal>END IF</literal>以降の次の文に制御が渡されます。
 （以降にある<literal>IF</literal>条件の検査はすべて実行<emphasis>されません</emphasis>。）
 全ての<literal>IF</literal>条件が真でない場合、<literal>ELSE</literal>ブロックが（もし存在すれば）実行されます。
-機能的には、<literal>IF-THEN-ELSE-IF-THEN</literal>コマンドを入れ子にしたものと同じですが、必要な<literal>END IF</literal>は1つだけです。
        </para>
 
        <para>
@@ -3794,7 +3793,7 @@ BEGIN
 <!--
         &#045;- Now "mviews" has one record with information about the materialized view
 -->
-        -- ここで"mviews"はマテリアライズドビューの1つのレコードを持ちます
+        -- ここで"mviews"はマテリアライズドビューの情報の1つのレコードを持ちます
 
         RAISE NOTICE 'Refreshing materialized view %.% (owner: %)...',
                      quote_ident(mviews.mv_schema),
@@ -4276,7 +4275,7 @@ GET STACKED DIAGNOSTICS <replaceable>variable</replaceable> { = | := } <replacea
      available status items are shown
      in <xref linkend="plpgsql-exception-diagnostics-values"/>.
 -->
-各<replaceable>item</replaceable>は、指定された<replaceable>変数</replaceable>（これは受け取るために正しいデータ型でなければなりません）に代入される状態値を識別するキーワードです。
+各<replaceable>item</replaceable>は、指定された<replaceable>variable</replaceable>（これは受け取るために正しいデータ型でなければなりません）に代入される状態値を識別するキーワードです。
 現在使用可能なステータス項目は<xref linkend="plpgsql-exception-diagnostics-values"/>に表示されています。
     </para>
 

--- a/doc/src/sgml/plpgsql.sgml
+++ b/doc/src/sgml/plpgsql.sgml
@@ -3522,7 +3522,7 @@ BEGIN
 <!--
     &#045;&#045; computations here will be skipped when stocks &gt; 100000
 -->
-    -- stokcs &gt; 100000 であればここでの演算は省略
+    -- stocks &gt; 100000 であればここでの演算は省略
 END;
 </programlisting>
        </para>
@@ -3794,7 +3794,7 @@ BEGIN
 <!--
         &#045;- Now "mviews" has one record with information about the materialized view
 -->
-        -- ここで"mviews"はcs_materialized_viewsの1つのレコードを持ちます
+        -- ここで"mviews"はマテリアライズドビューの1つのレコードを持ちます
 
         RAISE NOTICE 'Refreshing materialized view %.% (owner: %)...',
                      quote_ident(mviews.mv_schema),
@@ -4276,7 +4276,7 @@ GET STACKED DIAGNOSTICS <replaceable>variable</replaceable> { = | := } <replacea
      available status items are shown
      in <xref linkend="plpgsql-exception-diagnostics-values"/>.
 -->
-各<replaceable>item</replaceable>は、指定された変数（これは受け取るために正しいデータ型でなければなりません）に代入される状態値を識別するキーワードです。
+各<replaceable>item</replaceable>は、指定された<replaceable>変数</replaceable>（これは受け取るために正しいデータ型でなければなりません）に代入される状態値を識別するキーワードです。
 現在使用可能なステータス項目は<xref linkend="plpgsql-exception-diagnostics-values"/>に表示されています。
     </para>
 
@@ -4973,7 +4973,7 @@ MOVE <optional> <replaceable>direction</replaceable> { FROM | IN } </optional> <
      be checked to see whether there was a next row to move to.
 -->
 <command>MOVE</command>コマンドは、データを取り出さないでカーソルの位置を変更します。
-移動先の行を返さないでカーソルの位置だけを変更することを除けば、<command>FETCH</command>コマンドと同一の働きをします。
+<command>MOVE</command>コマンドは、移動先の行を返さないでカーソルの位置だけを変更することを除けば、<command>FETCH</command>コマンドと同一の働きをします。
 <command>SELECT INTO</command>と同様に、特殊な変数<literal>FOUND</literal>を用いて、移動先に行が存在するかどうかを検査できます。
     </para>
 
@@ -6327,7 +6327,6 @@ CREATE OR REPLACE FUNCTION update_emp_view() RETURNS TRIGGER AS $$
     BEGIN
         --
 <!--
-
         &#045;&#045; Perform the required operation on emp, and create a row in emp_audit
         &#045;&#045; to reflect the change made to emp.
 -->
@@ -8543,8 +8542,7 @@ $$ LANGUAGE plpgsql STRICT IMMUTABLE;
    </indexterm>
 
 <programlisting><![CDATA[
---
-]]><!--
+--]]><!--
 &#45;- instr functions that mimic Oracle's counterpart
 &#45;- Syntax: instr(string1, string2 [, n [, m]])
 &#45;- where [] denotes optional parameters.
@@ -8552,8 +8550,7 @@ $$ LANGUAGE plpgsql STRICT IMMUTABLE;
 -- Oracleのものと同じ動作をするinstr関数
 -- 構文: instr(string1, string2 [, n [, m]])
 -- ただし、[]は省略可能なパラメータ
---
-]]><!--
+--]]><!--
 &#45;- Search string1, beginning at the nth character, for the mth occurrence
 &#45;- of string2.  If n is negative, search backwards, starting at the abs(n)'th
 &#45;- character from the end of string1.


### PR DESCRIPTION
余分な改行が含まれてしまうので、CDATAの終わり部分を元に戻す。
追加で以下を修正。
* typo
* タグ不足