### PR TITLE
翻訳の著作権表記について見直し

### DIFF
--- a/doc/src/sgml/legal.sgml
+++ b/doc/src/sgml/legal.sgml
@@ -4,10 +4,8 @@
 
 <copyright>
  <year>1996&ndash;2022</year>
-<!--
  <holder>The PostgreSQL Global Development Group</holder>
--->
- <holder>PostgreSQL グローバル開発グループ</holder>
+ <holder>（翻訳）日本PostgreSQLユーザ会</holder>
 </copyright>
 
 <legalnotice id="legalnotice">
@@ -33,12 +31,18 @@ Copyright &copy; 1994&ndash;1995 <productname>Postgres95</productname>はカリ�
  </para>
 
  <para>
+日本PostgreSQLユーザ会(Japan PostgreSQL User Group)は翻訳の著作権を有します。
+ </para>
+
+ <para>
   Permission to use, copy, modify, and distribute this software and
   its documentation for any purpose, without fee, and without a
   written agreement is hereby granted, provided that the above
   copyright notice and this paragraph and the following two paragraphs
   appear in all copies.
+ </para>
 
+ <para>
   [訳注：日本語は参考程度と解釈してください。]
   上記の著作権表示、および
   本段落と続く2つの段落を全てのコピーに含めることを条件として、無料かつ
@@ -52,7 +56,9 @@ Copyright &copy; 1994&ndash;1995 <productname>Postgres95</productname>はカリ�
   DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS
   SOFTWARE AND ITS DOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA
   HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ </para>
 
+ <para>
   カリフォルニア大学は、いかなる当事者に対しても、利益の喪失を含む、
   直接的、間接的、特別、偶然あるいは必然的にかかわらず生じた
   損害について、たとえカリフォルニア大学がこれらの損害の可能性について
@@ -66,7 +72,9 @@ Copyright &copy; 1994&ndash;1995 <productname>Postgres95</productname>はカリ�
   PROVIDED HEREUNDER IS ON AN <quote>AS-IS</quote> BASIS, AND THE UNIVERSITY OF
   CALIFORNIA HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT,
   UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ </para>
 
+ <para>
   カリフォルニア大学は、商用目的における暗黙の保証と、特定目的での
   適合性に関してはもとより、これらに限らず、いかなる保証もしません。
   以下に用意されたソフトウェアは「そのまま」を基本原理とし、


### PR DESCRIPTION
legal.sgmlの見直し。
翻訳の著作権についてがそのままになっていたので修正。#363
日本語訳がそのまま続くと見づらかったので、別に分けた。

PostgreSQL Global Development Groupを日本語表記から元のままに修正。