### PR TITLE
client-auth.sgmlのPR2480にsearch+bindの変更を追加

### DIFF
--- a/doc/src/sgml/client-auth.sgml
+++ b/doc/src/sgml/client-auth.sgml
@@ -105,9 +105,9 @@ SQL 環境の中では存在するユーザ名でデータベースオブジェ�
    possible to place the authentication configuration file elsewhere,
    however; see the <xref linkend="guc-hba-file"/> configuration parameter.
 -->
-《マッチ度[90.000000]》クライアント認証はデータベースクラスタのデータディレクトリ内の、伝統的に<filename>pg_hba.conf</filename>という名前の設定ファイルで管理されています
+クライアント認証はデータベースクラスタのデータディレクトリ内の、伝統的に<filename>pg_hba.conf</filename>という名前の設定ファイルで管理されています
 （<acronym>HBA</acronym>とは、host-based authentication: ホストベース認証の略です）。
-デフォルトの<filename>pg_hba.conf</filename>ファイルは、データディレクトリが<command>initdb</command>で初期化される時にインストールされます。
+デフォルトの<filename>pg_hba.conf</filename>ファイルは、データディレクトリが<xref linkend="app-initdb"/>で初期化される時にインストールされます。
 しかし、この認証設定ファイルを他の場所に設置することができます。
 <xref linkend="guc-hba-file"/>設定パラメータを参照してください。
   </para>
@@ -1002,8 +1002,7 @@ openssl x509 -in myclient.crt -noout --subject -nameopt RFC2253 | sed "s/^subjec
    non-null <structfield>error</structfield> fields indicate problems in the
    corresponding lines of the file.
 -->
-<filename>pg_hba.conf</filename>に対する変更をテストする際、あるいはそのファイルをロードしても期待していた結果が得られなかった場合には、
-システムビュー<link linkend="view-pg-hba-file-rules"><structname>pg_hba_file_rules</structname></link>が役に立ちます。
+<filename>pg_hba.conf</filename>に対する変更をテストする際、あるいはそのファイルをロードしても期待していた結果が得られなかった場合には、システムビュー<link linkend="view-pg-hba-file-rules"><structname>pg_hba_file_rules</structname></link>が役に立ちます。
 そのビューの<structfield>error</structfield>フィールドがNULLでない行は、そのファイルの該当行に問題があることを示しています。
   </para>
 
@@ -1340,8 +1339,7 @@ mymap   /^(.*)@otherdomain\.com$   guest
    non-null <structfield>error</structfield> fields indicate problems in the
    corresponding lines of the file.
 -->
-《マッチ度[87.681159]》<filename>pg_hba.conf</filename>に対する変更をテストする際、あるいはそのファイルをロードしても期待していた結果が得られなかった場合には、
-システムビュー<link linkend="view-pg-hba-file-rules"><structname>pg_hba_file_rules</structname></link>が役に立ちます。
+<filename>pg_ident.conf</filename>に対する変更をテストする際、あるいはそのファイルをロードしても期待していた結果が得られなかった場合には、システムビュー<link linkend="view-pg-ident-file-mappings"><structname>pg_ident_file_mappings</structname></link>が役に立ちます。
 そのビューの<structfield>error</structfield>フィールドがNULLでない行は、そのファイルの該当行に問題があることを示しています。
   </para>
 
@@ -2190,7 +2188,7 @@ realmをユーザプリンシパル名に一致するように設定します。
 -->
 システムとデータベースユーザ名の間のマッピングを許可します。
 詳細は<xref linkend="auth-username-maps"/>を参照してください。
