### PR TITLE
他バージョンの文書として公式サイトへのリンク

### DIFF
--- a/doc/src/sgml/stylesheet-custom.xsl
+++ b/doc/src/sgml/stylesheet-custom.xsl
@@ -175,6 +175,9 @@
           </xsl:if>
 
         </table>
+        <div class="other_version">
+          <a><xsl:attribute name="href">https://www.postgresql.jp/document/</xsl:attribute>他のバージョンの文書</a>
+        </div>
       </xsl:if>
 
       <xsl:if test="$header.rule != 0">

--- a/doc/src/sgml/stylesheet-custom.xsl
+++ b/doc/src/sgml/stylesheet-custom.xsl
@@ -47,6 +47,13 @@
                                     or ($next and $navig.showtitles != 0)"/>
 
   <xsl:if test="$suppress.navigation = '0' and $suppress.header.navigation = '0'">
+  <xsl:choose>
+  <xsl:when test="$html.original = 1">
+    <div class="other_version">
+      <a><xsl:attribute name="href">https://www.postgresql.jp/document/</xsl:attribute>バージョンごとのドキュメント一覧</a>
+    </div>
+  </xsl:when>
+  </xsl:choose>
     <div class="navheader">
       <xsl:if test="$row1 or $row2 or $row3">
         <table width="100%" summary="Navigation header">
@@ -175,9 +182,6 @@
           </xsl:if>
 
         </table>
-        <div class="other_version">
-          <a><xsl:attribute name="href">https://www.postgresql.jp/document/</xsl:attribute>他のバージョンの文書</a>
-        </div>
       </xsl:if>
 
       <xsl:if test="$header.rule != 0">

--- a/doc/src/sgml/stylesheet.css
+++ b/doc/src/sgml/stylesheet.css
@@ -314,3 +314,20 @@ acronym		{ font-style: inherit; }
     width: 75%;
   }
 }
+
+.other_version {
+	position:absolute; top:0em; right:5%;
+	float: right;
+	margin-top: -0.2em;
+	margin-bottom: 0.5em;
+	width: auto;
+	padding: 0.4em 1em;
+	border: solid 1px #e0e0e0;
+	border-radius: 0.5em;
+	background: #f3f3f3;
+	background-image: -webkit-linear-gradient(#fbfbfb, #ebebeb);
+	background-image: -moz-linear-gradient(#fbfbfb, #ebebeb);
+	background-image: -o-linear-gradient(#fbfbfb, #ebebeb);
+	background-image: linear-gradient(#fbfbfb, #ebebeb);
+	box-shadow: 0 3px 8px -3px #000;
+}

--- a/doc/src/sgml/stylesheet.css
+++ b/doc/src/sgml/stylesheet.css
@@ -316,7 +316,8 @@ acronym		{ font-style: inherit; }
 }
 
 .other_version {
-	position:absolute; top:0em; right:5%;
+	top:0em;
+	right:5%;
 	float: right;
 	margin-top: -0.2em;
 	margin-bottom: 0.5em;


### PR DESCRIPTION
他バージョンの文書のリンクを追加してみました。
https://noborus.github.io/test/index.html
のように右上に表示します。公式サイトを模してボタンのようにしていますが、単なるリンクです。
#2467 の対応です。