### PR TITLE
update pg_recvlogical for 15.0

### DIFF
--- a/doc/src/sgml/ref/pg_recvlogical.sgml
+++ b/doc/src/sgml/ref/pg_recvlogical.sgml
@@ -100,7 +100,7 @@ PostgreSQL documentation
         The <option>&#45;-two-phase</option> can be specified with
         <option>&#45;-create-slot</option> to enable decoding of prepared transactions.
 -->
-《機械翻訳》<option>--two-phase</option>は<option>--create-slot</option>と一緒に指定して、準備されたトランザクションのデコードを有効にすることができます。
+<option>--two-phase</option>は<option>--create-slot</option>と一緒に指定して、プリペアドトランザクションのデコードを有効にすることができます。
        </para>
       </listitem>
      </varlistentry>
@@ -378,7 +378,7 @@ LSNが<replaceable>lsn</replaceable>と正確に一致するレコードがあ�
         Enables decoding of prepared transactions. This option may only be specified with
         <option>&#45;-create-slot</option>
 -->
-《機械翻訳》準備されたトランザクションのデコードを有効にします。
+プリペアドトランザクションのデコードを有効にします。
 このオプションは<option>--create-slot</option>でのみ指定できます
        </para>
        </listitem>


### PR DESCRIPTION
ref/pg_recvlogical.sgmlの15.0対応です。

prepared transactionは「プリペアドトランザクション」としましたが、最初に機械翻訳が提示してきた「準備されたトランザクション」の方が良かったでしょうか。
