### PR TITLE
機械翻訳の改善

### DIFF
--- a/doc/src/sgml/archive-modules.sgml
+++ b/doc/src/sgml/archive-modules.sgml
@@ -67,6 +67,11 @@
    <function>_PG_archive_module_init</function>.  This function is passed a
    struct that needs to be filled with the callback function pointers for
    individual actions.
+-->
+《機械翻訳》アーカイブ・ライブラリは、<xref linkend="guc-archive-library"/>の名前をライブラリ・ベース名として共有ライブラリを動的にロードすることによってロードされます。
+通常のライブラリ検索パスを使用してライブラリが検索されます。
+必要なアーカイブ・モジュール・コールバックを提供し、ライブラリが実際にアーカイブ・モジュールであることを示すには、<function>_PG_archive_module_init</function>という名前の関数を提供する必要があります。
+この関数には、個々のアクション用のコールバック関数ポインタを格納する必要がある構造体が渡されます。
 
 <programlisting>
 typedef struct ArchiveModuleCallbacks
@@ -78,14 +83,11 @@ typedef struct ArchiveModuleCallbacks
 typedef void (*ArchiveModuleInit) (struct ArchiveModuleCallbacks *cb);
 </programlisting>
 
+<!--
    Only the <function>archive_file_cb</function> callback is required.  The
    others are optional.
 -->
-《機械翻訳》アーカイブ・ライブラリは、<xref linkend="guc-archive-library"/>の名前をライブラリ・ベース名として共有ライブラリを動的にロードすることによってロードされます。
-通常のライブラリ検索パスを使用してライブラリが検索されます。
-必要なアーカイブ・モジュール・コールバックを提供し、ライブラリが実際にアーカイブ・モジュールであることを示すには、<function>_PG_archive_module_init</function>という名前の関数を提供する必要があります。
-この関数には、個々のアクション用のコールバック関数ポインタを格納する必要がある構造体が渡されます。
-<programlisting>typedef struct ArchiveModuleCallbacks{ArchiveCheckConfiguredCB check_configured_cb;ArchiveFileCB archive_file_cb;ArchiveShutdownCB shutdown_cb;}ArchiveModuleCallbacks;typedef void(*ArchiveModuleInit)(struct ArchiveModuleCallbacks*cb);</programlisting><function>archive_file_cb</function>コールバックのみが必要です。
+《機械翻訳》<function>archive_file_cb</function>コールバックのみが必要です。
 その他はオプションです。
   </para>
  </sect1>

--- a/doc/src/sgml/backup.sgml
+++ b/doc/src/sgml/backup.sgml
@@ -948,6 +948,7 @@ WALアーカイブを行わない場合、システムは通常数個のセグ�
    </para>
 
    <para>
+<!--
     In <varname>archive_command</varname>,
     <literal>%p</literal> is replaced by the path name of the file to
     archive, while <literal>%f</literal> is replaced by only the file name.
@@ -956,6 +957,11 @@ WALアーカイブを行わない場合、システムは通常数個のセグ�
     Use <literal>%%</literal> if you need to embed an actual <literal>%</literal>
     character in the command.  The simplest useful command is something
     like:
+-->
+《機械翻訳》<varname>archive_command</varname>では、<literal>%p</literal>はアーカイブするファイルのパス名に置き換えられますが、<literal>%f</literal>はファイル名のみに置き換えられます。
+(パス名は現在の作業ディレクトリ、つまりクラスタのデータディレクトリからの相対パスです。)
+実際の<literal>%</literal>文字をコマンドに埋め込む必要がある場合は<literal>%%</literal>を使用してください。
+最も簡単で便利なコマンドは以下のようなものです。
 <programlisting>
 archive_command = 'test ! -f /mnt/server/archivedir/%f &amp;&amp; cp %p /mnt/server/archivedir/%f'  # Unix
 archive_command = 'copy "%p" "C:\\server\\archivedir\\%f"'  # Windows
@@ -1337,15 +1343,18 @@ WALアーカイブが有効であり、正常に動作することを確認し�
      rights to run <function>pg_backup_start</function> (superuser,
      or a user who has been granted <literal>EXECUTE</literal> on the
      function) and issue the command:
+-->
+《機械翻訳》実行権限を持つユーザ<function>pg_backup_start</function>としてサーバ（どのデータベースであってもかまいません）に接続します。ユーザはスーパーユーザか、またはこの関数に<literal>EXECUTE</literal>権限を与えられたユーザです。以下のコマンドを発行します。
 <programlisting>
 SELECT pg_backup_start(label => 'label', fast => false);
 </programlisting>
+<!--
      where <literal>label</literal> is any string you want to use to uniquely
      identify this backup operation. The connection
      calling <function>pg_backup_start</function> must be maintained until the end of
      the backup, or the backup will be automatically aborted.
 -->
-《機械翻訳》実行権限を持つユーザ<function>pg_backup_start</function>としてサーバ(どのデータベースでも構いません)に接続し、以下のコマンドを発行します:<programlisting>SELECT pg_backup_start(label=>'label',fast=>false);</programlisting>ここで<literal>label</literal>は、このバックアップ操作を一意に識別するために使用したい文字列です。
+《機械翻訳》ここで<literal>label</literal>は、このバックアップ操作を一意に識別するために使用したい文字列です。
 <function>pg_backup_start</function>を呼び出す接続は、バックアップが終了するまで維持されなければなりません。
 さもないと、バックアップは自動的に打ち切られます。
     </para>

--- a/doc/src/sgml/basebackup-to-shell.sgml
+++ b/doc/src/sgml/basebackup-to-shell.sgml
@@ -101,10 +101,7 @@
   <title>Author</title>
 
   <para>
-<!--
    Robert Haas <email>rhaas@postgresql.org</email>
--->
-《機械翻訳》Robert Haas<email>rhaas@postgresql.org</email>
   </para>
  </sect2>
 

--- a/doc/src/sgml/basic-archive.sgml
+++ b/doc/src/sgml/basic-archive.sgml
@@ -98,10 +98,7 @@ basic_archive.archive_directory = '/path/to/archive/directory'
   <title>Author</title>
 
   <para>
-<!--
    Nathan Bossart
--->
-《機械翻訳》ネイサン・Bossart
   </para>
  </sect2>
 

--- a/doc/src/sgml/charset.sgml
+++ b/doc/src/sgml/charset.sgml
@@ -543,9 +543,14 @@ ICUロケールは、PostgreSQLがビルドされた際にICUサポートが設�
     shown earlier all use the <literal>libc</literal> provider, which is the
     default.  Here is an example to initialize a database cluster using the
     ICU provider:
+-->
+《機械翻訳》前述のように、ロケール設定を選択するコマンドおよびツールには、それぞれロケール・プロバイダを選択するオプションがあります。
+前述の例では、デフォルトである<literal>libc</literal>プロバイダを使用しています。
+次に、ICUプロバイダを使用してデータベース・クラスタを初期化する例を示します:
 <programlisting>
 initdb &#45;-locale-provider=icu &#45;-icu-locale=en
 </programlisting>
+<!--
     See the description of the respective commands and programs for
     details.  Note that you can mix locale providers at different
     granularities, for example use <literal>libc</literal> by default for the
@@ -553,9 +558,7 @@ initdb &#45;-locale-provider=icu &#45;-icu-locale=en
     provider, and then have collation objects using either provider within
     those databases.
 -->
-《機械翻訳》前述のように、ロケール設定を選択するコマンドおよびツールには、それぞれロケール・プロバイダを選択するオプションがあります。
-前述の例では、デフォルトである<literal>libc</literal>プロバイダを使用しています。
-次に、ICUプロバイダを使用してデータベース・クラスタを初期化する例を示します:<programlisting>initdb--locale-provider=icu--icu-locale=en</programlisting>詳細は、各コマンドおよびプログラムの説明を参照してください。
+《機械翻訳》詳細は、各コマンドおよびプログラムの説明を参照してください。
 異なる粒度でロケール・プロバイダを混在させることもできます。
 たとえば、クラスタではデフォルトで<literal>libc</literal>を使用しますが、<literal>icu</literal>プロバイダを使用するデータベースが1つあり、これらのデータベース内でいずれかのプロバイダを使用する照合オブジェクトがあることに注意してください。
    </para>

--- a/doc/src/sgml/color.sgml
+++ b/doc/src/sgml/color.sgml
@@ -120,8 +120,11 @@ PostgreSQLパッケージのたいていのプログラムは、色付けされ�
     <varlistentry>
      <term><literal>note</literal></term>
      <listitem>
+<!--
       <para>used to highlight the text <quote>detail</quote> and
       <quote>hint</quote> in such messages</para>
+-->
+      <para>《機械翻訳》メッセージでテキスト<quote>詳細</quote>と<quote>ヒント</quote>を強調するのに使われます</para>
      </listitem>
     </varlistentry>
 

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -9065,12 +9065,17 @@ CSV書式のログ出力を生成するためには<xref linkend="guc-logging-co
         collector and the associated logging destination. This provides a
         convenient way to find the logs currently in use by the instance. Here
         is an example of this file's content:
+-->
+《機械翻訳》<systemitem>stderr</systemitem>、<systemitem>csvlog</systemitem>、または<systemitem>jsonlog</systemitem>のいずれかが含まれている場合、ファイル<filename>current_logfiles</filename>が作成され、ロギングコレクタによって現在使用されているログファイルの場所と関連付けられたロギング先が記録されます。
+これにより、インスタンスによって現在使用されているログを簡単に見つけることができます。
+このファイルの内容の例を次に示します:
 <programlisting>
 stderr log/postgresql.log
 csvlog log/postgresql.csv
 jsonlog log/postgresql.json
 </programlisting>
 
+<!--
         <filename>current_logfiles</filename> is recreated when a new log file
         is created as an effect of rotation, and
         when <varname>log_destination</varname> is reloaded.  It is removed when
@@ -9079,9 +9084,7 @@ jsonlog log/postgresql.json
         included in <varname>log_destination</varname>, and when the logging
         collector is disabled.
 -->
-《機械翻訳》<systemitem>stderr</systemitem>、<systemitem>csvlog</systemitem>、または<systemitem>jsonlog</systemitem>のいずれかが含まれている場合、ファイル<filename>current_logfiles</filename>が作成され、ロギングコレクタによって現在使用されているログファイルの場所と関連付けられたロギング先が記録されます。
-これにより、インスタンスによって現在使用されているログを簡単に見つけることができます。
-このファイルの内容の例を次に示します:<programlisting>stderr log/postgresql.log csvlog log/postgresql.csv jsonlog log/postgresql.json</programlisting><filename>current_logfiles</filename>は、ローテーションの効果として新しいログファイルが作成されたとき、および<varname>log_destination</varname>がリロードされたときに再作成されます。
+《機械翻訳》<filename>current_logfiles</filename>は、ローテーションの効果として新しいログファイルが作成されたとき、および<varname>log_destination</varname>がリロードされたときに再作成されます。
 <systemitem>stderr</systemitem>、<systemitem>csvlog</systemitem>、<systemitem>jsonlog</systemitem>のいずれも<varname>log_destination</varname>に含まれていないとき、およびロギングコレクタが無効になっているときに削除されます。
        </para>
 

--- a/doc/src/sgml/config2.sgml
+++ b/doc/src/sgml/config2.sgml
@@ -237,12 +237,17 @@ CSV書式のログ出力を生成するためには<xref linkend="guc-logging-co
         collector and the associated logging destination. This provides a
         convenient way to find the logs currently in use by the instance. Here
         is an example of this file's content:
+-->
+《機械翻訳》<systemitem>stderr</systemitem>、<systemitem>csvlog</systemitem>、または<systemitem>jsonlog</systemitem>のいずれかが含まれている場合、ファイル<filename>current_logfiles</filename>が作成され、ロギングコレクタによって現在使用されているログファイルの場所と関連付けられたロギング先が記録されます。
+これにより、インスタンスによって現在使用されているログを簡単に見つけることができます。
+このファイルの内容の例を次に示します:
 <programlisting>
 stderr log/postgresql.log
 csvlog log/postgresql.csv
 jsonlog log/postgresql.json
 </programlisting>
 
