### PR TITLE
catalogs.sgmlのPostgreSQL1 15.0対応です(パート1)

### DIFF
--- a/doc/src/sgml/catalogs.sgml
+++ b/doc/src/sgml/catalogs.sgml
@@ -353,8 +353,12 @@
      </row>
 
      <row>
+<!--
       <entry><link linkend="catalog-pg-parameter-acl"><structname>pg_parameter_acl</structname></link></entry>
       <entry>configuration parameters for which privileges have been granted</entry>
+-->
+      <entry><link linkend="catalog-pg-parameter-acl"><structname>pg_parameter_acl</structname></link></entry>
+      <entry>権限が付与された設定パラメータ</entry>
      </row>
 
      <row>
@@ -3042,7 +3046,7 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
        <literal>p</literal> = permanent table/sequence, <literal>u</literal> = unlogged table/sequence,
        <literal>t</literal> = temporary table/sequence
 -->
-《マッチ度[75.694444]》<literal>p</literal>は永続テーブル、<literal>u</literal>はログを取らないテーブル、<literal>t</literal>は一時テーブルを表します。
+<literal>p</literal>は永続テーブル、<literal>u</literal>はログを取らないテーブル/シーケンス、<literal>t</literal>は一時テーブル/シーケンスを表します。
       </para></entry>
      </row>
 
@@ -3134,7 +3138,7 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
 <!--
        True if table or index has (or once had) any inheritance children or partitions
 -->
-《マッチ度[73.417722]》もしテーブルあるいはインデックスが子テーブルに継承されている（または以前に継承されていた）場合は真。
+もしテーブルあるいはインデックスが子テーブルあるいはパーテーションに継承されている（または以前に継承されていた）場合は真。
       </para></entry>
      </row>
 
@@ -3499,7 +3503,7 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
 <!--
        ICU locale ID for this collation object
 -->
-《機械翻訳》この照合オブジェクトのICUロケールID
+この照合オブジェクトのICUロケールID
       </para></entry>
      </row>
 
@@ -4000,8 +4004,8 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
        DEFAULT</literal> delete action, the columns that will be updated.
        If null, all of the referencing columns will be updated.
 -->
-《機械翻訳》外部キーに<literal>SET NULL</literal>または<literal>SET DEFAULT</literal>deleteアクションがある場合、更新される列。
-nullの場合、参照しているすべての列が更新されます。
+外部キーに<literal>SET NULL</literal>または<literal>SET DEFAULT</literal>削除アクションがある場合、更新される列。
+NULLの場合、参照しているすべての列が更新されます。
       </para></entry>
      </row>
 

--- a/doc/src/sgml/catalogs.sgml
+++ b/doc/src/sgml/catalogs.sgml
@@ -3046,7 +3046,7 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
        <literal>p</literal> = permanent table/sequence, <literal>u</literal> = unlogged table/sequence,
        <literal>t</literal> = temporary table/sequence
 -->
-<literal>p</literal>は永続テーブル、<literal>u</literal>はログを取らないテーブル/シーケンス、<literal>t</literal>は一時テーブル/シーケンスを表します。
+<literal>p</literal>は永続テーブル/シーケンス、<literal>u</literal>はログを取らないテーブル/シーケンス、<literal>t</literal>は一時テーブル/シーケンスを表します。
       </para></entry>
      </row>
 

--- a/doc/src/sgml/catalogs0.sgml
+++ b/doc/src/sgml/catalogs0.sgml
@@ -1,8 +1,8 @@
 <!-- 警告：このファイルは直接編集しないでください！
 1. catalogs.sgmlを編集したら、split-catalogs.shを起動します。
