### PR TITLE
xindex.sgmlの14.5対応です。

### DIFF
--- a/doc/src/sgml/xindex.sgml
+++ b/doc/src/sgml/xindex.sgml
@@ -701,7 +701,7 @@ BRINインデックスは、いずれも固定のストラテジ群を持たな�
         greater than zero, indicating whether the first key is less than,
         equal to, or greater than the second
 -->
-2つのキーを比較し、最初のキーが2番目のキーより小さいか、等しいか、大きいかを示す、0未満、0、もしくは0より大きい整数を返します。
+2つのキーを比較し、最初のキーが2番目のキーより小さいか、等しいか、大きいかを示す、0未満、0、もしくは0より大きい整数を返します
        </entry>
        <entry>1</entry>
       </row>
@@ -711,7 +711,7 @@ BRINインデックスは、いずれも固定のストラテジ群を持たな�
         Return the addresses of C-callable sort support function(s)
         (optional)
 -->
-C言語から呼び出し可能なソートサポート関数のアドレスを返します(省略可能)。
+C言語から呼び出し可能なソートサポート関数のアドレスを返します（省略可能）
        </entry>
        <entry>2</entry>
       </row>
@@ -721,7 +721,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
         Compare a test value to a base value plus/minus an offset, and return
         true or false according to the comparison result (optional)
 -->
-テスト値をベース値にオフセットを加減算したものと比較して、比較結果に従って真または偽を返します(省略可能)。
+テスト値をベース値にオフセットを加減算したものと比較して、比較結果に従って真または偽を返します（省略可能）
        </entry>
        <entry>3</entry>
       </row>
@@ -731,7 +731,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
         Determine if it is safe for indexes that use the operator
         class to apply the btree deduplication optimization (optional)
 -->
-演算子クラスを使うインデックスがB-tree重複排除最適化を安全に適用できるかどうかを決定します(省略可能)。
+演算子クラスを使うインデックスがB-tree重複排除最適化を安全に適用できるかどうかを決定します（省略可能）
        </entry>
        <entry>4</entry>
       </row>
@@ -741,7 +741,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
         Define options that are specific to this operator class
         (optional)
 -->
-この演算子クラスに固有のオプションの集合を定義します(省略可能)。
+この演算子クラスに固有のオプションを定義します（省略可能）
        </entry>
        <entry>5</entry>
       </row>
@@ -793,7 +793,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
          (optional)
 -->
 64bitソルトが与えられたキーに対する64ビットハッシュ値を計算します。
-ソルトが0なら結果の下位32ビットは関数1で計算された値と一致しなければなりません。(省略可能)
+ソルトが0なら結果の下位32ビットは関数1で計算された値と一致しなければなりません（省略可能）
        </entry>
        <entry>2</entry>
       </row>
@@ -803,7 +803,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
         Define options that are specific to this operator class
         (optional)
 -->
-この演算子クラスに固有のオプションの集合を定義します(省略可能)。
+この演算子クラスに固有のオプションを定義します（省略可能）
        </entry>
        <entry>3</entry>
       </row>
@@ -817,7 +817,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
    as shown in <xref linkend="xindex-gist-support-table"/>.
    (For more information see <xref linkend="gist"/>.)
 -->
-<xref linkend="xindex-gist-support-table"/>に示すように、GiSTインデックスには10のサポート関数があり、また、そのうち3つは省略可能です。
+<xref linkend="xindex-gist-support-table"/>に示すように、GiSTインデックスには11のサポート関数があり、また、そのうち6つは省略可能です。
 (詳細については<xref linkend="gist"/>を参照してください。)
   </para>
 
@@ -849,7 +849,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
        <entry>determine whether key satisfies the
         query qualifier</entry>
 -->
-       <entry>キーが問い合わせ条件を満たすかどうかを決定します。</entry>
+       <entry>キーが問い合わせ条件を満たすかどうかを決定します</entry>
        <entry>1</entry>
       </row>
       <row>
@@ -857,19 +857,25 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
 <!--
        <entry>compute union of a set of keys</entry>
 -->
-       <entry>キー集合の和集合を計算します。</entry>
+       <entry>キー集合の和集合を計算します</entry>
        <entry>2</entry>
       </row>
       <row>
        <entry><function>compress</function></entry>
+<!--
        <entry>compute a compressed representation of a key or value
         to be indexed (optional)</entry>
+-->
+       <entry>キーまたはインデックス付けされる値の圧縮表現を計算します（省略可能）</entry>
        <entry>3</entry>
       </row>
       <row>
        <entry><function>decompress</function></entry>
+<!--
        <entry>compute a decompressed representation of a
         compressed key (optional)</entry>
+-->
+       <entry>圧縮されたキーを伸張した表現を計算します（省略可能）</entry>
        <entry>4</entry>
       </row>
       <row>
@@ -878,7 +884,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
        <entry>compute penalty for inserting new key into subtree
        with given subtree's key</entry>
 -->
