### PR TITLE
acronyms.sgmlのPostgreSQL 15.0対応です。

### DIFF
--- a/doc/src/sgml/acronyms.sgml
+++ b/doc/src/sgml/acronyms.sgml
@@ -413,7 +413,10 @@
     <term><acronym>HOT</acronym></term>
     <listitem>
      <para>
+<!--
       <link linkend="storage-hot">Heap-Only Tuples</link>
+-->
+      <link linkend="storage-hot">Heap-Only Tuples（ヒープ専用タプル）</link>
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
リンク先の変更のみで、訳の部分は変えていません。
変える必要がないので。