### PR TITLE
backup.sgmlのPostgreSQL 15.0対応です。

### DIFF
--- a/doc/src/sgml/backup.sgml
+++ b/doc/src/sgml/backup.sgml
@@ -922,11 +922,11 @@ WALアーカイブを行わない場合、システムは通常数個のセグ�
     as a shell command that uses <literal>cp</literal>, or it could invoke a
     complex C function &mdash; it's all up to you.
 -->
-《マッチ度[88.070829]》WALデータをアーカイブする場合、完成したセグメントファイルのそれぞれの内容を取り出し、再利用のために回収される前にそのデータをどこかに保存することが必要です。
+WALデータをアーカイブする場合、完成したセグメントファイルのそれぞれの内容を取り出し、再利用のために回収される前にそのデータをどこかに保存することが必要です。
 アプリケーションと利用できるハードウェアに依存しますが、数多くの<quote>データをどこかに保存する</quote>方法があります。
 例えば、NFSでマウントした他のマシンのディレクトリにセグメントファイルをコピーすること、あるいは、テープ装置に書き出すこと（元々のファイル名を識別する手段があることを確認してください）、それらを一度にまとめてCDに焼くこと、そのほか全く異なったなんらかの方法などです。
 柔軟性をデータベース管理者に提供するために、<productname>PostgreSQL</productname>は、どのようにアーカイブがなされたかについて一切想定しないようになっています。
-その代わりに<productname>PostgreSQL</productname>は、管理者に完全なセグメントファイルをどこか必要な場所にコピーするシェルコマンドを指定させます。
+その代わりに<productname>PostgreSQL</productname>は、管理者に完全なセグメントファイルをどこか必要な場所にコピーするシェルコマンドあるいはアーカイブライブラリを指定させます。
 このコマンドは単純な<literal>cp</literal>でも構いませんし、また、複雑なシェルスクリプトを呼び出しても構いません。
 全て管理者に任されています。
    </para>
@@ -943,7 +943,7 @@ WALアーカイブを行わない場合、システムは通常数個のセグ�
     these settings will always be placed in the
     <filename>postgresql.conf</filename> file.
 -->
-《機械翻訳》WAL保管を有効にするには、<xref linkend="guc-wal-level"/>設定パラメータを<literal>replica</literal>以上に、<xref linkend="guc-archive-mode"/>を<literal>on</literal>に設定し、<xref linkend="guc-archive-command"/>設定パラメータで使用するシェルコマンドを指定するか、<xref linkend="guc-archive-library"/>設定パラメータで使用するライブラリを指定します。
+WAL保管を有効にするには、<xref linkend="guc-wal-level"/>設定パラメータを<literal>replica</literal>以上に、<xref linkend="guc-archive-mode"/>を<literal>on</literal>に設定し、<xref linkend="guc-archive-command"/>設定パラメータで使用するシェルコマンドを指定するか、<xref linkend="guc-archive-library"/>設定パラメータで使用するライブラリを指定します。
 実際には、これらの設定は常に<filename>postgresql.conf</filename>ファイルに置かれます。
    </para>
 
@@ -958,8 +958,8 @@ WALアーカイブを行わない場合、システムは通常数個のセグ�
     character in the command.  The simplest useful command is something
     like:
 -->
-《機械翻訳》<varname>archive_command</varname>では、<literal>%p</literal>はアーカイブするファイルのパス名に置き換えられますが、<literal>%f</literal>はファイル名のみに置き換えられます。
-(パス名は現在の作業ディレクトリ、つまりクラスタのデータディレクトリからの相対パスです。)
+<varname>archive_command</varname>では、<literal>%p</literal>はアーカイブするファイルのパス名に置き換えられますが、<literal>%f</literal>はファイル名のみに置き換えられます。
+（パス名は現在の作業ディレクトリ、つまりクラスタのデータディレクトリからの相対パスです。）
 実際の<literal>%</literal>文字をコマンドに埋め込む必要がある場合は<literal>%%</literal>を使用してください。
 最も簡単で便利なコマンドは以下のようなものです。
 <programlisting>
@@ -1024,9 +1024,9 @@ test ! -f /mnt/server/archivedir/00000001000000A900000065 &amp;&amp; cp pg_wal/0
     useful server resources.  For more information about archive modules, see
     <xref linkend="archive-modules"/>.
 -->