-       <entry>指定された副ツリーキーを持つ副ツリーに新しいキーを挿入する時のペナルティを計算します。</entry>
+       <entry>指定された副ツリーキーを持つ副ツリーに新しいキーを挿入する時のペナルティを計算します</entry>
        <entry>5</entry>
       </row>
       <row>
@@ -887,7 +893,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
        <entry>determine which entries of a page are to be moved
        to the new page and compute the union keys for resulting pages</entry>
 -->
-       <entry>ページのどのエントリを新しいページに移動させるかを決定し、結果ページ用の統合キーを計算します。</entry>
+       <entry>ページのどのエントリを新しいページに移動させるかを決定し、結果ページ用の統合キーを計算します</entry>
        <entry>6</entry>
       </row>
       <row>
@@ -895,7 +901,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
 <!--
        <entry>compare two keys and return true if they are equal</entry>
 -->
-       <entry>2つのキーを比較し、等しければ真を返します。</entry>
+       <entry>2つのキーを比較し、等しければ真を返します</entry>
        <entry>7</entry>
       </row>
       <row>
@@ -903,9 +909,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
 <!--
        <entry>determine distance from key to query value (optional)</entry>
 -->
-       <entry>
-キーと問い合わせ値との間の距離を決定します（省略可能）。
-       </entry>
+       <entry>キーと問い合わせ値との間の距離を決定します（省略可能）</entry>
        <entry>8</entry>
       </row>
       <row>
@@ -914,21 +918,25 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
        <entry>compute original representation of a compressed key for
        index-only scans (optional)</entry>
 -->
-       <entry>
-インデックスオンリースキャンのために圧縮されたキーの元の表現を計算します（省略可能）。
-       </entry>
+       <entry>インデックスオンリースキャンのために圧縮されたキーの元の表現を計算します（省略可能）</entry>
        <entry>9</entry>
       </row>
       <row>
        <entry><function>options</function></entry>
+<!--
        <entry>define options that are specific to this operator class
         (optional)</entry>
+-->
+       <entry>この演算子クラスに固有のオプションを定義します（省略可能）</entry>
        <entry>10</entry>
       </row>
       <row>
        <entry><function>sortsupport</function></entry>
+<!--
        <entry>provide a sort comparator to be used in fast index builds
         (optional)</entry>
+-->
+       <entry>高速インデックス構築で使用されるソート比較を提供する（省略可能）</entry>
        <entry>11</entry>
       </row>
      </tbody>
@@ -972,7 +980,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
 <!--
        <entry>provide basic information about the operator class</entry>
 -->
-       <entry>演算子クラスに関する基本情報を提供します。</entry>
+       <entry>演算子クラスに関する基本情報を提供します</entry>
        <entry>1</entry>
       </row>
       <row>
@@ -980,7 +988,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
 <!--
        <entry>determine how to insert a new value into an inner tuple</entry>
 -->
-       <entry>新しい値を内部タプルに挿入する方法を決定します。</entry>
+       <entry>新しい値を内部タプルに挿入する方法を決定します</entry>
        <entry>2</entry>
       </row>
       <row>
@@ -988,7 +996,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
 <!--
        <entry>determine how to partition a set of values</entry>
 -->
-       <entry>値集合を分割する方法を決定します。</entry>
+       <entry>値集合を分割する方法を決定します</entry>
        <entry>3</entry>
       </row>
       <row>
@@ -997,7 +1005,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
        <entry>determine which sub-partitions need to be searched for a
         query</entry>
 -->
-       <entry>ある問い合わせでサブパーティションの検索が必要かどうか決定します。</entry>
+       <entry>ある問い合わせでサブパーティションの検索が必要かどうか決定します</entry>
        <entry>4</entry>
       </row>
       <row>
@@ -1006,13 +1014,16 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
        <entry>determine whether key satisfies the
         query qualifier</entry>
 -->
-       <entry>キーが問い合わせ修飾子を満たすかどうか決定します。</entry>
+       <entry>キーが問い合わせ修飾子を満たすかどうか決定します</entry>
        <entry>5</entry>
       </row>
       <row>
        <entry><function>options</function></entry>
+<!--
        <entry>define options that are specific to this operator class
         (optional)</entry>
+-->
+       <entry>この演算子クラスに固有のオプションの集合を定義します（省略可能）</entry>
        <entry>6</entry>
       </row>
      </tbody>
@@ -1060,7 +1071,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
         equal to, or greater than the second
 -->
 2つのキーを比較し、0未満、0、0より大きな整数を返します。
-それぞれ最初のキーの方が大きい、等しい、小さいを示します。
+それぞれ最初のキーの方が大きい、等しい、小さいを示します
        </entry>
        <entry>1</entry>
       </row>
@@ -1069,7 +1080,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
 <!--
        <entry>extract keys from a value to be indexed</entry>
 -->
-       <entry>インデックス付けされる値からキーを抽出します。</entry>
+       <entry>インデックス付けされる値からキーを抽出します</entry>
        <entry>2</entry>
       </row>
       <row>
@@ -1077,7 +1088,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
 <!--
        <entry>extract keys from a query condition</entry>
 -->
-       <entry>問い合わせ条件からキーを抽出します。</entry>
+       <entry>問い合わせ条件からキーを抽出します</entry>
        <entry>3</entry>
       </row>
       <row>
