### PR TITLE
イベントトリガ関数のSub-object IDを翻訳

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -36934,7 +36934,10 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
        <row>
         <entry><literal>objsubid</literal></entry>
         <entry><type>integer</type></entry>
+<!--
         <entry>Sub-object ID (e.g., attribute number for a column)</entry>
+-->
+        <entry>オブジェクトのサブID（例えば、列の列番号）</entry>
        </row>
        <row>
         <entry><literal>command_tag</literal></entry>
@@ -37065,7 +37068,10 @@ FOR EACH ROW EXECUTE FUNCTION suppress_redundant_updates_trigger();
        <row>
         <entry><literal>objsubid</literal></entry>
         <entry><type>integer</type></entry>
+<!--
         <entry>Sub-object ID (e.g., attribute number for a column)</entry>
+-->
+        <entry>オブジェクトのサブID（例えば、列の列番号）</entry>
        </row>
        <row>
         <entry><literal>original</literal></entry>


### PR DESCRIPTION
`pg_event_trigger_ddl_commands()`関数と`pg_event_trigger_dropped_objects()`関数の`objsubid`列の説明だけ翻訳が抜けていたので翻訳してみました。