+<!--
         <filename>current_logfiles</filename> is recreated when a new log file
         is created as an effect of rotation, and
         when <varname>log_destination</varname> is reloaded.  It is removed when
@@ -251,9 +256,7 @@ jsonlog log/postgresql.json
         included in <varname>log_destination</varname>, and when the logging
         collector is disabled.
 -->
-《機械翻訳》<systemitem>stderr</systemitem>、<systemitem>csvlog</systemitem>、または<systemitem>jsonlog</systemitem>のいずれかが含まれている場合、ファイル<filename>current_logfiles</filename>が作成され、ロギングコレクタによって現在使用されているログファイルの場所と関連付けられたロギング先が記録されます。
-これにより、インスタンスによって現在使用されているログを簡単に見つけることができます。
-このファイルの内容の例を次に示します:<programlisting>stderr log/postgresql.log csvlog log/postgresql.csv jsonlog log/postgresql.json</programlisting><filename>current_logfiles</filename>は、ローテーションの効果として新しいログファイルが作成されたとき、および<varname>log_destination</varname>がリロードされたときに再作成されます。
+《機械翻訳》<filename>current_logfiles</filename>は、ローテーションの効果として新しいログファイルが作成されたとき、および<varname>log_destination</varname>がリロードされたときに再作成されます。
 <systemitem>stderr</systemitem>、<systemitem>csvlog</systemitem>、<systemitem>jsonlog</systemitem>のいずれも<varname>log_destination</varname>に含まれていないとき、およびロギングコレクタが無効になっているときに削除されます。
        </para>
 

--- a/doc/src/sgml/custom-rmgr.sgml
+++ b/doc/src/sgml/custom-rmgr.sgml
@@ -34,6 +34,9 @@
   <filename>src/backend/access/transam/README</filename> and
   <filename>src/include/access/xlog_internal.h</filename> in the
   <productname>PostgreSQL</productname> source.