-《機械翻訳》アーカイブの別の方法は、<varname>archive_library</varname>としてカスタム・アーカイブ・モジュールを使用することです。
+アーカイブするための別の方法は、<varname>archive_library</varname>としてカスタム・アーカイブ・モジュールを使用することです。
 このようなモジュールは<literal>C</literal>で記述されているため、独自のモジュールを作成するには、シェル・コマンドを記述するよりもかなり多くの労力が必要になる場合があります。
-ただし、アーカイブ・モジュールはシェルを介したアーカイブよりもパフォーマンスが高く、多くの有用なサーバー・リソースにアクセスできます。
+しかし、アーカイブ・モジュールはシェルを介したアーカイブよりもパフォーマンスが高く、多くの有用なサーバー・リソースにアクセスできます。
 アーカイブ・モジュールの詳細は<xref linkend="archive-modules"/>を参照してください。
    </para>
 
@@ -1040,7 +1040,7 @@ test ! -f /mnt/server/archivedir/00000001000000A900000065 &amp;&amp; cp pg_wal/0
     aborts and gets restarted by the postmaster. In such cases, the failure is
     not reported in <xref linkend="pg-stat-archiver-view"/>.
 -->
-《マッチ度[75.847458]》アーカイブ用コマンドがシグナル（サーバのシャットダウンの一部として使用される<systemitem>SIGTERM</systemitem>以外）やシェルによる125以上の終了ステータスを持つエラー（command not foundなど）によって終了すると、アーカイバプロセスは中止され、postmasterによって再起動されます。
+アーカイブ用コマンドがシグナル（サーバのシャットダウンの一部として使用される<systemitem>SIGTERM</systemitem>以外）やシェルによる125以上の終了ステータスを持つエラー（command not foundなど）、あるいはアーカイブ関数が<literal>ERROR</literal>または<literal>FATAL</literal>を出力したことによって終了すると、アーカイバプロセスは中止され、postmasterによって再起動されます。
 このような場合、失敗は<xref linkend="pg-stat-archiver-view"/>では報告されません。
    </para>
 
@@ -1052,7 +1052,7 @@ test ! -f /mnt/server/archivedir/00000001000000A900000065 &amp;&amp; cp pg_wal/0
     (such as sending the output of two different servers to the same archive
     directory).
 -->
-《マッチ度[86.644951]》通常アーカイブ用コマンドは既存のアーカイブ済みファイルの上書きを行わないように設計されなければなりません。
+通常アーカイブ用コマンドあるいはライブラリは、既存のアーカイブ済みファイルの上書きを行わないように設計されなければなりません。
 これは、管理者のミス（例えば2つの異なるサーバの出力を同一のアーカイブ用ディレクトリに送信してしまうなど）といった場合からアーカイブ状況の整合性を保護するための安全策として重要です。
    </para>
 
@@ -1069,10 +1069,10 @@ test ! -f /mnt/server/archivedir/00000001000000A900000065 &amp;&amp; cp pg_wal/0
     will return status zero when <option>-i</option> is used and the target file
     already exists, which is <emphasis>not</emphasis> the desired behavior.)
 -->
-《マッチ度[87.450980]》実際に既存のファイルを上書きしないこと、<emphasis>かつ、その場合に非ゼロのステータスを返すこと</emphasis>を確認するために使用するアーカイブ用コマンドを試験することを勧めます。
+使用予定のアーカイブ用コマンドあるいはライブラリが、当然のことながら既存のファイルを上書きしないこと、<emphasis>かつ、上書きしようとした場合には非ゼロのステータスあるいは<literal>false</literal>をそれぞれ返すこと</emphasis>を確認するために試験することを勧めます。
 上のUnix用のコマンド例では、別途<command>test</command>という段階を含めることでこれを確認しています。
 いくつかのUnixプラットフォームでは<command>cp</command>コマンドには<option>-i</option> 引数を使うことで煩雑な出力を少なくし使うことができますが、正しい終了コードが返ることを確認せずに使用するべきではありません。
-(具体的にはGNUの<command>cp</command>コマンドは<option>-i</option> オプションを使い、ターゲットファイルがすでに存在している場合、ゼロのステータスを返します。これは<emphasis>期待していない</emphasis>動作です。)
+（具体的にはGNUの<command>cp</command>コマンドは<option>-i</option> オプションを使い、ターゲットファイルがすでに存在している場合、ゼロのステータスを返します。これは<emphasis>期待していない</emphasis>動作です。）
    </para>
 
    <para>
