### PR TITLE
第4章の文章表現を見直しました。

### DIFF
--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -200,11 +200,11 @@ SQL構文は、どのトークンがコマンドを識別し、どれがオペ�
     standard.
 -->
 SQL識別子とキーワードは、文字（<literal>a</literal>〜<literal>z</literal>および発音区別符号付き文字と非Latin文字)、アンダースコア（<literal>_</literal>）で始まらなければいけません。
-識別子またはキーワードの中で続く文字は、文字、アンダースコア、数字（<literal>0</literal>〜<literal>9</literal>）あるいはドル記号(<literal>$</literal>)を使用することができます。
+識別子またはキーワードの中で続く文字は、文字、アンダースコア、数字（<literal>0</literal>〜<literal>9</literal>）あるいはドル記号(<literal>$</literal>)を使用できます。
 標準SQLの記述に従うと、ドル記号は識別子内では使用できないことに注意してください。
 ですから、これを使用するとアプリケーションの移植性は低くなる可能性があります。
 標準SQLでは、数字を含む、あるいはアンダースコアで始まったり終わったりするキーワードは定義されていません。
-したがって、この形式の識別子は標準の今後の拡張と競合する可能性がないという意味で安全と言えます。
+したがって、この形式の識別子は標準の今後の拡張と競合する可能性に対して安全です。
    </para>
 
    <para>
@@ -325,7 +325,7 @@ UPDATE "my_table" SET "a" = 5;
     to write portable applications you are advised to always quote a
     particular name or never quote it.)
 -->
-引用符が付かない名前は常に小文字に解釈されますが、識別子を引用符で囲むことによって大文字と小文字が区別されるようになります。
+引用符が付かない名前は常に小文字に解釈されますが、識別子を引用符で囲むことによって大文字と小文字が区別されます。
 例えば、識別子<literal>FOO</literal>、<literal>foo</literal>、<literal>"foo"</literal>は<productname>PostgreSQL</productname>によれば同じものとして解釈されますが、<literal>"Foo"</literal>と<literal>"FOO"</literal>は、これら3つとも、またお互いに違ったものとして解釈されます
 （<productname>PostgreSQL</productname>が引用符の付かない名前を小文字として解釈することは標準SQLと互換性がありません。標準SQLでは引用符の付かない名前は大文字に解釈されるべきだとされています。
 したがって標準SQLによれば、<literal>foo</literal>は<literal>"FOO"</literal>と同じであるべきで、<literal>"foo"</literal>とは異なるはずなのです。
@@ -363,7 +363,7 @@ UPDATE "my_table" SET "a" = 5;
 例えば、<literal>U&amp;"foo"</literal>となります。
 （これにより演算子<literal>&amp;</literal>との不明確性が生じることに注意してください。
 この問題を回避するには空白を演算子の前後に入れます。）
-引用符の中で、Unicode文字はバックスラッシュとそれに続く４桁１６進数の文字コード番号で、またはもう１つの方法として、バックスラッシュに続いてプラス符号、そして続いた６桁１６進数の文字コード番号によりエスケープ形式で指定されます。
+引用符の中で、Unicode文字はバックスラッシュとそれに続く4桁16進数の文字コード番号で、またはもう1つの方法として、バックスラッシュに続いてプラス符号、そして続いた6桁16進数の文字コード番号によりエスケープ形式で指定されます。
 例えば、識別子<literal>"data"</literal>は次のように書くことができます。
 <programlisting>
 U&amp;"d\0061t\+000061"
@@ -385,7 +385,7 @@ U&amp;"\0441\043B\043E\043D"
     the <literal>UESCAPE</literal><indexterm><primary>UESCAPE</primary></indexterm>
     clause after the string, for example:
 -->
-バックスラッシュ以外のエスケープ文字を使用したい場合、文字列の後に<literal>UESCAPE</literal><indexterm><primary>UESCAPE</primary></indexterm>句を使用して指定することが可能です。例をあげます。
+バックスラッシュ以外のエスケープ文字を使用したい場合、文字列の後に<literal>UESCAPE</literal><indexterm><primary>UESCAPE</primary></indexterm>句を使用して指定できます。例をあげます。
 <programlisting>
 U&amp;"d!0061t!+000061" UESCAPE '!'
 </programlisting>
@@ -396,7 +396,7 @@ U&amp;"d!0061t!+000061" UESCAPE '!'
     written in single quotes, not double quotes,
     after <literal>UESCAPE</literal>.
 -->
-エスケープ文字には、16進表記用の文字、プラス記号、単一引用符、二重引用符、空白文字以外の任意の単一文字を使用することができます。
+エスケープ文字には、16進表記用の文字、プラス記号、単一引用符、二重引用符、空白文字以外の任意の単一文字を使用できます。
 エスケープ文字は<literal>UESCAPE</literal>の後に二重引用符ではなく単一引用符で記述していることに注意してください。
    </para>
 
