### PR TITLE
config.sgmlの変更漏れを修正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -1674,7 +1674,7 @@ UNIXドメインソケットで接続しているセッションではこのパ�
         <filename>FILE:/usr/local/pgsql/etc/krb5.keytab</filename>
         (where the directory part is whatever was specified
         as <varname>sysconfdir</varname> at build time; use
-        <literal>pg_config &#45;&#45;sysconfdir</literal> to determine that).
+        <literal>pg_config &#45;-sysconfdir</literal> to determine that).
         If this parameter is set to an empty string, it is ignored and a
         system-dependent default is used.
         This parameter can only be set in the
@@ -2411,7 +2411,6 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
 -->
 このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
-
       </listitem>
      </varlistentry>
     </variablelist>
@@ -3525,7 +3524,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
 ゼロに設定することでバックグラウンド書き込みは無効になります。
 （分離し、そして専用の補助プロセスにより管理されるチェックポイントは影響を受けません。）
 デフォルト値は100バッファです。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみで設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
         </para>
        </listitem>
       </varlistentry>
@@ -3823,7 +3822,6 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
          <xref linkend="guc-max-parallel-workers-per-gather"/>.
 -->
 この値を変更する際は、<xref linkend="guc-max-parallel-workers"/>、<xref linkend="guc-max-parallel-maintenance-workers"/>、<xref linkend="guc-max-parallel-workers-per-gather"/>を変更することも考慮してください。
-
         </para>
        </listitem>
       </varlistentry>
@@ -4279,7 +4277,7 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
         off to on, it is necessary to force all modified buffers in the
         kernel to durable storage.  This can be done while the cluster
         is shutdown or while <varname>fsync</varname> is on by running <command>initdb
-        &#045;&#045;sync-only</command>, running <command>sync</command>, unmounting the
+        &#45;-sync-only</command>, running <command>sync</command>, unmounting the
         file system, or rebooting the server.
 -->
 <varname>fsync</varname>を無効(off)から有効(on)に変更したときの信頼できるリカバリのためには、カーネル内の全ての変更されたバッファを恒久的ストレージに強制的に吐き出させることが必要です。
@@ -4668,7 +4666,7 @@ WALの更新をディスクへ強制するのに使用される方法です。
         file or on the server command line.
         The default is <literal>on</literal>.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
 デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
@@ -4891,7 +4889,7 @@ WALを吐き出したとあと、非同期コミットしているトランザ�
 デフォルト値は200ミリ秒（<literal>200ms</literal>）です。
 多くのシステムでは、待機間隔の実質的な分解能は10ミリ秒です。
 10の倍数以外の値を<varname>wal_writer_delay</varname>に設定しても、その次に大きい10の倍数を設定した場合と同じ結果となります。
-このパラメータは<filename>postgresql.conf</filename>ファイル内またはサーバのコマンドラインでのみ設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -4926,7 +4924,7 @@ WALライタがWALを吐き出す頻度を量で指定します。
 <varname>wal_writer_flush_after</varname>が<literal>0</literal>に設定されている場合は、WALが書かれるたびにWALが吐出されます。
 この値が単位なしで指定された場合は、WALブロック単位であるとみなします。すなわち、<symbol>XLOG_BLCKSZ</symbol>バイト、一般的には8kBです。
 デフォルト値は<literal>1MB</literal>です。
-このパラメータは<filename>postgresql.conf</filename>ファイル内またはサーバのコマンドラインでのみ設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -5428,11 +5426,11 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
     <title>アーカイブからのリカバリ</title>
 
     <indexterm>
-<!--
      <primary>configuration</primary>
      <secondary>of recovery</secondary>
      <tertiary>of a standby server</tertiary>
--->
+    </indexterm>
+    <indexterm>
      <primary>設定</primary>
      <secondary>リカバリの</secondary>
      <tertiary>スタンバイサーバの</tertiary>
@@ -5537,7 +5535,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
 <literal>%r</literal>は通常ウォームスタンバイ構成でのみ使用されます。
 （<xref linkend="warm-standby"/>参照。）
 <literal>%</literal>文字自体を埋め込むには<literal>%%</literal>と書いてください。
-      </para>
+       </para>
 
        <para>
 <!--
@@ -8313,9 +8311,10 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </indexterm>
       <indexterm>
        <primary>GEQO</primary>
-<!--
        <see>genetic query optimization</see>
--->
+      </indexterm>
+      <indexterm>
+       <primary>GEQO</primary>
        <see>遺伝的問い合わせ最適化</see>
       </indexterm>
       <indexterm>
@@ -8949,7 +8948,7 @@ csvlog log/postgresql.csv
 <varname>log_destination</varname>で<systemitem>syslog</systemitem>オプションを使用できるようにするために、ほとんどのUnixシステムではシステムの<application>syslog</application>デーモンの設定を変更しなければならないでしょう。
 <productname>PostgreSQL</productname>ではログを<literal>LOCAL0</literal>から<literal>LOCAL7</literal>までの<application>syslog</application>ファシリティで記録することができます（<xref linkend="guc-syslog-facility"/>を参照してください）。
 しかし、ほとんどのプラットフォームのデフォルトの<application>syslog</application>設定ではこれらのメッセージはすべて破棄されます。
-うまく動作させるために<application>syslog</application>デーモンの設定に以下のようなものを追加しなければならないでしょう。
+うまく動作させるために
 <programlisting>
 local0.*    /var/log/postgresql
 </programlisting>
@@ -8957,6 +8956,7 @@ local0.*    /var/log/postgresql
          to the  <application>syslog</application> daemon's configuration file
          to make it work.
 -->
+<application>syslog</application>デーモンの設定に追加しなければならないでしょう。
         </para>
         <para>
 <!--
@@ -9392,7 +9392,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
          When logging to <application>syslog</application> and this is on (the
          default), then each message will be prefixed by an increasing
          sequence number (such as <literal>[2]</literal>).  This circumvents
-         the <quote>&#045;&#045;- last message repeated N times &#045;&#045;-</quote> suppression
+         the <quote>&#45;- last message repeated N times &#45;-</quote> suppression
          that many syslog implementations perform by default.  In more modern
          syslog implementations, repeated message suppression can be configured
          (for example, <literal>$RepeatedMsgReduction</literal>
@@ -10031,9 +10031,10 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
       <term><varname>log_autovacuum_min_duration</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>log_autovacuum_min_duration</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>log_autovacuum_min_duration</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -10265,7 +10266,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 デフォルトでは、接続ログメッセージは接続元ホストのIPアドレスのみを表示します。
 このパラメータを有効にすると、ホスト名もログに残るようになります。
 ホスト名解決方法の設定に依存しますが、これが無視できないほどの性能劣化を起こす可能性があることに注意してください。
-このパラメータは<filename>postgresql.conf</filename>ファイル内またはサーバのコマンドラインでのみ設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -10917,7 +10918,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
 <xref linkend="guc-timezone"/>と異なり、すべてのセッションで一貫性を持ってタイムスタンプが報告されるようにこの値はクラスタ全体に適用されます。
 組み込まれているデフォルトは<literal>GMT</literal>ですが、<filename>postgresql.conf</filename>により通常は上書きされます。<application>initdb</application>によりこれらと関連した設定をシステム環境にインストールされます。
 詳細は<xref linkend="datatype-timezones"/>を参照してください。
-このパラメータは<filename>postgresql.conf</filename>ファイル内またはサーバのコマンドラインでのみ設定することができます。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -10969,23 +10970,25 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
 ミリ秒単位のtimestamp、
 ユーザ名、
 データベース名、
-プロセス識別子、
+プロセスID、
 クライアントホスト：ポート番号、
-セッション識別子、
+セッションID、
 セッション前行番号、
 コマンドタグ、
 セッション開始時間、
-仮想トランザクション識別子、
-通常トランザクション識別子、
+仮想トランザクションID、
+通常トランザクションID、
 エラーの深刻度、
-SQL状態コード、
+SQLSTATEコード、
 エラーメッセージ、
 詳細エラーメッセージ、
 ヒント、
 エラーとなった内部的な問い合わせ（もしあれば）、
 内部問い合わせにおけるエラー位置の文字数、
 エラーの文脈、
-PostgreSQLソースコード上のエラー発生場所（<varname>log_error_verbosity</varname>が<literal>verbose</literal>に設定されているならば）
+エラーの原因となったユーザ問い合わせ(存在し<varname>log_min_error_statement</varname>で有効になっている場合)、
+エラー位置の文字数、
+PostgreSQLソースコード上のエラー発生場所（<varname>log_error_verbosity</varname>が<literal>verbose</literal>に設定されているならば）、
 アプリケーション名、バックエンドタイプ、パラレルグループリーダのプロセスID、問い合わせID。
 以下にcsvlog出力を格納するためのテーブル定義のサンプルを示します。
 
@@ -11573,9 +11576,10 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 
     <indexterm>
      <primary>autovacuum</primary>
-<!--
      <secondary>configuration parameters</secondary>
--->
+    </indexterm>
+    <indexterm>
+     <primary>autovacuum</primary>
      <secondary>設定パラメータ</secondary>
     </indexterm>
 
@@ -11986,7 +11990,7 @@ vacuumは同時に<filename>pg_xact</filename>サブディレクトリから古�
 -1に指定されると、一定の <xref linkend="guc-vacuum-cost-delay"/>の値が使用されます。
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
 デフォルト値は2ミリ秒です。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインのみで設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
 この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
@@ -12390,7 +12394,7 @@ vacuumは同時に<filename>pg_xact</filename>サブディレクトリから古�
         <command>ALTER TABLE</command>.)
         The supported compression methods are <literal>pglz</literal> and
         (if <productname>PostgreSQL</productname> was compiled with
-        <option>#045;&#045;with-lz4</option>) <literal>lz4</literal>.
+        <option>&#45;-with-lz4</option>) <literal>lz4</literal>.
         The default is <literal>pglz</literal>.
 -->
 この変数は圧縮可能な列の値のデフォルト<link linkend="storage-toast">TOAST</link>圧縮方式を設定します。
@@ -12512,13 +12516,11 @@ vacuumは同時に<filename>pg_xact</filename>サブディレクトリから古�
      <varlistentry id="guc-default-transaction-isolation" xreflabel="default_transaction_isolation">
       <term><varname>default_transaction_isolation</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary>transaction isolation level</primary>
--->
-       <primary>トランザクション分離レベル</primary>
-<!--
        <secondary>setting default</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>トランザクション分離レベル</primary>
        <secondary>デフォルト設定</secondary>
       </indexterm>
       <indexterm>
@@ -12559,13 +12561,11 @@ SQLトランザクションはそれぞれ、<quote>read uncommitted</quote>、<
      <varlistentry id="guc-default-transaction-read-only" xreflabel="default_transaction_read_only">
       <term><varname>default_transaction_read_only</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary>read-only transaction</primary>
--->
-       <primary>読み取り専用トランザクション</primary>
-<!--
        <secondary>setting default</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>読み取り専用トランザクション</primary>
        <secondary>デフォルト設定</secondary>
       </indexterm>
       <indexterm>
@@ -12599,10 +12599,10 @@ SQLトランザクションはそれぞれ、<quote>read uncommitted</quote>、<
      <varlistentry id="guc-default-transaction-deferrable" xreflabel="default_transaction_deferrable">
       <term><varname>default_transaction_deferrable</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary>deferrable transaction</primary>
        <secondary>setting default</secondary>
--->
+      </indexterm>
+      <indexterm>
        <primary>遅延トランザクション</primary>
        <secondary>デフォルト設定</secondary>
       </indexterm>
@@ -13224,7 +13224,6 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
        </para>
       </listitem>
      </varlistentry>
-
 
      <varlistentry id="guc-bytea-output" xreflabel="bytea_output">
       <term><varname>bytea_output</varname> (<type>enum</type>)
@@ -14168,7 +14167,7 @@ Windowsのホストでは、ライブラリのプリロードは、新しいサ�
         library directory is substituted for <literal>$libdir</literal>; this
         is where the modules provided by the standard
         <productname>PostgreSQL</productname> distribution are installed.
-        (Use <literal>pg_config &#045;-pkglibdir</literal> to find out the name of
+        (Use <literal>pg_config &#45;-pkglibdir</literal> to find out the name of
         this directory.) For example:
 -->
 <varname>dynamic_library_path</varname>の値は、絶対パスのディレクトリ名をコロン（Windowsの場合はセミコロン）で区切った一覧です。
@@ -14655,7 +14654,7 @@ GINインデックス走査により返されるセットのソフトな上限�
         even if they are not (currently) keywords.  This will affect the
         output of <command>EXPLAIN</command> as well as the results of functions
         like <function>pg_get_viewdef</function>.  See also the
-        <option>&#045;-quote-all-identifiers</option> option of
+        <option>&#45;-quote-all-identifiers</option> option of
         <xref linkend="app-pgdump"/> and <xref linkend="app-pg-dumpall"/>.
 -->
 データベースがSQLを生成する時、たとえ（現在）キーワードになっていなくても、全ての識別子を引用符で囲むことを強制します。
@@ -14878,7 +14877,7 @@ onなら、全てのエラーは現在のセッションを中止させます。
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル内またはサーバのコマンドラインでのみ設定することができます。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -15109,7 +15108,7 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
         macro <symbol>USE_ASSERT_CHECKING</symbol> is defined
         when <productname>PostgreSQL</productname> is built (accomplished
         e.g., by the <command>configure</command> option
-        <option>&#045;-enable-cassert</option>). By
+        <option>&#45;-enable-cassert</option>). By
         default <productname>PostgreSQL</productname> is built without
         assertions.
 -->
@@ -15653,7 +15652,7 @@ WALディスクブロックの容量を報告します。
         <symbol>DISCARD_CACHES_ENABLED</symbol> was defined at compile time
         (which happens automatically when using the
         <application>configure</application> option
-        <option>&#045;-enable-cassert</option>).  In production builds, its value
+        <option>&#45;-enable-cassert</option>).  In production builds, its value
         will always be <literal>0</literal> and attempts to set it to another
         value will raise an error.
 -->
@@ -15804,7 +15803,7 @@ WALディスクブロックの容量を報告します。
 これは、認証における誤動作を追跡するために、デバッガを使用してサーバプロセスに接続する機会を開発者に提供することを目的としたものです。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
 値がゼロ（デフォルト）の場合、この機能は無効になります。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -15868,7 +15867,7 @@ WALディスクブロックの容量を報告します。
 デフォルトの<literal>LOG</literal>は、ログ取得の決定に全く影響しません。
 その他の値は、あたかも<literal>LOG</literal>優先度を所有しているごとく、それ、またはより高い優先度でログ取得される復旧関連デバッグメッセージの要因となります。
 <varname>log_min_messages</varname>の通常設定に対し、これは無条件にそれらをサーバログに送り込みます。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバコマンドラインでのみ設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -16458,7 +16457,7 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
 デフォルトである<literal>on</literal>に設定すると、<productname>PostgreSQL</productname>はバックエンドがクラッシュした後に自動的に一時ファイルを削除します。
 無効にすると、ファイルは保存され、たとえばデバッグ目的で使用できます。
 しかしクラッシュを繰り返すと不要なファイルが溜まっていくかもしれません。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -16596,7 +16595,5 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
     </table>
 
   </sect1>
-
 <!-- split-config3-end -->
-
 </chapter>

--- a/doc/src/sgml/config0.sgml
+++ b/doc/src/sgml/config0.sgml
@@ -1682,7 +1682,7 @@ UNIXドメインソケットで接続しているセッションではこのパ�
         <filename>FILE:/usr/local/pgsql/etc/krb5.keytab</filename>
         (where the directory part is whatever was specified
         as <varname>sysconfdir</varname> at build time; use
-        <literal>pg_config &#45;&#45;sysconfdir</literal> to determine that).
+        <literal>pg_config &#45;-sysconfdir</literal> to determine that).
         If this parameter is set to an empty string, it is ignored and a
         system-dependent default is used.
         This parameter can only be set in the
@@ -2419,7 +2419,6 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
 -->
 このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
-
       </listitem>
      </varlistentry>
     </variablelist>
@@ -3533,7 +3532,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
 ゼロに設定することでバックグラウンド書き込みは無効になります。
 （分離し、そして専用の補助プロセスにより管理されるチェックポイントは影響を受けません。）
 デフォルト値は100バッファです。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみで設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
         </para>
        </listitem>
       </varlistentry>
@@ -3831,7 +3830,6 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
          <xref linkend="guc-max-parallel-workers-per-gather"/>.
 -->
 この値を変更する際は、<xref linkend="guc-max-parallel-workers"/>、<xref linkend="guc-max-parallel-maintenance-workers"/>、<xref linkend="guc-max-parallel-workers-per-gather"/>を変更することも考慮してください。
-
         </para>
        </listitem>
       </varlistentry>
@@ -4023,5 +4021,4 @@ SSDやそれ以外のメモリーベースの記憶装置は、多くの同時�
 &config2;
 &config3;
 <!-- split-config0-end -->
-
 </chapter>

--- a/doc/src/sgml/config1.sgml
+++ b/doc/src/sgml/config1.sgml
@@ -273,7 +273,7 @@
         off to on, it is necessary to force all modified buffers in the
         kernel to durable storage.  This can be done while the cluster
         is shutdown or while <varname>fsync</varname> is on by running <command>initdb
-        &#045;&#045;sync-only</command>, running <command>sync</command>, unmounting the
+        &#45;-sync-only</command>, running <command>sync</command>, unmounting the
         file system, or rebooting the server.
 -->
 <varname>fsync</varname>を無効(off)から有効(on)に変更したときの信頼できるリカバリのためには、カーネル内の全ての変更されたバッファを恒久的ストレージに強制的に吐き出させることが必要です。
@@ -662,7 +662,7 @@ WALの更新をディスクへ強制するのに使用される方法です。
         file or on the server command line.
         The default is <literal>on</literal>.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
 デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
@@ -885,7 +885,7 @@ WALを吐き出したとあと、非同期コミットしているトランザ�
 デフォルト値は200ミリ秒（<literal>200ms</literal>）です。
 多くのシステムでは、待機間隔の実質的な分解能は10ミリ秒です。
 10の倍数以外の値を<varname>wal_writer_delay</varname>に設定しても、その次に大きい10の倍数を設定した場合と同じ結果となります。
-このパラメータは<filename>postgresql.conf</filename>ファイル内またはサーバのコマンドラインでのみ設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -920,7 +920,7 @@ WALライタがWALを吐き出す頻度を量で指定します。
 <varname>wal_writer_flush_after</varname>が<literal>0</literal>に設定されている場合は、WALが書かれるたびにWALが吐出されます。
 この値が単位なしで指定された場合は、WALブロック単位であるとみなします。すなわち、<symbol>XLOG_BLCKSZ</symbol>バイト、一般的には8kBです。
 デフォルト値は<literal>1MB</literal>です。
-このパラメータは<filename>postgresql.conf</filename>ファイル内またはサーバのコマンドラインでのみ設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1422,11 +1422,11 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
     <title>アーカイブからのリカバリ</title>
 
     <indexterm>
-<!--
      <primary>configuration</primary>
      <secondary>of recovery</secondary>
      <tertiary>of a standby server</tertiary>
--->
+    </indexterm>
+    <indexterm>
      <primary>設定</primary>
      <secondary>リカバリの</secondary>
      <tertiary>スタンバイサーバの</tertiary>
@@ -1531,7 +1531,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
 <literal>%r</literal>は通常ウォームスタンバイ構成でのみ使用されます。
 （<xref linkend="warm-standby"/>参照。）
 <literal>%</literal>文字自体を埋め込むには<literal>%%</literal>と書いてください。
-      </para>
+       </para>
 
        <para>
 <!--
@@ -4307,9 +4307,10 @@ JITが有効な場合（<xref linkend="jit"/>参照）、それ以上ならJIT�
       </indexterm>
       <indexterm>
        <primary>GEQO</primary>
-<!--
        <see>genetic query optimization</see>
--->
+      </indexterm>
+      <indexterm>
+       <primary>GEQO</primary>
        <see>遺伝的問い合わせ最適化</see>
       </indexterm>
       <indexterm>

--- a/doc/src/sgml/config2.sgml
+++ b/doc/src/sgml/config2.sgml
@@ -234,7 +234,7 @@ csvlog log/postgresql.csv
 <varname>log_destination</varname>で<systemitem>syslog</systemitem>オプションを使用できるようにするために、ほとんどのUnixシステムではシステムの<application>syslog</application>デーモンの設定を変更しなければならないでしょう。
 <productname>PostgreSQL</productname>ではログを<literal>LOCAL0</literal>から<literal>LOCAL7</literal>までの<application>syslog</application>ファシリティで記録することができます（<xref linkend="guc-syslog-facility"/>を参照してください）。
 しかし、ほとんどのプラットフォームのデフォルトの<application>syslog</application>設定ではこれらのメッセージはすべて破棄されます。
-うまく動作させるために<application>syslog</application>デーモンの設定に以下のようなものを追加しなければならないでしょう。
+うまく動作させるために
 <programlisting>
 local0.*    /var/log/postgresql
 </programlisting>
@@ -242,6 +242,7 @@ local0.*    /var/log/postgresql
          to the  <application>syslog</application> daemon's configuration file
          to make it work.
 -->
+<application>syslog</application>デーモンの設定に追加しなければならないでしょう。
         </para>
         <para>
 <!--
@@ -677,7 +678,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
          When logging to <application>syslog</application> and this is on (the
          default), then each message will be prefixed by an increasing
          sequence number (such as <literal>[2]</literal>).  This circumvents
-         the <quote>&#045;&#045;- last message repeated N times &#045;&#045;-</quote> suppression
+         the <quote>&#45;- last message repeated N times &#45;-</quote> suppression
          that many syslog implementations perform by default.  In more modern
          syslog implementations, repeated message suppression can be configured
          (for example, <literal>$RepeatedMsgReduction</literal>
@@ -1316,9 +1317,10 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
       <term><varname>log_autovacuum_min_duration</varname> (<type>integer</type>)
       <indexterm>
        <primary><varname>log_autovacuum_min_duration</varname></primary>
-<!--
        <secondary>configuration parameter</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary><varname>log_autovacuum_min_duration</varname></primary>
        <secondary>設定パラメータ</secondary>
       </indexterm>
       </term>
@@ -1550,7 +1552,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 デフォルトでは、接続ログメッセージは接続元ホストのIPアドレスのみを表示します。
 このパラメータを有効にすると、ホスト名もログに残るようになります。
 ホスト名解決方法の設定に依存しますが、これが無視できないほどの性能劣化を起こす可能性があることに注意してください。
-このパラメータは<filename>postgresql.conf</filename>ファイル内またはサーバのコマンドラインでのみ設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -2202,7 +2204,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
 <xref linkend="guc-timezone"/>と異なり、すべてのセッションで一貫性を持ってタイムスタンプが報告されるようにこの値はクラスタ全体に適用されます。
 組み込まれているデフォルトは<literal>GMT</literal>ですが、<filename>postgresql.conf</filename>により通常は上書きされます。<application>initdb</application>によりこれらと関連した設定をシステム環境にインストールされます。
 詳細は<xref linkend="datatype-timezones"/>を参照してください。
-このパラメータは<filename>postgresql.conf</filename>ファイル内またはサーバのコマンドラインでのみ設定することができます。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -2254,23 +2256,25 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
 ミリ秒単位のtimestamp、
 ユーザ名、
 データベース名、
-プロセス識別子、
+プロセスID、
 クライアントホスト：ポート番号、
-セッション識別子、
+セッションID、
 セッション前行番号、
 コマンドタグ、
 セッション開始時間、
-仮想トランザクション識別子、
-通常トランザクション識別子、
+仮想トランザクションID、
+通常トランザクションID、
 エラーの深刻度、
-SQL状態コード、
+SQLSTATEコード、
 エラーメッセージ、
 詳細エラーメッセージ、
 ヒント、
 エラーとなった内部的な問い合わせ（もしあれば）、
 内部問い合わせにおけるエラー位置の文字数、
 エラーの文脈、
-PostgreSQLソースコード上のエラー発生場所（<varname>log_error_verbosity</varname>が<literal>verbose</literal>に設定されているならば）
+エラーの原因となったユーザ問い合わせ(存在し<varname>log_min_error_statement</varname>で有効になっている場合)、
+エラー位置の文字数、
+PostgreSQLソースコード上のエラー発生場所（<varname>log_error_verbosity</varname>が<literal>verbose</literal>に設定されているならば）、
 アプリケーション名、バックエンドタイプ、パラレルグループリーダのプロセスID、問い合わせID。
 以下にcsvlog出力を格納するためのテーブル定義のサンプルを示します。
 
@@ -2858,9 +2862,10 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 
     <indexterm>
      <primary>autovacuum</primary>
-<!--
      <secondary>configuration parameters</secondary>
--->
+    </indexterm>
+    <indexterm>
+     <primary>autovacuum</primary>
      <secondary>設定パラメータ</secondary>
     </indexterm>
 
@@ -3271,7 +3276,7 @@ vacuumは同時に<filename>pg_xact</filename>サブディレクトリから古�
 -1に指定されると、一定の <xref linkend="guc-vacuum-cost-delay"/>の値が使用されます。
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
 デフォルト値は2ミリ秒です。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインのみで設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
 この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
@@ -3675,7 +3680,7 @@ vacuumは同時に<filename>pg_xact</filename>サブディレクトリから古�
         <command>ALTER TABLE</command>.)
         The supported compression methods are <literal>pglz</literal> and
         (if <productname>PostgreSQL</productname> was compiled with
-        <option>#045;&#045;with-lz4</option>) <literal>lz4</literal>.
+        <option>&#45;-with-lz4</option>) <literal>lz4</literal>.
         The default is <literal>pglz</literal>.
 -->
 この変数は圧縮可能な列の値のデフォルト<link linkend="storage-toast">TOAST</link>圧縮方式を設定します。
@@ -3797,13 +3802,11 @@ vacuumは同時に<filename>pg_xact</filename>サブディレクトリから古�
      <varlistentry id="guc-default-transaction-isolation" xreflabel="default_transaction_isolation">
       <term><varname>default_transaction_isolation</varname> (<type>enum</type>)
       <indexterm>
-<!--
        <primary>transaction isolation level</primary>
--->
-       <primary>トランザクション分離レベル</primary>
-<!--
        <secondary>setting default</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>トランザクション分離レベル</primary>
        <secondary>デフォルト設定</secondary>
       </indexterm>
       <indexterm>

--- a/doc/src/sgml/config3.sgml
+++ b/doc/src/sgml/config3.sgml
@@ -11,13 +11,11 @@
      <varlistentry id="guc-default-transaction-read-only" xreflabel="default_transaction_read_only">
       <term><varname>default_transaction_read_only</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary>read-only transaction</primary>
--->
-       <primary>読み取り専用トランザクション</primary>
-<!--
        <secondary>setting default</secondary>
--->
+      </indexterm>
+      <indexterm>
+       <primary>読み取り専用トランザクション</primary>
        <secondary>デフォルト設定</secondary>
       </indexterm>
       <indexterm>
@@ -51,10 +49,10 @@
      <varlistentry id="guc-default-transaction-deferrable" xreflabel="default_transaction_deferrable">
       <term><varname>default_transaction_deferrable</varname> (<type>boolean</type>)
       <indexterm>
-<!--
        <primary>deferrable transaction</primary>
        <secondary>setting default</secondary>
--->
+      </indexterm>
+      <indexterm>
        <primary>遅延トランザクション</primary>
        <secondary>デフォルト設定</secondary>
       </indexterm>
@@ -676,7 +674,6 @@ PostgreSQLは<literal>origin</literal>と<literal>local</literal>の設定を内
        </para>
       </listitem>
      </varlistentry>
-
 
      <varlistentry id="guc-bytea-output" xreflabel="bytea_output">
       <term><varname>bytea_output</varname> (<type>enum</type>)
@@ -1620,7 +1617,7 @@ Windowsのホストでは、ライブラリのプリロードは、新しいサ�
         library directory is substituted for <literal>$libdir</literal>; this
         is where the modules provided by the standard
         <productname>PostgreSQL</productname> distribution are installed.
-        (Use <literal>pg_config &#045;-pkglibdir</literal> to find out the name of
+        (Use <literal>pg_config &#45;-pkglibdir</literal> to find out the name of
         this directory.) For example:
 -->
 <varname>dynamic_library_path</varname>の値は、絶対パスのディレクトリ名をコロン（Windowsの場合はセミコロン）で区切った一覧です。
@@ -2107,7 +2104,7 @@ GINインデックス走査により返されるセットのソフトな上限�
         even if they are not (currently) keywords.  This will affect the
         output of <command>EXPLAIN</command> as well as the results of functions
         like <function>pg_get_viewdef</function>.  See also the
-        <option>&#045;-quote-all-identifiers</option> option of
+        <option>&#45;-quote-all-identifiers</option> option of
         <xref linkend="app-pgdump"/> and <xref linkend="app-pg-dumpall"/>.
 -->
 データベースがSQLを生成する時、たとえ（現在）キーワードになっていなくても、全ての識別子を引用符で囲むことを強制します。
@@ -2330,7 +2327,7 @@ onなら、全てのエラーは現在のセッションを中止させます。
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル内またはサーバのコマンドラインでのみ設定することができます。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -2561,7 +2558,7 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
         macro <symbol>USE_ASSERT_CHECKING</symbol> is defined
         when <productname>PostgreSQL</productname> is built (accomplished
         e.g., by the <command>configure</command> option
-        <option>&#045;-enable-cassert</option>). By
+        <option>&#45;-enable-cassert</option>). By
         default <productname>PostgreSQL</productname> is built without
         assertions.
 -->
@@ -3105,7 +3102,7 @@ WALディスクブロックの容量を報告します。
         <symbol>DISCARD_CACHES_ENABLED</symbol> was defined at compile time
         (which happens automatically when using the
         <application>configure</application> option
-        <option>&#045;-enable-cassert</option>).  In production builds, its value
+        <option>&#45;-enable-cassert</option>).  In production builds, its value
         will always be <literal>0</literal> and attempts to set it to another
         value will raise an error.
 -->
@@ -3256,7 +3253,7 @@ WALディスクブロックの容量を報告します。
 これは、認証における誤動作を追跡するために、デバッガを使用してサーバプロセスに接続する機会を開発者に提供することを目的としたものです。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
 値がゼロ（デフォルト）の場合、この機能は無効になります。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -3320,7 +3317,7 @@ WALディスクブロックの容量を報告します。
 デフォルトの<literal>LOG</literal>は、ログ取得の決定に全く影響しません。
 その他の値は、あたかも<literal>LOG</literal>優先度を所有しているごとく、それ、またはより高い優先度でログ取得される復旧関連デバッグメッセージの要因となります。
 <varname>log_min_messages</varname>の通常設定に対し、これは無条件にそれらをサーバログに送り込みます。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバコマンドラインでのみ設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -3910,7 +3907,7 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
 デフォルトである<literal>on</literal>に設定すると、<productname>PostgreSQL</productname>はバックエンドがクラッシュした後に自動的に一時ファイルを削除します。
 無効にすると、ファイルは保存され、たとえばデバッグ目的で使用できます。
 しかしクラッシュを繰り返すと不要なファイルが溜まっていくかもしれません。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -4048,5 +4045,4 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
     </table>
 
   </sect1>
-
 <!-- split-config3-end -->


### PR DESCRIPTION
以下の修正が含まれます。
原文が同じ文の箇所を同じ訳に統一。
コメント内ハイフンの表記変更。
indextermのコメントになっていた漏れを修正。
タグチェックによる修正。