### PR TITLE
fix oversight in rule.sgml

### DIFF
--- a/doc/src/sgml/rules.sgml
+++ b/doc/src/sgml/rules.sgml
@@ -1182,8 +1182,8 @@ SELECT t1.a, t2.b, t1.ctid FROM t1, t2 WHERE t1.a = t2.a;
     updatable</firstterm>.  For detailed information on the kinds of view that can
     be automatically updated, see <xref linkend="sql-createview"/>.
 -->
-副問い合わせが単一のテーブルを参照しかつ十分に単純である時、リライタは副問い合わせを被参照テーブルに自動的に置き換え、したがって、<command>INSERT</command>、<command>UPDATE</command>あるいは<command>DELETE</command>を適切な方法で被参照テーブルに適用する事ができます。
-この場合の<quote>十分に単純</quote>であるとは<firstterm>自動的に更新可能</firstterm>ある事です。より詳細な自動的に更新可能なビューの情報については、<xref linkend="sql-createview"/>を参照してください。
+副問い合わせが単一の基底リレーションを参照しかつ十分に単純である時、リライタは副問い合わせを基となる基底リレーションに自動的に置き換え、したがって、<command>INSERT</command>、<command>UPDATE</command>あるいは<command>DELETE</command>を適切な方法で基底リレーションに適用する事ができます。
+この場合の<quote>十分に単純</quote>なビューは<firstterm>自動的に更新可能</firstterm>であると呼ばれます。自動的に更新可能なビューに関するより詳細な情報については、<xref linkend="sql-createview"/>を参照してください。
 </para>
 
 <para>
@@ -1277,7 +1277,7 @@ SELECT t1.a, t2.b, t1.ctid FROM t1, t2 WHERE t1.a = t2.a;
     the query as an update on the underlying base relation, an error will
     be thrown because the executor cannot update a view as such.
 -->
-ビューに<literal>INSTEAD</literal>ルールも<literal>INSTEAD OF</literal>トリガも定義されておらず、かつ、リライタが問い合わせを自動的に被参照テーブルへの更新に書き換える事ができなかった場合、エグゼキュータはビューを更新できませんのでエラーが発生します。
+ビューに<literal>INSTEAD</literal>ルールも<literal>INSTEAD OF</literal>トリガも定義されておらず、かつ、リライタが問い合わせを自動的に基となる基底リレーションへの更新に書き換える事ができなかった場合、エグゼキュータはビューを更新できませんのでエラーが発生します。
 </para>
 
 </sect2>


### PR DESCRIPTION
rules.sgml で原文に追従できていなかった部分を見つけました。

具体的にはrelationに対して「テーブル」と訳している部分がありました。おそらくviewはテーブルに限らずリレーションに対して作れるよということで、原文が変わったのだと思いますが、それに追従できていませんでした。15で変更されたものではないので、今回の翻訳でも更新の対象にならなかったのだろうと思います。