-SSAPI/Kerberosプリンシパル<literal>username@EXAMPLE.COM</literal>(もしくは、あまり一般的ではありませんが<literal>username/hostbased@EXAMPLE.COM</literal>)に対しては、もし<literal>include_realm</literal>が0に設定されていない限り、マッピングに使われるユーザ名は<literal>username@EXAMPLE.COM</literal>(もしくは<literal>username/hostbased@EXAMPLE.COM</literal>)です。
+SSPI/Kerberosプリンシパル<literal>username@EXAMPLE.COM</literal>(もしくは、あまり一般的ではありませんが<literal>username/hostbased@EXAMPLE.COM</literal>)に対しては、もし<literal>include_realm</literal>が0に設定されていない限り、マッピングに使われるユーザ名は<literal>username@EXAMPLE.COM</literal>(もしくは<literal>username/hostbased@EXAMPLE.COM</literal>)です。
 0に設定されている場合には、<literal>username</literal>(もしくは<literal>username/hostbased</literal>)がマッピング時のシステムユーザ名です。
        </para>
       </listitem>
@@ -2389,7 +2387,7 @@ peer認証方式はカーネルからクライアント上のオペレーティ�
     <systemitem class="osname">macOS</systemitem>,
     and <systemitem class="osname">Solaris</systemitem>.
 -->
-peer認証はオペレーティングシステムが、<function>getpeereid()</function>関数、<symbol>SO_PEERCRED</symbol>のソケットパラメータ、もしくは同じような仕組みを提供しているときにのみ使用可能です。現状では、<systemitem class="osname">Linux</systemitem>、<systemitem class="osname">OS X</systemitem>を含む<systemitem class="osname">BSD</systemitem>系、そして<systemitem class="osname">Solaris</systemitem>に含まれています。
+peer認証はオペレーティングシステムが、<function>getpeereid()</function>関数、<symbol>SO_PEERCRED</symbol>のソケットパラメータ、もしくは同じような仕組みを提供しているときにのみ使用可能です。現状では、<systemitem class="osname">Linux</systemitem>、<systemitem class="osname">macOS</systemitem>を含む<systemitem class="osname">BSD</systemitem>系、そして<systemitem class="osname">Solaris</systemitem>に含まれています。
    </para>
 
   </sect1>

--- a/doc/src/sgml/client-auth.sgml
+++ b/doc/src/sgml/client-auth.sgml
@@ -2453,7 +2453,7 @@ LDAP認証は2つのモードで動作します。1つ目のモードでは、�
     in where the user objects are located in the directory, but will cause
     two separate connections to the LDAP server to be made.
 -->
-2つ目のモードでは、それはsearch/bindモードを呼び出すもので、サーバは最初に<replaceable>ldapbinddn</replaceable>と<replaceable>ldapbindpasswd</replaceable>で指定された、
+2つ目のモードでは、それはsearch+bindモードを呼び出すもので、サーバは最初に<replaceable>ldapbinddn</replaceable>と<replaceable>ldapbindpasswd</replaceable>で指定された、
 固定されたユーザ名とパスワードを使用してLDAPディレクトリにバインドします。
 それからデータベースにログインしようとしているユーザを検索します。
 もしユーザとパスワードが指定されていなかった場合は、ディレクトリに対して匿名でバインドします。
@@ -2579,7 +2579,7 @@ SSLがそこでも使用されていない限り、PostgreSQLサーバとPostgre
 <!--
     The following options are used in search+bind mode only:
 -->
-以下のオプションはsearch/bindモードのみで使用されます。
+以下のオプションはsearch+bindモードのみで使用されます。
     <variablelist>
      <varlistentry>
       <term><literal>ldapbasedn</literal></term>
@@ -2641,7 +2641,7 @@ SSLがそこでも使用されていない限り、PostgreSQLサーバとPostgre
          user name.  This allows for more flexible search filters than
          <literal>ldapsearchattribute</literal>.
 -->
-search/bind認証を行うときに使用する検索フィルタです。
+search+bind認証を行うときに使用する検索フィルタです。
 <literal>$username</literal>の出現はユーザ名に置き換えられます。
 これにより<literal>ldapsearchattribute</literal>よりも柔軟な検索フィルタが可能になります。
         </para>