@@ -1091,7 +1091,7 @@ test ! -f /mnt/server/archivedir/00000001000000A900000065 &amp;&amp; cp pg_wal/0
     transactions will be lost, but the database will remain offline until
     you free some space.)
 -->
-《マッチ度[92.660550]》アーカイブ設定を設計する時には、操作者の介入が必要であったり、アーカイブ場所の容量不足の理由でアーカイブ用コマンドが繰り返し失敗した時にどうなるかを考慮してください。
+アーカイブ設定を設計する時には、操作者の介入が必要であったり、アーカイブ場所の容量不足の理由でアーカイブ用コマンドあるいはライブラリが繰り返し失敗した時にどうなるかを考慮してください。
 例えば、これはオートチェンジャ機能のないテープに書き出している場合に発生する可能性があります。
 テープが一杯になった場合、テープを交換するまでアーカイブを行うことができなくなります。
 こうした状況を相応の早さで解消できるよう、適切に操作者に対しエラーや要求を確実に連絡できるようにしなければなりません。
@@ -1111,7 +1111,7 @@ test ! -f /mnt/server/archivedir/00000001000000A900000065 &amp;&amp; cp pg_wal/0
     disk space. You are advised to monitor the archiving process to ensure that
     it is working as you intend.
 -->
-《マッチ度[91.853035]》サーバのWALデータの生成に要する平均速度に追いついている限り、アーカイブ用コマンドの処理速度は重要ではありません。
+サーバのWALデータの生成に要する平均速度に追いついている限り、アーカイブ用コマンドあるいはライブラリの処理速度は重要ではありません。
 アーカイブプロセスが多少遅れたとしても通常の操作は続けられます。
 アーカイブ処理がかなり遅れると、災害時に損失するデータの量が増加することになります。
 また、これは<filename>pg_wal/</filename>ディレクトリ内に多くのアーカイブ処理待ちのセグメントファイルが格納され、ディスク容量が不足する状況になる可能性があることを意味します。
@@ -1126,7 +1126,7 @@ test ! -f /mnt/server/archivedir/00000001000000A900000065 &amp;&amp; cp pg_wal/0
     preserve the original relative path (<literal>%p</literal>) but it is necessary to
     preserve the file name (<literal>%f</literal>).
 -->
-《マッチ度[90.857143]》アーカイブ用コマンドを作成する時、アーカイブされるファイル名は最長64文字までで、ASCII文字と数字とドットのどんな組合せを使用しても構いません。
+アーカイブ用コマンドあるいはライブラリを作成する時、アーカイブされるファイル名は最長64文字までで、ASCII文字と数字とドットのどんな組合せを使用しても構いません。
 元の相対パス（<literal>%p</literal>）を保存する必要はありませんが、ファイル名（<literal>%f</literal>）を保存する必要はあります。
    </para>
 
@@ -1163,7 +1163,7 @@ WALアーカイブによって<productname>PostgreSQL</productname>データベ�
     storage.  <varname>archive_timeout</varname> settings of a minute or so are
     usually reasonable.
 -->
-《マッチ度[91.782554]》アーカイブコマンドは完全なWALセグメントに対してのみ呼び出されます。
+アーカイブコマンドあるいは関数は完全なWALセグメントに対してのみ呼び出されます。
 このため、サーバが少ししかWAL流量がない（処理を行わないなぎの期間がある）場合、トランザクションの完了とアーカイブ格納領域への安全な記録との間に長期にわたる遅延があることになります。
 古い未アーカイブのデータをどうするかについて制限を付けるために、<xref linkend="guc-archive-timeout"/>を設定して、強制的にサーバを新しいWALセグメントにある程度の間隔で切り替えるようにすることができます。
 強制切り替えにより早期にアーカイブされたアーカイブ済みファイルは完全に完了したファイルと同じ大きさを持つことに注意してください。
@@ -1200,10 +1200,10 @@ WALアーカイブによって<productname>PostgreSQL</productname>データベ�
     This will cause WAL files to accumulate in <filename>pg_wal/</filename> until a
     working <varname>archive_command</varname> is re-established.
 -->
-《マッチ度[86.577181]》<varname>wal_level</varname>が<literal>minimal</literal>の場合、<xref linkend="populate-pitr"/>に書かれているように、いくつかのSQLコマンドはWALロギングを回避するため最適化されます。
+<varname>wal_level</varname>が<literal>minimal</literal>の場合、<xref linkend="populate-pitr"/>に書かれているように、いくつかのSQLコマンドはWALロギングを回避するため最適化されます。
 アーカイビングもしくはストリーミングレプリケーションがこれら構文の１つを実行中に作動させられると、アーカイブ復旧のための十分な情報をWALが含まなくなります。（クラッシュ復旧は影響を受けません。）
 このことにより、<varname>wal_level</varname>はサーバの起動時のみ変更可能です。