@@ -574,7 +574,7 @@ SELECT 'foo'      'bar';
 -->
 <productname>PostgreSQL</productname>では、また、<quote>エスケープ</quote>文字列定数を受け付けます。
 これは標準SQLの拡張です。
-エスケープ文字列定数は、<literal>E</literal>(大文字でも小文字でもかまいません)を開始単一引用符の直前に記述することで指定されます。
+エスケープ文字列定数は、<literal>E</literal>（大文字でも小文字でもかまいません）を開始単一引用符の直前に記述することで指定されます。
 例えば<literal>E'foo'</literal>です。
 （複数行に渡るエスケープ文字列定数では、最初の開始引用符の前にのみ<literal>E</literal>を記述してください。）
 エスケープ文字列の中では、バックスラッシュ文字（<literal>\</literal>）によりC言語のような<firstterm>バックスラッシュ</firstterm>シーケンスが開始し、その中でバックスラッシュとそれに続く文字の組み合わせが（<xref linkend="sql-backslash-table"/>で示したように）特別なバイト値を表現します。
@@ -643,7 +643,7 @@ SELECT 'foo'      'bar';
 <!--
         <entry>octal byte value</entry>
 -->
-        <entry>８進数バイト値</entry>
+        <entry>8進数バイト値</entry>
        </row>
        <row>
         <entry>
@@ -654,7 +654,7 @@ SELECT 'foo'      'bar';
 <!--
         <entry>hexadecimal byte value</entry>
 -->
-        <entry>１６進数バイト値</entry>
+        <entry>16進数バイト値</entry>
        </row>
        <row>
         <entry>
@@ -680,7 +680,7 @@ SELECT 'foo'      'bar';
      <literal>\'</literal>, in addition to the normal way of <literal>''</literal>.
 -->
 バックスラッシュの後のそのほかの全ての文字はそのまま扱われます。
-従って、バックスラッシュ文字を含ませるときは２つのバックスラッシュ（<literal>\\</literal>）を記載します。
+従って、バックスラッシュ文字を含ませるときは2つのバックスラッシュ（<literal>\\</literal>）を記載します。
 同時に、エスケープ文字列の中では、単一引用符を、通常の方法の<literal>''</literal>に加え、<literal>\'</literal>としても含めることができます。
     </para>
 
@@ -695,7 +695,7 @@ SELECT 'foo'      'bar';
      will check that the character conversion is possible.
 -->
 特に8進数や16進数エスケープを用いて作成されるバイトシーケンスが、サーバ文字セット符号化方式において有効な文字で構成されていることはコードを書く人の責任です。
-便利な代替手段は、Unicodeエスケープか、<xref linkend="sql-syntax-strings-uescape"/>で説明するもう一つのUnicodeエスケープ構文を代わりとして使用することです。そうすればサーバが文字変換が可能か検査するでしょう。
+便利な代替手段は、Unicodeエスケープか、<xref linkend="sql-syntax-strings-uescape"/>で説明するもう一つのUnicodeエスケープ構文を代わりとして使用することです。そうすればサーバが文字変換を可能か検査するでしょう。
     </para>
 
     <caution>
@@ -715,7 +715,7 @@ SELECT 'foo'      'bar';
      character, write the string constant with an <literal>E</literal>.
 -->
 設定パラメータ<xref linkend="guc-standard-conforming-strings"/>が <literal>off</literal>の場合、<productname>PostgreSQL</productname>はバックスラッシュエスケープを通常の文字列定数とエスケープ文字列定数の両方で認識します。
-しかし、<productname>PostgreSQL</productname>9.1からデフォルトは<literal>on</literal>になりました。これはバックスラッシュエスケープはエスケープ文字列定数でのみ認識されるということになります。
+しかし、<productname>PostgreSQL</productname>9.1からデフォルトは<literal>on</literal>になりました。これはバックスラッシュエスケープがエスケープ文字列定数でのみ認識されるということになります。
 この振る舞いはSQL標準仕様に即していますが、バックスラッシュエスケープを常に認識するという歴史的な動作に依存しているアプリケーションは動作しなくなるでしょう。
 回避策として、このパラメータを<literal>off</literal>にすることはできますが、バックスラッシュエスケープの使用を避けるよう移植するのが良いでしょう。
 特殊文字を表現するためにバックスラッシュを使用する必要がある場合、<literal>E</literal>をつけて文字列定数を記述してください。
@@ -777,7 +777,7 @@ Unicodeエスケープ文字列定数は、<literal>U&amp;</literal>（大文字
 例えば、<literal>U&amp;'foo'</literal>となります。
 （これにより演算子<literal>&amp;</literal>との曖昧性が生じることに注意してください。
 この問題を回避するには空白を演算子の前後に入れます。）