@@ -2719,7 +2719,7 @@ LDAP URLは現在、<productname>OpenLDAP</productname>のみでサポートさ�
     It is an error to mix configuration options for simple bind with options
     for search+bind.
 -->
-seartch/bindオプションと単純バインドに対するオプションの設定を混在させるのはエラーです。
+search+bindオプションと単純バインドに対するオプションの設定を混在させるのはエラーです。
    </para>
 
    <para>
@@ -2733,7 +2733,7 @@ seartch/bindオプションと単純バインドに対するオプションの�
     option is specified the default is
     <literal>ldapsearchattribute=uid</literal>.
 -->
-search/bindモードを使用するときは、<literal>ldapsearchattribute</literal>で指定される単一の属性を使って、あるいは<literal>ldapsearchfilter</literal>で指定されるカスタム検索フィルターを使って、検索を実行できます。
+search+bindモードを使用するときは、<literal>ldapsearchattribute</literal>で指定される単一の属性を使って、あるいは<literal>ldapsearchfilter</literal>で指定されるカスタム検索フィルターを使って、検索を実行できます。
 <literal>ldapsearchattribute=foo</literal>の指定は、<literal>ldapsearchfilter="(foo=$username)"</literal>と同等です。
 どちらのオプションもない場合は、<literal>ldapsearchattribute=uid</literal>がデフォルトです。
    </para>
@@ -2776,7 +2776,7 @@ host ... ldap ldapserver=ldap.example.net ldapprefix="cn=" ldapsuffix=", dc=exam
 <!--
     Here is an example for a search+bind configuration:
 -->
-以下はsearch/bind設定の例です。
+以下はsearch+bind設定の例です。
 <programlisting>
 host ... ldap ldapserver=ldap.example.net ldapbasedn="dc=example, dc=net" ldapsearchattribute=uid
 </programlisting>
@@ -2796,7 +2796,7 @@ host ... ldap ldapserver=ldap.example.net ldapbasedn="dc=example, dc=net" ldapse
 <!--
     Here is the same search+bind configuration written as a URL:
 -->
-URLとして記述した同じsearch/bind設定の例です。
+URLとして記述した同じsearch+bind設定の例です。
 <programlisting>
 host ... ldap ldapurl="ldap://ldap.example.net/dc=example,dc=net?uid?sub"
 </programlisting>
@@ -2815,7 +2815,7 @@ LDAPに対し認証をサポートする幾つかの他のソフトウェアは�
     <literal>ldapsearchattribute</literal> to allow authentication by
     user ID or email address:
 -->
-<literal>ldapsearchattribute</literal>の代わりに<literal>ldapsearchfilter</literal>を使用してユーザーIDまたは電子メールアドレスによる認証を可能にするsearch/bind設定の例です。
+<literal>ldapsearchattribute</literal>の代わりに<literal>ldapsearchfilter</literal>を使用してユーザーIDまたは電子メールアドレスによる認証を可能にするsearch+bind設定の例です。
 <programlisting>
 host ... ldap ldapserver=ldap.example.net ldapbasedn="dc=example, dc=net" ldapsearchfilter="(|(uid=$username)(mail=$username))"
 </programlisting>
@@ -2827,7 +2827,7 @@ host ... ldap ldapserver=ldap.example.net ldapbasedn="dc=example, dc=net" ldapse
     discovery to find the host name(s) and port(s) for the LDAP service for the
     domain name <literal>example.net</literal>:
 -->
-DNS SRV検出を使用してドメイン名<literal>example.net</literal>のLDAPサービスのホスト名とポート番号を検索する、search/bind設定の例です。
+DNS SRV検出を使用してドメイン名<literal>example.net</literal>のLDAPサービスのホスト名とポート番号を検索する、search+bind設定の例です。
 <programlisting>
 host ... ldap ldapbasedn="dc=example,dc=net"
 </programlisting>


### PR DESCRIPTION
前から気になっていたsearch/bindをsearch+bindに変更したものです。
LDAPに詳しくないのですが、変更して良いでしょうか？

さらにtypo修正