-とは言っても、<varname>archive_command</varname>は構成ファイルを再読み込みすることで変更できます。
+とは言っても、<varname>archive_command</varname>と<varname>archive_library</varname>は構成ファイルを再読み込みすることで変更できます。
 一時的にアーカイビングを停止したい場合、１つの方法は<varname>archive_command</varname>を空文字列（<literal>''</literal>）に設定することです。
 このようにすると、動作する<varname>archive_command</varname>が再構築されるまでWALファイルは<filename>pg_wal/</filename>に蓄積します。
    </para>
@@ -1226,7 +1226,7 @@ WALアーカイブによって<productname>PostgreSQL</productname>データベ�
 -->
 ベースバックアップを取得する最も簡単な方法は<xref linkend="app-pgbasebackup"/> を実行する方法です。
 通常のファイルやTAR形式のファイルとしてベースバックアップを取得することができます。
-もし、<xref linkend="app-pgbasebackup"/>より柔軟性が求められる場合は、低レベルなAPIを使ってバックアップを作成することもできます(詳細は <xref linkend="backup-lowlevel-base-backup"/>を参照)。
+もし、<xref linkend="app-pgbasebackup"/>より柔軟性が求められる場合は、低レベルなAPIを使ってバックアップを作成することもできます（詳細は <xref linkend="backup-lowlevel-base-backup"/>を参照）。
    </para>
 
    <para>
@@ -1266,8 +1266,8 @@ WALアーカイブによって<productname>PostgreSQL</productname>データベ�
 この目的のために、ベースバックアップの過程で即座にWALアーカイブ領域に<firstterm>バックアップ履歴ファイル</firstterm>が作成されます。
 このファイルにはファイルシステムのバックアップに最初に必要とされるWALセグメントの名前が付けられます。
 例えば、最初のWALファイルが <literal>0000000100001234000055CD</literal>である場合、バックアップ履歴ファイルは<literal>0000000100001234000055CD.007C9330.backup</literal>というように名付けられます。
-(ファイル名の2番目のパートはWALファイルの厳密な位置が記載されます。通常は無視することができます。)
-一旦、安全にファイルシステムのバックアップとそのバックアップ中に使用されたWALセグメントファイル(バックアップ履歴ファイルから特定できます)を取得すると、それより数値の小さな全てのWALアーカイブセグメントはファイルシステムの復旧には必要が無く、削除することができます。
+（ファイル名の2番目のパートはWALファイルの厳密な位置が記載されます。通常は無視することができます。）
+一旦、安全にファイルシステムのバックアップとそのバックアップ中に使用されたWALセグメントファイル（バックアップ履歴ファイルから特定できます）を取得すると、それより数値の小さな全てのWALアーカイブセグメントはファイルシステムの復旧には必要が無く、削除することができます。
 しかし、データを確実に復旧させるためには数世代のバックアップセットを保持することを考慮すべきです。
    </para>
 
@@ -1324,7 +1324,7 @@ WALアーカイブによって<productname>PostgreSQL</productname>データベ�
      started using this backup API and those started using
      <xref linkend="app-pgbasebackup"/>).
 -->
-《機械翻訳》複数のバックアップを同時に実行できます(このバックアップAPIを使用して開始されたバックアップと<xref linkend="app-pgbasebackup"/>を使用して開始されたバックアップの両方)。
+複数のバックアップを同時に実行できます（このバックアップAPIを使用して開始されたバックアップと<xref linkend="app-pgbasebackup"/>を使用して開始されたバックアップの両方）。
     </para>
     <para>
   <orderedlist>
@@ -1344,7 +1344,7 @@ WALアーカイブが有効であり、正常に動作することを確認し�
      or a user who has been granted <literal>EXECUTE</literal> on the
      function) and issue the command:
 -->
-《機械翻訳》実行権限を持つユーザ<function>pg_backup_start</function>としてサーバ（どのデータベースであってもかまいません）に接続します。ユーザはスーパーユーザか、またはこの関数に<literal>EXECUTE</literal>権限を与えられたユーザです。以下のコマンドを発行します。
+実行権限を持つユーザ<function>pg_backup_start</function>としてサーバ（どのデータベースであってもかまいません）に接続します。ユーザはスーパーユーザか、またはこの関数に<literal>EXECUTE</literal>権限を与えられたユーザです。以下のコマンドを発行します。
 <programlisting>
 SELECT pg_backup_start(label => 'label', fast => false);
 </programlisting>