-引用符の中で、Unicode文字はバックスラッシュとそれに続く４桁１６進数の文字コード番号で、またはもう１つの方法として、バックスラッシュに続いてプラス符号、そして続いた６桁１６進数の文字コード番号によりエスケープ形式で指定されます。
+引用符の中で、Unicode文字はバックスラッシュとそれに続く4桁16進数の文字コード番号で、またはもう1つの方法として、バックスラッシュに続いてプラス符号、そして続いた6桁16進数の文字コード番号によりエスケープ形式で指定されます。
 例えば、文字列<literal>'data'</literal>は次のように書かれます。
 <programlisting>
 U&amp;'d\0061t\+000061'
@@ -799,7 +799,7 @@ U&amp;'\0441\043B\043E\043D'
      the <literal>UESCAPE</literal><indexterm><primary>UESCAPE</primary></indexterm>
      clause after the string, for example:
 -->
-バックスラッシュ以外のエスケープ文字を使用したい場合、文字列の後に<literal>UESCAPE</literal><indexterm><primary>UESCAPE</primary></indexterm>句を使用して指定することが可能です。例をあげます。
+バックスラッシュ以外のエスケープ文字を使用したい場合、文字列の後に<literal>UESCAPE</literal><indexterm><primary>UESCAPE</primary></indexterm>句を使用して指定できます。例をあげます。
 <programlisting>
 U&amp;'d!0061t!+000061' UESCAPE '!'
 </programlisting>
@@ -808,7 +808,7 @@ U&amp;'d!0061t!+000061' UESCAPE '!'
      hexadecimal digit, the plus sign, a single quote, a double quote,
      or a whitespace character.
 -->
-エスケープ文字には、16進表記用の文字、プラス記号、単一引用符、二重引用符、空白文字以外の任意の単一文字を使用することができます。
+エスケープ文字には、16進表記用の文字、プラス記号、単一引用符、二重引用符、空白文字以外の任意の単一文字を使用できます。
     </para>
 
     <para>
@@ -904,8 +904,8 @@ $SomeTag$Dianne's horse$SomeTag$
      dollar signs, unless they are part of a sequence matching the opening
      tag.
 -->
-ドル引用符付けされた文字列の内側では、単一引用符をエスケープすることなく使用できることを理解して下さい。
-実際には、ドル引用符付けされた文字列の内側の文字はまったくエスケープが必要なく、文字列定数はすべてそのまま記述することができます。
+ドル引用符付けされた文字列の内側では、単一引用符をエスケープすることなく使用できることを理解してください。
+実際には、ドル引用符付けされた文字列の内側の文字はまったくエスケープが必要なく、文字列定数はすべてそのまま記述できます。
 その並びが開始タグに一致しない限り、バックスラッシュもドル記号も特別なものではありません。
     </para>
 
@@ -915,7 +915,7 @@ $SomeTag$Dianne's horse$SomeTag$
      different tags at each nesting level.  This is most commonly used in
      writing function definitions.  For example:
 -->
-各入れ子レベルに異なるタグを付けることで、ドル引用符付けされた文字列を入れ子にすることができます。
+各入れ子レベルに異なるタグを付けることで、ドル引用符付けされた文字列を入れ子にできます。
 これは、関数定義を作成する時に非常によく使用されます。
 以下に例を示します。
 <programlisting>
@@ -946,7 +946,7 @@ $function$
      is correct, but <literal>$TAG$String content$tag$</literal> is not.
 -->
 もしあれば、ドル引用符付けされた文字列のタグは、引用符付けされていない識別子と同じ規則に従います。
-ただし、タグにはドル記号を含めることはできません。
+ただし、タグにドル記号を含めることはできません。
 タグは大文字小文字を区別します。
 したがって、<literal>$tag$String content$tag$</literal>は正しいのですが、<literal>$TAG$String content$tag$</literal>は間違いです。
     </para>
@@ -1029,7 +1029,7 @@ $function$
      Dollar quoting cannot be used in a bit-string constant.
 -->
 どちらの形式のビット文字列定数でも、通常の文字列定数と同じように複数行にわたって続けて書くことができます。
-ドル引用符付けはビット文字列定数では使用できません。
+ドル引用符付けはビット文字列定数で使用できません。
     </para>
    </sect3>
 
@@ -1125,9 +1125,9 @@ $function$
 -->
 数値定数に最初に割り振られるデータ型は、型解決アルゴリズムの開始点に過ぎません。
 ほとんどの場合、定数は文脈に基づいて自動的に最も適切な型に変換されます。
-必要であれば、特定のデータ型にキャストして、数値がそのデータ型として解釈されるように強制することができます。
+必要であれば、特定のデータ型にキャストして、数値がそのデータ型として解釈されるように強制できます。
 <indexterm><primary>型キャスト</primary></indexterm>
