### PR TITLE
update pgcrypto for 15.0

### DIFF
--- a/doc/src/sgml/pgcrypto.sgml
+++ b/doc/src/sgml/pgcrypto.sgml
@@ -38,7 +38,7 @@
   <filename>pgcrypto</filename> requires OpenSSL and won't be installed if
   OpenSSL support was not selected when PostgreSQL was built.
 -->
-《機械翻訳》<filename>pgcrypto</filename>はOpenSSLを必要とし、PostgreSQLの構築時にOpenSSLサポートが選択されなかった場合にはインストールされません。
+<filename>pgcrypto</filename>はOpenSSLを必要とし、PostgreSQLの構築時にOpenSSLサポートが選択されなかった場合にはインストールされません。
  </para>
 
  <sect2>
@@ -69,10 +69,10 @@ digest(data bytea, type text) returns bytea
     Moreover, any digest algorithm <productname>OpenSSL</productname> supports
     is automatically picked up.
 -->
-《マッチ度[64.108911]》与えられた<parameter>data</parameter>のバイナリハッシュを計算します。
+与えられた<parameter>data</parameter>のバイナリハッシュを計算します。
 <parameter>type</parameter>は使用するアルゴリズムです。
 標準アルゴリズムは<literal>md5</literal>、<literal>sha1</literal>、<literal>sha224</literal>、<literal>sha256</literal>、<literal>sha384</literal>、および<literal>sha512</literal>です。
-<filename>pgcrypto</filename>が<productname>OpenSSL</productname>付きで構築された場合、より多くのアルゴリズムを利用することができます。
+さらに、<productname>OpenSSL</productname>がサポートするダイジェストアルゴリズムが自動的に選択されます。
    </para>
 
    <para>
@@ -1144,9 +1144,14 @@ pgp_sym_encrypt(data, psw, 'compress-algo=1, cipher-algo=aes256')
 使用する暗号アルゴリズム。
    </para>
 <literallayout>
+<!--
 Values: bf, aes128, aes192, aes256, 3des, cast5
 Default: aes128
 Applies to: pgp_sym_encrypt, pgp_pub_encrypt
+-->
+値: bf, aes128, aes192, aes256, 3des, cast5
+デフォルト: aes128
+適用範囲: pgp_sym_encrypt, pgp_pub_encrypt
 </literallayout>
   </sect4>
 
@@ -1731,8 +1736,8 @@ gen_random_uuid() returns uuid
    internally calls the <link linkend="functions-uuid">core
    function</link> of the same name.)
 -->
-《マッチ度[52.317881]》バージョン4(ランダムな)UUIDを返します。
-(廃れたものです。この関数は今ではコアの<productname>PostgreSQL</productname>にも含まれています。)
+バージョン4(ランダムな)UUIDを返します。
+(廃れたものです。この関数は内部では同名の<link linkend="functions-uuid">コア関数</link>を呼び出します。)
   </para>
  </sect2>
 
@@ -1772,8 +1777,8 @@ ZLIB付きでコンパイルされた場合、PGP暗号化関数は暗号化前�
     <filename>pgcrypto</filename> requires <productname>OpenSSL</productname>.
     Otherwise, it will not be built or installed.
 -->
-《機械翻訳》<filename>pgcrypto</filename>は<productname>OpenSSL</productname>を必要とします。
-そうしないと、構築もインストールもされません。
+<filename>pgcrypto</filename>は<productname>OpenSSL</productname>を必要とします。
+そうでなければ、構築もインストールもされません。
    </para>
 
    <para>


### PR DESCRIPTION
pgcrypto.sgml の15.0対応です。


差分の量が多いように見えたのですが、ほとんどがOpenSSLを必須にしたことによる削除でした。