### PR TITLE
update trigger for 15.0

### DIFF
--- a/doc/src/sgml/trigger.sgml
+++ b/doc/src/sgml/trigger.sgml
@@ -243,11 +243,11 @@
     statement-level <literal>AFTER</literal> <command>INSERT</command>
     triggers.
 -->
-<command>INSERT</command>が<literal>ON CONFLICT DO UPDATE</literal>句を含む場合、<varname>EXCLUDED</varname>列が参照されていると、行単位<literal>BEFORE</literal> <command>INSERT</command>トリガおよび行単位<literal>BEFORE</literal> <command>UPDATE</command>トリガの両方の効果が適用され、それが更新後の行の最後の状態から明らかな場合がありえます。
+<command>INSERT</command>が<literal>ON CONFLICT DO UPDATE</literal>句を含む場合、<varname>EXCLUDED</varname>列が参照されていると、行レベルの<literal>BEFORE</literal> <command>INSERT</command>トリガおよび行レベルの<literal>BEFORE</literal> <command>UPDATE</command>トリガの両方の効果が適用され、それが更新後の行の最後の状態から明らかな場合がありえます。
 ただし、両方の行レベルの<literal>BEFORE</literal>トリガを実行するために<varname>EXCLUDED</varname>の参照が必要なわけではありません。
-驚くような結果の可能性について、<literal>BEFORE</literal> <command>INSERT</command>と<literal>BEFORE</literal> <command>UPDATE</command>の両方の文単位トリガーがあり、それらがいずれも挿入あるいは更新対象の行に影響を与える場合に考慮すべきです（これは更新が冪等ではないが、ほぼ同等であるときには、それでも問題になります）。
-文単位の<command>UPDATE</command>トリガは<literal>ON CONFLICT DO UPDATE</literal>が指定されたとき、その<command>UPDATE</command>によって行が影響を受けたかどうかに関わらず（そしてその代替である<command>UPDATE</command>部分が実行されたかどうかに関わらず）実行されることに注意してください。
-<literal>ON CONFLICT DO UPDATE</literal>句のある<command>INSERT</command>では、まず文単位の<literal>BEFORE</literal> <command>INSERT</command>トリガ、次に文単位の<literal>BEFORE</literal> <command>UPDATE</command>トリガ、次いで文単位の<literal>AFTER</literal> <command>UPDATE</command>トリガ、最後に文単位の<literal>AFTER</literal> <command>INSERT</command>トリガを実行します。
+驚くような結果の可能性について、<literal>BEFORE</literal> <command>INSERT</command>と<literal>BEFORE</literal> <command>UPDATE</command>の両方の行レベルのトリガがあり、それらがいずれも挿入あるいは更新対象の行に影響を与える場合に考慮すべきです（これは更新が冪等ではないが、ほぼ同等であるときには、それでも問題になります）。
+文レベルの<command>UPDATE</command>トリガは<literal>ON CONFLICT DO UPDATE</literal>が指定されたとき、その<command>UPDATE</command>によって行が影響を受けたかどうかに関わらず（そしてその代替である<command>UPDATE</command>部分が実行されたかどうかに関わらず）実行されることに注意してください。
+<literal>ON CONFLICT DO UPDATE</literal>句のある<command>INSERT</command>では、まず文レベルの<literal>BEFORE</literal> <command>INSERT</command>トリガ、次に文レベルの<literal>BEFORE</literal> <command>UPDATE</command>トリガ、次いで文レベルの<literal>AFTER</literal> <command>UPDATE</command>トリガ、最後に文レベルの<literal>AFTER</literal> <command>INSERT</command>トリガを実行します。
    </para>
 
    <para>
@@ -290,8 +290,8 @@
     the <command>MERGE</command> query and (for row-level triggers) what
     actions are performed.
 -->
-《機械翻訳》<command>MERGE</command>には個別のトリガーは定義されません。
-かわりに、ステートメント・レベルまたは行レベルの<command>UPDATE</command>、<command>DELETE</command>および<command>INSERT</command>トリガーが、<command>MERGE</command>問合せで指定されたアクション(ステートメント・レベル・トリガーの場合)および実行されたアクション(行レベル・トリガーの場合)に応じて起動されます。
+<command>MERGE</command>には個別のトリガは定義されません。
+かわりに、文レベルまたは行レベルの<command>UPDATE</command>、<command>DELETE</command>および<command>INSERT</command>トリガが、<command>MERGE</command>問い合わせで指定されたアクション(文レベルトリガの場合)および実行されたアクション(行レベルトリガの場合)に応じて起動されます。
    </para>
 
    <para>
@@ -307,10 +307,10 @@
     triggers are fired for certain types of action, no row-level triggers
     are fired for the same kind of action.
 -->
-《機械翻訳》<command>MERGE</command>コマンドの実行中、文レベルの<literal>BEFORE</literal>および<literal>AFTER</literal>トリガーは、アクションが最終的に実行されるかどうかに関係なく、<command>MERGE</command>コマンドのアクションで指定されたイベントに対して発行されます。
-これは、行を更新しない<command>UPDATE</command>文と同じですが、文レベルのトリガーが発行されます。
-行レベルのトリガーは、行が実際に更新、挿入または削除されたときにのみ発行されます。
-したがって、文レベルのトリガーは特定のタイプのアクションに対して発行されますが、同じ種類のアクションに対して行レベルのトリガーが発行されないことは完全に合法です。
+<command>MERGE</command>コマンドの実行中、文レベルの<literal>BEFORE</literal>および<literal>AFTER</literal>トリガは、アクションが最終的に実行されるかどうかに関係なく、<command>MERGE</command>コマンドのアクションで指定されたイベントに対して発行されます。
+これは、行を更新しない<command>UPDATE</command>文と同じですが、文レベルのトリガは発行されます。
+行レベルのトリガは、行が実際に更新、挿入または削除されたときにのみ発行されます。
+したがって、文レベルのトリガが特定のタイプのアクションに対して発行されるものの、同じ種類のアクションに対して行レベルのトリガが発行されないことは完全に合法です。
    </para>
 
    <para>


### PR DESCRIPTION
trigger.sgmlの15.0対応です。

新規で対応すべきところは《機械翻訳》で始まる2段落だけだったのですが、参考に確認したところで「トリガー」を見つけ、さらに「文/行単位」と「文/行レベル」の原文との不一致を見つけてしまったので、そちらも合わせて対応しています。
（「文/行単位」と「文/行レベル」は原文でも「どちらの言い方もあるよ」とは言っているので、そこまでこだわらなくてもいいのかもしれませんが、（気づいた範囲で）より原文に忠実にしています。）