@@ -1354,7 +1354,7 @@ SELECT pg_backup_start(label => 'label', fast => false);
      calling <function>pg_backup_start</function> must be maintained until the end of
      the backup, or the backup will be automatically aborted.
 -->
-《機械翻訳》ここで<literal>label</literal>は、このバックアップ操作を一意に識別するために使用したい文字列です。
+ここで<literal>label</literal>は、このバックアップ操作を一意に識別するために使用したい文字列です。
 <function>pg_backup_start</function>を呼び出す接続は、バックアップが終了するまで維持されなければなりません。
 さもないと、バックアップは自動的に打ち切られます。
     </para>
@@ -1372,9 +1372,9 @@ SELECT pg_backup_start(label => 'label', fast => false);
      request an immediate checkpoint, which will finish as fast as possible using
      as much I/O as possible.
 -->
-《機械翻訳》オンラインバックアップは、常にチェックポイントの先頭から開始されます。
+オンラインバックアップは、常にチェックポイントの先頭から開始されます。
 デフォルトでは、<function>pg_backup_start</function>は、次の定期的にスケジュールされたチェックポイントが完了するまで待機します。
-これには長い時間がかかる場合があります(設定パラメータ<xref linkend="guc-checkpoint-timeout"/>および<xref linkend="guc-checkpoint-completion-target"/>を参照してください)。
+これには長い時間がかかる場合があります（設定パラメータ<xref linkend="guc-checkpoint-timeout"/>および<xref linkend="guc-checkpoint-completion-target"/>を参照してください）。
 これは、実行中のシステムへの影響を最小限に抑えるため、通常は望ましい方法です。
 できるだけ早くバックアップを開始したい場合は、<function>pg_backup_start</function>の2番目のパラメータとして<literal>true</literal>を渡すと、即時のチェックポイントが要求されます。
 このチェックポイントは、できるだけ多くのI/Oを使用してできるだけ早く完了します。
@@ -1431,7 +1431,7 @@ SELECT * FROM pg_backup_stop(wait_for_archive => true);
      vital to the backup working and must be written byte for byte without
      modification, which may require opening the file in binary mode.
 -->
-《マッチ度[89.361702]》<function>pg_stop_backup</function>は3つの値を含んだ1行を返します。
+<function>pg_backup_stop</function>は3つの値を含んだ1行を返します。
 2番目の値は、バックアップのルートディレクトリ内の<filename>backup_label</filename>という名称のファイルを作成の上、値を書き込む必要があります。
 3番目の値は、空でない限りは<filename>tablespace_map</filename>という名称のファイルを作成の上、値を書き込む必要があります。
 これらのファイルはバックアップが動作するために極めて重要であり、1バイトも変更なしに書き込まれる必要があるため、バイナリモードで開かれる必要があるかもしれません。
@@ -1463,15 +1463,15 @@ SELECT * FROM pg_backup_stop(wait_for_archive => true);
      <function>pg_backup_stop</function> terminates because of this your backup
      may not be valid.
 -->
-《マッチ度[82.098313]》バックアップ中に使用されたWALセグメントファイルがアーカイブされれば完了です。
-<function>pg_stop_backup</function>の返り値の1番目の値で識別されるファイルは、バックアップファイル一式を完結させるのに必要となる最終セグメントです。
-プライマリでは、<varname>archive_mode</varname>が有効で、かつ<literal>wait_for_archive</literal>パラメータが<literal>true</literal>であれば、<function>pg_stop_backup</function> は最終セグメントがアーカイブされるまで戻りません。
-スタンバイでは、<function>pg_stop_backup</function>がアーカイブ完了を待つためには、<varname>archive_mode</varname>は<literal>always</literal>でなければなりません。
-すでに<varname>archive_command</varname>を設定していますので、これらのファイルのアーカイブ操作は自動的に発生します。
+バックアップ中に使用されたWALセグメントファイルがアーカイブされれば完了です。
+<function>pg_backup_stop</function>の返り値の1番目の値で識別されるファイルは、バックアップファイル一式を完結させるのに必要となる最終セグメントです。
+プライマリでは、<varname>archive_mode</varname>が有効で、かつ<literal>wait_for_archive</literal>パラメータが<literal>true</literal>であれば、<function>pg_backup_stop</function> は最終セグメントがアーカイブされるまで戻りません。
+スタンバイでは、<function>pg_backup_stop</function>がアーカイブ完了を待つためには、<varname>archive_mode</varname>は<literal>always</literal>でなければなりません。
+すでに<varname>archive_command</varname>あるいは<varname>archive_library</varname>を設定していますので、これらのファイルのアーカイブ操作は自動的に発生します。
 ほとんどの場合、これは瞬時に行われます。
 しかし、バックアップの完了を確認できるよう、アーカイブシステムを監視し、遅延が無いことの確認をお勧めします。
 アーカイブコマンドの失敗によりアーカイブ処理が遅れてしまったとしても、アーカイブが成功し、そしてバックアップが完了するまで再試行を繰り返すようになっています。