-例えば、以下のようにして数値を<type>real</type>型（<type>float4</type>）として処理することができます。
+例えば、以下のようにして数値を<type>real</type>型（<type>float4</type>）として処理できます。
 
 <programlisting>
 <!--
@@ -1166,7 +1166,7 @@ REAL '1.23'  -- 文字列書式
      A constant of an <emphasis>arbitrary</emphasis> type can be
      entered using any one of the following notations:
 -->
-<emphasis>任意の</emphasis>型の定数は下記の表記のいずれかを使って入力することができます。
+<emphasis>任意の</emphasis>型の定数は下記の表記のいずれかを使って入力できます。
 <synopsis>
 <replaceable>type</replaceable> '<replaceable>string</replaceable>'
 '<replaceable>string</replaceable>'::<replaceable>type</replaceable>
@@ -1191,7 +1191,7 @@ CAST ( '<replaceable>string</replaceable>' AS <replaceable>type</replaceable> )
      The string constant can be written using either regular SQL
      notation or dollar-quoting.
 -->
-文字列定数は通常のSQL記法でもドル引用符付けでも記述することができます。
+文字列定数は通常のSQL記法でもドル引用符付けでも記述できます。
     </para>
 
     <para>
@@ -1243,7 +1243,7 @@ CAST ( '<replaceable>string</replaceable>' AS <replaceable>type</replaceable> )
 <literal>CAST()</literal>構文はSQLに従っています。
 <literal><replaceable>type</replaceable> '<replaceable>string</replaceable>'</literal>構文は、標準を一般化したものです。
 SQLでは、この構文を数個のデータ型でのみ規定しています。
-しかし、<productname>PostgreSQL</productname>ではすべての型で使用することができます。
+しかし、<productname>PostgreSQL</productname>ではすべての型で使用できます。
 <literal>::</literal>付きの構文は、歴史的に<productname>PostgreSQL</productname>で使用されてきました。
 関数呼び出し構文も同じく歴史的に使用されているものです。
     </para>
@@ -1309,7 +1309,7 @@ SQLでは、この構文を数個のデータ型でのみ規定しています�
        queries without requiring spaces between tokens.
 -->
 例えば、<literal>@-</literal>は演算子名として認められていますが、<literal>*-</literal>は認められていません。
-この制限により<productname>PostgreSQL</productname>は、SQLに準拠する問い合わせをトークン同士の間に空白を要求せず、解析することができます。
+この制限により<productname>PostgreSQL</productname>は、SQLに準拠する問い合わせをトークン同士の間に空白を要求せず、解析できます。
       </para>
      </listitem>
     </itemizedlist>
@@ -1506,8 +1506,8 @@ SQLでは、この構文を数個のデータ型でのみ規定しています�
     comments.
 -->
 コメントは<literal>/*</literal>で始まり、対応する<literal>*/</literal>で終わります。
-これらのブロックコメントはC言語とは異なり、標準SQLで規定されているように入れ子にすることができます。
-したがって、既存のブロックコメントを含む可能性のある大きなコードのブロックをコメントアウトすることができます。
+これらのブロックコメントはC言語とは異なり、標準SQLで規定されているように入れ子にできます。
+したがって、既存のブロックコメントを含む可能性のある大きなコードのブロックをコメントアウトできます。
    </para>
 
    <para>
@@ -2019,7 +2019,7 @@ SELECT 3 OPERATOR(pg_catalog.+) 4;
 <!--
     A column can be referenced in the form:
 -->
-列は、下記のような形式で参照することができます。
+列は、下記のような形式で参照できます。
 <synopsis>
 <replaceable>correlation</replaceable>.<replaceable>columnname</replaceable>
 </synopsis>
@@ -2034,7 +2034,7 @@ SELECT 3 OPERATOR(pg_catalog.+) 4;
     is unique across all the tables being used in the current query.  (See also <xref linkend="queries"/>.)
 -->
 <replaceable>correlation</replaceable>は、テーブル名（スキーマで修飾されている場合もあります）、あるいは<literal>FROM</literal>句で定義されたテーブルの別名です。
-correlationの名前と区切り用のドットは、もし列名が現在の問い合わせで使われる全てのテーブルを通して一意である場合は省略することができます。
+correlationの名前と区切り用のドットは、もし列名が現在の問い合わせで使われる全てのテーブルを通して一意である場合は省略できます。
 （<xref linkend="queries"/>も参照してください）。
    </para>
   </sect2>
@@ -2072,7 +2072,7 @@ correlationの名前と区切り用のドットは、もし列名が現在の問
 パラメータはSQL関数定義およびプリペアド問い合わせの中で使用されます。
 また、クライアントライブラリの中には、SQLコマンド文字列とデータ値を分離して指定できる機能をサポートするものもあります。
 この場合、パラメータは行外データ値を参照するために使用されます。