+-->
+《機械翻訳》新しいカスタムWAL資源マネージャを作成するためには、まず資源マネージャメソッドの実装を持つ<structname>RmgrData</structname>構造体を定義します。
+<productname>PostgreSQL</productname>ソースで<filename>src/backend/access/transam/README</filename>と<filename>src/include/access/xlog_internal.h</filename>を参照してください。
 <programlisting>
 /*
  * Method table for resource managers.
@@ -65,19 +68,6 @@ typedef struct RmgrData
                               struct XLogRecordBuffer *buf);
 } RmgrData;
 </programlisting>
--->
-《機械翻訳》新しいカスタムWAL資源マネージャを作成するためには、まず資源マネージャメソッドの実装を持つ<structname>RmgrData</structname>構造体を定義します。
-<productname>PostgreSQL</productname>ソースで<filename>src/backend/access/transam/README</filename>と<filename>src/include/access/xlog_internal.h</filename>を参照してください。
-<programlisting>/**資源マネージャ用のメソッドテーブルです。
-**この構造体は*rmgr.c内のPG_RMGR定義と同期させなければなりません。
-**rm_identifyはxl_infoに基づいたレコードの名前を(rmidへの*参照なしで)返さなければなりません。
-**rm_identifyはxl_infoに基づいたレコードの名前を(rmidへの*参照なしで)返さなければなりません。
-例えば、XLOG_BTREE_VACUUMは*"VACUUM"という名前になります。
-その後、rm_descを呼び出して*レコードの追加詳細を取得することができます(例えば、最後のブロック)。
-**rm_maskは、リソースマネージャによって変更されたページを入力として受け取り、wal_consistency_checkingによってフラグ付けされないビットをマスクします。
-**RmgrTable[]はRmgrId値によってインデックス付けされます(rmgrlist.hを参照)。
-rm_nameが*NULLの場合、対応するRmgrTableエントリは無効と見なされます。
-*/typedef struct RmgrData{const char*rm_name;void(*rm_redo)(XLogReaderState*record);void(*rm_desc)(StringInfo buf,XLogReaderState*record);const char*(*rm_identify)(uint8 info);void(*rm_startup)(void);void(*rm_cleanup)(void);void(*rm_mask)(char*pagedata,BlockNumber blkno);void(*rm_decode)(struct LogicalDecodingContext*XLogRecordBuffer RmgrData</programlisting>
  </para>
  <para>
 <!--

--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -1174,6 +1174,11 @@ CREATE TABLE products (
     rows that contain a null value in at least one of the constrained
     columns.  This behavior can be changed by adding the clause <literal>NULLS
     NOT DISTINCT</literal>, like
+-->
+《機械翻訳》一般に、一意性制約は、制約に含まれるすべての列の値が等しい表に複数の行がある場合に違反します。
+デフォルトでは、2つのNULL値はこの比較では等しくないとみなされます。
+つまり、一意性制約が存在する場合でも、制約された列の少なくとも1つにNULL値を含む重複行を格納できます。
+この動作は、次のように句<literal>NULLS NOT DISTINCT</literal>を追加することで変更できます。
 <programlisting>
 CREATE TABLE products (
     product_no integer UNIQUE <emphasis>NULLS NOT DISTINCT</emphasis>,
@@ -1181,7 +1186,10 @@ CREATE TABLE products (
     price numeric
 );
 </programlisting>
+<!--
     or
+-->
+または
 <programlisting>
 CREATE TABLE products (
     product_no integer,
@@ -1190,19 +1198,16 @@ CREATE TABLE products (
     UNIQUE <emphasis>NULLS NOT DISTINCT</emphasis> (product_no)
 );
 </programlisting>
+<!--
     The default behavior can be specified explicitly using <literal>NULLS
     DISTINCT</literal>.  The default null treatment in unique constraints is
     implementation-defined according to the SQL standard, and other
     implementations have a different behavior.  So be careful when developing
     applications that are intended to be portable.
 -->
-《機械翻訳》一般に、一意性制約は、制約に含まれるすべての列の値が等しい表に複数の行がある場合に違反します。
-デフォルトでは、この比較では2つのNULL値が等しいとはみなされません。
-これは、一意性制約が存在する場合でも、制約された列の少なくとも1つにNULL値を含む重複行を格納できることを意味します。
-この動作は、<programlisting>CREATE TABLE products(product_no integer UNIQUE<emphasis>NULLS NOT DISTINCT</emphasis>,name text,price numeric);</programlisting>または<programlisting>CREATE TABLE products(product_no integer,name text,price numeric,UNIQUE<emphasis>NULLS NOT DISTINCT</emphasis>(product_no));</programlisting>のような句<literal>NULLS NOT DISTINCT</literal>を追加することで変更できます。
-デフォルトの動作は、<literal>NULLS DISTINCT</literal>を使用して明示的に指定できます。
-一意性制約におけるデフォルトのNULL処理は標準SQLに従って実装で定義されており、他の実装では異なる動作があります。
-移植性を意図したアプリケーションを開発する場合は注意が必要です。
+《機械翻訳》デフォルトの動作は、<literal>NULLS DISTINCT</literal>を使用して明示的に指定できます。
+一意性制約でのデフォルトのNULL処理は、標準SQLに従って実装によって定義されますが、他の実装では動作が異なります。
+そのため、移植可能なアプリケーションを開発する際には注意が必要です。
    </para>
   </sect2>
 

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -7324,7 +7324,7 @@ substring('foobar' from 'o(.)b')   <lineannotation>o</lineannotation>
 <replaceable>pattern</replaceable>は<replaceable>string</replaceable>で検索されます。
 通常は文字列の先頭から検索されますが、<replaceable>start</replaceable>パラメータが指定されている場合は、その文字インデックスから検索が開始されます。
 <replaceable>flags</replaceable>パラメータは、オプションのテキスト文字列であり、関数の動作を変更する0個以上の単一文字フラグを含みます。
-たとえば、then i rongをdash flags squareに含めると、大文字と小文字を区別しないマッチングを指定します。
+ たとえば、<replaceable>flags</replaceable>に<literal>i</literal>を含めると、大文字と小文字を区別しないマッチングを指定します。
 サポートされているフラグは<xref linkend="posix-embedded-options-table"/>で説明されています。
     </para>
 

--- a/doc/src/sgml/func1.sgml
+++ b/doc/src/sgml/func1.sgml
@@ -7255,7 +7255,7 @@ substring('foobar' from 'o(.)b')   <lineannotation>o</lineannotation>
 <replaceable>pattern</replaceable>は<replaceable>string</replaceable>で検索されます。
 通常は文字列の先頭から検索されますが、<replaceable>start</replaceable>パラメータが指定されている場合は、その文字インデックスから検索が開始されます。
 <replaceable>flags</replaceable>パラメータは、オプションのテキスト文字列であり、関数の動作を変更する0個以上の単一文字フラグを含みます。
-たとえば、then i rongをdash flags squareに含めると、大文字と小文字を区別しないマッチングを指定します。
+ たとえば、<replaceable>flags</replaceable>に<literal>i</literal>を含めると、大文字と小文字を区別しないマッチングを指定します。
 サポートされているフラグは<xref linkend="posix-embedded-options-table"/>で説明されています。
     </para>
 

--- a/doc/src/sgml/lobj.sgml
+++ b/doc/src/sgml/lobj.sgml
@@ -283,8 +283,8 @@ Oid lo_creat(PGconn *conn, int mode);
 そのため<function>lo_creat</function>は0秒引数を持つ<function>lo_create</function>とまったく同じです。
 しかし、8.1より古いサーバで作業する必要がない限り、<function>lo_creat</function>を使用する理由はほとんどありません。
 このような古いサーバで作業するには、<function>lo_create</function>ではなく<function>lo_creat</function>を使用する必要があります。
-<replaceable class="parameter">mode</replaceable>を<symbol>INV_READ</symbol>、<symbol>INV_WRITE</symbol>、<symbol>INV_READ</symbol>spectro echos醇^INV_WRITE fapnのいずれかに設定する必要があります(これらのシンボリック定数は、ヘッダファイルで定義されています。
-libpq/libpq-fs.h iko)。
+<replaceable class="parameter">mode</replaceable>を<symbol>INV_READ</symbol>、<symbol>INV_WRITE</symbol>、<symbol>INV_READ</symbol><literal>|</literal><symbol>INV_WRITE</symbol>のいずれかに設定する必要があります。
+(これらのシンボリック定数は、<filename>libpq/libpq-fs.h</filename>ヘッダファイルで定義されています。）
     </para>
 
     <para>

--- a/doc/src/sgml/logical-replication.sgml
+++ b/doc/src/sgml/logical-replication.sgml
@@ -509,7 +509,10 @@ PostgreSQLは両方の仕組みを同時にサポートします。
     <title>Examples</title>
 
     <para>
+<!--
      Create some test tables on the publisher.
+-->
+《機械翻訳》パブリッシャでテスト・テーブルを作成します。
 <programlisting>
 test_pub=# CREATE TABLE t1(a int, b text, PRIMARY KEY(a));
 CREATE TABLE
@@ -520,7 +523,10 @@ CREATE TABLE
 </programlisting></para>
 
     <para>
+<!--
      Create the same tables on the subscriber.
+-->
+《機械翻訳》サブスクライバ上に同じテーブルを作成します。
 <programlisting>
 test_sub=# CREATE TABLE t1(a int, b text, PRIMARY KEY(a));
 CREATE TABLE
@@ -1002,7 +1008,10 @@ test_sub=# SELECT * FROM t3;
    <title>Examples</title>
 
    <para>
+<!--
     Create some tables to be used in the following examples.
+-->
+《機械翻訳》次の例で使用するテーブルをいくつか作成します。
 <programlisting>
 test_pub=# CREATE TABLE t1(a int, b int, c text, PRIMARY KEY(a,c));
 CREATE TABLE
@@ -1118,9 +1127,12 @@ Publications:
 </programlisting></para>
 
    <para>
+<!--
     On the subscriber node, create a table <literal>t1</literal> with the same
     definition as the one on the publisher, and also create the subscription
     <literal>s1</literal> that subscribes to the publication <literal>p1</literal>.
+-->
+《機械翻訳》サブスクライバノードで、パブリッシャと同じ定義のテーブル<literal>t1</literal>を作成し、パブリケーション<literal>p1</literal>をサブスクライブするサブスクリプション<literal>s1</literal>も作成します。
 <programlisting>
 test_sub=# CREATE TABLE t1(a int, b int, c text, PRIMARY KEY(a,c));
 CREATE TABLE
@@ -1298,14 +1310,20 @@ test_sub=# SELECT * FROM t1;
    </para>
 
    <para>
+<!--
     Create a partitioned table on the publisher.
+-->
+《機械翻訳》パブリッシャでパーティション表を作成します。
 <programlisting>
 test_pub=# CREATE TABLE parent(a int PRIMARY KEY) PARTITION BY RANGE(a);
 CREATE TABLE
 test_pub=# CREATE TABLE child PARTITION OF parent DEFAULT;
 CREATE TABLE
 </programlisting>
+<!--
    Create the same tables on the subscriber.
+-->
+《機械翻訳》サブスクライバ上に同じテーブルを作成します。
 <programlisting>
 test_sub=# CREATE TABLE parent(a int PRIMARY KEY) PARTITION BY RANGE(a);
 CREATE TABLE
@@ -1566,7 +1584,10 @@ test_sub=# SELECT * FROM child ORDER BY a;
    <title>Examples</title>
 
    <para>
+<!--
     Create a table <literal>t1</literal> to be used in the following example.
+-->
+《機械翻訳》次の例で使用するテーブル<literal>t1</literal>を作成します。
 <programlisting>
 test_pub=# CREATE TABLE t1(id int, a text, b text, c text, d text, e text, PRIMARY KEY(id));
 CREATE TABLE
@@ -1627,11 +1648,14 @@ Publications:
 </programlisting></para>
 
     <para>
+<!--
      On the subscriber node, create a table <literal>t1</literal> which now
      only needs a subset of the columns that were on the publisher table
      <literal>t1</literal>, and also create the subscription
      <literal>s1</literal> that subscribes to the publication
      <literal>p1</literal>.
+-->
+《機械翻訳》サブスクライバノードで、パブリッシャテーブル<literal>t1</literal>にあったカラムのサブセットだけが必要なテーブル<literal>t1</literal>を作成し、パブリケーション<literal>p1</literal>をサブスクライブするサブスクリプション<literal>s1</literal>も作成します。
 <programlisting>
 test_sub=# CREATE TABLE t1(id int, b text, a text, d text, PRIMARY KEY(id));
 CREATE TABLE
@@ -1741,11 +1765,16 @@ test_sub=# SELECT * FROM t1 ORDER BY id;
    transaction that conflicts with the existing data.  When a conflict produces
    an error, the replication won't proceed, and the logical replication worker will
    emit the following kind of message to the subscriber's server log:
+-->
+《機械翻訳》解決は、受信した変更と競合しないようにサブスクライバのデータまたは権限を変更するか、既存のデータと競合するトランザクションをスキップすることによって実行できます。
+競合によってエラーが発生した場合、レプリケーションは処理されません。
+論理レプリケーション・ワーカーは、次のようなメッセージをサブスクライバのサーバー・ログに発行します。
 <screen>
 ERROR:  duplicate key value violates unique constraint "test_pkey"
 DETAIL:  Key (c)=(1) already exists.
 CONTEXT:  processing remote data for replication origin "pg_16395" during "INSERT" for replication target relation "public.test" in transaction 725 finished at 0/14C0378
 </screen>
+<!--
    The LSN of the transaction that contains the change violating the constraint and
    the replication origin name can be found from the server log (LSN 0/14C0378 and
    replication origin <literal>pg_16395</literal> in the above case).  The
@@ -1767,12 +1796,7 @@ CONTEXT:  processing remote data for replication origin "pg_16395" during "INSER
    might not violate any constraint.  This can easily make the subscriber
    inconsistent.
 -->
-《機械翻訳》解決は、受信した変更と競合しないようにサブスクライバのデータまたは権限を変更するか、既存のデータと競合するトランザクションをスキップすることによって実行できます。
-競合によってエラーが発生した場合、レプリケーションは処理されません。
-論理レプリケーション・ワーカーは、次のようなメッセージをサブスクライバのサーバー・ログに発行します。
-<screen>ERROR:重複キー値が一意性制約"test_pkey"に違反しています。
-DETAIL:Key(c)=(1)already exists.CONTEXT:レプリケーション・ターゲット関係"public.test"の"INSERT"中に複製開始点"pg_16395"のリモート・データを処理しています。
-in transaction 725 finished at 0/14C0378</screen>制約と複製開始点名に違反する変更を含むトランザクションのLSNは、サーバー・ログ(LSN 0/14C0378と複製開始点<literal>pg_16395</literal>)から見つけることができます。
+《機械翻訳》制約と複製開始点名に違反する変更を含むトランザクションのLSNは、サーバー・ログ(LSN 0/14C0378と複製開始点<literal>pg_16395</literal>)から見つけることができます。
 競合を発生させたトランザクションは、終了LSNで<command>ALTER SUBSCRIPTION.SKIP</command>を使用してスキップできます(LSN 0/14C0378)。
 終了LSNは、パブリッシャでトランザクションがコミットまたは準備されたLSNである可能性があります。
 あるいは、<link linkend="pg-replication-origin-advance"><function>pg_replication_origin_advance()</function>関数を呼び出して、トランザクションをスキップすることもできます。

--- a/doc/src/sgml/mvcc.sgml
+++ b/doc/src/sgml/mvcc.sgml
@@ -633,10 +633,11 @@ SQL標準では、ある分離レベルで発生しては<emphasis>ならない<
 -->
 《機械翻訳》<command>MERGE</command>を使用すると、ユーザーは<command>INSERT</command>、<command>UPDATE</command>および<command>DELETE</command>サブコマンドの様々な組み合わせを指定できます。
 <command>INSERT</command>および<command>UPDATE</command>サブコマンドを指定した<command>MERGE</command>コマンドは、<literal>ON CONFLICT DO UPDATE</literal>句を指定した<command>INSERT</command>に似ていますが、<command>INSERT</command>または<command>UPDATE</command>のいずれかが発生することを保証するものではありません。
-<command>MERGE</command>がbutterUPDATEスクリプトまたはframDELETEスクリプトを実行しようとしたときに、行が同時に更新されていても、現在のターゲットと現在のソースタプルに対して結合条件が渡されている場合は、cle MERGEファイルはcurmeUPDATEコマンドまたはcir DELETEコマンドと同じように動作し、更新された行に対してアクションを実行します。
-しかし、dragMERGEスキャンは複数のアクションを指定でき、それらは条件付きである可能性があるため、最初に一致したアクションがアクションリストの後の方に表示される場合でも、各アクションの条件は更新された行に対して最初のアクションから再評価されます。
-一方、行が同時に更新または削除されて結合条件が失敗した場合は、find MERGE起動は次に条件のNOT MATCHED 20アクションを評価し、成功した最初のアクションを実行します。
-MERGEロックがINSERTロックを実行しようとしたときに一意性インデックスが存在し、重複行が同時に挿入された場合、一意性違反エラーが発生します。
+<command>MERGE</command>が<command>UPDATE</command>または<command>DELETE</command>を試行し、行が同時に更新されますが、結合条件が現在のターゲットタプルと現在のソースタプルに適用される場合、<command>MERGE</command>は<command>UPDATE</command>または<command>DELETE</command>コマンドと同じように動作し、更新された行に対してアクションを実行します。
+ただし、<command>MERGE</command>は複数のアクションを指定でき、それらは条件付きにすることができるため、各アクションの条件は更新された行に対して最初のアクションから再評価されます。
+最初に一致したアクションがアクションリストの後の方に現れる場合でも同様です。
+一方、行が同時に更新または削除されて結合条件が失敗した場合、<command>MERGE</command>は条件の<literal>NOT MATCHED</literal>アクションを次に評価し、成功した最初のアクションを実行します。
+<command>MERGE</command>が<command>INSERT</command>を試行し、一意なインデックスが存在し、重複した行が同時に挿入された場合、一意性違反エラーが発生します。<command>MERGE</command>は<literal>MATCHED</literal>条件の評価を再開してこのようなエラーを回避しようとはしません。
    </para>
 
    <para>
@@ -2605,7 +2606,7 @@ SELECT pg_advisory_lock(q.id) FROM
 -->
 《機械翻訳》場合によっては、SQLSTATEコード<literal>23505</literal>(<literal>unique_violation</literal>)を持つ一意キーの失敗、およびSQLSTATEコード<literal>23P01</literal>(<literal>exclusion_violation</literal>)を持つ排他制約の失敗を再試行することも適切です。
 たとえば、現在格納されているキーを検査した後にアプリケーションが主キー列に新しい値を選択した場合、別のアプリケーション・インスタンスが同じ新しいキーを同時に選択したため、一意キーの失敗が発生する可能性があります。
-これは実質的にシリアル化の失敗ですが、挿入された値と以前の読取り間の接続を確認できないため、サーバーはシリアル化の失敗を検出できません。
+これは実質的にシリアル化の失敗ですが、サーバは挿入された値と前の読み取りとの間の関係を<quote>参照</quote>できないため、シリアル化の失敗を検出しません。
 また、原則としてシリアル化の問題が根本原因であると判断するのに十分な情報があるにもかかわらず、サーバーが一意キーまたは排他制約のエラーを発行する場合もあります。
 <literal>serialization_failure</literal>エラーを無条件に再試行することをお薦めしますが、これらの他のエラー・コードを再試行する場合は、一時的な失敗ではなく永続的なエラー条件を表す可能性があるため、より注意が必要です。
    </para>

--- a/doc/src/sgml/protocol.sgml
+++ b/doc/src/sgml/protocol.sgml
@@ -3039,7 +3039,10 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        </varlistentry>
       </variablelist>
 
+<!--
       <para>The following options are supported:</para>
+-->
+      <para>《機械翻訳》次のオプションがサポートされています。</para>
 
       <variablelist>
        <varlistentry>
@@ -3107,8 +3110,11 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
       </variablelist>
 
       <para>
+<!--
        In response to this command, the server will send a one-row result set
        containing the following fields:
+-->
+《機械翻訳》このコマンドに応答して、サーバは以下のフィールドを含む1行の結果セットを送信します。
 
        <variablelist>
         <varlistentry>
@@ -3208,15 +3214,19 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
 <!--
        In response to this command, the server will return a one-row result set,
        containing the following fields:
+-->
+《機械翻訳》このコマンドに応答して、サーバは以下のフィールドを含む1行の結果セットを返します:
+
        <variablelist>
         <varlistentry>
          <term><literal>slot_type</literal> (<type>text</type>)</term>
          <listitem>
           <para>
+<!--
            The replication slot's type, either <literal>physical</literal> or
            <literal>NULL</literal>.
 -->
-《機械翻訳》このコマンドに応答して、サーバは以下のフィールドを含む1行の結果セットを返します:<variablelist><varlistentry><term><literal>slot_type</literal>(<type>text</type>)</term><listitem><para>レプリケーションスロットのタイプ、<literal>physical</literal>または<literal>NULL</literal>。
+《機械翻訳》レプリケーションスロットのタイプ、<literal>physical</literal>または<literal>NULL</literal>。
           </para>
          </listitem>
         </varlistentry>
@@ -4032,7 +4042,7 @@ CopyBothResponse内部のメッセージは、2つのCommandCompleteメッセー
            <literal>3</literal>).
 -->
 《機械翻訳》<literal>level</literal>キーワードは圧縮レベルを設定します。
-<literal>gzip</literal>の場合、圧縮レベルは<literal>1</literal>から<literal>9</literal>までの整数(デフォルト<literal>Z_DEFAULT_COMPRESSION</literal>または<literal>-1</literal>)、<literal>lz4</literal>の場合は1から12までの整数(高速圧縮モードの場合デフォルト<literal>0</literal>)、<literal>zstd</literal>の場合は<literal>ZSTD_minCLevel()</literal>(通常<literal>-131072</literal>)から<literal>ZSTD_maxCLevel()</literal>(通常はarth 22 fon),(デフォルトはZSTD_CLEVEL_DEFAULTιまたはcurs 3 dpa)までの整数です。
+<literal>gzip</literal>の場合、圧縮レベルは<literal>1</literal>から<literal>9</literal>までの整数(デフォルト<literal>Z_DEFAULT_COMPRESSION</literal>または<literal>-1</literal>)、<literal>lz4</literal>の場合は1から12までの整数(高速圧縮モードの場合デフォルト<literal>0</literal>)、<literal>zstd</literal>の場合は<literal>ZSTD_minCLevel()</literal>(通常<literal>-131072</literal>)から<literal>ZSTD_maxCLevel()</literal>(通常は<literal>22</literal>),(デフォルトは<literal>ZSTD_CLEVEL_DEFAULT</literal>または<literal>3</literal>)までの整数です。
           </para>
 
           <para>

--- a/doc/src/sgml/ref/create_publication.sgml
+++ b/doc/src/sgml/ref/create_publication.sgml
@@ -492,12 +492,11 @@ CREATE PUBLICATION mypublication FOR TABLE users, departments;
   <para>
 <!--
    Create a publication that publishes all changes from active departments:
+-->
+《機械翻訳》アクティブな部署からのすべての変更を発行するパブリケーションを作成します。
 <programlisting>
 CREATE PUBLICATION active_departments FOR TABLE departments WHERE (active IS TRUE);
 </programlisting>
--->
-《機械翻訳》アクティブな部署からのすべての変更を発行するパブリケーションを作成します。
-<programlisting>CREATE PUBLICATION active_departments FOR TABLE departments WHERE(active IS TRUE);</programlisting>
   </para>
 
   <para>

--- a/doc/src/sgml/ref/initdb.sgml
+++ b/doc/src/sgml/ref/initdb.sgml
@@ -218,7 +218,7 @@ PostgreSQL documentation
         and <literal>local</literal> lines).  See <xref linkend="auth-pg-hba-conf"/>
         for an overview of valid values.
 -->
-《機械翻訳》このオプションは、<filename>pg_hba.conf</filename>で使用されるローカルユーザーのデフォルトの認証方法を指定します(<literal>host</literal>と醇P醇P醇P醇P.conf line)。
+《機械翻訳》このオプションは、<filename>pg_hba.conf</filename>で使用されるローカルユーザーのデフォルトの認証方法を指定します（<literal>host</literal>および<literal>local</literal>行）。
 有効な値の概要については<xref linkend="auth-pg-hba-conf"/>を参照してください。
        </para>
 

--- a/doc/src/sgml/ref/merge.sgml
+++ b/doc/src/sgml/ref/merge.sgml
@@ -137,7 +137,7 @@ DELETE
 挿入アクションを指定する場合は、<replaceable class="parameter">target_table_name</replaceable>に対して<literal>INSERT</literal>権限を持っている必要があります。
 削除アクションを指定する場合は、<replaceable class="parameter">target_table_name</replaceable>に対して<literal>DELETE</literal>権限を持っている必要があります。
 権限は文の開始時に一度テストされ、特定の<literal>WHEN</literal>句が実行されたかどうかがチェックされます。
-<replaceable class="parameter">data_source</replaceable>と、chat条件群で参照される<replaceable class="parameter">target_table_name</replaceable>の列に対して<literal>SELECT</literal>権限が必要です。
+<replaceable class="parameter">data_source</replaceable>および<literal>condition</literal>で参照される<replaceable class="parameter">target_table_name</replaceable>のすべての列に対して<literal>SELECT</literal>権限が必要です。
   </para>
 
   <para>
@@ -545,15 +545,18 @@ DELETE
 <!--
    On successful completion, a <command>MERGE</command> command returns a command
    tag of the form
+-->
+《機械翻訳》正常に完了すると、<command>MERGE</command>コマンドは
 <screen>
 MERGE <replaceable class="parameter">total_count</replaceable>
 </screen>
+<!--
    The <replaceable class="parameter">total_count</replaceable> is the total
    number of rows changed (whether inserted, updated, or deleted).
    If <replaceable class="parameter">total_count</replaceable> is 0, no rows
    were changed in any way.
 -->
-《機械翻訳》正常に完了すると、<command>MERGE</command>コマンドは<screen>MERGE<replaceable class="parameter">total_count</replaceable></screen>という形式のコマンドタグを返します。
+という形式のコマンドタグを返します。
 <replaceable class="parameter">total_count</replaceable>は変更された行の合計数です(挿入、更新、または削除のいずれか)。
 <replaceable class="parameter">total_count</replaceable>が0の場合、行はまったく変更されていません。
   </para>
@@ -760,6 +763,8 @@ MERGE <replaceable class="parameter">total_count</replaceable>
 <!--
    Perform maintenance on <literal>customer_accounts</literal> based
    upon new <literal>recent_transactions</literal>.
+-->
+《機械翻訳》新規<literal>recent_transactions</literal>に基づいて、<literal>customer_accounts</literal>のメンテナンスを実行します。
 
 <programlisting>
 MERGE INTO customer_account ca
@@ -771,9 +776,6 @@ WHEN NOT MATCHED THEN
   INSERT (customer_id, balance)
   VALUES (t.customer_id, t.transaction_value);
 </programlisting>
--->
-《機械翻訳》新規<literal>recent_transactions</literal>に基づいて、<literal>customer_accounts</literal>のメンテナンスを実行します。
-<programlisting>MERGE INTO customer_account ca USING recent_transactions t ON t.customer_id=ca.customer_id WHEN MATCHED THEN UPDATE SET balance=balance+transaction_value WHEN NOT MATCHED THEN INSERT(customer_id,balance)VALUES(t.customer_id,t.transaction_value);</programlisting>
   </para>
 
   <para>
@@ -781,6 +783,8 @@ WHEN NOT MATCHED THEN
    Notice that this would be exactly equivalent to the following
    statement because the <literal>MATCHED</literal> result does not change
    during execution.
+-->
+《機械翻訳》<literal>MATCHED</literal>の結果は実行中に変更されないため、これは次の文とまったく同じになります。
 
 <programlisting>
 MERGE INTO customer_account ca
@@ -792,9 +796,6 @@ WHEN NOT MATCHED THEN
   INSERT (customer_id, balance)
   VALUES (t.customer_id, t.transaction_value);
 </programlisting>
--->
-《機械翻訳》<literal>MATCHED</literal>の結果は実行中に変更されないため、これは次の文とまったく同じになります。
-<programlisting>MERGE INTO customer_account ca USING(SELECT customer_id,transaction_value FROM recent_transactions)AS t ON t.customer_id=ca.customer_id WHEN MATCHED THEN UPDATE SET balance=balance+transaction_value WHEN NOT MATCHED THEN INSERT(customer_id,balance)VALUES(t.customer_id,t.transaction_value);</programlisting>
   </para>
 
   <para>
@@ -802,6 +803,10 @@ WHEN NOT MATCHED THEN
    Attempt to insert a new stock item along with the quantity of stock. If
    the item already exists, instead update the stock count of the existing
    item. Don't allow entries that have zero stock.
+-->
+《機械翻訳》在庫数量とともに新規在庫品目を挿入しようとしました。
+品目がすでに存在する場合は、既存品目の在庫数を更新します。
+在庫数が0のエントリは許可しません。
 <programlisting>
 MERGE INTO wines w
 USING wine_stock_changes s
@@ -814,13 +819,11 @@ WHEN MATCHED THEN
   DELETE;
 </programlisting>
 
+<!--
    The <literal>wine_stock_changes</literal> table might be, for example, a
    temporary table recently loaded into the database.
 -->
-《機械翻訳》在庫数量とともに新規在庫品目を挿入しようとしました。
-品目がすでに存在する場合は、既存品目の在庫数を更新します。
-在庫数が0のエントリは許可しません。
-<programlisting>MERGE INTO wines w USING wine_stock_changes s ON s.winename=w.winename WHEN NOT MATCHED AND s.stock_delta>0 THEN INSERT VALUES(s.winename,s.stock_delta)WHEN MATCHED AND w.stock+s.stock_delta>0 THEN UPDATE SET在庫=w.在庫+s.在庫_delta WHEN MATCHED THEN DELETE;</programlisting><literal>wine_stock_changes</literal>テーブルは、たとえば、最近データベースにロードされた一時テーブルです。
+《機械翻訳》<literal>wine_stock_changes</literal>テーブルは、たとえば、最近データベースにロードされた一時テーブルです。
   </para>
 
  </refsect1>

--- a/doc/src/sgml/release-15.sgml
+++ b/doc/src/sgml/release-15.sgml
@@ -202,7 +202,7 @@ Author: Stephen Frost <sfrost@snowman.net>
       backup mode</link> (David Steele, Nathan Bossart)
 -->
 《機械翻訳》長く非推奨<link linkend="backup-base-backup">排他バックアップモード</link>を削除しました。
-(デヴィッド・スティール、ネイサン・Bossart)
+(David Steele, Nathan Bossart)
      </para>
 
      <para>
@@ -289,6 +289,7 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
       is passed an empty-string array element (Jean-Christophe Arnu)
 -->
 《機械翻訳》<link linkend="textsearch-functions-table"><function>array_to_tsvector()</function></link>に空文字列の配列要素(Jean-Christophe Arnu)が渡された場合にエラーを生成します。
+(Jean-Christophe Arnu)
      </para>
 
      <para>
@@ -351,7 +352,8 @@ Author: Peter Eisentraut <peter@eisentraut.org>
       e.g., <literal>U&amp;""</literal>
       (Peter Eisentraut)
 -->
-《機械翻訳》<literal>U&amp;""</literal>のように長さ0<link linkend="sql-syntax-identifiers">ユニコード識別子</link>を許可しない(Peter Eisentraut)
+《機械翻訳》<literal>U&amp;""</literal>のように長さ0<link linkend="sql-syntax-identifiers">ユニコード識別子</link>を許可しない
+(Peter Eisentraut)
      </para>
 
      <para>
@@ -502,7 +504,7 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
       functions</link> (Joe Koshakow)
 -->
 《機械翻訳》<link linkend="functions-datetime-table">interval justification関数</link>で整数オーバーフローを検出します。
-(Koshakow譲)
+(Joe Koshakow)
      </para>
 
      <para>
@@ -575,7 +577,8 @@ Author: Jeff Davis <jdavis@postgresql.org>
       Allow <link linkend="logical-replication">logical replication</link>
       to run as the owner of the subscription (Mark Dilger)
 -->
-《機械翻訳》<link linkend="logical-replication">論理レプリケーション</link>をサブスクリプションの所有者として実行できるようにする(Mark Dilger)
+《機械翻訳》<link linkend="logical-replication">論理レプリケーション</link>をサブスクリプションの所有者として実行できるようにする
+(Mark Dilger)
      </para>
 
      <para>
@@ -628,7 +631,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
       references the session's temporary object schema, refer to it as
       <literal>pg_temp</literal> (Amul Sul)
 -->
-《機械翻訳》<link linkend="sql-explain"><command>EXPLAIN</command></link>がセッションの一時オブジェクトスキーマを参照する場合は、<literal>pg_temp</literal>(Amul Sul)として参照します。
+《機械翻訳》<link linkend="sql-explain"><command>EXPLAIN</command></link>がセッションの一時オブジェクトスキーマを参照する場合は、<literal>pg_temp</literal>として参照します。
+(Amul Sul)
      </para>
 
      <para>
@@ -654,7 +658,7 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
       with multiple indexes (Andrei Zubkov)
 -->
 《機械翻訳》<link linkend="monitoring-pg-statio-all-tables-view"><structname>pg_statio_all_tables</structname></link>を、複数のインデックスを持つ<acronym>TOAST</acronym>テーブルの稀なケースの値を合計するように修正しました。
-(Andreiズブコフ)
+(Andrei Zubkov)
      </para>
 
      <para>
@@ -682,7 +686,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
       are not one of the extension's declared variables
       (Florin Irion, Tom Lane)
 -->
-《機械翻訳》インストールされている拡張機能の名前と一致するが、拡張機能の宣言された変数の1つではない設定<link linkend="runtime-config-custom">カスタムオプション</link>を禁止する(Florin Irion,Tom Lane)
+《機械翻訳》インストールされている拡張機能の名前と一致するが、拡張機能の宣言された変数の1つではない設定<link linkend="runtime-config-custom">カスタムオプション</link>を禁止する
+(Florin Irion,Tom Lane)
      </para>
 
      <para>
@@ -710,7 +715,7 @@ Author: Andres Freund <andres@anarazel.de>
       Horiguchi)
 -->
 《機械翻訳》古いサーバ変数<varname>stats_temp_directory</varname>を削除します。
-(Andres Freund、堀口京太郎)
+(Andres Freund, Kyotaro Horiguchi)
      </para>
     </listitem>
 
@@ -729,7 +734,7 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
       (Fabien Coelho)
 -->
 《機械翻訳》<link linkend="functions-math-random-table"><function>random()</function></link>の計算に使用するアルゴリズムを改良しました。
-(ファビアン・コエリョ)
+(Fabien Coelho)
      </para>
 
      <para>
@@ -755,7 +760,7 @@ Author: Alvaro Herrera <alvherre@alvh.no-ip.org>
       function is no longer supported in pipeline mode (Álvaro Herrera)
 -->
 《機械翻訳》<application>libpq</application>の<link linkend="libpq-PQsendQuery"><function>PQsendQuery()</function></link>関数はパイプラインモードでサポートされなくなりました。
-(アルバロ・エレラ)
+(Álvaro Herrera)
      </para>
 
      <para>
@@ -778,7 +783,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
       On non-Windows platforms, consult the <envar>HOME</envar> environment
       variable to find the user's home directory (Anders Kaseorg)
 -->
-《機械翻訳》Windows以外のプラットフォームでは、<envar>HOME</envar>環境変数を調べてユーザーのホームディレクトリを見つけます(Anders Kaseorg)
+《機械翻訳》Windows以外のプラットフォームでは、<envar>HOME</envar>環境変数を調べてユーザーのホームディレクトリを見つけます
+(Anders Kaseorg)
      </para>
 
      <para>
@@ -851,7 +857,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
       Avoid unnecessary casting of constants in queries sent by <link
       linkend="postgres-fdw">postgres_fdw</link> (Dian Fay)
 -->
-《機械翻訳》<link linkend="postgres-fdw">postgres_fdw</link>(Dian Fay)が送信する問い合わせで、不要な定数のキャストを行わないようにします。
+《機械翻訳》<link linkend="postgres-fdw">postgres_fdw</link>が送信する問い合わせで、不要な定数のキャストを行わないようにします。
+(Dian Fay)
      </para>
 
      <para>
@@ -874,7 +881,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
       Remove <link linkend="xml2">xml2</link>'s
       <function>xml_is_well_formed()</function> function (Tom Lane)
 -->
-《機械翻訳》Remove<link linkend="xml2">xml2</link>の<function>xml_is_well_formed()</function>関数(Tom Lane)
+《機械翻訳》Remove<link linkend="xml2">xml2</link>の<function>xml_is_well_formed()</function>関数
+(Tom Lane)
      </para>
 
      <para>
@@ -897,7 +905,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
       Allow <link linkend="custom-scan">custom scan providers</link>
       to indicate if they support projections (Sven Klemm)
 -->
-《機械翻訳》<link linkend="custom-scan">カスタムスキャンプロバイダ</link>がプロジェクションをサポートしているかどうかを示すことを許可する(Sven Klemm)
+《機械翻訳》<link linkend="custom-scan">カスタムスキャンプロバイダ</link>がプロジェクションをサポートしているかどうかを示すことを許可する
+(Sven Klemm)
      </para>
 
      <para>
@@ -974,7 +983,8 @@ Author: Peter Eisentraut <peter@eisentraut.org>
        collations to be set as the default for clusters and databases
        (Peter Eisentraut)
 -->
-《機械翻訳》<link linkend="locale"><acronym>ICU</acronym></link>照合をクラスタとデータベースのデフォルトとして設定できるようにする(Peter Eisentraut)
+《機械翻訳》<link linkend="locale"><acronym>ICU</acronym></link>照合をクラスタとデータベースのデフォルトとして設定できるようにする
+(Peter Eisentraut)
       </para>
 
       <para>
@@ -1003,7 +1013,7 @@ Author: Michael Paquier <michael@paquier.xyz>
        Rouhaud)
 -->
 《機械翻訳》システムビュー<link linkend="view-pg-ident-file-mappings"><structname>pg_ident_file_mappings</structname></link>をレポート<filename>pg_ident.conf</filename>情報に追加しました。
-(ジュリアンRouhaud)
+(Julien Rouhaud)
       </para>
      </listitem>
 
@@ -1025,7 +1035,8 @@ Author: David Rowley <drowley@postgresql.org>
         Improve planning time for queries referencing partitioned tables
         (David Rowley)
 -->
-《機械翻訳》Improve planning time for queries referencing partitioned tables(Davidロウリー)
+《機械翻訳》Improve planning time for queries referencing partitioned tables
+(David Rowley)
        </para>
 
        <para>
@@ -1048,7 +1059,7 @@ Author: David Rowley <drowley@postgresql.org>
         (David Rowley)
 -->
 《機械翻訳》パーティションの順序付けられたスキャンを許可して、より多くのケースでソートされないようにします。
-(Davidロウリー)
+(David Rowley)
        </para>
 
        <para>
@@ -1074,7 +1085,8 @@ Author: Alvaro Herrera <alvherre@alvh.no-ip.org>
         Improve foreign key behavior of updates on partitioned tables
         that move rows between partitions (Amit Langote)
 -->
-《機械翻訳》Improve foreign key behavior of updates on partitioned table that move rows between partitions(Amit Langote)
+《機械翻訳》Improve foreign key behavior of updates on partitioned table that move rows between partitions
+(Amit Langote)
        </para>
 
        <para>
@@ -1103,7 +1115,8 @@ Author: Alvaro Herrera <alvherre@alvh.no-ip.org>
         Allow <link linkend="sql-cluster"><command>CLUSTER</command></link>
         on partitioned tables (Justin Pryzby)
 -->
-《機械翻訳》Allow<link linkend="sql-cluster"><command>CLUSTER</command></link>on partitioned tables(Justin Pryzby)
+《機械翻訳》Allow<link linkend="sql-cluster"><command>CLUSTER</command></link>on partitioned tables
+(Justin Pryzby)
        </para>
       </listitem>
 
@@ -1120,7 +1133,7 @@ Author: Alvaro Herrera <alvherre@alvh.no-ip.org>
         triggers on all partitions (Arne Roland, Álvaro Herrera)
 -->
 《機械翻訳》パーティションテーブルの<link linkend="sql-altertable"><command>ALTER TRIGGER RENAME</command></link>を修正し、すべてのパーティションでトリガの名前を正しく変更できるようにしました。
-(アルネ・ローランド、アルバロ・エレラ)
+(Arne Roland, Álvaro Herrera)
        </para>
 
        <para>
@@ -1256,7 +1269,7 @@ Author: Tomas Vondra <tomas.vondra@postgresql.org>
         children (Tomas Vondra, Justin Pryzby)
 -->
 《機械翻訳》<link linkend="sql-createstatistics">拡張統計</link>が親とそのすべての子の統計を記録できるようにします。
-(Tomas Vondra,Justin Pryzby)
+(Tomas Vondra, Justin Pryzby)
        </para>
 
        <para>
@@ -1309,7 +1322,7 @@ Author: David Rowley <drowley@postgresql.org>
         clauses with many constants (David Rowley, James Coleman)
 -->
 《機械翻訳》多くの定数を持つ<link linkend="functions-subquery-notin"><literal>NOT IN</literal></link>句のハッシュルックアップを許可しました。
-(David Coleman、James Coleman、ロウリー)
+(David Rowley, James Coleman)
        </para>
 
        <para>
@@ -1332,7 +1345,7 @@ Author: David Rowley <drowley@postgresql.org>
        (David Rowley)
 -->
 《機械翻訳》<command>SELECT DISTINCT</command>の並列化を可能にしました。
-(Davidロウリー)
+(David Rowley)
       </para>
      </listitem>
 
@@ -1349,7 +1362,7 @@ Author: John Naylor <john.naylor@postgresql.org>
         (John Naylor, Heikki Linnakangas)
 -->
 《機械翻訳》一度に16バイトを処理することで<acronym>UTF</acronym>-8テキストのエンコーディング検証を高速化します。
-(John Naylor,Heikki Linnakangas)
+(John Naylor, Heikki Linnakangas)
        </para>
 
        <para>
@@ -1375,7 +1388,8 @@ Author: Heikki Linnakangas <heikki.linnakangas@iki.fi>
         linkend="guc-work-mem"><varname>work_mem</varname></link>
         (Heikki Linnakangas)
 -->
-《機械翻訳》<link linkend="guc-work-mem"><varname>work_mem</varname></link>Heikki Linnakangas)をheikki Linnakangas)
+《機械翻訳》<link linkend="guc-work-mem"><varname>work_mem</varname></link>を超えるソートのパフォーマンスを改善します。
+(Heikki Linnakangas)
        </para>
 
        <para>