-<function>pg_stop_backup</function>実行においての時間期限を設けたい場合、適切な<varname>statement_timeout</varname>の値を設定できますが、この設定値によって<function>pg_stop_backup</function>が中断したときにバックアップが正当ではない可能性があるということを肝に銘じてください。
+<function>pg_backup_stop</function>実行においての時間期限を設けたい場合、適切な<varname>statement_timeout</varname>の値を設定できますが、この設定値によって<function>pg_backup_stop</function>が中断したときにバックアップが正当ではない可能性があるということを肝に銘じてください。
     </para>
     <para>
 <!--
@@ -1486,8 +1486,8 @@ SELECT * FROM pg_backup_stop(wait_for_archive => true);
      then the backup might not include all of the WAL files and will
      therefore be incomplete and not able to be restored.
 -->
-《マッチ度[88.819876]》バックアップに必要なすべてのWALセグメントファイルのアーカイブが成功したことを、バックアップ作業の中で監視して確認するのであれば、<literal>wait_for_archive</literal>パラメータ(デフォルトでtrueです)をfalseに設定し、バックアップレコードがWALに書き込まれたら即座に<function>pg_stop_backup</function>が戻るようにすることができます。
-デフォルトでは、<function>pg_stop_backup</function>はすべてのWALがアーカイブされるのを待つので、少し時間がかかることがあります。
+バックアップに必要なすべてのWALセグメントファイルのアーカイブが成功したことを、バックアップ作業の中で監視して確認するのであれば、<literal>wait_for_archive</literal>パラメータ(デフォルトでtrueです)をfalseに設定し、バックアップレコードがWALに書き込まれたら即座に<function>pg_backup_stop</function>が戻るようにすることができます。
+デフォルトでは、<function>pg_backup_stop</function>はすべてのWALがアーカイブされるのを待つので、少し時間がかかることがあります。
 このオプションは慎重に使わなければなりません。
 WALのアーカイブを適切に監視していない場合、バックアップにはすべてのWALファイルが含まれず、不完全かもしれません。
 そうなると、リストアできません。
@@ -1594,7 +1594,7 @@ GNUの <application>tar</application>で1.23以降のバージョンを使用し
     and <filename>pg_subtrans/</filename> (but not the directories themselves) can be
     omitted from the backup as they will be initialized on postmaster startup.
 -->
-《マッチ度[52.777778]》ディレクトリ<filename>pg_dynshmem/</filename>、<filename>pg_notify/</filename>、<filename>pg_serial/</filename>、<filename>pg_snapshots/</filename>、<filename>pg_stat_tmp/</filename>、<filename>pg_subtrans/</filename>の中身はバックアップから除外できます。（ただし、ディレクトリ自体は除外できません。）
+ディレクトリ<filename>pg_dynshmem/</filename>、<filename>pg_notify/</filename>、<filename>pg_serial/</filename>、<filename>pg_snapshots/</filename>、<filename>pg_stat_tmp/</filename>、<filename>pg_subtrans/</filename>の中身はバックアップから除外できます。（ただし、ディレクトリ自体は除外できません。）
 というのも、postmaster起動時に初期化されるからです。
    </para>
 
@@ -1632,7 +1632,7 @@ GNUの <application>tar</application>で1.23以降のバージョンを使用し
     contents are critical to the proper operation of the system's recovery
     process.
 -->