-パラメータ参照の形式は以下の通りです。
+パラメータ参照の形式は以下のとおりです。
 <synopsis>
 $<replaceable>number</replaceable>
 </synopsis>
@@ -2147,8 +2147,8 @@ CREATE FUNCTION dept(text) RETURNS dept
     is multidimensional.
     For example:
 -->
-一般的には、配列<replaceable>expression</replaceable>は括弧で括らなければなりませんが、添字を付けるそのexpressionが単なる列参照や位置パラメータであった場合、その括弧を省略することができます。
-また、元の配列が多次元の場合は複数の添字を連結することができます。
+一般的には、配列<replaceable>expression</replaceable>は括弧で括らなければなりませんが、添字を付けるそのexpressionが単なる列参照や位置パラメータであった場合、その括弧を省略できます。
+また、元の配列が多次元の場合は複数の添字を連結できます。
 以下に例を示します。
 
 <programlisting>
@@ -2199,7 +2199,7 @@ $1[10:42]
     For example:
 -->
 一般的には、行<replaceable>expression</replaceable>は括弧で括らなければなりません。
-しかし、選択元となる式が単なるテーブル参照や位置パラメータの場合、括弧を省略することができます。
+しかし、選択元となる式が単なるテーブル参照や位置パラメータの場合、括弧を省略できます。
 以下に例を示します。
 
 <programlisting>
@@ -2227,7 +2227,7 @@ $1.somecolumn
     or that <structname>mytable</structname> is a table name not a schema name
     in the second case.
 -->
-<structfield>compositecol</structfield>がテーブル名でなく列名であること、または２番目の場合の<structname>mytable</structname>がスキーマ名でなくテーブル名であることを示すため丸括弧が要求されます。
+<structfield>compositecol</structfield>がテーブル名でなく列名であること、または2番目の場合の<structname>mytable</structname>がスキーマ名でなくテーブル名であることを示すため丸括弧が要求されます。
    </para>
 
    <para>
@@ -2357,7 +2357,7 @@ sqrt(2)
     The arguments can optionally have names attached.
     See <xref linkend="sql-syntax-calling-funcs"/> for details.
 -->
-引数には名前を任意で付与することができます。詳細は<xref linkend="sql-syntax-calling-funcs"/>を見て下さい。
+引数には名前を任意で付与できます。詳細は<xref linkend="sql-syntax-calling-funcs"/>を見てください。
    </para>
 
    <note>
@@ -2627,7 +2627,7 @@ SELECT string_agg(a ORDER BY a, ',') FROM table;  -- incorrect
 <!--
     An example of an ordered-set aggregate call is:
 -->
-順序集合集約の例は以下の通りです。
+順序集合集約の例は以下のとおりです。
 
 <programlisting>
 SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY income) FROM households;
@@ -2674,7 +2674,7 @@ FROM generate_series(1,10) AS s(i);
     by the user.
 -->
 定義済みの集約関数は<xref linkend="functions-aggregate"/>で説明されています。
-ユーザは他の集約関数を追加することができます。
+ユーザは他の集約関数を追加できます。
    </para>
 
    <para>
@@ -2685,7 +2685,7 @@ FROM generate_series(1,10) AS s(i);
     because those clauses are logically evaluated before the results
     of aggregates are formed.
 -->
-集約式は、<command>SELECT</command>コマンドの結果リストもしくは<literal>HAVING</literal>句内でのみ記述することができます。
+集約式は、<command>SELECT</command>コマンドの結果リストもしくは<literal>HAVING</literal>句内でのみ記述できます。
 <literal>WHERE</literal>などの他の句では許されません。
 これらの句は集約結果が形成される前に論理的に評価されるためです。
    </para>
@@ -2808,7 +2808,7 @@ EXCLUDE NO OTHERS
     Here, <replaceable>expression</replaceable> represents any value
     expression that does not itself contain window function calls.
 -->
-ここで、<replaceable>expression</replaceable>はそれ自身ウィンドウ関数呼び出しを含まない任意の値式を表わします。
+ここで、<replaceable>expression</replaceable>はそれ自身のウィンドウ関数呼び出しを含まない任意の値式を表わします。
    </para>
 
    <para>
@@ -2827,7 +2827,7 @@ EXCLUDE NO OTHERS
 <replaceable>window_name</replaceable>は、問い合わせの<literal>WINDOW</literal>句で定義された名前付きウィンドウ仕様への参照です。
 あるいはまた、完全な<replaceable>window_definition</replaceable>を<literal>WINDOW</literal>句で定義された名前付きウィンドウと同じ構文を使って丸括弧の中に書くことができます。
 詳細は<xref linkend="sql-select"/>マニュアルページを見てください。