@@ -1403,7 +1417,8 @@ Author: John Naylor <john.naylor@postgresql.org>
         Improve performance and reduce memory consumption of in-memory
         sorts (Ronan Dunklau, David Rowley, Thomas Munro, John Naylor)
 -->
-《機械翻訳》パフォーマンスを改善し、インメモリソートのメモリ消費を削減する(Ronan Dunklau氏、David Moon氏、Thomas Munro氏、John Naylor氏)ロウリー
+《機械翻訳》パフォーマンスを改善し、インメモリソートのメモリ消費を削減する
+ (Ronan Dunklau, David Rowley, Thomas Munro, John Naylor)
        </para>
       </listitem>
 
@@ -1422,7 +1437,7 @@ Author: Michael Paquier <michael@paquier.xyz>
         LZ4 and Zstandard compression (Andrey Borodin, Justin Pryzby)
 -->
 《機械翻訳》<acronym>WAL</acronym><link linkend="guc-full-page-writes">フルページ書き込み</link>がLZ4とZstandard圧縮を使用できるようにしました。
-(Andrey Brodin,Justin Pryzby)
+(Andrey Borodin, Justin Pryzby)
        </para>
 
        <para>
@@ -1491,7 +1506,7 @@ Author: Etsuro Fujita <efujita@postgresql.org>
         Etsuro Fujita)
 -->
 《機械翻訳》複数の<link linkend="ddl-foreign-data">外部テーブル</link>を参照するクエリが、より多くの場合に並列外部テーブルスキャンを実行できるようにしました。