-2. するとcatalogs[0-4].sgmlが生成されます。
-3. catalogs.sgmlとともにcatalogs[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
-4. レビューはcatalogs[0-4].sgmlに対して行います。
+2. するとcatalogs[0-3].sgmlが生成されます。
+3. catalogs.sgmlとともにcatalogs[0-3].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
+4. レビューはcatalogs[0-3].sgmlに対して行います。
 5. 指摘された点があればcatalogs.sgmlに反映し、1に戻ります。
 6. catalogs.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
 -->
@@ -361,8 +361,12 @@
      </row>
 
      <row>
+<!--
       <entry><link linkend="catalog-pg-parameter-acl"><structname>pg_parameter_acl</structname></link></entry>
       <entry>configuration parameters for which privileges have been granted</entry>
+-->
+      <entry><link linkend="catalog-pg-parameter-acl"><structname>pg_parameter_acl</structname></link></entry>
+      <entry>権限が付与された設定パラメータ</entry>
      </row>
 
      <row>
@@ -3050,7 +3054,7 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
        <literal>p</literal> = permanent table/sequence, <literal>u</literal> = unlogged table/sequence,
        <literal>t</literal> = temporary table/sequence
 -->
-《マッチ度[75.694444]》<literal>p</literal>は永続テーブル、<literal>u</literal>はログを取らないテーブル、<literal>t</literal>は一時テーブルを表します。
+<literal>p</literal>は永続テーブル、<literal>u</literal>はログを取らないテーブル/シーケンス、<literal>t</literal>は一時テーブル/シーケンスを表します。
       </para></entry>
      </row>
 
@@ -3142,7 +3146,7 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
 <!--
        True if table or index has (or once had) any inheritance children or partitions
 -->
-《マッチ度[73.417722]》もしテーブルあるいはインデックスが子テーブルに継承されている（または以前に継承されていた）場合は真。
+もしテーブルあるいはインデックスが子テーブルあるいはパーテーションに継承されている（または以前に継承されていた）場合は真。
       </para></entry>
      </row>
 
@@ -3507,7 +3511,7 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
 <!--
        ICU locale ID for this collation object
 -->
-《機械翻訳》この照合オブジェクトのICUロケールID
+この照合オブジェクトのICUロケールID
       </para></entry>
      </row>
 
@@ -4008,8 +4012,8 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
        DEFAULT</literal> delete action, the columns that will be updated.
        If null, all of the referencing columns will be updated.
 -->
-《機械翻訳》外部キーに<literal>SET NULL</literal>または<literal>SET DEFAULT</literal>deleteアクションがある場合、更新される列。
-nullの場合、参照しているすべての列が更新されます。
+外部キーに<literal>SET NULL</literal>または<literal>SET DEFAULT</literal>削除アクションがある場合、更新される列。
+NULLの場合、参照しているすべての列が更新されます。
       </para></entry>
      </row>
 

--- a/doc/src/sgml/catalogs0.sgml
+++ b/doc/src/sgml/catalogs0.sgml
@@ -3054,7 +3054,7 @@ TOASTテーブルは<quote>行に収まらない</quote>大きい属性を副テ
        <literal>p</literal> = permanent table/sequence, <literal>u</literal> = unlogged table/sequence,
        <literal>t</literal> = temporary table/sequence
 -->
-<literal>p</literal>は永続テーブル、<literal>u</literal>はログを取らないテーブル/シーケンス、<literal>t</literal>は一時テーブル/シーケンスを表します。
+<literal>p</literal>は永続テーブル/シーケンス、<literal>u</literal>はログを取らないテーブル/シーケンス、<literal>t</literal>は一時テーブル/シーケンスを表します。
       </para></entry>
      </row>
 

--- a/doc/src/sgml/catalogs1.sgml
+++ b/doc/src/sgml/catalogs1.sgml
@@ -1,8 +1,8 @@
 <!-- 警告：このファイルは直接編集しないでください！
 1. catalogs.sgmlを編集したら、split-catalogs.shを起動します。
-2. するとcatalogs[0-4].sgmlが生成されます。
-3. catalogs.sgmlとともにcatalogs[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
-4. レビューはcatalogs[0-4].sgmlに対して行います。
+2. するとcatalogs[0-3].sgmlが生成されます。
+3. catalogs.sgmlとともにcatalogs[0-3].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
+4. レビューはcatalogs[0-3].sgmlに対して行います。
 5. 指摘された点があればcatalogs.sgmlに反映し、1に戻ります。
 6. catalogs.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
 -->

--- a/doc/src/sgml/catalogs2.sgml
+++ b/doc/src/sgml/catalogs2.sgml
@@ -1,8 +1,8 @@
 <!-- 警告：このファイルは直接編集しないでください！
 1. catalogs.sgmlを編集したら、split-catalogs.shを起動します。
-2. するとcatalogs[0-4].sgmlが生成されます。
-3. catalogs.sgmlとともにcatalogs[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
-4. レビューはcatalogs[0-4].sgmlに対して行います。
+2. するとcatalogs[0-3].sgmlが生成されます。
+3. catalogs.sgmlとともにcatalogs[0-3].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
+4. レビューはcatalogs[0-3].sgmlに対して行います。
 5. 指摘された点があればcatalogs.sgmlに反映し、1に戻ります。
 6. catalogs.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
 -->

--- a/doc/src/sgml/catalogs3.sgml
+++ b/doc/src/sgml/catalogs3.sgml
@@ -1,8 +1,8 @@
 <!-- 警告：このファイルは直接編集しないでください！
 1. catalogs.sgmlを編集したら、split-catalogs.shを起動します。
-2. するとcatalogs[0-4].sgmlが生成されます。
-3. catalogs.sgmlとともにcatalogs[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
-4. レビューはcatalogs[0-4].sgmlに対して行います。
+2. するとcatalogs[0-3].sgmlが生成されます。
+3. catalogs.sgmlとともにcatalogs[0-3].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
+4. レビューはcatalogs[0-3].sgmlに対して行います。
 5. 指摘された点があればcatalogs.sgmlに反映し、1に戻ります。
 6. catalogs.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
 -->

--- a/doc/src/sgml/merge-catalogs.sh
+++ b/doc/src/sgml/merge-catalogs.sh
@@ -1,69 +1,76 @@
 #! /bin/sh
 cat catalogs[0-3].sgml > catalogs.sgml
 patch -p0 -R catalogs.sgml <<EOF
-diff --git a/doc/src/sgml/catalogs.sgml b/doc/src/sgml/catalogs.sgml
-index 68d065541b..a4c8fdd50a 100644
---- a/doc/src/sgml/catalogs.sgml
-+++ b/doc/src/sgml/catalogs.sgml
-@@ -1,3 +1,11 @@
-+<!-- 警告：このファイルは直接編集しないでください！
-+1. catalogs.sgmlを編集したら、split-catalogs.shを起動します。
-+2. するとcatalogs[0-4].sgmlが生成されます。
-+3. catalogs.sgmlとともにcatalogs[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
-+4. レビューはcatalogs[0-4].sgmlに対して行います。
-+5. 指摘された点があればcatalogs.sgmlに反映し、1に戻ります。
-+6. catalogs.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
-+-->
- <!-- doc/src/sgml/catalogs.sgml -->
- <!--
-  Documentation of the system catalogs, directed toward PostgreSQL developers
-@@ -4066,7 +4074,19 @@ nullの場合、参照しているすべての列が更新されます。
-   </note>
-  </sect1>
- 
-+&catalogs1;
-+&catalogs2;
-+&catalogs3;
-+&catalogs4;
- <!-- split-catalogs0-end -->
-+<!-- 警告：このファイルは直接編集しないでください！
-+1. catalogs.sgmlを編集したら、split-catalogs.shを起動します。
-+2. するとcatalogs[0-4].sgmlが生成されます。
-+3. catalogs.sgmlとともにcatalogs[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
-+4. レビューはcatalogs[0-4].sgmlに対して行います。
-+5. 指摘された点があればcatalogs.sgmlに反映し、1に戻ります。
-+6. catalogs.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
-+-->
- <!-- split-catalogs1-start -->
- 
-  <sect1 id="catalog-pg-conversion">
-@@ -7927,6 +7947,14 @@ trueの場合、NULL値は等しいものとみなします(インデックス
-  </sect1>
- 
- <!-- split-catalogs1-end -->
-+<!-- 警告：このファイルは直接編集しないでください！
-+1. catalogs.sgmlを編集したら、split-catalogs.shを起動します。
-+2. するとcatalogs[0-4].sgmlが生成されます。
-+3. catalogs.sgmlとともにcatalogs[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
-+4. レビューはcatalogs[0-4].sgmlに対して行います。
-+5. 指摘された点があればcatalogs.sgmlに反映し、1に戻ります。
-+6. catalogs.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
-+-->
- <!-- split-catalogs2-start -->
- 
-  <sect1 id="catalog-pg-parameter-acl">
-@@ -12354,6 +12382,14 @@ NULLは<literal>NONE</literal>を表します。
-  </sect1>
- 
- <!-- split-catalogs2-end -->
-+<!-- 警告：このファイルは直接編集しないでください！
-+1. catalogs.sgmlを編集したら、split-catalogs.shを起動します。
-+2. するとcatalogs[0-4].sgmlが生成されます。
-+3. catalogs.sgmlとともにcatalogs[0-4].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
-+4. レビューはcatalogs[0-4].sgmlに対して行います。
-+5. 指摘された点があればcatalogs.sgmlに反映し、1に戻ります。
-+6. catalogs.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
-+-->
- <!-- split-catalogs3-start -->
- 
-  <sect1 id="catalog-pg-ts-config-map">
+*** catalogs.sgml	2022-11-05 13:25:08.638458571 +0900
+--- /tmp/catalogs-merged.sgml	2022-11-05 13:29:20.289287807 +0900
+***************
+*** 1,3 ****
+--- 1,11 ----
++ <!-- 警告：このファイルは直接編集しないでください！
++ 1. catalogs.sgmlを編集したら、split-catalogs.shを起動します。
++ 2. するとcatalogs[0-3].sgmlが生成されます。
++ 3. catalogs.sgmlとともにcatalogs[0-3].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
++ 4. レビューはcatalogs[0-3].sgmlに対して行います。
++ 5. 指摘された点があればcatalogs.sgmlに反映し、1に戻ります。
++ 6. catalogs.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
++ -->
+  <!-- doc/src/sgml/catalogs.sgml -->
+  <!--
+   Documentation of the system catalogs, directed toward PostgreSQL developers
+***************
+*** 4066,4072 ****
+--- 4074,4092 ----
+    </note>
+   </sect1>
+  
++ &catalogs1;
++ &catalogs2;
++ &catalogs3;
++ &catalogs4;
+  <!-- split-catalogs0-end -->
++ <!-- 警告：このファイルは直接編集しないでください！
++ 1. catalogs.sgmlを編集したら、split-catalogs.shを起動します。
++ 2. するとcatalogs[0-3].sgmlが生成されます。
++ 3. catalogs.sgmlとともにcatalogs[0-3].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
++ 4. レビューはcatalogs[0-3].sgmlに対して行います。
++ 5. 指摘された点があればcatalogs.sgmlに反映し、1に戻ります。
++ 6. catalogs.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
++ -->
+  <!-- split-catalogs1-start -->
+  
+   <sect1 id="catalog-pg-conversion">
+***************
+*** 7927,7932 ****
+--- 7947,7960 ----
+   </sect1>
+  
+  <!-- split-catalogs1-end -->
++ <!-- 警告：このファイルは直接編集しないでください！
++ 1. catalogs.sgmlを編集したら、split-catalogs.shを起動します。
++ 2. するとcatalogs[0-3].sgmlが生成されます。
++ 3. catalogs.sgmlとともにcatalogs[0-3].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
++ 4. レビューはcatalogs[0-3].sgmlに対して行います。
++ 5. 指摘された点があればcatalogs.sgmlに反映し、1に戻ります。
++ 6. catalogs.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
++ -->
+  <!-- split-catalogs2-start -->
+  
+   <sect1 id="catalog-pg-parameter-acl">
+***************
+*** 12354,12359 ****
+--- 12382,12395 ----
+   </sect1>
+  
+  <!-- split-catalogs2-end -->
++ <!-- 警告：このファイルは直接編集しないでください！
++ 1. catalogs.sgmlを編集したら、split-catalogs.shを起動します。
++ 2. するとcatalogs[0-3].sgmlが生成されます。
++ 3. catalogs.sgmlとともにcatalogs[0-3].sgmlのうち変更されたファイルをcommit/pushしてpull requestを作成してください。
++ 4. レビューはcatalogs[0-3].sgmlに対して行います。
++ 5. 指摘された点があればcatalogs.sgmlに反映し、1に戻ります。
++ 6. catalogs.sgmlの変更がなければ、pull requestをマージして終了です。お疲れ様でした！
++ -->
+  <!-- split-catalogs3-start -->
+  
+   <sect1 id="catalog-pg-ts-config-map">
+EOF


### PR DESCRIPTION
斉藤さんに刺激を受けて:-)私も分割修正を試みています。
このPRではcatalogs0.sgmlの部分のみを対応しました。
今後、catalogs[1-3].sgmlについても別PRで対応していきます。
また、pull request 2441のmerge-catalogs.shのミスを修正
catalogs[1-3]は本文内容の変更はありませんが、分割処理で追加されたコメントにcatalogs4.sgml についても言及されているのが間違いだったので修正しています。