-《マッチ度[89.441931]》バックアップラベルファイルには、<function>pg_start_backup</function>に付与したラベル文字列と<function>pg_start_backup</function>が実行された時刻、最初のWALファイルの名前が含まれます。
+バックアップラベルファイルには、<function>pg_backup_start</function>に付与したラベル文字列と<function>pg_backup_start</function>が実行された時刻、最初のWALファイルの名前が含まれます。
 したがって、当惑した時にバックアップファイルの中身を検索し、そのダンプファイルがどのバックアップセッションに由来したものかを確認することができます。
 テーブル空間マップファイルにはディレクトリ<filename>pg_tblspc/</filename>に存在するシンボリックリンク名と各シンボリックリンクのフルパスが含まれています。
 このファイルはあなたのためだけの情報ではありません。
@@ -1648,8 +1648,8 @@ GNUの <application>tar</application>で1.23以降のバージョンを使用し
     backup is which and how far back the associated WAL files go.
     It is generally better to follow the continuous archiving procedure above.
 -->
-《マッチ度[88.010204]》サーバが停止している時にバックアップを作成することも可能です。
-この場合、わかりきったことですが、<function>pg_start_backup</function>や<function>pg_stop_backup</function>を使用することができません。
+サーバが停止している時にバックアップを作成することも可能です。
+この場合、わかりきったことですが、<function>pg_backup_start</function>や<function>pg_backup_stop</function>を使用することができません。
 そのため、どのバックアップが、どのWALファイルと関連し、どこまで戻せばよいかを独自の方法で残さなければなりません。
 通常は、上述の継続的アーカイブ手順に従う方をお勧めします。
    </para>
@@ -1924,7 +1924,7 @@ restore_command = 'cp /mnt/server/archivedir/%f %p'
       recover to such a time, you must go back to your previous base backup
       and roll forward from there.)
 -->
-《マッチ度[86.495177]》停止時点はバックアップの終了時刻、つまり、<function>pg_stop_backup</function>の最終時刻より後の時点でなければなりません。
+停止時点はバックアップの終了時刻、つまり、<function>pg_backup_stop</function>の最終時刻より後の時点でなければなりません。
 バックアップを行っている最中のある時点までベースバックアップを使用して復旧させることはできません
 （こうした時点まで復旧させるには、その前のベースバックアップまで戻って、そこからロールフォワードしてください）。
      </para>

--- a/doc/src/sgml/backup.sgml
+++ b/doc/src/sgml/backup.sgml
@@ -927,7 +927,7 @@ WALデータをアーカイブする場合、完成したセグメントファ�
 例えば、NFSでマウントした他のマシンのディレクトリにセグメントファイルをコピーすること、あるいは、テープ装置に書き出すこと（元々のファイル名を識別する手段があることを確認してください）、それらを一度にまとめてCDに焼くこと、そのほか全く異なったなんらかの方法などです。
 柔軟性をデータベース管理者に提供するために、<productname>PostgreSQL</productname>は、どのようにアーカイブがなされたかについて一切想定しないようになっています。
 その代わりに<productname>PostgreSQL</productname>は、管理者に完全なセグメントファイルをどこか必要な場所にコピーするシェルコマンドあるいはアーカイブライブラリを指定させます。
-このコマンドは単純な<literal>cp</literal>でも構いませんし、また、複雑なC関数を呼び出しても構いません。
+このコマンドは単純な<literal>cp</literal>を使ったシェルコマンドでも構いませんし、また、複雑なC関数を呼び出しても構いません。
 全て管理者に任されています。
    </para>
 
@@ -1204,7 +1204,7 @@ WALアーカイブによって<productname>PostgreSQL</productname>データベ�
 アーカイビングもしくはストリーミングレプリケーションがこれら構文の１つを実行中に作動させられると、アーカイブ復旧のための十分な情報をWALが含まなくなります。（クラッシュ復旧は影響を受けません。）
 このことにより、<varname>wal_level</varname>はサーバの起動時のみ変更可能です。
 とは言っても、<varname>archive_command</varname>と<varname>archive_library</varname>は構成ファイルを再読み込みすることで変更できます。
-一時的にアーカイビングを停止したい場合、１つの方法は<varname>archive_command</varname>を空文字列（<literal>''</literal>）に設定することです。
+シェルでアーカイブしており、一時的にアーカイビングを停止したい場合、１つの方法は<varname>archive_command</varname>を空文字列（<literal>''</literal>）に設定することです。
 このようにすると、動作する<varname>archive_command</varname>が再構築されるまでWALファイルは<filename>pg_wal/</filename>に蓄積します。
    </para>
   </sect2>
@@ -1344,7 +1344,7 @@ WALアーカイブが有効であり、正常に動作することを確認し�
      or a user who has been granted <literal>EXECUTE</literal> on the
      function) and issue the command:
 -->