-(Andrey Fujita,Etsuro Fujita,Lepikhov)
+(Andrey Lepikhov, Etsuro Fujita)
        </para>
       </listitem>
 
@@ -1525,7 +1540,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
         Improve the performance of spinlocks on high-core-count ARM64
         systems (Geoffrey Blake)
 -->
-《機械翻訳》Improve performance of spinlocks on high-core-count ARM64 systems(Geoffrey Blake)
+《機械翻訳》Improve performance of spinlocks on high-core-count ARM64 systems
+(Geoffrey Blake)
        </para>
       </listitem>
 
@@ -1549,7 +1565,8 @@ Author: Robert Haas <rhaas@postgresql.org>
         Enable default logging of checkpoints and slow autovacuum
         operations (Bharath Rupireddy)
 -->
-《機械翻訳》チェックポイントと遅い自動バキューム操作のデフォルトロギングを有効にする(ババルトRupireddy)
+《機械翻訳》チェックポイントと遅い自動バキューム操作のデフォルトロギングを有効にする
+(Bharath Rupireddy)
        </para>
 
        <para>
@@ -1582,7 +1599,8 @@ Author: Alvaro Herrera <alvherre@alvh.no-ip.org>
         Generate progress messages in the server log during slow server
         starts (Nitin Jadhav, Robert Haas)
 -->
-《機械翻訳》遅いサーバ起動時にサーバログに進行メッセージを生成する(Nitin Jadhav,Robert Haas)
+《機械翻訳》遅いサーバ起動時にサーバログに進行メッセージを生成する
+(Nitin Jadhav, Robert Haas)
        </para>
 
        <para>
