### PR TITLE
spi.sgmlのコメント位置ミスを修正

### DIFF
--- a/doc/src/sgml/spi.sgml
+++ b/doc/src/sgml/spi.sgml
@@ -94,8 +94,8 @@ SPIを使用するソースコードファイルでは<filename>executor/spi.h</
 
   <refnamediv>
    <refname>SPI_connect</refname>
-<!--
    <refname>SPI_connect_ext</refname>
+<!--
    <refpurpose>connect a C function to the SPI manager</refpurpose>
 -->
    <refpurpose>SPIマネージャにC関数を接続する</refpurpose>
@@ -271,7 +271,7 @@ C関数の現在の呼び出し期間内で必要なSPI操作が完了した後�
 <!--
       if called from an unconnected C function
 -->
-未接続のC関数から呼び出された場合。
+未接続のC関数から呼び出された場合
      </para>
     </listitem>
    </varlistentry>
@@ -488,7 +488,6 @@ typedef struct SPITupleTable
     MemoryContext tuptabcxt;    /* 結果テーブルのメモリコンテキスト */
     slist_node  next;           /* 内部情報のためのリンク */
     SubTransactionId subid;     /* SPITupleTableが生成されたサブトランザクション */
-
 } SPITupleTable;
 </programlisting>
 <!--
@@ -778,7 +777,7 @@ typedef struct SPITupleTable
 <!--
        if called from an unconnected C function
 -->
-未接続なC関数から呼び出された場合。
+未接続のC関数から呼び出された場合
       </para>
      </listitem>
     </varlistentry>
@@ -2538,7 +2537,7 @@ int SPI_execute_plan_extended(SPIPlanPtr <parameter>plan</parameter>,
   </para>
 
   <para>
-<!--    
+<!--
    Query parameter values are represented by
    a <literal>ParamListInfo</literal> struct, which is convenient for passing
    down values that are already available in that format.  Dynamic parameter
@@ -4768,7 +4767,7 @@ int SPI_register_relation(EphemeralNamedRelation <parameter>enr</parameter>)
 <!--
        if called from an unconnected C function
 -->
-接続されていないC関数から呼び出された場合
+未接続のC関数から呼び出された場合
       </para>
      </listitem>
     </varlistentry>
@@ -4913,7 +4912,7 @@ int SPI_unregister_relation(const char * <parameter>name</parameter>)
 <!--
        if called from an unconnected C function
 -->
-接続されていないC関数から呼び出された場合
+未接続のC関数から呼び出された場合
       </para>
      </listitem>
     </varlistentry>
@@ -5074,7 +5073,7 @@ int SPI_register_trigger_data(TriggerData *<parameter>tdata</parameter>)
 <!--
        if called from an unconnected C function
 -->
-接続されていないC関数から呼び出された場合
+未接続のC関数から呼び出された場合
       </para>
      </listitem>
     </varlistentry>
@@ -5935,7 +5934,10 @@ const char * SPI_result_code_string(int <parameter>code</parameter>);
  </refsynopsisdiv>
 
  <refsect1>
+<!--
   <title>Description</title>
+-->
+  <title>説明</title>
 
   <para>
 <!--
@@ -5948,7 +5950,10 @@ const char * SPI_result_code_string(int <parameter>code</parameter>);
  </refsect1>
 
  <refsect1>
+<!--
   <title>Arguments</title>
+-->
+  <title>引数</title>
 
   <variablelist>
    <varlistentry>
@@ -6413,7 +6418,6 @@ HeapTuple SPI_copytuple(HeapTuple <parameter>row</parameter>)
 -->
 コピーされた行、あるいはエラー時は<symbol>NULL</symbol>
 （エラーの表示については<varname>SPI_result</varname>を参照してください）
-
   </para>
  </refsect1>
 </refentry>
@@ -6640,7 +6644,7 @@ HeapTuple SPI_modifytuple(Relation <parameter>rel</parameter>, HeapTuple <parame
 <!--
       an array of length <parameter>ncols</parameter>, containing the numbers
       of the columns that are to be changed (column numbers start at 1)
- -->
+-->
 変更される列番号を含む、<parameter>ncols</parameter>長の配列（列番号は1から始まります）
      </para>
     </listitem>
@@ -7438,8 +7442,8 @@ CREATE FUNCTION execq(text, integer) RETURNS int8
 INSERT 0 1
 =&gt; SELECT execq('SELECT * FROM a', 0);
 <!--
-INFO:  EXECQ:  0    &#045;&#045; inserted by execq
-INFO:  EXECQ:  1    &#045;&#045; returned by execq and inserted by upper INSERT
+INFO:  EXECQ:  0    &#45;- inserted by execq
+INFO:  EXECQ:  1    &#45;- returned by execq and inserted by upper INSERT
 -->
 INFO:  EXECQ:  0    -- execqによって挿入された
 INFO:  EXECQ:  1    -- execqによって返され、上位のINSERTによって挿入された
@@ -7459,14 +7463,14 @@ INFO:  EXECQ:  1    -- execqによって返され、上位のINSERTによって�
 INFO:  EXECQ:  0
 INFO:  EXECQ:  1
 <!--
-INFO:  EXECQ:  2    &#045;&#045; 0 + 2, only one row inserted - as specified
+INFO:  EXECQ:  2    &#45;- 0 + 2, only one row inserted - as specified
 -->
 INFO:  EXECQ:  2    -- 指定された、0 + 2という1つの行のみが挿入された
 
  execq
 -------
 <!--
-     3              &#045;&#045; 10 is the max value only, 3 is the real number of rows
+     3              &#45;- 10 is the max value only, 3 is the real number of rows
 -->
      3              -- 10は最大値を示すのみで、3が実際の行数です。
 (1 row)
@@ -7479,7 +7483,7 @@ INSERT 0 1
  x
 ---
 <!--
- 1                  &#045;&#045; no rows in a (0) + 1
+ 1                  &#45;- no rows in a (0) + 1
 -->
  1                  -- aテーブルに行がない(0) + 1
 (1 row)
@@ -7492,13 +7496,13 @@ INSERT 0 1
 ---
  1
 <!--
- 2                  &#045;&#045; there was one row in a + 1
+ 2                  &#45;- there was one row in a + 1
 -->
  2                  -- aテーブルに1行あり + 1
 (2 rows)
 
 <!--
-&#045;&#045; This demonstrates the data changes visibility rule:
+&#45;- This demonstrates the data changes visibility rule:
 -->
 --   これはデータ変更に関する可視性規則を説明します。
 
@@ -7515,8 +7519,8 @@ INSERT 0 2
  1
  2
 <!--
- 2                  &#045;&#045; 2 rows * 1 (x in first row)
- 6                  &#045;&#045; 3 rows (2 + 1 just inserted) * 2 (x in second row)
+ 2                  &#45;- 2 rows * 1 (x in first row)
+ 6                  &#45;- 3 rows (2 + 1 just inserted) * 2 (x in second row)
 (4 rows)               ^^^^^^
                        rows visible to execq() in different invocations
 -->


### PR DESCRIPTION
コメントの開始位置がミスっていたのを修正。
同じ文言の統一。
ハイフンの修正。