### PR TITLE
catalogs.sgmlのPostgreSQL 15.0対応です(catalogs1.sgml部分)

### DIFF
--- a/doc/src/sgml/catalogs.sgml
+++ b/doc/src/sgml/catalogs.sgml
@@ -4179,8 +4179,7 @@ NULLの場合、参照しているすべての列が更新されます。
        Source encoding ID (<link linkend="pg-encoding-to-char"><function>pg_encoding_to_char()</function></link>
        can translate this number to the encoding name)
 -->
-《マッチ度[58.169935]》このデータベースの文字エンコード方式。
-（<function>pg_encoding_to_char()</function>で、この番号からエンコード方式名称に変換できます。）
+ソースエンコーディングID（<link linkend="pg-encoding-to-char"><function>pg_encoding_to_char()</function></link>で、この番号からエンコード方式名称に変換できます。）
       </para></entry>
      </row>
 
@@ -4193,8 +4192,7 @@ NULLの場合、参照しているすべての列が更新されます。
        Destination encoding ID (<link linkend="pg-encoding-to-char"><function>pg_encoding_to_char()</function></link>
        can translate this number to the encoding name)
 -->
-《マッチ度[58.227848]》このデータベースの文字エンコード方式。
-（<function>pg_encoding_to_char()</function>で、この番号からエンコード方式名称に変換できます。）
+ディスティネーションエンコーディングID（<link linkend="pg-encoding-to-char"><function>pg_encoding_to_char()</function></link>で、この番号からエンコード方式名称に変換できます。）
       </para></entry>
      </row>
 
@@ -4336,8 +4334,7 @@ NULLの場合、参照しているすべての列が更新されます。
        (<link linkend="pg-encoding-to-char"><function>pg_encoding_to_char()</function></link> can translate
        this number to the encoding name)
 -->
-《マッチ度[66.081871]》このデータベースの文字エンコード方式。
-（<function>pg_encoding_to_char()</function>で、この番号からエンコード方式名称に変換できます。）
+このデータベースの文字エンコード（<link linkend="pg-encoding-to-char"><function>pg_encoding_to_char()</function></link>で、この番号からエンコード方式名称に変換できます。）
       </para></entry>
      </row>
 
@@ -4350,7 +4347,7 @@ NULLの場合、参照しているすべての列が更新されます。
        Locale provider for this database: <literal>c</literal> = libc,
        <literal>i</literal> = icu
 -->
-《機械翻訳》このデータベースのロケールプロバイダ:<literal>c</literal>=libc,<literal>i</literal>=icu
+このデータベースのロケールプロバイダ：<literal>c</literal>=libc、<literal>i</literal>=icu
       </para></entry>
      </row>
 
@@ -4490,7 +4487,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
 <!--
        ICU locale ID for this database
 -->
-《マッチ度[54.838710]》このデータベースのLC_CTYPE
+このデータベースのICUロケールID
       </para></entry>
      </row>
 
@@ -4504,8 +4501,8 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
        database is created and then checked when it is used, to detect
        changes in the collation definition that could lead to data corruption.
 -->
-《マッチ度[85.365854]》この照合順序に対する提供者固有のバージョンです。
-これは照合順序が作成された時に記録され、データの破壊につながりかねない照合順序定義の変更を検知するために使用時に検査されます。
+この照合順序に対する提供者固有のバージョンです。
+これはデータベースが作成された時に記録され、データの破壊につながりかねない照合順序定義の変更を検知するために使用時に検査されます。
       </para></entry>
      </row>
 
@@ -4843,7 +4840,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
 <!--
        The OID of the system catalog the dependent object is in
 -->
-《マッチ度[75.000000]》参照されるオブジェクトが存在するシステムカタログのOID
+依存するオブジェクトが存在するシステムカタログのOID
       </para></entry>
      </row>
 
@@ -4859,7 +4856,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
 <!--
        The OID of the specific dependent object
 -->
-《マッチ度[65.000000]》特定の参照されるオブジェクトのOID
+依存する特定のオブジェクトのOID
       </para></entry>
      </row>
 