@@ -1610,7 +1628,8 @@ Author: Andres Freund <andres@anarazel.de>
         system</link> data in shared memory (Kyotaro Horiguchi, Andres
         Freund, Melanie Plageman)
 -->
-《機械翻訳》<link linkend="monitoring-stats">累積統計システム</link>データを共有メモリに保存する(堀口京太郎、フロインドアンドレス、Plagemanメラニー)
+《機械翻訳》<link linkend="monitoring-stats">累積統計システム</link>データを共有メモリに保存する
+(Kyotaro Horiguchi, Andres Freund, Melanie Plageman)
        </para>
 
        <para>
@@ -1657,8 +1676,8 @@ Author: Michael Paquier <michael@paquier.xyz>
         (BUFFERS)</command></link> output for temporary file block I/O
         (Masahiko Sawada)
 -->
-《機械翻訳》一時ファイルブロックI/Oのための<link linkend="sql-explain"><command>EXPLAIN(BUFFERS)</command>出力を追加します。
-(澤田正彦)</link>
+《機械翻訳》一時ファイルブロックI/Oのための<link linkend="sql-explain"><command>EXPLAIN(BUFFERS)</command></link>出力を追加します。
+(Masahiko Sawada)
        </para>
       </listitem>
 
@@ -1673,7 +1692,8 @@ Author: Michael Paquier <michael@paquier.xyz>
         Allow <link linkend="guc-log-destination">log output</link> in
         <acronym>JSON</acronym> format (Sehrope Sarkuni, Michael Paquier)
 -->
-《機械翻訳》<acronym>JSON</acronym>フォーマットで<link linkend="guc-log-destination">ログ出力</link>を許可する(Sehrope・Sarkuni、Michael Paquier)
+《機械翻訳》<acronym>JSON</acronym>フォーマットで<link linkend="guc-log-destination">ログ出力</link>を許可する
+(Sehrope Sarkuni, Michael Paquier)
        </para>
 
        <para>
@@ -1751,7 +1771,7 @@ Author: Dean Rasheed <dean.a.rasheed@gmail.com>
         controlled by privileges of the view's caller (Christoph Heiss)
 -->
 《機械翻訳》<link linkend="sql-createview">ビュー</link>によるテーブルアクセスを、ビューの呼び出し元の特権によってオプションで制御できるようにしました。
-(クリストフ・ハイス)
+(Christoph Heiss)
        </para>
 
        <para>
@@ -1860,7 +1880,7 @@ Author: Jeff Davis <jdavis@postgresql.org>
         (Bharath Rupireddy)
 -->
 《機械翻訳》<link linkend="predefined-roles-table"><literal>pg_read_all_stats</literal></link>事前定義済みロールのメンバがビュー<link linkend="view-pg-backend-memory-contexts"><structname>pg_backend_memory_contexts</structname></link>および<link linkend="view-pg-shmem-allocations"><structname>pg_shmem_allocations</structname></link>にアクセスできるようにします。
-(バラスRupireddy)
+(Bharath Rupireddy)
        </para>
 
        <para>
@@ -1920,7 +1940,7 @@ Author: Michael Paquier <michael@paquier.xyz>
         to report the size of allocated shared memory (Nathan Bossart)
 -->
 《機械翻訳》割り当てられた共有メモリのサイズを報告するサーバ変数<link linkend="guc-shared-memory-size"><varname>shared_memory_size</varname></link>を追加しました。
-(ネイサン・Bossart)
+(Nathan Bossart)
        </para>
       </listitem>
 
@@ -1962,7 +1982,8 @@ Author: Jeff Davis <jdavis@postgresql.org>
         linkend="guc-shared-preload-libraries"><varname>shared_preload_libraries</varname></link>
         in single-user mode (Jeff Davis)
 -->
-《機械翻訳》シングルユーザモードでサーバ変数<link linkend="guc-shared-preload-libraries"><varname>shared_preload_libraries</varname></link>を利用する(Jeff Davis)
+《機械翻訳》シングルユーザモードでサーバ変数<link linkend="guc-shared-preload-libraries"><varname>shared_preload_libraries</varname></link>を利用する
+(Jeff Davis)
        </para>
 
        <para>
@@ -2061,7 +2082,7 @@ Author: Robert Haas <rhaas@postgresql.org>
        Robert Haas)
 -->
 《機械翻訳》サーバサイド<link linkend="backup-base-backup">ベースバックアップ</link>のLZ4およびZstandard圧縮のサポートを追加しました。
-(Jeevan Ladhe、Robert Haas)
+(Jeevan Ladhe, Robert Haas)
       </para>
      </listitem>
 
@@ -2122,7 +2143,8 @@ Author: Robert Haas <rhaas@postgresql.org>
 <!--
        Allow archiving via loadable modules (Nathan Bossart)
 -->
-《機械翻訳》ローダブルモジュールによるアーカイブが可能(Nathan Bossart)
+《機械翻訳》ローダブルモジュールによるアーカイブが可能
+(Nathan Bossart)
       </para>
 
       <para>
@@ -2176,7 +2198,8 @@ Author: Alvaro Herrera <alvherre@alvh.no-ip.org>
         Allow <link linkend="sql-createpublication">publication</link> of
         all tables in a schema (Vignesh C, Hou Zhijie, Amit Kapila)
 -->
-《機械翻訳》スキーマ内のすべてのテーブルの<link linkend="sql-createpublication">公開</link>を許可する(Vignesh C,Hou Zhijie,Amit Kapila)
+《機械翻訳》スキーマ内のすべてのテーブルの<link linkend="sql-createpublication">公開</link>を許可する
+(Vignesh C, Hou Zhijie, Amit Kapila)
        </para>
 
        <para>
@@ -2208,7 +2231,8 @@ Author: Amit Kapila <akapila@postgresql.org>
         <literal>WHERE</literal> clause (Hou Zhijie, Euler Taveira,
         Peter Smith, Ajin Cherian, Tomas Vondra, Amit Kapila)
 -->
-《機械翻訳》<literal>WHERE</literal>句を使用したパブリケーション・コンテンツのフィルタ処理を許可する(Hou Zhijie、Eulerタベイラ、Peter Smith、Ajin Cherian、Tomas Vondra、Amit Kapila)
+《機械翻訳》<literal>WHERE</literal>句を使用したパブリケーション・コンテンツのフィルタ処理を許可する
+(Hou Zhijie, Euler Taveira, Peter Smith, Ajin Cherian, Tomas Vondra, Amit Kapila)
        </para>
 
        <para>
@@ -2232,7 +2256,8 @@ Author: Tomas Vondra <tomas.vondra@postgresql.org>
         be restricted to specific columns (Tomas Vondra, Álvaro Herrera,
         Rahila Syed)
 -->
-《機械翻訳》パブリケーション・コンテンツを特定のカラムに制限できるようにする(Tomas Vondra、アルバロ・エレラ、Rahila Syed)
+《機械翻訳》パブリケーション・コンテンツを特定のカラムに制限できるようにする
+(Tomas Vondra, Álvaro Herrera, Rahila Syed)
        </para>
       </listitem>
 
@@ -2249,7 +2274,7 @@ Author: Amit Kapila <akapila@postgresql.org>
         ... SKIP</command></link> (Masahiko Sawada)
 -->
 《機械翻訳》<link linkend="sql-altersubscription"><command>ALTER SUBSCRIPTION.SKIP</command></link>を使用して、サブスクライバー上のトランザクションのスキップを許可します。
-(澤田正彦)
+(Masahiko Sawada)
        </para>
       </listitem>
 
@@ -2269,7 +2294,8 @@ Author: Amit Kapila <akapila@postgresql.org>
         replication (Peter Smith, Ajin Cherian, Amit Kapila, Nikhil
         Sontakke, Stas Kelvich)
 -->
-《機械翻訳》準備された(2フェーズ)トランザクションのサポートを論理レプリケーションに追加(Peter Smith、Ajin Cherian、Amit Kapila、Nikhil Sontakke、Stas Kelvich)
+《機械翻訳》準備された(2フェーズ)トランザクションのサポートを論理レプリケーションに追加
+(Peter Smith, Ajin Cherian, Amit Kapila, Nikhil Sontakke, Stas Kelvich)
        </para>
 
        <para>
@@ -2296,7 +2322,8 @@ Author: Amit Kapila <akapila@postgresql.org>
         Prevent logical replication of empty transactions (Ajin Cherian,
         Hou Zhijie, Euler Taveira)
 -->
-《機械翻訳》空のトランザクションの論理レプリケーションを防止する(Ajin Cherian、Hou Zhijie、Eulerタベイラ)
+《機械翻訳》空のトランザクションの論理レプリケーションを防止する
+(Ajin Cherian, Hou Zhijie, Euler Taveira)
        </para>
 
        <para>
@@ -2320,7 +2347,7 @@ Author: Michael Paquier <michael@paquier.xyz>
         contents of logical replication slots (Bharath Rupireddy)
 -->
 《機械翻訳》論理レプリケーションスロットのディレクトリコンテンツを監視するための<acronym>SQL</acronym>関数を追加します。
-(バラスRupireddy)
+(Bharath Rupireddy)
        </para>
 
        <para>
@@ -2347,7 +2374,8 @@ Author: Amit Kapila <akapila@postgresql.org>
         Allow subscribers to stop the application of logical replication changes on error
         (Osumi Takamichi, Mark Dilger)
 -->
-《機械翻訳》Allow subscribers to stop the application of logical replication changes on error(Osumi Takamichi,Mark Dilger)
+《機械翻訳》Allow subscribers to stop the application of logical replication changes on error
+(Osumi Takamichi, Mark Dilger)
        </para>
 
        <para>
@@ -2371,7 +2399,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
         Adjust subscriber server variables to match the publisher so
         datetime and float8 values are interpreted consistently (Japin Li)
 -->
-《機械翻訳》サブスクライバサーバ変数をパブリッシャに合わせて調整し、datetimeとfloat8の値が一貫して解釈されるようにします(Japin Li)
+《機械翻訳》サブスクライバサーバ変数をパブリッシャに合わせて調整し、datetimeとfloat8の値が一貫して解釈されるようにします
+(Japin Li)
        </para>
 
        <para>
@@ -2397,7 +2426,7 @@ Author: Amit Kapila <akapila@postgresql.org>
         to report on subscriber activity (Masahiko Sawada)
 -->
 《機械翻訳》システムビュー<link linkend="monitoring-pg-stat-subscription-stats"><structname>pg_stat_subscription_stats</structname></link>を追加しを追加しました。
-(沢田雅彦)
+(Masahiko Sawada)
        </para>
 
        <para>
@@ -2423,7 +2452,7 @@ Author: Amit Kapila <akapila@postgresql.org>
         system view (Hou Zhijie)
 -->
 《機械翻訳》<link linkend="view-pg-publication-tables"><structname>pg_publication_tables</structname></link>システムビューで重複するエントリを抑制します。
-(侯志傑)
+(Hou Zhijie)
        </para>
 
        <para>
@@ -2459,7 +2488,7 @@ Author: Alvaro Herrera <alvherre@alvh.no-ip.org>
        Deolasee, Álvaro Herrera, Amit Langote)
 -->
 《機械翻訳》<acronym>SQL</acronym><link linkend="sql-merge"><command>MERGE</command></link>コマンドを追加して、あるテーブルを別のテーブルに合わせます。
-(Simon Riggs、Pavan Delasee、アルバロ・エレラ、Amit Langote)
+(Simon Riggs, Pavan Deolasee, Álvaro Herrera, Amit Langote)
       </para>
 
       <para>
@@ -2486,7 +2515,7 @@ Author: Peter Eisentraut <peter@eisentraut.org>
        (Rémi Lapeyre)
 -->
 《機械翻訳》<link linkend="sql-copy"><command>COPY</command></link>テキストフォーマットの<literal>HEADER</literal>オプションのサポートを追加しました。
-(レミ・ラペール)
+(Rémi Lapeyre)
       </para>
 
       <para>
