### PR TITLE
round関数の訳を修正

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -2053,8 +2053,8 @@ NULL引数の数を返す。
         <quote>round to nearest even</quote> is the most common rule.
 -->
 最も近い整数へ丸めます。
-<type>numeric</type>では小数点以下を切り上げて同値を処理します。
-<type>double precision</type>では同値処理の振る舞いはプラットフォーム依存です。
+<type>numeric</type>の場合、小数点以下を四捨五入します。
+<type>double precision</type>では端数処理の振る舞いはプラットフォーム依存です。
 しかし、最も普通の規則は<quote>最近接偶数への丸め(round to nearest even)</quote>です。
        </para>
        <para>

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -2053,8 +2053,8 @@ NULL引数の数を返す。
         <quote>round to nearest even</quote> is the most common rule.
 -->
 最も近い整数へ丸めます。
-<type>numeric</type>では小数点以下を切り上げて端数を処理します。
-<type>double precision</type>では端数処理の振る舞いはプラットフォーム依存です。
+<type>numeric</type>では小数点以下を切り上げて同値を処理します。
+<type>double precision</type>では同値処理の振る舞いはプラットフォーム依存です。
 しかし、最も普通の規則は<quote>最近接偶数への丸め(round to nearest even)</quote>です。
        </para>
        <para>


### PR DESCRIPTION
tieは端数ではなく同値という意味なので、同値と訳していいかと思います。
「小数点以下を切り上げて端数を処理します。」の説明を読んで、例えば
SELECT round(CAST(42.5 AS numeric));
は42を返すのかと思いましたが、実際は43が返ってきます。
英文のいわんとするところは、0.5や1.5のように、最も近いintegerが2つ存在する場合…同値(tie)が存在する場合の処理について、numericの場合は切り上げて処理される、とのことなのかと思います。
これを日本語に訳す場合、自分はいい言葉が思いつきませんでしたが、端数ですと意味が違ってしまうので、同値がいいかと思いました。