@@ -5167,11 +5164,11 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
    data type, but no such entry actually appears
    in <structname>pg_depend</structname>.
 -->
-《機械翻訳》<application>initdb</application>中に作成されたほとんどのオブジェクトは<quote>固定</quote>とみなされます。
+<application>initdb</application>中に作成されたほとんどのオブジェクトは<quote>固定(pinned)</quote>とみなされます。
 これは、システム自体がオブジェクトに依存していることを意味します。
 したがって、オブジェクトを削除することは決してできません。
 また、固定されたオブジェクトが削除されないことを知っているため、依存メカニズムはオブジェクトへの依存関係を示す<structname>pg_depend</structname>エントリをわざわざ作成する必要がありません。
-したがって、例えば、<type>numeric</type>型のテーブル列は理論上<type>numeric</type>データ型に<literal>NORMAL</literal>依存しますが、そのようなエントリは実際には<structname>pg_depend</structname>にはありません。
+ですから、例えば、<type>numeric</type>型のテーブル列は理論上<type>numeric</type>データ型に<literal>NORMAL</literal>依存しますが、そのようなエントリは実際には<structname>pg_depend</structname>にはありません。
   </para>
 
  </sect1>
@@ -6274,9 +6271,9 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
        it is true, it will consider null values to be equal (so the index can
        only contain one null value in a column).
 -->
-《機械翻訳》この値はユニークインデックスに対してのみ使用されます。
-falseの場合、このユニークインデックスはNULL値を区別するものとみなします(PostgreSQLのデフォルト動作では、インデックスはカラムに複数のNULL値を含むことができます)。
-trueの場合、NULL値は等しいものとみなします(インデックスはカラムに1つのNULL値しか含むことができません)。
+この値はユニークインデックスに対してのみ使用されます。
+偽の場合、このユニークインデックスはNULL値を区別するものとみなします（PostgreSQLのデフォルト動作では、インデックスはカラムに複数のNULL値を含むことができます）。
+真の場合、NULL値は等しいものとみなします(インデックスはカラムに1つのNULL値しか含むことができません)。
       </para></entry>
      </row>
 