@@ -2539,7 +2568,7 @@ Author: Robert Haas <rhaas@postgresql.org>
        (Shruthi KC, Antonin Houska)
 -->
 《機械翻訳》<link linkend="sql-createdatabase"><command>CREATE DATABASE</command></link>がデータベース<acronym>OID</acronym>を設定できるようにしました。
-(Shruthi KC,Antonin Houska)
+(Shruthi KC, Antonin Houska)
       </para>
      </listitem>
 
@@ -2602,7 +2631,7 @@ Author: Michael Paquier <michael@paquier.xyz>
        METHOD</literal> (Justin Pryzby, Jeff Davis)
 -->
 《機械翻訳》<link linkend="sql-altertable"><command>ALTER TABLE</command></link>がテーブルの<literal>ACCESS METHOD</literal>を変更できるようにしました。
-(Justin Pryzby,Jeff Davis)
+(Justin Pryzby, Jeff Davis)
       </para>
      </listitem>
 
@@ -2634,7 +2663,8 @@ Author: Peter Eisentraut <peter@eisentraut.org>
        Allow creation of unlogged <link
        linkend="sql-createsequence">sequences</link> (Peter Eisentraut)
 -->
-《機械翻訳》Allow creation of unlogged<link linkend="sql-createsequence">sequences</link>(Peter Eisentraut)
+《機械翻訳》Allow creation of unlogged<link linkend="sql-createsequence">sequences</link>
+(Peter Eisentraut)
       </para>
      </listitem>
 
@@ -2649,7 +2679,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
        Track dependencies on individual columns in the results of
        functions returning composite types (Tom Lane)
 -->
-《機械翻訳》複合型を返す関数の結果における個々の列の依存関係を追跡する(Tom Lane)
+《機械翻訳》複合型を返す関数の結果における個々の列の依存関係を追跡する
+(Tom Lane)
       </para>
 
       <para>
@@ -2693,7 +2724,7 @@ Author: Dean Rasheed <dean.a.rasheed@gmail.com>
        Tom Lane)
 -->
 《機械翻訳》<link linkend="datatype-numeric"><type>数値</type></link>値のスケールを負にするか、精度より大きくすることができます。
-(Dean Rasheed、Tom Lane)
+(Dean Rasheed, Tom Lane)
       </para>
 
       <para>
@@ -2751,7 +2782,8 @@ Author: Peter Eisentraut <peter@eisentraut.org>
        Update the display width information of modern Unicode characters,
        like emojis (Jacob Champion)
 -->
-《機械翻訳》emojis(Jacob Champion)のような最新のUnicode文字の表示幅情報を更新します。
+《機械翻訳》emojisのような最新のUnicode文字の表示幅情報を更新します。
+(Jacob Champion)
       </para>
 
       <para>
@@ -2818,7 +2850,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
        Add regular expression functions for compatibility with other
        relational systems (Gilles Darold, Tom Lane)
 -->
-《機械翻訳》他のリレーショナルシステムと互換性を持たせるための正規表現関数の追加(ギレスDarold,Tom Lane)
+《機械翻訳》他のリレーショナルシステムと互換性を持たせるための正規表現関数の追加
+(Gilles Darold, Tom Lane)
       </para>
 
       <para>
@@ -2890,7 +2923,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
        value, use the transaction start time rather than wall clock time
        to determine whether DST applies (Aleksander Alekseev, Tom Lane)
 -->
-《機械翻訳》<link linkend="functions-datetime-zoneconvert"><literal>AT TIME ZONE</literal></link>を<type>time with time zone</type>値に適用する場合、DSTが適用されるかどうかを判断するために、壁時計時刻ではなくトランザクション開始時刻を使用します(アレクサンデル・アレクシーフ、Tom Lane)。
+《機械翻訳》<link linkend="functions-datetime-zoneconvert"><literal>AT TIME ZONE</literal></link>を<type>time with time zone</type>値に適用する場合、DSTが適用されるかどうかを判断するために、壁時計時刻ではなくトランザクション開始時刻を使用します。
+(Aleksander Alekseev, Tom Lane)
       </para>
 
       <para>
@@ -2944,7 +2978,7 @@ Author: David Rowley <drowley@postgresql.org>
        and <function>pg_size_bytes()</function> (David Christensen)
 -->
 《機械翻訳》<link linkend="functions-admin-dbsize"><function>pg_size_pretty()</function></link>と<function>pg_size_bytes()</function>にペタバイト単位のサポートを追加しました。
-(Davidクリステンセン)
+(David Christensen)
       </para>
      </listitem>
 
@@ -3030,7 +3064,8 @@ Author: Peter Eisentraut <peter@eisentraut.org>
        Allow <acronym>IP</acronym> address matching against a server
        certificate's Subject Alternative Name (Jacob Champion)
 -->
-《機械翻訳》<acronym>IP</acronym>アドレスとサーバ証明書のサブジェクト代替名とのマッチングを許可する(Jacob Champion)
+《機械翻訳》<acronym>IP</acronym>アドレスとサーバ証明書のサブジェクト代替名とのマッチングを許可する
+(Jacob Champion)
       </para>
      </listitem>
 
@@ -3063,7 +3098,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
        <acronym>TCP</acronym> settings as normal client connections
        (Jelte Fennema)
 -->
-《機械翻訳》通常のクライアント接続と同じ<acronym>TCP</acronym>設定を使用するように、クライアントによって送信されたクエリーのキャンセルを変更します(ジェルトFennema)。
+《機械翻訳》通常のクライアント接続と同じ<acronym>TCP</acronym>設定を使用するように、クライアントによって送信されたクエリーのキャンセルを変更します。
+(Jelte Fennema)
       </para>
 
       <para>
@@ -3116,7 +3152,7 @@ Author: Tatsuo Ishii <ishii@postgresql.org>
        Marina Polyakova)
 -->
 《機械翻訳》シリアライゼーションとデッドロック障害が発生した後、<link linkend="pgbench"><application>pgbench</application></link>が再試行できるようにしました。
-(永田油江、ポリャコワまりな)
+(Yugo Nagata, Marina Polyakova)
       </para>
      </listitem>
 
@@ -3159,7 +3195,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
         Add <command>\dconfig</command> command to report server variables
         (Mark Dilger, Tom Lane)
 -->
-《機械翻訳》レポートサーバ変数に<command>\dconfig</command>コマンドを追加しました(Mark Dilger,Tom Lane)
+《機械翻訳》レポートサーバ変数に<command>\dconfig</command>コマンドを追加しました
+(Mark Dilger, Tom Lane)
        </para>
 
        <para>
@@ -3184,7 +3221,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
         to assign the value of an environment variable to a
         <application>psql</application> variable (Tom Lane)
 -->
-《機械翻訳》環境変数の値を<application>psql</application>変数に代入するAdd<command>\getenv</command>コマンド(Tom Lane)
+《機械翻訳》環境変数の値を<application>psql</application>変数に代入するAdd<command>\getenv</command>コマンド
+(Tom Lane)
        </para>
       </listitem>
 
@@ -3201,7 +3239,7 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
         show large-object privileges (Pavel Luzanov)
 -->
 《機械翻訳》<literal>\lo_list</literal>および<literal>\dl</literal>コマンドに<literal>+</literal>オプションを追加してラージオブジェクト権限を表示します。
-(パベルLuzanov)
+(Pavel Luzanov)
        </para>
       </listitem>
 
@@ -3217,7 +3255,7 @@ Author: Thomas Munro <tmunro@postgresql.org>
         command (Pavel Stehule, Thomas Munro)
 -->
 《機械翻訳》<command>\watch</command>コマンドにページャオプションを追加しました。
-(パベルStehule,Thomas Munro)
+(Pavel Stehule, Thomas Munro)
        </para>
 
        <para>
@@ -3243,7 +3281,7 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
         comments in queries sent to the server (Tom Lane, Greg Nancarrow)
 -->
 《機械翻訳》Make<application>psql</application>は、サーバに送信されるクエリにクエリ内ダブルハイフンコメントを含めます。
-(Tom Lane,Greg Nancarrow)
+(Tom Lane, Greg Nancarrow)
        </para>
 
        <para>
@@ -3271,7 +3309,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
         meta-<literal>#</literal> command will insert a double-hyphen
         comment marker (Tom Lane)
 -->
-《機械翻訳》<application>Readline</application>のmeta-<literal>#</literal>コマンドが二重ハイフンのコメントマーカー(Tom Lane)を挿入するように<application>psql</application>を調整します。
+《機械翻訳》<application>Readline</application>のmeta-<literal>#</literal>コマンドが二重ハイフンのコメントマーカーを挿入するように<application>psql</application>を調整します。
+(Tom Lane)
        </para>
 
        <para>
@@ -3296,7 +3335,7 @@ Author: Peter Eisentraut <peter@eisentraut.org>
         queries are passed to the server at once (Fabien Coelho)
 -->
 《機械翻訳》Make<application>psql</application>は、複数の問い合わせが一度にサーバに渡された場合にすべての結果を出力します。
-(ファビアンコエリョ)
+(Fabien Coelho)
        </para>
 
        <para>
@@ -3392,7 +3431,7 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
         Herrera, Tom Lane, Masahiko Sawada)
 -->
 《機械翻訳》<application>psql</application>のタブ補完機能を改善しました。
-加藤慎也、Dagfinn Ilmari Mannsåker、Peter Smith、光勇谷川、Ken Kato、David Fetter、Haiying Tang、Peter Eisentraut、Alvaroエレラ、Tom Lane、Masahiko Sawadaの各氏)
+(Shinya Kato, Dagfinn Ilmari Mannsåker, Peter Smith, Koyu Tanigawa, Ken Kato, David Fetter, Haiying Tang, Peter Eisentraut, Álvaro Herrera, Tom Lane, Masahiko Sawada)
        </para>
       </listitem>
 
@@ -3446,7 +3485,8 @@ Author: Noah Misch <noah@leadboat.com>
         <literal>public</literal> schema ownership changes and security
         labels (Noah Misch)
 -->
-《機械翻訳》Make<application>pg_dump</application>ダンプ<literal>public</literal>スキーマ所有権変更とセキュリティラベル(Noah Misch)
+《機械翻訳》Make<application>pg_dump</application>ダンプ<literal>public</literal>スキーマ所有権変更とセキュリティラベル
+(Noah Misch)
        </para>
       </listitem>
 
@@ -3585,7 +3625,7 @@ Author: Robert Haas <rhaas@postgresql.org>
        Jeevan Ladhe)
 -->
 《機械翻訳》<application>pg_basebackup</application>がベースバックアップファイルのサーバ側gzip、LZ4、Zstandard圧縮、クライアント側LZ4、Zstandard圧縮を行うことを許可しました。
-(Dipeshパンディット、ジーバンLadhe)
+(Dipesh Pandit, Jeevan Ladhe)
       </para>
 
       <para>
@@ -3640,7 +3680,7 @@ Author: Robert Haas <rhaas@postgresql.org>
        options (Michael Paquier, Robert Haas)
 -->
 《機械翻訳》<application>pg_basebackup</application>の<option>--compress</option>オプションで、圧縮場所(サーバまたはクライアント)、圧縮方法、圧縮オプションを制御できます。
-(Michael Paquier,Robert Haas)
+(Michael Paquier, Robert Haas)
       </para>
      </listitem>
 
@@ -3659,7 +3699,7 @@ Author: Michael Paquier <michael@paquier.xyz>
        (Georgios Kokolatos)
 -->
 《機械翻訳》<link linkend="app-pgreceivewal"><application>pg_receivewal</application></link>にLZ4圧縮メソッドを追加しました。
-Georgios Kokolatos)
+(Georgios Kokolatos)
       </para>
 
       <para>
@@ -3734,7 +3774,7 @@ Author: Michael Paquier <michael@paquier.xyz>
        Bluth)
 -->
 《機械翻訳》<link linkend="app-pgrewind"><application>pg_rewind</application></link>オプション<option>--config-file</option>を追加して、サーバ設定ファイルがデータディレクトリ外に保存されている場合の使用を簡単にしました。
-(Gunnar Bluth)
+ (Gunnar Bluth)
       </para>
      </listitem>
 
