### PR TITLE
fix 'free space map'

### DIFF
--- a/doc/src/sgml/glossary.sgml
+++ b/doc/src/sgml/glossary.sgml
@@ -1087,7 +1087,7 @@ WALファイルと組み合わせてリカバリ、ログシッピング、ま�
 リレーションが格納される個々のセグメントファイルの集合。
 <firstterm>主フォーク</firstterm>には、実際のデータが格納されます。
 また、メタデータのための2つの二次フォークが存在します。
-<glossterm linkend="glossary-fsm">フリースペースマップ</glossterm>と<glossterm linkend="glossary-vm">可視性マップ</glossterm>です。
+<glossterm linkend="glossary-fsm">空き領域マップ</glossterm>と<glossterm linkend="glossary-vm">可視性マップ</glossterm>です。
 <glossterm linkend="glossary-unlogged">unloggedリレーション</glossterm>には<firstterm>初期化フォーク(init fork)</firstterm>もあります。
     </para>
    </glossdef>
@@ -1097,7 +1097,7 @@ WALファイルと組み合わせてリカバリ、ログシッピング、ま�
 <!--
    <glossterm>Free space map (fork)</glossterm>
 -->
-   <glossterm>Free space map【フリースペースマップ】（フォーク）</glossterm>
+   <glossterm>Free space map【空き領域マップ】（フォーク）</glossterm>
    <glossdef>
     <para>
 <!--
@@ -1108,7 +1108,7 @@ WALファイルと組み合わせてリカバリ、ログシッピング、ま�
      size.
 -->
 テーブルのメインフォークの個々のデータページ関するメタデータを保持する格納構造。
-個々のページに対応するフリースペースマップのエントリには今後追加されるタプルが使用できるフリースペースの量が格納され、与えられた大きさの新しいタプルで使用できるフリースペースの量を効率的に探索できる構造になっています。
+個々のページに対応する空き領域マップのエントリには今後追加されるタプルが使用できる空き領域の量が格納され、与えられた大きさの新しいタプルで使用できる空き領域の量を効率的に探索できる構造になっています。
     </para>
     <para>
 <!--


### PR DESCRIPTION
free space mapの訳を揃えました。

「フリースペースマップ」と「空き領域マップ」があったのですが、「空き領域マップ」が多数派でしたので、「空き領域マップ」に。
今回の修正は glossary.sgml のみですが、#2442 で一つ「空き領域マップ」にしています。これで「フリースペースマップ」はなくなったはず。