-<literal>OVER wname</literal>は<literal>OVER (wname ...)</literal>とは厳密には等価ではないことを指摘しておくのは価値のあることでしょう。
+<literal>OVER wname</literal>は<literal>OVER (wname ...)</literal>と厳密には等価でないことを指摘しておくのは価値のあることでしょう。
 後者はウィンドウ定義をコピーしたり修正したりすることを示唆しており、参照されるウィンドウ仕様がフレーム句を含む場合には拒絶されます。
    </para>
 
@@ -2883,7 +2883,7 @@ EXCLUDE NO OTHERS
     a <replaceable>frame_end</replaceable> of <literal>UNBOUNDED FOLLOWING</literal> means
     that the frame ends with the last row of the partition.
 -->
-<replaceable>frame_start</replaceable>が<literal>UNBOUNDED PRECEDING</literal>ならばフレームがパーティションの最初の行から始まること意味し、同様に、<replaceable>frame_end</replaceable>が<literal>UNBOUNDED FOLLOWING</literal>ならばフレームがパーティションの最後の行で終わること意味します。
+<replaceable>frame_start</replaceable>が<literal>UNBOUNDED PRECEDING</literal>ならばフレームがパーティションの最初の行から始まることを意味し、同様に、<replaceable>frame_end</replaceable>が<literal>UNBOUNDED FOLLOWING</literal>ならばフレームがパーティションの最後の行で終わることを意味します。
    </para>
 
    <para>
@@ -3007,7 +3007,7 @@ EXCLUDE NO OTHERS
     <literal>EXCLUDE NO OTHERS</literal> simply specifies explicitly the
     default behavior of not excluding the current row or its peers.
 -->
-フレームの開始、終了オプションで含まれることになる行であっても、<replaceable>frame_exclusion</replaceable>オプションで現在行周辺の行がフレームに含まれないようにすることができます。
+フレームの開始、終了オプションで含まれることになる行であっても、<replaceable>frame_exclusion</replaceable>オプションで現在行周辺の行がフレームに含まれないようにできます。
 <literal>EXCLUDE CURRENT ROW</literal>は、現在の行をフレームから除外します。
 <literal>EXCLUDE GROUP</literal>は、現在行とその順序付ピアをフレームから除外します。
 <literal>EXCLUDE TIES</literal>は、現在行そのものを除き、フレームにおける現在行のピアをフレームから除外します。
@@ -3069,7 +3069,7 @@ EXCLUDE NO OTHERS
     statistical aggregate can be used as a window function.  (Ordered-set
     and hypothetical-set aggregates cannot presently be used as window functions.)
 -->
-組み込みウィンドウ関数は<xref linkend="functions-window-table"/>に記載されています。その他のウィンドウ関数をユーザが追加することが可能です。
+組み込みウィンドウ関数は<xref linkend="functions-window-table"/>に記載されています。その他のウィンドウ関数をユーザが追加できます。
 また、全ての組み込み、またはユーザ定義の、汎用または統計集約関数もウィンドウ関数として使用できます。
 (順序集合と仮想集合集約は現在のところウィンドウ関数として使用できません。)
    </para>
@@ -3104,7 +3104,7 @@ EXCLUDE NO OTHERS
     <xref linkend="functions-window"/>, and
     <xref linkend="queries-window"/>.
 -->
-更なるウィンドウ関数についての情報は<xref linkend="tutorial-window"/>、<xref linkend="functions-window"/>、<xref linkend="queries-window"/>にあります。
+さらなるウィンドウ関数についての情報は<xref linkend="tutorial-window"/>、<xref linkend="functions-window"/>、<xref linkend="queries-window"/>にあります。
    </para>
   </sect2>
 
