### PR TITLE
catalogs.sgmlをPostgreSQL 15.0対応するための準備です。

### DIFF
--- a/doc/src/sgml/catalogs.sgml
+++ b/doc/src/sgml/catalogs.sgml
@@ -13881,3 +13881,4 @@ NULLは<literal>NONE</literal>を表します。
  </sect1>
 
 </chapter>
+<!-- split-catalogs3-end -->

--- a/doc/src/sgml/catalogs3.sgml
+++ b/doc/src/sgml/catalogs3.sgml
@@ -1533,3 +1533,4 @@
  </sect1>
 
 </chapter>
+<!-- split-catalogs3-end -->

--- a/doc/src/sgml/catalogs4.sgml
+++ b/doc/src/sgml/catalogs4.sgml
@@ -1,8 +1,0 @@
-<!-- 警告：このファイルは直接編集しないでください！
-1. catalogs.sgmlを編集したら、split-catalogs.shを起動します。
-2. するとcatalogs[0-4].sgmlが生成されます。
-3. catalogs.sgmlとともにcatalogs[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
-4. レビューはcatalogs[0-4].sgmlに対して行います。
-5. 指摘された点があればcatalogs.sgmlに反映し、1に戻ります。
-6. catalogs.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
--->

--- a/doc/src/sgml/merge-catalogs.sh
+++ b/doc/src/sgml/merge-catalogs.sh
@@ -1,8 +1,8 @@
 #! /bin/sh
-cat catalogs[0-4].sgml > catalogs.sgml
+cat catalogs[0-3].sgml > catalogs.sgml
 patch -p0 -R catalogs.sgml <<EOF
 diff --git a/doc/src/sgml/catalogs.sgml b/doc/src/sgml/catalogs.sgml
-index 6f32e43930..b55d8e5255 100644
+index 68d065541b..a4c8fdd50a 100644
 --- a/doc/src/sgml/catalogs.sgml
 +++ b/doc/src/sgml/catalogs.sgml
 @@ -1,3 +1,11 @@
@@ -17,7 +17,7 @@ index 6f32e43930..b55d8e5255 100644
  <!-- doc/src/sgml/catalogs.sgml -->
  <!--
   Documentation of the system catalogs, directed toward PostgreSQL developers
-@@ -3845,7 +3853,19 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
+@@ -4066,7 +4074,19 @@ nullの場合、参照しているすべての列が更新されます。
    </note>
   </sect1>
  
@@ -37,7 +37,7 @@ index 6f32e43930..b55d8e5255 100644
  <!-- split-catalogs1-start -->
  
   <sect1 id="catalog-pg-conversion">
-@@ -7466,6 +7486,14 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
+@@ -7927,6 +7947,14 @@ trueの場合、NULL値は等しいものとみなします(インデックス
   </sect1>
  
  <!-- split-catalogs1-end -->
@@ -51,8 +51,8 @@ index 6f32e43930..b55d8e5255 100644
 +-->
  <!-- split-catalogs2-start -->
  
-  <sect1 id="catalog-pg-partitioned-table">
-@@ -11376,6 +11404,14 @@ NULLは<literal>NONE</literal>を表します。
+  <sect1 id="catalog-pg-parameter-acl">
+@@ -12354,6 +12382,14 @@ NULLは<literal>NONE</literal>を表します。
   </sect1>
  
  <!-- split-catalogs2-end -->
@@ -67,19 +67,3 @@ index 6f32e43930..b55d8e5255 100644
  <!-- split-catalogs3-start -->
  
   <sect1 id="catalog-pg-ts-config-map">
-@@ -15168,6 +15204,14 @@ SELECT * FROM pg_locks pl LEFT JOIN pg_prepared_xacts ppx
-  </sect1>
- 
- <!-- split-catalogs3-end -->
-+<!-- 警告：このファイルは直接編集しないでください！
-+1. catalogs.sgmlを編集したら、split-catalogs.shを起動します。
-+2. するとcatalogs[0-4].sgmlが生成されます。
-+3. catalogs.sgmlとともにcatalogs[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
-+4. レビューはcatalogs[0-4].sgmlに対して行います。
-+5. 指摘された点があればcatalogs.sgmlに反映し、1に戻ります。
-+6. catalogs.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
-+-->
- <!-- split-catalogs4-start -->
- 
-  <sect1 id="view-pg-prepared-statements">
-EOF

--- a/doc/src/sgml/split-catalogs.sh
+++ b/doc/src/sgml/split-catalogs.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-# This script splits catalogs.sgml into 4 files: namely catalogs[0-4].sgml.
+# This script splits catalogs.sgml into 4 files: namely catalogs[0-3].sgml.
 # catalogs.sgml remains untouched. catalogs0.sgml should be included by
 # postgres.sgml instead of catalogs.sgml.
 # "<!-- split-catalogs1-start --> and <!-- split-catalogs1-end --> etc. must be in catalogs.sgml
@@ -8,9 +8,9 @@
 comment='
 <!-- 警告：このファイルは直接編集しないでください！
 1. catalogs.sgmlを編集したら、split-catalogs.shを起動します。
-2. するとcatalogs[0-4].sgmlが生成されます。
-3. catalogs.sgmlとともにcatalogs[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
-4. レビューはcatalogs[0-4].sgmlに対して行います。
+2. するとcatalogs[0-3].sgmlが生成されます。
+3. catalogs.sgmlとともにcatalogs[0-3].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
+4. レビューはcatalogs[0-3].sgmlに対して行います。
 5. 指摘された点があればcatalogs.sgmlに反映し、1に戻ります。
 6. catalogs.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
 -->
@@ -26,6 +26,4 @@ echo "$comment"|sed -e '/^$/d' > catalogs2.sgml
 sed -n -e '/^<!-- split-catalogs2-start -->$/,/^<!-- split-catalogs2-end -->$/p' catalogs.sgml >> catalogs2.sgml
 echo "$comment"|sed -e '/^$/d' > catalogs3.sgml
 sed -n -e '/^<!-- split-catalogs3-start -->$/,/^<!-- split-catalogs3-end -->$/p' catalogs.sgml >> catalogs3.sgml
-echo "$comment"|sed -e '/^$/d' > catalogs4.sgml
-sed -n -e '/^<!-- split-catalogs4-start -->$/,/^<!-- split-catalogs4-end -->$/p' catalogs.sgml >> catalogs4.sgml
 


### PR DESCRIPTION
- マージミスで、catalogs.sgmlの"split-catalogs3"マークが消えていたのを復活
- view関係がcatalogs.sgmlからsystem-views.sgmlに移動したことにより、分割ファイルのcatalogs4.sgmlが不要になったので削除
- catalogs4.sgmlが削除されたのでそれに合わせてsplit-catalogs.sgmlを調整
- PostgreSQL 15.0の変更に合わせてmerge-catalogs.shを調整