### PR TITLE
update plpython for 15.0

### DIFF
--- a/doc/src/sgml/plpython.sgml
+++ b/doc/src/sgml/plpython.sgml
@@ -23,7 +23,7 @@
   To install PL/Python in a particular database, use
   <literal>CREATE EXTENSION plpython3u</literal>.
 -->
-《機械翻訳》特定のデータベースにPL/Pythonをインストールするには、<literal>CREATE EXTENSION plpython3u</literal>を使用します。
+PL/Pythonを特定のデータベースにインストールするには、<literal>CREATE EXTENSION plpython3u</literal>を使用してください。
  </para>
 
   <tip>
@@ -49,11 +49,11 @@
   database administrator.  Only superusers can create functions in
   untrusted languages such as <literal>plpython3u</literal>.
 -->
-《マッチ度[96.217852]》PL/Pythonは<quote>信頼されない</quote>、つまり、ユーザが実行可能なことを制限する方法を提供しない言語としてのみ利用可能です。
-したがって、<literal>plpythonu</literal>という名前に変更されました。
+PL/Pythonは<quote>信頼されない</quote>、つまり、ユーザが実行可能なことを制限する方法を提供しない言語としてのみ利用可能です。
+したがって、<literal>plpython3u</literal>という名前に変更されました。
 Pythonで新しい安全な実行手法が開発されたら、将来信頼できる<literal>plpython</literal>の亜種は利用可能になるかもしれません。
 データベース管理者としてログインしたユーザにより行えることをすべて行うことができますので、信頼されないPL/Pythonによる関数開発者は、その関数は不必要なものを行うために使用できないことに注意しなければなりません。
-スーパーユーザのみが<literal>plpythonu</literal>などの信頼されない言語で関数を作成することができます。
+スーパーユーザのみが<literal>plpython3u</literal>などの信頼されない言語で関数を作成することができます。
  </para>
 
  <note>
@@ -252,7 +252,7 @@ PostgreSQLの<type>boolean</type>はPythonの<type>bool</type>に変換されま
        PostgreSQL <type>smallint</type>, <type>int</type>, <type>bigint</type>
        and <type>oid</type> are converted to Python <type>int</type>.
 -->
-《マッチ度[50.746269]》PostgreSQLの<type>real</type>および<type>double</type>はPythonの<type>float</type>に変換されます。
+PostgreSQLの<type>smallint</type>、<type>int</type>、<type>bigint</type>および<type>oid</type>はPythonの<type>int</type>に変換されます。
       </para>
      </listitem>
 
@@ -293,7 +293,7 @@ PostgreSQLの<type>numeric</type>はPythonの<type>Decimal</type>に変換され
 <!--
        PostgreSQL <type>bytea</type> is converted to Python <type>bytes</type>.
 -->
-《マッチ度[79.166667]》PostgreSQLの<type>boolean</type>はPythonの<type>bool</type>に変換されます。
+PostgreSQLの<type>bytea</type>は、Pythonの<type>bytes</type>に変換されます。
       </para>
      </listitem>
 
@@ -304,7 +304,7 @@ PostgreSQLの<type>numeric</type>はPythonの<type>Decimal</type>に変換され
        are converted to a Python <type>str</type> (in Unicode like all Python
        strings).
 -->
-《機械翻訳》PostgreSQLの文字列型を含む他のすべてのデータ型は、Python<type>str</type>に変換されます(すべてのPython文字列と同様にUnicodeで)。
+PostgreSQLの文字列型を含む、上記以外のデータ型はすべてPythonの<type>str</type>に(すべてのPython文字列と同様にUnicodeで)変換されます。
       </para>
      </listitem>
 
@@ -313,7 +313,7 @@ PostgreSQLの<type>numeric</type>はPythonの<type>Decimal</type>に変換され
 <!--
        For nonscalar data types, see below.
 -->
-スカラ型以外については後述します。
+スカラデータ型以外については後述します。
       </para>
      </listitem>
     </itemizedlist>
@@ -349,7 +349,7 @@ PostgreSQLの戻り値の型が<type>boolean</type>の場合、戻り値は<emph
        Python built-ins, with the result being converted to
        <type>bytea</type>.
 -->
-《マッチ度[74.528302]》PostgreSQLの戻り値の型が<type>bytea</type>の場合、戻り値は文字列(Python 2)またはbytes(Python 3)に、それぞれ対応するPythonのビルトインを使用して変換され、その結果が<type>bytea</type>に変換されます。
+PostgreSQLの戻り値の型が<type>bytea</type>の場合、対応するPythonのビルトインを使用してPythonの<type>bytes</type>に変換され、その結果が<type>bytea</type>に変換されます。
       </para>
      </listitem>
 
@@ -372,7 +372,7 @@ PostgreSQLの戻り値の型が<type>boolean</type>の場合、戻り値は<emph
        Strings are automatically converted to the PostgreSQL server encoding
        when they are passed to PostgreSQL.
 -->
-《機械翻訳》文字列はPostgreSQLに渡されるときに自動的にPostgreSQLサーバのエンコーディングに変換されます。
+文字列はPostgreSQLに渡される時に、自動的にPostgreSQLサーバの符号化方式に変換されます。
       </para>
      </listitem>
 
@@ -1867,7 +1867,7 @@ plpy.execute("UPDATE tbl SET %s = %s WHERE key = %s" % (
    <literal>plpythonu</literal> and <literal>plpython2u</literal> language
    names.
 -->
-《機械翻訳》PL/PythonはPython 3のみをサポートしています。
+PL/PythonはPython 3のみをサポートします。
 <productname>PostgreSQL</productname>の以前のバージョンでは、<literal>plpythonu</literal>と<literal>plpython2u</literal>という言語名を使用してPython 2がサポートされていました。
   </para>
  </sect1>
@@ -1946,7 +1946,7 @@ Pythonインタプリタにより受け付けられる環境変数の一部は�
    the <command>python</command> man page are only effective in a
    command-line interpreter and not an embedded Python interpreter.)
 -->
-（<command>python</command>マニュアルページに列挙された環境変数の一部はコマンドラインインタプリタでのみ影響を与え埋め込みPythonインタプリタには影響しないというPL/Pythonの制御を超えたPythonの詳細実装があるようです。）
+（<command>python</command>マニュアルページに列挙された環境変数の一部はコマンドラインインタプリタでのみ影響を与え、組み込みPythonインタプリタには影響しないというPL/Pythonの制御を超えたPythonの詳細実装があるようです。）
   </para>
  </sect1>
 </chapter>


### PR DESCRIPTION
plpython.sgmlの15.0対応です。

差分が大きいように見えたのですが、ほとんどがバージョン2系統のサポートをやめたことによる削除ですね。