### PR TITLE
update insert for 14.5

### DIFF
--- a/doc/src/sgml/ref/insert.sgml
+++ b/doc/src/sgml/ref/insert.sgml
@@ -106,6 +106,7 @@ INSERT INTO <replaceable class="parameter">table_name</replaceable> [ AS <replac
   </para>
 
   <para>
+<!--
    <command>INSERT</command> into tables that lack unique indexes will
    not be blocked by concurrent activity.  Tables with unique indexes
    might block if concurrent sessions perform actions that lock or modify
@@ -114,6 +115,11 @@ INSERT INTO <replaceable class="parameter">table_name</replaceable> [ AS <replac
    <literal>ON CONFLICT</literal> can be used to specify an alternative
    action to raising a unique constraint or exclusion constraint
    violation error. (See <xref linkend="sql-on-conflict"/> below.)
+-->
+一意インデックスのないテーブルへの<command>INSERT</command>は同時実行中の処理によりブロックされることはありません。
+挿入される一意インデックスの値と一致する行をロックまたは修正する動作を同時実行中のセッションがしている場合には、一意インデックスのあるテーブルはブロックします。詳細は<xref linkend="index-unique-checks"/>で扱っています。
+<literal>ON CONFLICT</literal>は一意制約または排他制約について、違反のエラーを発生させるのに代わる動作を指定するのに使うことができます。
+（以下の<xref linkend="sql-on-conflict"/>を参照してください。）
   </para>
 
   <para>


### PR DESCRIPTION
ref/insert.sgml の 14.5 対応です。

後半の２つの文は既存の訳の復活です。