@@ -3185,7 +3185,7 @@ CAST ( <replaceable>expression</replaceable> AS <replaceable>type</replaceable> 
     explicit casting syntax.  This restriction is intended to prevent
     surprising conversions from being applied silently.
 -->
-評価式が生成しなければならない型に曖昧さがない場合（例えばテーブル列への代入時など）、明示的な型キャストは通常は省略することができます。
+評価式が生成しなければならない型に曖昧さがない場合（例えばテーブル列への代入時など）、明示的な型キャストは通常は省略できます。
 その場合、システムは自動的に型キャストを適用します。
 しかし、自動キャストは、システムカタログに<quote>暗黙的に適用しても問題なし</quote>と示されている場合にのみ実行されます。
 その他のキャストは明示的なキャスト構文で呼び出す必要があります。
@@ -3214,7 +3214,7 @@ CAST ( <replaceable>expression</replaceable> AS <replaceable>type</replaceable> 
 しかし、これはその型の名前が関数の名前としても有効な場合にのみ動作します。
 例えば、<literal>double precision</literal> はこの方式で使用できませんが、同等の<literal>float8</literal>は使用できます。
 また、<literal>interval</literal>、<literal>time</literal>、<literal>timestamp</literal>という名前は、構文が衝突するため、二重引用符で括った場合にのみこの方式で使用できます。
-このように、この関数のようなキャスト構文は一貫性がなくなりがちですので、おそらくアプリケーションでは使用すべきではありません。
+このように、この関数のようなキャスト構文は一貫性がなくなりがちですので、おそらくアプリケーションで使用すべきではありません。
    </para>
 
    <note>
@@ -3255,7 +3255,7 @@ CAST ( <replaceable>expression</replaceable> AS <replaceable>type</replaceable> 
     an expression.  It is appended to the expression it applies to:
 -->
 <literal>COLLATE</literal>句は式の照合順序規則を上書きします。
-適用するため次の様に式の後に追記します。
+適用するため次のように式の後に追記します。
 <synopsis>
 <replaceable>expr</replaceable> COLLATE <replaceable>collation</replaceable>
 </synopsis>
@@ -3286,8 +3286,8 @@ CAST ( <replaceable>expression</replaceable> AS <replaceable>type</replaceable> 
     overriding the sort order in an <literal>ORDER BY</literal> clause, for
     example:
 -->
-<literal>COLLATE</literal>句の主な使われ方が２つあります。
-１つは<literal>ORDER BY</literal>句での並び替え順序を上書きをするもので、例えば次のようにします。
+<literal>COLLATE</literal>句の主な使われ方が2つあります。
+1つは<literal>ORDER BY</literal>句での並び替え順序を上書きするもので、例えば次のようにします。
 <programlisting>
 SELECT a, b, c FROM tbl WHERE ... ORDER BY a COLLATE "C";
 </programlisting>
@@ -3314,7 +3314,7 @@ SELECT * FROM tbl WHERE a &gt; 'foo' COLLATE "C";
 後者の場合、<literal>COLLATE</literal>句が、処理対象と想定している入力演算子の引数に対して付与されることに注意してください。
 演算子や関数の呼び出しのどの引数に対して<literal>COLLATE</literal>句が付与されるかは問題ではありません。演算子や関数により適用される照合順序は対象となる全ての引数を考慮して引き出され、そして明示的に指定された<literal>COLLATE</literal>句がその他の全ての引数に対しての照合順序を上書きするからです。
 (しかし、複数の引数に対して一致しない<literal>COLLATE</literal>句の付与はエラーとなります。詳細は<xref linkend="collation"/>を参照してください。)
-このため、前述の例と同じ結果を次のようにして取得することができます。
+このため、前述の例と同じ結果を次のようにして取得できます。
 <programlisting>
 SELECT * FROM tbl WHERE a COLLATE "C" &gt; 'foo';
 </programlisting>
@@ -3366,9 +3366,9 @@ SELECT * FROM tbl WHERE (a &gt; 'foo') COLLATE "C";
 （問い合わせの記述方法については<xref linkend="queries"/>を参照してください）。
 その<command>SELECT</command>問い合わせは実行され、返される単一の値はその値の前後の評価式で使用されます。
 1行を超える行や1列を超える列がスカラ副問い合わせ用の問い合わせとして使用された場合はエラーになります
-（しかし、ある実行時に、副問い合わせが行を返さない場合はエラーとはなりません。
+（しかし、ある実行時に、副問い合わせが行を返さない場合はエラーになりません。
 そのスカラ結果はNULLとして扱われます）。
-副問い合わせは、その周りの問い合わせ内の値を参照することができます。
+副問い合わせは、その周りの問い合わせ内の値を参照できます。
 その値は副問い合わせの評価時には定数として扱われます。
 副問い合わせに関する他の式については<xref linkend="functions-subquery"/>も参照してください。
    </para>
@@ -3620,7 +3620,7 @@ SELECT ROW(1,2.5,'this is a test');
     The key word <literal>ROW</literal> is optional when there is more than one
     expression in the list.
 -->
-<literal>ROW</literal>キーワードは、2つ以上の式がリスト内にある場合は省略することができます。
+<literal>ROW</literal>キーワードは、2つ以上の式がリスト内にある場合は省略できます。
    </para>
 
    <para>
@@ -3669,7 +3669,7 @@ SELECT ROW(t.f1, t.f2, 42) FROM t;
     to avoid ambiguity.  For example:
 -->
 デフォルトでは、<literal>ROW</literal>式により作成される値は匿名レコード型になります。
-必要に応じて、名前付きの複合型、つまりテーブルの行型あるいは<command>CREATE TYPE AS</command>で作成された複合型にキャストすることができます。
+必要に応じて、名前付きの複合型、つまりテーブルの行型あるいは<command>CREATE TYPE AS</command>で作成された複合型にキャストできます。
 曖昧性を防止するために明示的なキャストが必要となることもあります。
 以下に例を示します。
 <programlisting>
@@ -3720,7 +3720,7 @@ SELECT getf1(CAST(ROW(11,'this is a test',2.5) AS myrowtype));
    it is possible to compare two row values or test a row with
    <literal>IS NULL</literal> or <literal>IS NOT NULL</literal>, for example:
 -->
-行コンストラクタは、複合型のテーブル列に格納する複合型の値を構築するため、あるいは複合型のパラメータを受け付ける関数に渡すために使用することができます。
+行コンストラクタは、複合型のテーブル列に格納する複合型の値を構築するため、あるいは複合型のパラメータを受け付ける関数に渡すために使用できます。
 また、以下の例のように、2つの行値を比較することも、<literal>IS NULL</literal>もしくは<literal>IS NOT NULL</literal>で行を検査することも可能です。
 <programlisting>
 SELECT ROW(1,2.5,'this is a test') = ROW(1, 3, 'not the same');
@@ -4004,7 +4004,7 @@ LANGUAGE SQL IMMUTABLE STRICT;
 <function>concat_lower_or_upper</function>関数は、<literal>a</literal>と<literal>b</literal>の指定必須となる2つのパラメータを持ちます。
 加えて、<literal>uppercase</literal>というデフォルトが<literal>false</literal>となっている省略可能なパラメータを一つ持ちます。
 <literal>a</literal>と<literal>b</literal>で入力された文字列が結合され、<literal>uppercase</literal>パラメータにより大文字か小文字に変換されます。
-他のこの関数定義についての詳細は、ここでは重要ではありません。(詳細は<xref linkend="extend"/>を参照して下さい。)
+他のこの関数定義についての詳細は、ここでは重要ではありません。(詳細は<xref linkend="extend"/>を参照してください。)
    </para>
 
    <sect2 id="sql-syntax-calling-funcs-positional">
@@ -4057,7 +4057,7 @@ SELECT concat_lower_or_upper('Hello', 'World');
      from right to left so long as they have defaults.
 -->
 ここでは<literal>uppercase</literal>パラメータが省略されていますので、そのデフォルト値である<literal>false</literal>を受け取ることとなり、結果は小文字になります。
-位置表記では引数がデフォルト値を持つ限り右側から左の方向で、引数を省略することができます。
+位置表記では引数がデフォルト値を持つ限り右側から左の方向で、引数を省略できます。
     </para>
    </sect2>
 
@@ -4098,7 +4098,7 @@ SELECT concat_lower_or_upper(a =&gt; 'Hello', b =&gt; 'World');
      order, for example:
 -->
 この場合も、<literal>uppercase</literal>引数が省略されていますので、暗黙的に<literal>false</literal>に設定されます。
-名前付け表記の使用の利点の１つとして、引数を任意の順序で指定できる点があります。
+名前付け表記使用の利点の1つとして、引数を任意の順序で指定できる点があります。
 以下に例を示します。
 <screen>
 SELECT concat_lower_or_upper(a =&gt; 'Hello', b =&gt; 'World', uppercase =&gt; true);

--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -715,7 +715,7 @@ SELECT 'foo'      'bar';
      character, write the string constant with an <literal>E</literal>.
 -->
 設定パラメータ<xref linkend="guc-standard-conforming-strings"/>が <literal>off</literal>の場合、<productname>PostgreSQL</productname>はバックスラッシュエスケープを通常の文字列定数とエスケープ文字列定数の両方で認識します。
-しかし、<productname>PostgreSQL</productname>9.1からデフォルトは<literal>on</literal>になりました。これはバックスラッシュエスケープがエスケープ文字列定数でのみ認識されるということになります。
+しかし、<productname>PostgreSQL</productname>9.1からデフォルトは<literal>on</literal>になりました。これはバックスラッシュエスケープがエスケープ文字列定数でのみ認識されます。
 この振る舞いはSQL標準仕様に即していますが、バックスラッシュエスケープを常に認識するという歴史的な動作に依存しているアプリケーションは動作しなくなるでしょう。
 回避策として、このパラメータを<literal>off</literal>にすることはできますが、バックスラッシュエスケープの使用を避けるよう移植するのが良いでしょう。
 特殊文字を表現するためにバックスラッシュを使用する必要がある場合、<literal>E</literal>をつけて文字列定数を記述してください。


### PR DESCRIPTION
・冗長表現の見直し（例：使用することができます⇒使用できます）
・助詞の繰り返しの見直し
・漢字の開きの見直し（例：下さい⇒ください）
・数字を半角に統一した
・（）を全角に統一した

上記修正と合わせて、文章を見直した箇所もあります。
意味を変えずに読みやすさの向上を意図しました。