### PR TITLE
monitoring.sgmの15.0対応の第1弾です

### DIFF
--- a/doc/src/sgml/monitoring.sgml
+++ b/doc/src/sgml/monitoring.sgml
@@ -5288,7 +5288,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
 <!--
        Name of the WAL file most recently successfully archived
 -->
-《マッチ度[57.142857]》アーカイブに成功した最後のWALファイルの名前です。
+最後に成功したアーカイブのWALファイルの名前です。
       </para></entry>
      </row>
 
@@ -5300,7 +5300,7 @@ WALレシーバーが接続している<productname>PostgreSQL</productname>イ�
 <!--
        Time of the most recent successful archive operation
 -->
-《マッチ度[69.230769]》最後に成功したアーカイブ操作の時刻です。
+最後に成功したアーカイブ操作の時刻です。
       </para></entry>
      </row>
 
@@ -5324,7 +5324,7 @@ WALファイルのアーカイブに失敗した回数です。
 <!--
        Name of the WAL file of the most recent failed archival operation
 -->
-《マッチ度[75.384615]》最後にアーカイブ操作に失敗したWALファイルの名前です。
+最後にアーカイブ操作に失敗したWALファイルの名前です。
       </para></entry>
      </row>
 
@@ -5336,7 +5336,7 @@ WALファイルのアーカイブに失敗した回数です。
 <!--
        Time of the most recent failed archival operation
 -->
-《マッチ度[67.346939]》最後にアーカイブ操作に失敗した時刻です。
+最後にアーカイブ操作に失敗した時刻です。
       </para></entry>
      </row>
 
@@ -5872,7 +5872,7 @@ WALファイルが<function>issue_xlog_fsync</function>要求によりディス�
 <!--
        Number of live rows fetched by sequential scans and index entries returned by index scans in this database
 -->
-《機械翻訳》順次スキャンによってフェッチされたライブ・ローと、このデータベース内のインデックス・スキャンによって返されたインデックス・エントリの数
+シーケンシャルスキャンとこのデータベース内のインデックススキャンによって返されたインデックスエントリから取り出された行数です。
       </para></entry>
      </row>
 
@@ -5884,7 +5884,7 @@ WALファイルが<function>issue_xlog_fsync</function>要求によりディス�
 <!--
        Number of live rows fetched by index scans in this database
 -->
-《マッチ度[64.406780]》データベース内の問い合わせで取り出された行数です。
+データベース内のインデックススキャンで取り出された行数です。
       </para></entry>
      </row>
 
@@ -6393,7 +6393,7 @@ WALファイルが<function>issue_xlog_fsync</function>要求によりディス�
 <!--
        Number of live rows fetched by sequential scans
 -->
-シーケンシャルスキャンによって取り出された有効行の個数です。
+シーケンシャルスキャンによって取り出された行数です。
       </para></entry>
      </row>
 
@@ -6417,7 +6417,7 @@ WALファイルが<function>issue_xlog_fsync</function>要求によりディス�
 <!--
        Number of live rows fetched by index scans
 -->
-インデックススキャンによって取り出された有効行の個数です。
+インデックススキャンによって取り出された行数です。
       </para></entry>
      </row>
 
@@ -6441,7 +6441,7 @@ WALファイルが<function>issue_xlog_fsync</function>要求によりディス�
 <!--
        Number of rows updated (includes <link linkend="storage-hot">HOT updated rows</link>)
 -->
-《マッチ度[50.588235]》更新された行数です。（HOT更新された行数を含みます）
+更新された行数です（<link linkend="storage-hot">HOT updated rows</link>更新された行数を含みます）。
       </para></entry>
      </row>
 

--- a/doc/src/sgml/monitoring.sgml
+++ b/doc/src/sgml/monitoring.sgml
@@ -778,7 +778,7 @@ WALの活動状況に関する統計情報を1行のみで表示します。
 -->
       <entry>
 <structname>pg_stat_all_tables</structname>と似ていますが、現在のトランザクションにて実施された処理結果をカウントします。(数値が見える時点では、これらの数値は<structname>pg_stat_all_tables</structname>と関連するビューに含まれて<emphasis>いません</emphasis>。)
-このビューでは、有効行数、無効行数、およびバキュームやアナライズの活動は表示しません。
+このビューでは、有効な行数、無効な行数、およびバキュームやアナライズの活動は表示しません。
       </entry>
      </row>
 
@@ -5872,7 +5872,7 @@ WALファイルが<function>issue_xlog_fsync</function>要求によりディス�
 <!--
        Number of live rows fetched by sequential scans and index entries returned by index scans in this database
 -->
-シーケンシャルスキャンとこのデータベース内のインデックススキャンによって返されたインデックスエントリから取り出された行数です。
+シーケンシャルスキャンとこのデータベース内のインデックススキャンによって返されたインデックスエントリから取り出された有効な行数です。
       </para></entry>
      </row>
 
@@ -5884,7 +5884,7 @@ WALファイルが<function>issue_xlog_fsync</function>要求によりディス�
 <!--
        Number of live rows fetched by index scans in this database
 -->
-データベース内のインデックススキャンで取り出された行数です。
+データベース内のインデックススキャンで取り出された有効な行数です。
       </para></entry>
      </row>
 
@@ -6393,7 +6393,7 @@ WALファイルが<function>issue_xlog_fsync</function>要求によりディス�
 <!--
        Number of live rows fetched by sequential scans
 -->
-シーケンシャルスキャンによって取り出された行数です。
+シーケンシャルスキャンによって取り出された有効な行数です。
       </para></entry>
      </row>
 
@@ -6417,7 +6417,7 @@ WALファイルが<function>issue_xlog_fsync</function>要求によりディス�
 <!--
        Number of live rows fetched by index scans
 -->
-インデックススキャンによって取り出された行数です。
+インデックススキャンによって取り出された有効な行数です。
       </para></entry>
      </row>
 
@@ -6478,7 +6478,7 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
 <!--
        Estimated number of live rows
 -->
-有効行数の推定値です。
+有効な行数の推定値です。
       </para></entry>
      </row>
 
@@ -6490,7 +6490,7 @@ HOT更新（つまりインデックスの更新を別途必要としない）�
 <!--
        Estimated number of dead rows
 -->
-無効行数の推定値です。
+無効な行数の推定値です。
       </para></entry>
      </row>
 

--- a/doc/src/sgml/monitoring.sgml
+++ b/doc/src/sgml/monitoring.sgml
@@ -6441,7 +6441,7 @@ WALファイルが<function>issue_xlog_fsync</function>要求によりディス�
 <!--
        Number of rows updated (includes <link linkend="storage-hot">HOT updated rows</link>)
 -->
-更新された行数です（<link linkend="storage-hot">HOT updated rows</link>更新された行数を含みます）。
+更新された行数です（<link linkend="storage-hot">HOT更新された行数</link>を含みます）。
       </para></entry>
      </row>
 


### PR DESCRIPTION
レビューしやすい単位でPRを分割して送る実験です。

monioring.sgmlの対応を全部終わらせてから送ろうとすると時間がかかり、レビューもまた時間がかかります。
分割することで、できそうなところから先行し、スキマ時間でもレビューできる単位にする試みです。