@@ -1101,7 +1112,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
         or greater than zero, indicating whether GIN should ignore this index
         entry, treat the entry as a match, or stop the index scan (optional)
 -->
-問い合わせからの部分キーとインデックスからのキーを比較し、それぞれ、GINがこのインデックス項目を無視しなければならないか、一致する項目として扱わなければならないか、インデックススキャンを中止しなければならないかを示す、ゼロより小さい、ゼロ、ゼロより大きい整数値のいずれかを返します(省略可能)。
+問い合わせからの部分キーとインデックスからのキーを比較し、それぞれ、GINがこのインデックス項目を無視しなければならないか、一致する項目として扱わなければならないか、インデックススキャンを中止しなければならないかを示す、ゼロより小さい、ゼロ、ゼロより大きい整数値のいずれかを返します（省略可能）
        </entry>
        <entry>5</entry>
       </row>
@@ -1124,7 +1135,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
         define options that are specific to this operator class
         (optional)
 -->
-この演算子クラスに固有のオプションの集合を定義します(省略可能)。
+この演算子クラスに固有のオプションの集合を定義します（省略可能）
        </entry>
        <entry>7</entry>
       </row>
@@ -1210,7 +1221,7 @@ C言語から呼び出し可能なソートサポート関数のアドレスを�
         define options that are specific to this operator class
         (optional)
 -->
-この演算子クラスに固有のオプションの集合を定義します(省略可能)。
+この演算子クラスに固有のオプションの集合を定義します（省略可能）
        </entry>
        <entry>5</entry>
       </row>
@@ -1967,7 +1978,7 @@ SELECT sum(x) OVER (ORDER BY x RANGE BETWEEN 5 PRECEDING AND 10 FOLLOWING)
 異なるソート順序（異なるB-tree演算子クラス）では異なる振る舞いを要するかもしれないため、選択を決め打ちすることは望ましくありません。
 そのため、B-tree演算子クラスはそのソート順に意味がある加算と減算の振る舞いをカプセル化する<firstterm>in_range</firstterm>サポート関数を指定することができます。
 <literal>RANGE</literal>句のオフセットとして使う意味のある複数のデータ型がある場合にむけて、複数のin_rangeサポート関数を提供することもできます。
-ウィンドウの<literal>ORDER BY</literal>句と関連しているB-tree演算子クラスが、一致するin_rangeサポート関数を持たない場合、<literal>PRECEDING</literal>/<literal>FOLLOWING</literal>オプションはサポートされません。
+ウィンドウの<literal>ORDER BY</literal>句と関連しているB-tree演算子クラスが、一致するin_rangeサポート関数を持たない場合、<literal>RANGE</literal> <replaceable>offset</replaceable> <literal>PRECEDING</literal>/<literal>FOLLOWING</literal>オプションはサポートされません。
   </para>
 
   <para>
@@ -2119,7 +2130,7 @@ SELECT * FROM table WHERE integer_column &lt; 4;
 この式は、整数列にB-treeインデックスを使用することにより、正確に満たすことができます。
 しかし、一致する行へ厳密ではなくとも導く手段としてインデックスが有用である場合があります。
 例えば、GiSTインデックスで、幾何オブジェクトの外接矩形のみを格納したとします。
-その結果、多角形のような長方形でないオブジェクトとの重なりをテストするWHERE条件は正確に満たすことができません。
+その結果、多角形のような長方形でないオブジェクトとの重なりをテストする<literal>WHERE</literal>条件は正確に満たすことができません。
 もっとも、このインデックスを使用して、対象オブジェクトの外接矩形に重なる外接矩形を持つオブジェクトを検索し、さらに、検索されたオブジェクトのみに対して正確に重なるかどうかをテストすることはできます。
 この筋書きを適用する場合、インデックスは演算子に対して<quote>非可逆</quote>と言われます。
 非可逆インデックス検索は、ある行が問い合わせ条件を実際に満足するかしないかの時に<firstterm>recheck</firstterm>フラグを返すインデックスメソッドを持つことで実装されます。
@@ -2178,7 +2189,7 @@ SP-GiST演算子クラスがデータの取得もサポートする場合、逆�
 GINでは、<literal>STORAGE</literal>型は<quote>キー</quote>の値の型を識別します。
 通常これはインデックス付けされる列の型とは異なります。
 例えば、整数配列の列用の演算子クラスは単なる整数をキーとして持つかもしれません。
-GINの<literal>extractValue</literal>および<literal>extractQuery</literal>サポートルーチンが、インデックス付けされた値からキーを取り出す責任を負います。
+GINの<function>extractValue</function>および<function>extractQuery</function>サポートルーチンが、インデックス付けされた値からキーを取り出す責任を負います。
 BRINはGINと同様です。<literal>STORAGE</literal>型は格納された要約値の型を識別し、演算子クラスのサポートプロシージャは要約値を正しく解釈する責任を負います。
   </para>
  </sect2>


### PR DESCRIPTION
テーブル内の最後の「。」は不要で、合わせています。