@@ -6363,8 +6360,8 @@ trueの場合、NULL値は等しいものとみなします(インデックス�
        event horizon, because the table may contain broken <link linkend="storage-hot">HOT chains</link> with
        incompatible rows that they can see
 -->
-《マッチ度[80.891720]》真の場合、<structname>pg_index</structname>行の<structfield>xmin</structfield>が<symbol>TransactionXmin</symbol>イベント境界値を下回るまで、問い合わせはインデックスを使用してはいけません。
-なぜなら、テーブルは互換性の無い行と共に破壊されたHOTチェインを含み、それらが可視であるかもしれないからです。
+真の場合、<structname>pg_index</structname>行の<structfield>xmin</structfield>が<symbol>TransactionXmin</symbol>イベント境界値を下回るまで、問い合わせはインデックスを使用してはいけません。
+なぜなら、テーブルは互換性の無い行と共に破壊された<link linkend="storage-hot">HOTチェイン</link>を含み、それらが可視であるかもしれないからです。
       </para></entry>
      </row>
 
@@ -6429,8 +6426,8 @@ trueの場合、NULL値は等しいものとみなします(インデックス�
        corresponding index attribute is an expression over the table columns,
        rather than a simple column reference.
 -->
-《マッチ度[88.116592]》このインデックスがどのテーブル列をインデックスとしているかを示す<structfield>indnatts</structfield>配列の値です。
-例えば、<literal>1 3</literal>は1番目と3番目のテーブル列がインデックスキーとなっていることを示します。
+このインデックスがどのテーブル列をインデックスとしているかを示す<structfield>indnatts</structfield>配列の値です。
+例えば、<literal>1 3</literal>は1番目と3番目のテーブル列がインデックス項目となっていることを示します。
 キー列は、（INCLUDE句で指定した）非キー列の前に来ます。
 この配列でゼロとなっているのは対応するインデックスの属性が単純な列参照ではなくテーブル列に渡った演算式であることを示します。
       </para></entry>

--- a/doc/src/sgml/catalogs1.sgml
+++ b/doc/src/sgml/catalogs1.sgml
@@ -114,8 +114,7 @@
        Source encoding ID (<link linkend="pg-encoding-to-char"><function>pg_encoding_to_char()</function></link>
        can translate this number to the encoding name)
 -->
-《マッチ度[58.169935]》このデータベースの文字エンコード方式。
-（<function>pg_encoding_to_char()</function>で、この番号からエンコード方式名称に変換できます。）
+ソースエンコーディングID（<link linkend="pg-encoding-to-char"><function>pg_encoding_to_char()</function></link>で、この番号からエンコード方式名称に変換できます。）
       </para></entry>
      </row>
 
@@ -128,8 +127,7 @@
        Destination encoding ID (<link linkend="pg-encoding-to-char"><function>pg_encoding_to_char()</function></link>
        can translate this number to the encoding name)
 -->
-《マッチ度[58.227848]》このデータベースの文字エンコード方式。
-（<function>pg_encoding_to_char()</function>で、この番号からエンコード方式名称に変換できます。）
+ディスティネーションエンコーディングID（<link linkend="pg-encoding-to-char"><function>pg_encoding_to_char()</function></link>で、この番号からエンコード方式名称に変換できます。）
       </para></entry>
      </row>
 
@@ -271,8 +269,7 @@
        (<link linkend="pg-encoding-to-char"><function>pg_encoding_to_char()</function></link> can translate
        this number to the encoding name)
 -->
-《マッチ度[66.081871]》このデータベースの文字エンコード方式。
-（<function>pg_encoding_to_char()</function>で、この番号からエンコード方式名称に変換できます。）
+このデータベースの文字エンコード（<link linkend="pg-encoding-to-char"><function>pg_encoding_to_char()</function></link>で、この番号からエンコード方式名称に変換できます。）
       </para></entry>
      </row>
 
@@ -285,7 +282,7 @@
        Locale provider for this database: <literal>c</literal> = libc,
        <literal>i</literal> = icu
 -->
-《機械翻訳》このデータベースのロケールプロバイダ:<literal>c</literal>=libc,<literal>i</literal>=icu
+このデータベースのロケールプロバイダ：<literal>c</literal> = libc、<literal>i</literal> = icu
       </para></entry>
      </row>
 
@@ -425,7 +422,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
 <!--
        ICU locale ID for this database
 -->
-《マッチ度[54.838710]》このデータベースのLC_CTYPE
+このデータベースのICUロケールID
       </para></entry>
      </row>
 
@@ -439,8 +436,8 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
        database is created and then checked when it is used, to detect
        changes in the collation definition that could lead to data corruption.
 -->
-《マッチ度[85.365854]》この照合順序に対する提供者固有のバージョンです。
-これは照合順序が作成された時に記録され、データの破壊につながりかねない照合順序定義の変更を検知するために使用時に検査されます。
+この照合順序に対する提供者固有のバージョンです。
+これはデータベースが作成された時に記録され、データの破壊につながりかねない照合順序定義の変更を検知するために使用時に検査されます。
       </para></entry>
      </row>
 
@@ -778,7 +775,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
 <!--
        The OID of the system catalog the dependent object is in
 -->
-《マッチ度[75.000000]》参照されるオブジェクトが存在するシステムカタログのOID
+依存するオブジェクトが存在するシステムカタログのOID
       </para></entry>
      </row>
 
@@ -794,7 +791,7 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
 <!--
        The OID of the specific dependent object
 -->
-《マッチ度[65.000000]》特定の参照されるオブジェクトのOID
+依存する特定のオブジェクトのOID
       </para></entry>
      </row>
 
@@ -1102,11 +1099,11 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
    data type, but no such entry actually appears
    in <structname>pg_depend</structname>.
 -->
-《機械翻訳》<application>initdb</application>中に作成されたほとんどのオブジェクトは<quote>固定</quote>とみなされます。
+<application>initdb</application>中に作成されたほとんどのオブジェクトは<quote>固定(pinned)</quote>とみなされます。
 これは、システム自体がオブジェクトに依存していることを意味します。
 したがって、オブジェクトを削除することは決してできません。
 また、固定されたオブジェクトが削除されないことを知っているため、依存メカニズムはオブジェクトへの依存関係を示す<structname>pg_depend</structname>エントリをわざわざ作成する必要がありません。
-したがって、例えば、<type>numeric</type>型のテーブル列は理論上<type>numeric</type>データ型に<literal>NORMAL</literal>依存しますが、そのようなエントリは実際には<structname>pg_depend</structname>にはありません。
+ですから、例えば、<type>numeric</type>型のテーブル列は理論上<type>numeric</type>データ型に<literal>NORMAL</literal>依存しますが、そのようなエントリは実際には<structname>pg_depend</structname>にはありません。
   </para>
 
  </sect1>
@@ -2209,9 +2206,9 @@ falseの場合、スーパーユーザまたはデータベースの所有者だ
        it is true, it will consider null values to be equal (so the index can
        only contain one null value in a column).
 -->
-《機械翻訳》この値はユニークインデックスに対してのみ使用されます。
-falseの場合、このユニークインデックスはNULL値を区別するものとみなします(PostgreSQLのデフォルト動作では、インデックスはカラムに複数のNULL値を含むことができます)。
-trueの場合、NULL値は等しいものとみなします(インデックスはカラムに1つのNULL値しか含むことができません)。
+この値はユニークインデックスに対してのみ使用されます。
+偽の場合、このユニークインデックスはNULL値を区別するものとみなします（PostgreSQLのデフォルト動作では、インデックスはカラムに複数のNULL値を含むことができます）。
+真の場合、NULL値は等しいものとみなします(インデックスはカラムに1つのNULL値しか含むことができません)。
       </para></entry>
      </row>
 
@@ -2298,8 +2295,8 @@ trueの場合、NULL値は等しいものとみなします(インデックス�
        event horizon, because the table may contain broken <link linkend="storage-hot">HOT chains</link> with
        incompatible rows that they can see
 -->
-《マッチ度[80.891720]》真の場合、<structname>pg_index</structname>行の<structfield>xmin</structfield>が<symbol>TransactionXmin</symbol>イベント境界値を下回るまで、問い合わせはインデックスを使用してはいけません。
-なぜなら、テーブルは互換性の無い行と共に破壊されたHOTチェインを含み、それらが可視であるかもしれないからです。
+真の場合、<structname>pg_index</structname>行の<structfield>xmin</structfield>が<symbol>TransactionXmin</symbol>イベント境界値を下回るまで、問い合わせはインデックスを使用してはいけません。
+なぜなら、テーブルは互換性の無い行と共に破壊された<link linkend="storage-hot">HOTチェイン</link>を含み、それらが可視であるかもしれないからです。
       </para></entry>
      </row>
 
@@ -2364,8 +2361,8 @@ trueの場合、NULL値は等しいものとみなします(インデックス�
        corresponding index attribute is an expression over the table columns,
        rather than a simple column reference.
 -->
-《マッチ度[88.116592]》このインデックスがどのテーブル列をインデックスとしているかを示す<structfield>indnatts</structfield>配列の値です。
-例えば、<literal>1 3</literal>は1番目と3番目のテーブル列がインデックスキーとなっていることを示します。
+このインデックスがどのテーブル列をインデックスとしているかを示す<structfield>indnatts</structfield>配列の値です。
+例えば、<literal>1 3</literal>は1番目と3番目のテーブル列がインデックス項目となっていることを示します。
 キー列は、（INCLUDE句で指定した）非キー列の前に来ます。
 この配列でゼロとなっているのは対応するインデックスの属性が単純な列参照ではなくテーブル列に渡った演算式であることを示します。
       </para></entry>


### PR DESCRIPTION
"part2"を誤ってcatalogs2.sgmlの訳に使ってしまったので「catalogs1.sgml部分」としています。