@@ -3812,7 +3852,7 @@ Author: Daniel Gustafsson <dgustafsson@postgresql.org>
         with invalid connection settings (Jeevan Ladhe)
 -->
 《機械翻訳》無効な接続設定を持つすべてのデータベースを<application>pg_upgrade</application>レポートするようにしました。
-(ジーバンLadhe)
+(Jeevan Ladhe)
        </para>
 
        <para>
@@ -3841,7 +3881,7 @@ Author: Robert Haas <rhaas@postgresql.org>
         (Shruthi KC, Antonin Houska)
 -->
 《機械翻訳》Make<application>pg_upgrade</application>は、テーブル空間とデータベースOID、およびリレーションrelfilenode番号を保持します。
-(Shruthi KC,Antonin Houska)
+(Shruthi KC, Antonin Houska)
        </para>
       </listitem>
 
@@ -3909,7 +3949,7 @@ Author: Thomas Munro <tmunro@postgresql.org>
         (David Christensen, Thomas Munro)
 -->
 《機械翻訳》<application>pg_waldump</application>出力をリレーションファイルノード、ブロック番号、フォーク番号、フルページイメージでフィルタリングできるようにしました。
-(Davidクリステンセン、Thomas Munro)
+(David Christensen, Thomas Munro)
        </para>
       </listitem>
 
@@ -3925,7 +3965,7 @@ Author: Michael Paquier <michael@paquier.xyz>
         before an interrupted exit (Bharath Rupireddy)
 -->
 《機械翻訳》中断された終了前に<application>pg_waldump</application>統計を報告するようにしました。
-(ババルトRupireddy)
+(Bharath Rupireddy)
        </para>
 
        <para>
@@ -3952,6 +3992,7 @@ Author: Michael Paquier <michael@paquier.xyz>
         (Masahiko Sawada, Michael Paquier)
 -->
 《機械翻訳》<application>pg_waldump</application>によって報告されたいくつかのトランザクション<acronym>WAL</acronym>レコードの記述を改善しました。
+(Masahiko Sawada, Michael Paquier)
        </para>
       </listitem>
 
@@ -4004,7 +4045,7 @@ Author: Fujii Masao <fujii@postgresql.org>
        Barwick)
 -->
 《機械翻訳》<link linkend="functions-info-catalog-table"><function>pg_encoding_to_char()</function></link>と<function>pg_char_to_encoding()</function>のドキュメントを追加しました。
-(Ian Lawrenceバーウィック)
+(Ian Lawrence Barwick)
       </para>
      </listitem>
 
@@ -4020,7 +4061,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
        linkend="functions-string-other"><literal>^@</literal></link>
        starts-with operator (Tom Lane)
 -->
-《機械翻訳》<link linkend="functions-string-other"><literal>^@</literal></link>starts-with演算子をドキュメント化する(Tom Lane)
+《機械翻訳》<link linkend="functions-string-other"><literal>^@</literal></link>starts-with演算子をドキュメント化する
+(Tom Lane)
       </para>
      </listitem>
 
@@ -4044,7 +4086,8 @@ Author: Andres Freund <andres@anarazel.de>
        Add support for continuous integration testing using cirrus-ci
        (Andres Freund, Thomas Munro, Melanie Plageman)
 -->
-《機械翻訳》cirrus-ciを使用した継続的統合テストのサポートを追加(Andres Freund、Thomas Munro、Melanie Plageman)
+《機械翻訳》cirrus-ciを使用した継続的統合テストのサポートを追加
+(Andres Freund, Thomas Munro, Melanie Plageman)
       </para>
      </listitem>
 
@@ -4061,7 +4104,8 @@ Author: Robert Haas <rhaas@postgresql.org>
        to enable Zstandard builds (Jeevan Ladhe, Robert Haas, Michael
        Paquier)
 -->
-《機械翻訳》Zstandardビルドを有効にするためのconfigureオプション<link linkend="configure-options-features"><option>--with-zstd</option></link>を追加しました(Jeevan Ladhe,Robert Haas,Michael Paquier)
+《機械翻訳》Zstandardビルドを有効にするためのconfigureオプション<link linkend="configure-options-features"><option>--with-zstd</option></link>を追加しました
+(Jeevan Ladhe, Robert Haas, Michael Paquier)
       </para>
      </listitem>
 
@@ -4192,7 +4236,8 @@ Author: Robert Haas <rhaas@postgresql.org>
        Add support for extensions to set custom backup targets (Robert
        Haas)
 -->
-《機械翻訳》カスタムバックアップターゲットfor extensions to set custom backup targets(Robert Haas)
+《機械翻訳》カスタムバックアップターゲットfor extensions to set custom backup targets
+(Robert Haas)
       </para>
      </listitem>
 
@@ -4207,7 +4252,8 @@ Author: Jeff Davis <jdavis@postgresql.org>
        Allow extensions to define custom <acronym>WAL</acronym>
        resource managers (Jeff Davis)
 -->
-《機械翻訳》Allow extensions to define custom<acronym>WAL</acronym>resource managers(Jeff Davis)
+《機械翻訳》Allow extensions to define custom<acronym>WAL</acronym>resource managers
+(Jeff Davis)
       </para>
      </listitem>
 
@@ -4280,7 +4326,8 @@ Author: Peter Eisentraut <peter@eisentraut.org>
        linkend="pgcrypto"><application>pgcrypto</application></link>
        extension (Peter Eisentraut)
 -->
-《機械翻訳》OpenSSLに<link linkend="pgcrypto"><application>pgcrypto</application></link>拡張モジュールのビルドを要求します(Peter Eisentraut)
+《機械翻訳》OpenSSLに<link linkend="pgcrypto"><application>pgcrypto</application></link>拡張モジュールのビルドを要求します
+(Peter Eisentraut)
       </para>
      </listitem>
 
@@ -4295,7 +4342,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
        Require <application>Perl</application>
        version 5.8.3 or later (Dagfinn Ilmari Mannsåker)
 -->
-《機械翻訳》<application>Perl</application>バージョン5.8.3以降が必要です(Dagfinn Ilmari Mannsåker)
+《機械翻訳》<application>Perl</application>バージョン5.8.3以降が必要です
+(Dagfinn Ilmari Mannsåker)
       </para>
      </listitem>
 
@@ -4310,7 +4358,8 @@ Author: Andres Freund <andres@anarazel.de>
        Require <application>Python</application>
        version 3.2 or later (Andres Freund)
 -->
-《機械翻訳》<application>Python</application>バージョン3.2以降が必要です(Andres Freund)
+《機械翻訳》<application>Python</application>バージョン3.2以降が必要です
+(Andres Freund)
       </para>
      </listitem>
 
@@ -4335,7 +4384,8 @@ Author: Peter Eisentraut <peter@eisentraut.org>
        linkend="amcheck"><application>amcheck</application></link> to
        check sequences (Mark Dilger)
 -->
-《機械翻訳》<link linkend="amcheck"><application>amcheck</application></link>がシーケンスをチェックできるようにしました(Mark Dilger)
+《機械翻訳》<link linkend="amcheck"><application>amcheck</application></link>がシーケンスをチェックできるようにしました
+(Mark Dilger)
       </para>
      </listitem>
 
@@ -4407,7 +4457,8 @@ Author: Tomas Vondra <tomas.vondra@postgresql.org>
        linkend="btree-gist"><application>btree_gist</application></link>
        indexes on boolean columns (Emre Hasegeli)
 -->
-《機械翻訳》Allow<link linkend="btree-gist"><application>btree_gist</application></link>indexes on boolean columns(Emre Hasegeli)
+《機械翻訳》Allow<link linkend="btree-gist"><application>btree_gist</application></link>indexes on boolean columns
+(Emre Hasegeli)
       </para>
 
       <para>
@@ -4457,7 +4508,7 @@ Author: Michael Paquier <michael@paquier.xyz>
        (Masahiko Sawada)
 -->
 《機械翻訳》<link linkend="pgstatstatements"><application>pg_stat_statements</application></link>に一時ファイルブロックI/Oのカウンタを追加しました。
-澤田正彦)
+ (Masahiko Sawada)
       </para>
      </listitem>
 
@@ -4490,7 +4541,7 @@ Author: Jeff Davis <jdavis@postgresql.org>
        (Bharath Rupireddy)
 -->
 《機械翻訳》新しいモジュール<link linkend="pgwalinspect"><application>pg_walinspect</application></link>を追加しました。
-(バハースRupireddy)
+(Bharath Rupireddy)
       </para>
 
       <para>
@@ -4514,7 +4565,8 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
        linkend="sepgsql"><application>sepgsql</application></link> log
        messages (Dave Page)
 -->
-《機械翻訳》<link linkend="sepgsql"><application>sepgsql</application></link>ログメッセージにpermissive/enforcing状態を示します(Dave Page)
+《機械翻訳》<link linkend="sepgsql"><application>sepgsql</application></link>ログメッセージにpermissive/enforcing状態を示します
+(Dave Page)
       </para>
      </listitem>
 
@@ -4558,7 +4610,7 @@ Author: Fujii Masao <fujii@postgresql.org>
         application name of postgres_fdw connections (Hayato Kuroda)
 -->
 《機械翻訳》postgres_fdw接続のアプリケーション名を制御するサーバ変数<varname>postgres_fdw.application_name</varname>を追加しました。
-(黒田隼人)
+(Hayato Kuroda)
        </para>
 
        <para>
@@ -4588,7 +4640,7 @@ Author: Etsuro Fujita <efujita@postgresql.org>
         servers (Etsuro Fujita)
 -->
 《機械翻訳》<application>postgres_fdw</application>サーバでの並列コミットを許可しました。
-(藤田悦郎)
+(Etsuro Fujita)
        </para>
 
        <para>

--- a/doc/src/sgml/xfunc.sgml
+++ b/doc/src/sgml/xfunc.sgml
@@ -4912,16 +4912,19 @@ C言語関数は最終パラメータが<literal>VARIADIC "any"</literal>であ�
      in its <function>_PG_init</function> function.  This
      <literal>shmem_request_hook</literal> can reserve LWLocks or shared memory.
      Shared memory is reserved by calling:
-<programlisting>
-void RequestAddinShmemSpace(int size)
-</programlisting>
-     from your <literal>shmem_request_hook</literal>.
 -->
 《機械翻訳》アドインは、サーバ起動時にLWLocksと共有メモリの割り当てを予約できます。
 アドインの共有ライブラリは、<xref linkend="guc-shared-preload-libraries"/><indexterm><primary>shared_preload_libraries</primary></indexterm>で指定して事前ロードする必要があります。
 共有ライブラリは、<function>_PG_init</function>関数に<literal>shmem_request_hook</literal>を登録する必要があります。
 この<literal>shmem_request_hook</literal>は、LWLocksまたは共有メモリを予約できます。
-共有メモリは、<literal>shmem_request_hook</literal>から<programlisting>void RequestAddinShmemSpace(int size)</programlisting>を呼び出すことで予約されます。
+共有メモリは、
+<programlisting>
+void RequestAddinShmemSpace(int size)
+</programlisting>
+<!--
+     from your <literal>shmem_request_hook</literal>.
+-->
+《機械翻訳》<literal>shmem_request_hook</literal>から上記を呼び出すことで予約されます。
     </para>
     <para>
 <!--
@@ -4931,10 +4934,15 @@ LWLocksは以下を
 <programlisting>
 void RequestNamedLWLockTranche(const char *tranche_name, int num_lwlocks)
 </programlisting>
+<!--
      from your <literal>shmem_request_hook</literal>.  This will ensure that an array of
      <literal>num_lwlocks</literal> LWLocks is available under the name
      <literal>tranche_name</literal>.  Use <function>GetNamedLWLockTranche</function>
      to get a pointer to this array.
+-->
+《機械翻訳》<literal>shmem_request_hook</literal>を参照してください。
+ これにより、<literal>num_lwlocks</literal>LWLocksの配列が<literal>tranche_name</literal>という名前で使用可能になります。
+ この配列へのポインタを取得するには、<function>GetNamedLWLockTranche</function>を使用してください。
     </para>
     <para>
 <!--


### PR DESCRIPTION
機械翻訳が入っていなかったところに追加
programlisting等を抜くように修正
名前の訳が入ってしまっていたのを修正