-実行権限を持つユーザ<function>pg_backup_start</function>としてサーバ（どのデータベースであってもかまいません）に接続します。ユーザはスーパーユーザか、またはこの関数に<literal>EXECUTE</literal>権限を与えられたユーザです。以下のコマンドを発行します。
+<function>pg_backup_start</function>の実行権限を持つユーザとしてサーバ（どのデータベースであってもかまいません）に接続します。ユーザはスーパーユーザか、またはこの関数に<literal>EXECUTE</literal>権限を与えられたユーザです。以下のコマンドを発行します。
 <programlisting>
 SELECT pg_backup_start(label => 'label', fast => false);
 </programlisting>

--- a/doc/src/sgml/backup.sgml
+++ b/doc/src/sgml/backup.sgml
@@ -927,7 +927,7 @@ WALデータをアーカイブする場合、完成したセグメントファ�
 例えば、NFSでマウントした他のマシンのディレクトリにセグメントファイルをコピーすること、あるいは、テープ装置に書き出すこと（元々のファイル名を識別する手段があることを確認してください）、それらを一度にまとめてCDに焼くこと、そのほか全く異なったなんらかの方法などです。
 柔軟性をデータベース管理者に提供するために、<productname>PostgreSQL</productname>は、どのようにアーカイブがなされたかについて一切想定しないようになっています。
 その代わりに<productname>PostgreSQL</productname>は、管理者に完全なセグメントファイルをどこか必要な場所にコピーするシェルコマンドあるいはアーカイブライブラリを指定させます。
-このコマンドは単純な<literal>cp</literal>でも構いませんし、また、複雑なシェルスクリプトを呼び出しても構いません。
+このコマンドは単純な<literal>cp</literal>でも構いませんし、また、複雑なC関数を呼び出しても構いません。
 全て管理者に任されています。
    </para>
 
@@ -943,7 +943,7 @@ WALデータをアーカイブする場合、完成したセグメントファ�
     these settings will always be placed in the
     <filename>postgresql.conf</filename> file.
 -->
-WAL保管を有効にするには、<xref linkend="guc-wal-level"/>設定パラメータを<literal>replica</literal>以上に、<xref linkend="guc-archive-mode"/>を<literal>on</literal>に設定し、<xref linkend="guc-archive-command"/>設定パラメータで使用するシェルコマンドを指定するか、<xref linkend="guc-archive-library"/>設定パラメータで使用するライブラリを指定します。
+WALアーカイブを有効にするには、<xref linkend="guc-wal-level"/>設定パラメータを<literal>replica</literal>以上に、<xref linkend="guc-archive-mode"/>を<literal>on</literal>に設定し、<xref linkend="guc-archive-command"/>設定パラメータで使用するシェルコマンドを指定するか、<xref linkend="guc-archive-library"/>設定パラメータで使用するライブラリを指定します。
 実際には、これらの設定は常に<filename>postgresql.conf</filename>ファイルに置かれます。
    </para>
 
@@ -1040,7 +1040,7 @@ test ! -f /mnt/server/archivedir/00000001000000A900000065 &amp;&amp; cp pg_wal/0
     aborts and gets restarted by the postmaster. In such cases, the failure is
     not reported in <xref linkend="pg-stat-archiver-view"/>.
 -->
-アーカイブ用コマンドがシグナル（サーバのシャットダウンの一部として使用される<systemitem>SIGTERM</systemitem>以外）やシェルによる125以上の終了ステータスを持つエラー（command not foundなど）、あるいはアーカイブ関数が<literal>ERROR</literal>または<literal>FATAL</literal>を出力したことによって終了すると、アーカイバプロセスは中止され、postmasterによって再起動されます。
+アーカイブコマンドがシグナル（サーバのシャットダウンの一部として使用される<systemitem>SIGTERM</systemitem>以外）やシェルによる125以上の終了ステータスを持つエラー（command not foundなど）、あるいはアーカイブ関数が<literal>ERROR</literal>または<literal>FATAL</literal>を出力したことによって終了すると、アーカイバプロセスは中止され、postmasterによって再起動されます。
 このような場合、失敗は<xref linkend="pg-stat-archiver-view"/>では報告されません。
    </para>
 


### PR DESCRIPTION
1453-1454行あたりで、原文の間違いでarchive_commandが繰り返されているのは訳からは削除しています。 なお、原文の間違いについては修正パッチを本家に投稿済みです。