### PR TITLE
第5章の文章表現を見直しました。

### DIFF
--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -246,8 +246,8 @@ DROP TABLE products;
    to avoid the error messages, but this is not standard SQL.)
 -->
 存在しないテーブルを削除しようとすると、エラーになります。
-もっともテーブルが存在するかどうか関係なくスクリプト全体を動作させることができるように、テーブルを作成する前に、エラーメッセージを無視して無条件に削除操作を行うことは、SQLスクリプトファイルではよく行われることです。
-（この操作を行いたければ、エラーメッセージの出力を防ぐ<literal>DROP TABLE IF EXISTS</literal>という構文を使用することができます。
+もっともテーブルが存在するかどうかに関係なくスクリプト全体を動作させることができるように、テーブルを作成する前に、エラーメッセージを無視して無条件に削除操作を行うことは、SQLスクリプトファイルではよく行われることです。
+（この操作を行いたければ、エラーメッセージの出力を防ぐ<literal>DROP TABLE IF EXISTS</literal>という構文を使用できます。
 しかし、これは標準SQLではありません。）
   </para>
 
@@ -396,7 +396,7 @@ CREATE TABLE products (
 生成列は常に他の列から計算される特別な列です。
 ですから、これは列におけるテーブルに対するビューのようなものです。
 生成列には格納と仮想の2種類があります。
-格納生成列はそれが書かれた（挿入または更新）時に計算され、あたかも通常の列のようにストレージが割当てられます。
+格納生成列はそれが書かれた（挿入または更新）時に計算され、あたかも通常の列のようにストレージが割り当てられます。
 仮想列にはストレージは割り当てられず、列が読み出された時に計算されます。
 つまり、仮想生成列はビューに似ており、格納生成列はマテリアライズドビューに似ています。（常に自動的に更新される点は除きます。）
 今の所PostgreSQLは格納生成列のみを実装しています。
@@ -432,7 +432,7 @@ CREATE TABLE people (
    <literal>DEFAULT</literal> may be specified.
 -->
 生成列には直接書き込みができません。
-<command>INSERT</command>あるいは<command>UPDATE</command>コマンドでは値を生成列には指定できませんが、キーワード<literal>DEFAULT</literal>が指定できます。
+<command>INSERT</command>あるいは<command>UPDATE</command>コマンドでは値を生成列に指定できませんが、キーワード<literal>DEFAULT</literal>が指定できます。
   </para>
 
   <para>
@@ -571,7 +571,7 @@ CREATE TABLE people (
       underlying base columns.
 -->
 生成列は元になる基底列とは別にアクセス権限を維持します。
-ですから、ある特定のロールが生成列を読み出しつつも、元になる基底列からは読み出さないように調整することが可能です。
+ですから、ある特定のロールが生成列を読み出しつつも、元になる基底列からは読み出さないように調整できます。
      </para>
     </listitem>
     <listitem>
@@ -632,8 +632,8 @@ CREATE TABLE people (
    that would violate a constraint, an error is raised.  This applies
    even if the value came from the default value definition.
 -->
-このような問題を解決するため、SQLでは列およびテーブルに対する制約を定義することができます。
-制約によってテーブル内のデータを自由に制御することができます。
+このような問題を解決するため、SQLでは列およびテーブルに対する制約を定義できます。
+制約によってテーブル内のデータを自由に制御できます。
 制約に違反するデータを列に格納しようとすると、エラーとなります。
 このことは、デフォルト値として定義された値を格納する場合にも適用されます。
   </para>
@@ -712,8 +712,8 @@ CREATE TABLE products (
     need to change it.  The syntax is:
 -->
 制約に個別に名前を付けることもできます。
-名前を付けることで、エラーメッセージがわかりやすくなりますし、変更したい制約を参照できるようになります。
-構文は以下の通りです。
+名前を付けることで、エラーメッセージがわかりやすくなりますし、変更したい制約を参照できます。
+構文は以下のとおりです。
 <programlisting>
 CREATE TABLE products (
     product_no integer,
@@ -761,7 +761,7 @@ CREATE TABLE products (
 最初の2つの制約は上で説明した通りです。
 3つ目の制約では新しい構文を使っています。
 これは特定の列に付加されるのではなく、カンマで区切られた列リスト内の別個の項目として現れます。
-列定義およびこれらの制約定義は、任意の順序で列挙することができます。
+列定義およびこれらの制約定義は、任意の順序で列挙できます。
    </para>
 
    <para>
@@ -847,9 +847,9 @@ CREATE TABLE products (
     ensure that a column does not contain null values, the not-null
     constraint described in the next section can be used.
 -->
-検査制約では、検査式が真またはNULL値と評価された場合に、条件が満たされることに注意して下さい。
+検査制約では、検査式が真またはNULL値と評価された場合に、条件が満たされることに注意してください。
 ほとんどの式は、演算項目に一つでもNULLがあればNULLと評価されるので、検査制約では制約対象の列にNULL値が入るのを防げません。
-列がNULL値を含まないようにするために、次節で説明する非NULL制約を使用することができます。
+列がNULL値を含まないようにするために、次節で説明する非NULL制約を使用できます。
    </para>
 
    <note>
@@ -902,7 +902,7 @@ CREATE TABLE products (
      times.  (The warning above about not referencing other table data is
      really a special case of this restriction.)
 -->
-<productname>PostgreSQL</productname>は<literal>CHECK</literal>制約の条件は不変であると仮定します。
+<productname>PostgreSQL</productname>は<literal>CHECK</literal>制約の条件が不変であると仮定します。
 つまり同じ入力行に対して常に同じ結果が返るということです。
 この仮定により<literal>CHECK</literal>制約が挿入あるいは更新時にのみ検査され、他のときには検査されないことが正当化されます。
 （他のテーブルデータを参照しないことによる上述の警告はこの制限の本当に特別な場合です。）
@@ -922,7 +922,7 @@ CREATE TABLE products (
      and re-add the constraint, thereby rechecking it against all table rows.
 -->
 この仮定に反する一般的な例は、<literal>CHECK</literal>式でユーザ定義関数を参照し、その関数の振る舞いを変更することです。
-<productname>PostgreSQL</productname>はこれを禁止はしませんが、今や<literal>CHECK</literal>制約に違反する行がテーブル中に存在することを通知しません。
+<productname>PostgreSQL</productname>はこれを禁止しませんが、今や<literal>CHECK</literal>制約に違反する行がテーブル中に存在することを通知しません。
 これによって後でデータベースのダンプとリストアの失敗を引き起こすでしょう。
 そのような変更に対処するおすすめの方法は、（<command>ALTER TABLE</command>を使って）制約を削除し、関数定義を調整し、そして制約を再度追加して、それによってテーブル全体の行に対して再チェックを行うことです。
     </para>
@@ -957,7 +957,7 @@ CREATE TABLE products (
     assume the null value.  A syntax example:
 -->
 非NULL制約は単純に、列がNULL値を取らないことを指定します。
-構文の例は以下の通りです。
+構文の例は以下のとおりです。
 <programlisting>
 CREATE TABLE products (
     product_no integer <emphasis>NOT NULL</emphasis>,
@@ -1022,7 +1022,7 @@ CREATE TABLE products (
 これは、列がNULLでなければならないということではありません。
 そのような制約は意味がありません。
 この制約は、列がNULLであってもよいというデフォルトの振舞いを選択するだけのものです。
-<literal>NULL</literal>制約は標準SQLには存在しませんので、移植予定のアプリケーションでは使用すべきではありません。
+<literal>NULL</literal>制約は標準SQLに存在しませんので、移植予定のアプリケーションで使用すべきではありません。
 （これは、<productname>PostgreSQL</productname>と他の一部のデータベースシステムとの互換性のために追加された機能に過ぎません。）
 もっとも、スクリプトファイルでの制約の切り替えが簡単であるという理由でこの機能を歓迎するユーザもいます。
 例えば、最初に
@@ -1036,7 +1036,7 @@ CREATE TABLE products (
 <!--
     and then insert the <literal>NOT</literal> key word where desired.
 -->
-と書いてから、必要な場所に<literal>NOT</literal>キーワードを挿入することができます。
+と書いてから、必要な場所に<literal>NOT</literal>キーワードを挿入できます。
    </para>
 
    <tip>
@@ -1079,7 +1079,7 @@ CREATE TABLE products (
     table.  The syntax is:
 -->
 一意性制約によって、列あるいは列のグループに含まれるデータが、テーブル内の全ての行で一意であることを確実にします。
-列制約の場合の構文は以下の通りです。
+列制約の場合の構文は以下のとおりです。
 <programlisting>
 CREATE TABLE products (
     product_no integer <emphasis>UNIQUE</emphasis>,
@@ -1297,7 +1297,7 @@ CREATE TABLE example (
     usually best to follow it.
 -->
 1つのテーブルは最大1つの主キーを持つことができます。
-（一意性制約および非NULL制約には個数の制限はありません。
+（一意性制約および非NULL制約に個数の制限はありません。
 機能的にはほとんど同じものですが、主キーとして識別される制約は1つのみです。）
 リレーショナルデータベース理論では、全てのテーブルに主キーが1つ必要とされています。
 この規則は<productname>PostgreSQL</productname>では強制されませんが、たいていの場合はこれに従うことが推奨されます。
@@ -1367,7 +1367,7 @@ CREATE TABLE example (
 <!--
     Say you have the product table that we have used several times already:
 -->
-これでまで何度か例に使用したproductsテーブルについて考えてみます。
+これまで何度か例に使用したproductsテーブルについて考えてみます。
 <programlisting>
 CREATE TABLE products (
     product_no integer PRIMARY KEY,
@@ -1584,7 +1584,7 @@ SQLではこのような場合も扱うことができます。
     removes an order, the order items are removed as well:
 -->
 具体例として、上の例の多対多関係に次のポリシーを実装してみましょう。
-（<literal>order_items</literal>によって）注文で参照されたままの製品を削除しようしても、この操作を行えないようにします。
+（<literal>order_items</literal>によって）注文で参照されたままの製品を削除しようとしても、この操作を行えないようにします。
 注文が削除されると、注文項目も削除されます。
 <programlisting>
 CREATE TABLE products (
@@ -1634,10 +1634,10 @@ CREATE TABLE order_items (
 <literal>RESTRICT</literal>は、被参照行が削除されるのを防ぎます。
 <literal>NO ACTION</literal>は、制約が検査された時に参照行がまだ存在していた場合に、エラーとなることを意味しています。
 これは、何も指定しない場合のデフォルトの振舞いとなります
-（これらの本質的な違いは、<literal>NO ACTION</literal>では検査をトランザクション中で後回しにすることができるのに対し、<literal>RESTRICT</literal>では後回しにできないということです）。
+（これらの本質的な違いは、<literal>NO ACTION</literal>では検査をトランザクション中で後回しにできるのに対し、<literal>RESTRICT</literal>では後回しにできないということです）。
 <literal>CASCADE</literal>は被参照行が削除された時、それを参照する行も同様に削除されることを指定します。
 他にも2つのオプション、<literal>SET NULL</literal>と<literal>SET DEFAULT</literal>があります。
-これらは、被参照行が削除された際に、参照行の参照列がそれぞれNULLか各列のデフォルト値に設定されるようになります。
+これらは、被参照行が削除された際に、参照行の参照列がそれぞれNULLか各列のデフォルト値に設定されます。
 これらは制約を守ることを免除することではない、ということに注意してください。
 例えば、動作に<literal>SET DEFAULT</literal>を指定したとしても、デフォルト値が外部キー制約を満たさない場合には操作は失敗します。
    </para>
@@ -1737,7 +1737,7 @@ CREATE TABLE posts (
     referencing column(s) as <literal>NOT NULL</literal>.
 -->
 通常、参照行はその参照列のいずれかがnullの場合は外部キー制約を満たす必要がありません。
-もし<literal>MATCH FULL</literal>が外部キー宣言に追加された場合、その参照列の全てがnullの場合にのみ参照行は制約を満たすことから逃れることができます(つまりnullと非nullの組み合わせは<literal>MATCH FULL</literal>制約に違反することが保証されます)。
+もし<literal>MATCH FULL</literal>が外部キー宣言に追加された場合、その参照列の全てがnullの場合にのみ参照行は制約を満たすことから逃れることができます（つまりnullと非nullの組み合わせは<literal>MATCH FULL</literal>制約に違反することが保証されます）。
 もし参照行が外部キー制約を満たさない可能性を排除したい場合は、参照列を<literal>NOT NULL</literal>として宣言してください。
    </para>
 
@@ -1756,7 +1756,7 @@ CREATE TABLE posts (
     automatically create an index on the referencing columns.
 -->
 外部キーは主キーであるかまたは一意性制約を構成する列を参照しなければなりません。
-これは、被参照列は常に(主キーまたは一意性制約の基礎となる)インデックスを持つことを意味します。
+これは、被参照列は常に（主キーまたは一意性制約の基礎となる）インデックスを持つことを意味します。
 このため、参照行に一致する行があるかどうかのチェックは効率的です。
 被参照テーブルからの行の<command>DELETE</command>や被参照行の<command>UPDATE</command>は、古い値と一致する行に対して参照テーブルのスキャンが必要となるので、参照行にもインデックスを付けるのは大抵は良い考えです。
 これは常に必要という訳ではなく、また、インデックスの方法には多くの選択肢がありますので、外部キー制約の宣言では参照列のインデックスが自動的に作られるということはありません。
@@ -1804,7 +1804,7 @@ CREATE TABLE posts (
     The syntax is:
 -->
 排他制約によって、2つの行に関して指定された列もしくは式を指定された演算子を利用して比較した場合に、少なくとも演算子の比較の1つが偽もしくはnullを返すことを確実にします。
-構文は以下の通りです。
+構文は以下のとおりです。
 <programlisting>
 CREATE TABLE circles (
     c circle,
@@ -1819,7 +1819,7 @@ CREATE TABLE circles (
     TABLE ... CONSTRAINT ... EXCLUDE</command></link> for details.
 -->
 詳細は<link linkend="sql-createtable-exclude"><command>CREATE
-TABLE ... CONSTRAINT ... EXCLUDE</command></link>を参照して下さい。
+TABLE ... CONSTRAINT ... EXCLUDE</command></link>を参照してください。
    </para>
 
    <para>
@@ -2023,7 +2023,7 @@ TABLE ... CONSTRAINT ... EXCLUDE</command></link>を参照して下さい。
 -->
 コマンド識別子もまた、32ビット量です。
 このため、単一トランザクション内のコマンド数には2<superscript>32</superscript>（40億）個までという<acronym>SQL</acronym>コマンドのハード制限が発生します。
-実際、この制限は問題にはなりません。
+実際、この制限は問題になりません。
 これは<acronym>SQL</acronym>コマンド数に対する制限であり、処理される行数に対する制限ではないことに注意してください。
 また、データベースの内容を実際に変更するコマンドのみがコマンド識別子を消費します。
    </para>
@@ -2057,7 +2057,7 @@ TABLE ... CONSTRAINT ... EXCLUDE</command></link>を参照して下さい。
    the data contained in the table: here we are interested in altering
    the definition, or structure, of the table.
 -->
-テーブルの作成後に間違いに気付いたり、あるいはアプリケーションの要件が変わったりした場合には、テーブルをいったん削除して再度作成することができます。
+テーブルの作成後に間違いに気付いたり、あるいはアプリケーションの要件が変わったりした場合には、テーブルをいったん削除して再度作成できます。
 しかし、テーブルにデータを入力済みの場合、あるいはそのテーブルが他のデータベースオブジェクト（例えば外部キー制約）によって参照されている場合、これは良い方法ではありません。
 そのため、<productname>PostgreSQL</productname> では既存のテーブルに変更を加えるための一連のコマンドが用意されています。テーブル内のデータを変更するという概念ではないことに注意してください。
 ここでは、テーブルの定義や構造を変更することに焦点を合わせます。
@@ -2195,7 +2195,7 @@ ALTER TABLE products ADD COLUMN description text;
     You can also define constraints on the column at the same time,
     using the usual syntax:
 -->
-次の構文を使用すると、列の制約も同時に定義することができます。
+次の構文を使用すると、列の制約も同時に定義できます。
 <programlisting>
 ALTER TABLE products ADD COLUMN description text CHECK (description &lt;&gt; '');
 </programlisting>
@@ -2208,7 +2208,7 @@ ALTER TABLE products ADD COLUMN description text CHECK (description &lt;&gt; '')
     correctly.
 -->
 実際には<command>CREATE TABLE</command>内の列の記述に使用されている全てのオプションが、ここで使用できます。
-ただしデフォルト値は与えられている制約を満足するものでなくてはならないことに注意してください。満足しない場合は<literal>ADD</literal>が失敗します。一方で、新規の列に正しく値を入れた後で制約を追加することができます（下記参照）。
+ただしデフォルト値は与えられている制約を満足するものでなくてはならないことに注意してください。満足しない場合は<literal>ADD</literal>が失敗します。一方で、新規の列に正しく値を入れた後で制約を追加できます（下記参照）。
    </para>
 
   </sect2>
@@ -2255,7 +2255,7 @@ ALTER TABLE products DROP COLUMN description CASCADE;
     See <xref linkend="ddl-depend"/> for a description of the general
     mechanism behind this.
 -->
-この背後にある一般的な仕組みに関する説明については<xref linkend="ddl-depend"/>を参照してください。
+この背後にある一般的な仕組みに関する説明は<xref linkend="ddl-depend"/>を参照してください。
    </para>
   </sect2>
 
@@ -2596,7 +2596,7 @@ ALTER TABLE products RENAME TO items;
 すなわち<literal>SELECT</literal>、 <literal>INSERT</literal>、<literal>UPDATE</literal>、<literal>DELETE</literal>、<literal>TRUNCATE</literal>、<literal>REFERENCES</literal>、<literal>TRIGGER</literal>、<literal>CREATE</literal>、<literal>CONNECT</literal>、<literal>TEMPORARY</literal>、 <literal>EXECUTE</literal>、<literal>USAGE</literal>、<literal>SET</literal>、<literal>ALTER SYSTEM</literal>です。
 特定のオブジェクトに適用可能な権限は、オブジェクトの型（テーブル、関数など）により変わります。
 これらの権限の詳細な意味を以下に示します。
-以降の節および章でもこれらの権限の使用方法についての説明があります。
+以降の節および章でもこれらの権限の使用方法について説明があります。
   </para>
 
   <para>
@@ -2624,7 +2624,7 @@ ALTER TABLE <replaceable>table_name</replaceable> OWNER TO <replaceable>new_owne
    both the current owner of the object (or a member of the owning role) and
    a member of the new owning role.
 -->
-スーパーユーザはいつでも所有者を変更できます。通常のロールは、対象オブジェクトの現在の所有者(または所有者ロールのメンバー)であり、かつ新しい所有者ロールのメンバーである場合に限り、所有者を変更できます。
+スーパーユーザはいつでも所有者を変更できます。通常のロールは、対象オブジェクトの現在の所有者（または所有者ロールのメンバー）であり、かつ新しい所有者ロールのメンバーである場合に限り、所有者を変更できます。
   </para>
 
   <para>
@@ -2654,7 +2654,7 @@ GRANT UPDATE ON accounts TO joe;
    there are many users of a database &mdash; for details see
    <xref linkend="user-manag"/>.
 -->
-システム内の全てのロールに権限を付与するには、特別な<quote>ロール</quote>名である<literal>PUBLIC</literal>を使用することができます。
+システム内の全てのロールに権限を付与するには、特別な<quote>ロール</quote>名である<literal>PUBLIC</literal>を使用できます。
 また、<quote>グループ</quote>ロールを使用すれば、データベース内に多くのユーザが存在する場合に権限の管理が簡単になります。
 詳細は<xref linkend="user-manag"/>を参照してください。
   </para>
@@ -2695,7 +2695,7 @@ REVOKE ALL ON accounts FROM PUBLIC;
    can always re-grant their own privileges.
 -->
 オブジェクトの所有者は、所有する通常の権限を削除することを選択できます。たとえば、他のものと同様、自身のためにテーブルを読み取り専用にできます。
-しかし、所有者は常にすべての付与オプションを持つものとして扱われます。ですから、いつでも自身の権限を再び付与することができます。
+しかし、所有者は常にすべての付与オプションを持つものとして扱われます。ですから、いつでも自身の権限を再び付与できます。
   </para>
 
   <para>
@@ -2724,8 +2724,8 @@ REVOKE ALL ON accounts FROM PUBLIC;
 《マッチ度[82.113821]》テーブル、ビュー、マテリアライズドビュー、あるいはそれ以外のテーブルのように見えるオブジェクトに対して<command>SELECT</command>をある列、あるいは指定した列（複数可）に許可します。
 また、<command>COPY TO</command>の利用を許可します。
 この権限は<command>UPDATE</command>あるいは<command>DELETE</command>において既存の列を参照する場合にも必要になります。
-シーケンスにおいてはこの権限は<function>currval</function>関数の使用を許可します。
-ラージオブジェクトにおいてはこの権限はオブジェクトの読み出しを許可します。
+シーケンスにおいてこの権限は<function>currval</function>関数の使用を許可します。
+ラージオブジェクトにおいてこの権限はオブジェクトの読み出しを許可します。
 《機械翻訳》表、ビュー、マテリアライズド・ビューまたはその他の表に類似したオブジェクトの任意の列または特定の列からの<command>SELECT</command>を許可します。
 <command>COPY TO</command>の使用も許可します。
 この権限は、<command>UPDATE</command>、<command>DELETE</command>または<command>MERGE</command>の既存の列値を参照する場合にも必要です。
@@ -2777,9 +2777,9 @@ REVOKE ALL ON accounts FROM PUBLIC;
 テーブル、ビューなどの列を<command>UPDATE</command>することを許可します。
 （実用的には、単純ではない<command>UPDATE</command>コマンドには<literal>SELECT</literal>権限も必要になります。
 どの行を更新するかを決定したり、列に対して新しい値を計算するためにテーブルの列を参照しなければならないからです。）
-<literal>SELECT ... FOR UPDATE</literal>と<literal>SELECT ... FOR SHARE</literal>は<literal>SELECT</literal>権限に加えて更にこの権限が必要になります。
-シーケンスではこの権限は<function>nextval</function>と<function>setval</function>関数の利用を許可します。
-ラージオブジェクトではこの権限はオブジェクトへの書き込みあるいは切り詰めを行うことを許可します。
+<literal>SELECT ... FOR UPDATE</literal>と<literal>SELECT ... FOR SHARE</literal>は<literal>SELECT</literal>権限に加えてさらにこの権限が必要になります。
+シーケンスでこの権限は<function>nextval</function>と<function>setval</function>関数の利用を許可します。
+ラージオブジェクトでこの権限はオブジェクトへの書き込みあるいは切り詰めを行うことを許可します。
       </para>
      </listitem>
     </varlistentry>
@@ -2944,7 +2944,7 @@ REVOKE ALL ON accounts FROM PUBLIC;
 -->
 スキーマに対しては、（オブジェクト自身の権限要件が満たされているものと仮定した上で）スキーマ内に含まれるオブジェクトへのアクセスを許可します。
 本質的に、これは権限を授与されたものがスキーマ内のオブジェクトを<quote>検査</quote>することを許可します。
-この許可がなくても依然としてオブジェクト名を見ることを可能です。たとえば、システムカタログを問い合わせることによってです。
+この許可がなくても依然としてオブジェクト名を見ることが可能です。たとえば、システムカタログを問い合わせることによってです。
 また、この許可を剥奪した後でも、既存のセッションはすでにこの検査を実施していると主張するかも知れません。
 ですからこれはオブジェクトへのアクセスを妨げる完全にセキュアな方法ではありません。
       </para>
@@ -2985,7 +2985,7 @@ REVOKE ALL ON accounts FROM PUBLIC;
        mappings associated with that server.
 -->
 外部サーバに対しては、そのサーバを使って外部テーブルを作ることを許可します。
-権限を授与されたものは、そのサーバに結びついたユーザマッピングを作成、変更、削除することができます。
+権限を授与されたものは、そのサーバに結びついたユーザマッピングを作成、変更、削除できます。
       </para>
      </listitem>
     </varlistentry>
@@ -3414,7 +3414,7 @@ GRANT SELECT (col1), UPDATE (col1) ON mytable TO miriam_rw;
 -->
 あるオブジェクトに対して<quote>Access privileges</quote>列が空なら、そのオブジェクトがデフォルトの権限を持つことを意味します。
 （つまり、関連するシステムカタログの権限エントリがNULLだということです。）
-デフォルト権限は常に所有者の全権限を含み、更に上で説明示したようにオブジェクトタイプ依存の<literal>PUBLIC</literal>に対する権限を持つことができます。
+デフォルト権限は常に所有者の全権限を含み、さらに上で説明を示したようにオブジェクトタイプ依存の<literal>PUBLIC</literal>に対する権限を持つことができます。
 オブジェクトに対する初回の<command>GRANT</command>あるいは<command>REVOKE</command>により、デフォルト権限（たとえば<literal>miriam=arwdDxt/miriam</literal>）が設定され、次に特定の要求に従って変更されます。
 同様に、<quote>Column privileges</quote>に示されるエントリは非デフォルトの権限を持つ列のためだけのものです。
 （注意：<quote>デフォルト権限</quote>は常にオブジェクトのタイプの組み込みのデフォルト権限を意味します。
@@ -3427,7 +3427,7 @@ GRANT SELECT (col1), UPDATE (col1) ON mytable TO miriam_rw;
    access privileges display.  A <literal>*</literal> will appear only when
    grant options have been explicitly granted to someone.
 -->
-所有者の暗黙的な許可オプションはアクセス権限表示では印を付けられないことに注意してください。
+所有者の暗黙的な許可オプションはアクセス権限表示で印を付けられないことに注意してください。
 <literal>*</literal>は許可オプションが明示的に誰かに許可されたときにのみ現れます。
   </para>
  </sect1>
@@ -3466,7 +3466,7 @@ GRANT SELECT (col1), UPDATE (col1) ON mytable TO miriam_rw;
 -->
 <xref linkend="sql-grant"/>によって利用できるSQL標準の<link linkend="ddl-priv">権限システム</link>に加えて、通常の問い合わせでどの行が戻され、データ更新のコマンドでどの行を挿入、更新、削除できるかをユーザ単位で制限する<firstterm>行セキュリティポリシー</firstterm>をテーブルに定義できます。
 この機能は<firstterm>行単位セキュリティ</firstterm>としても知られています。
-デフォルトではテーブルには何もポリシーはなく、SQLの権限システムによってテーブルのアクセス権限があるユーザは、テーブル内のすべての行について同じように、問い合わせや更新をすることができます。
+デフォルトではテーブルには何もポリシーはなく、SQLの権限システムによってテーブルのアクセス権限があるユーザは、テーブル内のすべての行について同じように、問い合わせや更新をできます。
   </para>
 
   <para>
@@ -3523,7 +3523,7 @@ GRANT SELECT (col1), UPDATE (col1) ON mytable TO miriam_rw;
 式が<literal>true</literal>を返さない行は処理対象になりません。
 可視である行と変更可能な行について独立した制御ができるように、別々の式を指定することも可能です。
 ポリシーの式は問い合わせの一部分として、問い合わせをしているユーザの権限で実行されます。
-ただし、呼び出しユーザに利用できないデータにアクセスするために、セキュリティ定義関数を使うことができます。
+ただし、呼び出しユーザが利用できないデータにアクセスするために、セキュリティ定義関数を使うことができます。
   </para>
 
   <para>
@@ -3565,7 +3565,7 @@ GRANT SELECT (col1), UPDATE (col1) ON mytable TO miriam_rw;
    have a unique name.  Different tables may have policies with the
    same name.
 -->
-各ポリシーには名前があり、1つのテーブルに複数のポリシーを定義することができます。
+各ポリシーには名前があり、1つのテーブルに複数のポリシーを定義できます。
 ポリシーはテーブルごとに定義されるので、1つのテーブルの各ポリシーは異なる名前でなければなりません。
 異なるテーブルであれば、同じ名前のポリシーが存在しても構いません。
   </para>
@@ -3581,7 +3581,7 @@ GRANT SELECT (col1), UPDATE (col1) ON mytable TO miriam_rw;
 -->
 ある問い合わせに複数のポリシーが適用される場合、（デフォルトの許容(permissive)ポリシーについては）<literal>OR</literal>または（制限(restrictive)ポリシーについては） <literal>AND</literal>を使って結合されます。
 これは、あるロールが、それが属するすべてのロールの権限を合わせ持つのと類似しています。
-許容ポリシーと制限ポリシーについては以下で更に説明します。
+許容ポリシーと制限ポリシーについては以下でさらに説明します。
   </para>
 
   <para>
@@ -3689,7 +3689,7 @@ CREATE POLICY user_mod_policy ON users
    environments.  The table <literal>passwd</literal> emulates a Unix password
    file:
 -->
-以下のより大きな例で、この機能が実運用の環境で如何にして使えるかを示します。
+以下のより大きな例で、この機能が実運用の環境でいかにして使えるかを示します。
 <literal>passwd</literal>テーブルはUnixのパスワードファイルと同等のものです。
   </para>
 
@@ -3947,7 +3947,7 @@ UPDATE 0
 これは最も単純で、しかも効率の良い場合です。
 可能であれば、行セキュリティの適用はこのように動作するよう設計するのが最善です。
 ポリシーの決定をするために他の行あるいは他のテーブルを参照する必要がある場合は、ポリシーの式で副<command>SELECT</command>を使う、あるいは<command>SELECT</command>を含む関数を使うことができます。
-ただし、そのようなアクセスは注意深く設計しなければ、情報漏洩を起こすような競合条件を作り出す場合があることに注意して下さい。
+ただし、そのようなアクセスは注意深く設計しなければ、情報漏洩を起こすような競合条件を作り出す場合があることに注意してください。
 例えば、以下のテーブル設計を考えます。
   </para>
 
@@ -4092,7 +4092,7 @@ SELECT * FROM information WHERE group_id = 2 FOR UPDATE;
    situation.
 -->
 この問題を回避する方法はいくつかあります。
-一つの簡単な答は行セキュリティポリシーの副<command>SELECT</command>で<literal>SELECT ... FOR SHARE</literal>を使うことです。
+一つの簡単な答えは行セキュリティポリシーの副<command>SELECT</command>で<literal>SELECT ... FOR SHARE</literal>を使うことです。
 しかし、これは影響を受けるユーザに対し、参照先テーブル（この場合は<structname>users</structname>）の<literal>UPDATE</literal>権限を付与する必要があり、望ましくないかもしれません。
 （しかし、もう一つの行セキュリティポリシーを適用して、彼らが実際にその権限を行使することを防ぐことはできます。
 また、副<command>SELECT</command>をセキュリティ定義関数内に埋め込むことも可能です。）
@@ -4108,7 +4108,7 @@ SELECT * FROM information WHERE group_id = 2 FOR UPDATE;
    For additional details see <xref linkend="sql-createpolicy"/>
    and <xref linkend="sql-altertable"/>.
 -->
-更なる詳細は<xref linkend="sql-createpolicy"/>と<xref linkend="sql-altertable"/>を参照して下さい。
+さらなる詳細は<xref linkend="sql-createpolicy"/>と<xref linkend="sql-altertable"/>を参照してください。
   </para>
 
  </sect1>
@@ -4614,9 +4614,9 @@ publicスキーマはデフォルトで存在するということ以外に特�
     special provision: you must write
 -->
 検索パスはデータ型名、関数名、演算子名についても、テーブル名の場合と同じように機能します。
-データ型および関数の名前は、テーブル名とまったく同じように修飾することができます。
+データ型および関数の名前は、テーブル名とまったく同じように修飾できます。
 式で修飾演算子名を書く場合には、特別な決まりがあります。
-それは以下の通りです。
+それは以下のとおりです。
 <synopsis>
 <literal>OPERATOR(</literal><replaceable>schema</replaceable><literal>.</literal><replaceable>operator</replaceable><literal>)</literal>
 </synopsis>
@@ -4727,7 +4727,7 @@ REVOKE CREATE ON SCHEMA public FROM PUBLIC;
 このスキーマにはシステムテーブルと全ての組み込みデータ型、関数および演算子が含まれています。
 <literal>pg_catalog</literal>は常に検索パスに含まれています。
 パスに明示的にリストされていない場合は、パスのスキーマを検索する<emphasis>前</emphasis>に暗黙的に検索されます。
-これにより組み込みの名前が常に検索されることが保証されます。
+これにより組み込みの名前が常に検索されることを保証されます。
 しかし、ユーザ定義の名前で組み込みの名前を上書きする場合は、<literal>pg_catalog</literal>を明示的にパスの最後に置くことができます。
    </para>
 
@@ -4995,7 +4995,7 @@ REVOKE CREATE ON SCHEMA public FROM PUBLIC;
 どの州についても州都を素早く検索したいとします。
 これは、2つのテーブルを作成することにより実現できます。
 1つは州都のテーブルで、もう1つは州都ではない市のテーブルです。
-しかし、州都であるか否かに関わらず、市に対するデータを問い合わせたいときには何が起こるでしょうか？
+しかし、州都であるか否かに関わらず、市に対するデータを問い合わせたいときには何が起こるのでしょうか？
 継承はこの問題を解決できます。
 <structname>cities</structname>から継承される<structname>capitals</structname>テーブルを定義するのです。
 
@@ -5131,7 +5131,7 @@ WHERE c.elevation &gt; 500;
 <!--
    which returns:
 -->
-出力は以下の通りです。
+出力は以下のとおりです。
 
 <programlisting>
  tableoid |   name    | elevation
@@ -5210,7 +5210,7 @@ VALUES ('Albany', NULL, NULL, 'NY');
 <command>INSERT</command>は、いつも指定されたテーブルそれ自体に対してデータを挿入します。
 ルール（詳細は<xref linkend="rules"/>を参照してください）を使用して挿入を中継できる場合もあります。
 しかし、ルールを使用しても上記のような場合は解決できません。
-なぜなら、<structname>cities</structname>テーブルに<structfield>state</structfield>列が含まれていないため、ルールが適用される前にコマンドが拒否されてしまうからです。
+なぜなら、<structname>cities</structname>テーブルに<structfield>state</structfield>列が含まれていないため、ルールが適用される前にコマンドを拒否されてしまうからです。
   </para>
 
   <para>
@@ -5220,7 +5220,7 @@ VALUES ('Albany', NULL, NULL, 'NY');
    otherwise with <literal>NO INHERIT</literal> clauses.  Other types of constraints
    (unique, primary key, and foreign key constraints) are not inherited.
 -->
-親テーブル上の検査制約と非NULL制約は、<literal>NO INHERIT</literal>句によって明示的に指定され無い限り、その子テーブルに自動的に継承されます。
+親テーブル上の検査制約と非NULL制約は、<literal>NO INHERIT</literal>句によって明示的に指定されない限り、その子テーブルに自動的に継承されます。
 他の種類の制約（一意性制約、主キー、外部キー制約）は継承されません。
   </para>
 
@@ -5443,7 +5443,7 @@ VALUES ('Albany', NULL, NULL, 'NY');
       cities(name)</literal> would allow the other table to contain city names, but
       not capital names.  There is no good workaround for this case.
 -->
-他のテーブルの列に<literal>REFERENCES cities(name)</literal>を指定すると、他のテーブルが市の名前を持つことはできますが、州都の名前を持つことできません。
+他のテーブルの列に<literal>REFERENCES cities(name)</literal>を指定すると、他のテーブルが市の名前を持つことはできますが、州都の名前を持つことはできません。
 この場合は良い回避策がありません。
      </para>
     </listitem>
@@ -5526,7 +5526,7 @@ VALUES ('Albany', NULL, NULL, 'NY');
        fit in memory.
 -->
 特定の条件下で問い合わせのパフォーマンスが劇的に向上することがあります。
-特にテーブル内のアクセスが集中する行の殆どが単一または少数のパーティションに存在している場合がそうです。
+特にテーブル内のアクセスが集中する行のほとんどが単一または少数のパーティションに存在している場合がそうです。
 パーティショニングは実質的にインデックスの上位木レベルの代わりになり、インデックスの頻繁に使われる部分がメモリに収まりやすくなるようにします。
       </para>
      </listitem>
@@ -5540,7 +5540,7 @@ VALUES ('Albany', NULL, NULL, 'NY');
        index, which would require random-access reads scattered across the
        whole table.
 -->
-問い合わせや更新が一つのパーティションの大部分にアクセスする場合、インデックス使用してテーブル全体にまたがるランダムアクセス読み取りをする代わりに、そのパーティションへの順次アクセスをすることでパフォーマンスを向上させることができます。
+問い合わせや更新が一つのパーティションの大部分にアクセスする場合、インデックスを使用してテーブル全体にまたがるランダムアクセス読み取りをする代わりに、そのパーティションへの順次アクセスをすることでパフォーマンスを向上させることができます。
       </para>
      </listitem>
 
@@ -5566,7 +5566,7 @@ VALUES ('Albany', NULL, NULL, 'NY');
 <!--
        Seldom-used data can be migrated to cheaper and slower storage media.
 -->
-滅多に使用されないデータを安価で低速なストレージメディアに移行することができます。
+めったに使用されないデータを安価で低速なストレージメディアに移行できます。
       </para>
      </listitem>
     </itemizedlist>
@@ -5685,7 +5685,7 @@ VALUES ('Albany', NULL, NULL, 'NY');
     as described above, plus a list of columns or expressions to be used
     as the <firstterm>partition key</firstterm>.
 -->
-<productname>PostgreSQL</productname>ではテーブルをパーティションに分割すると宣言することができます。
+<productname>PostgreSQL</productname>ではテーブルをパーティションに分割すると宣言できます。
 分割されたテーブルは<firstterm>パーティションテーブル</firstterm>と呼ばれます。
 この宣言は上で述べた<firstterm>パーティショニング方式</firstterm>を含んでおり、加えて<firstterm>パーティションキー</firstterm>として使用される列あるいは式のリストからなります。
    </para>
@@ -5724,7 +5724,7 @@ VALUES ('Albany', NULL, NULL, 'NY');
 -->
 パーティションは自身をパーティション化テーブルであると定義することができ、その結果<firstterm>サブパーティショニング</firstterm>となります。
 すべてのパーティションは親のパーティションと同じ列を持たなければなりませんが、パーティションは他のパーティションとは別の独自のインデックス、制約、デフォルト値を持つことができます。
-パーティションテーブルおよびパーティションの作成についての更なる詳細については<xref linkend="sql-createtable"/>を参照してください。
+パーティションテーブルおよびパーティションの作成についてのさらなる詳細については<xref linkend="sql-createtable"/>を参照してください。
    </para>
 
    <para>
@@ -5919,7 +5919,7 @@ CREATE TABLE measurement_y2006m02 PARTITION OF measurement
        the partition's own bounds allow; the system does not try to check
        whether that's really the case.
 -->
-<structname>measurement_y2006m02</structname>のパーティションの作成後、<structname>measurement</structname>に挿入されるデータで<structname>measurement_y2006m02</structname>に振り向けられるもの（あるいは<structname>measurement_y2006m02</structname>に直接挿入されるデータでそのパーティション制約を満たしているもの）はすべて、<structfield>peaktemp</structfield>列に基いて更にその下のパーティションの一つにリダイレクトされます。
+<structname>measurement_y2006m02</structname>のパーティションの作成後、<structname>measurement</structname>に挿入されるデータで<structname>measurement_y2006m02</structname>に振り向けられるもの（あるいは<structname>measurement_y2006m02</structname>に直接挿入されるデータでそのパーティション制約を満たしているもの）はすべて、<structfield>peaktemp</structfield>列に基いてさらにその下のパーティションの一つにリダイレクトされます。
 指定するパーティションキーは親のパーティションキーと重なっても構いませんが、サブパーティションの境界を指定するときは、それが受け付けるデータの集合がパーティション自体の境界でできるものの部分集合を構成するように注意してください。
 システムは本当にそのようになっているかどうか、検査しようとしません。
       </para>
@@ -5960,7 +5960,7 @@ CREATE TABLE measurement_y2006m02 PARTITION OF measurement
        tables.
 -->
 キー列にインデックスを作成し、またその他のインデックスも必要に応じてパーティションテーブル上に作成します。
-（厳密に言えば、キー列のインデックスは必要なわけではありませんが、ほとんどの場合に役に立つでしょう。）
+（厳密に言えば、キー列のインデックスが必要なわけではありませんが、ほとんどの場合に役に立つでしょう。）
 これは個々のパーティションに対応するインデックスを自動的に作るので、作成したすべてのパーティション、あるいは後でアタッチしたパーティションもそのようなインデックスを持ちます。
 パーティションテーブルのインデックスあるいは一意制約はパーティションテーブルがそうであるのと同様、<quote>仮想</quote>です。
 実際のデータは個々のパーティションテーブル上の子インデックスにあります。
@@ -6042,7 +6042,7 @@ DROP TABLE measurement_y2006m02;
      right.  This has two forms:
 -->
 別の方法で多くの場合に望ましいのは、パーティションテーブルからパーティションを削除する一方で、パーティションそれ自体はテーブルとしてアクセス可能なまま残すことです。
-これには２つの形式があります。
+これには2つの形式があります。
 
 <programlisting>
 ALTER TABLE measurement DETACH PARTITION measurement_y2006m02;
@@ -6076,7 +6076,7 @@ ALTER TABLE measurement DETACH PARTITION measurement_y2006m02 CONCURRENTLY;
      empty partition in the partitioned table just as the original partitions
      were created above:
 -->
-同様に、新しいデータを扱うために新しいパーティションを追加することができます。
+同様に、新しいデータを扱うために新しいパーティションを追加できます。
 上で元のパーティションを作ったのと全く同じように、パーティションテーブル内に空のパーティションを以下のように作成できます。
 
 <programlisting>
@@ -6141,7 +6141,7 @@ ALTER TABLE measurement ATTACH PARTITION measurement_y2008m02
      partitions are reached.
 -->
 上で説明したように、<command>ATTACH PARTITION</command>コマンドを実行する前に、マッチするパーティション制約を記述する<literal>CHECK</literal>制約を、パーティションに追加するテーブルに作成することを推奨します。
-こうすることで、システムは、そうしなければ必要になる暗示的なパーティション制約を検証するための走査を、省略することができます。
+こうすることで、システムは、そうしなければ必要になる暗示的なパーティション制約を検証するための走査を、省略できます。
 このような<literal>CHECK</literal>制約がなければ、そのパーティションに<literal>ACCESS EXCLUSIVE</literal>ロック、を保持したままで、パーティション制約を検証するためにテーブルを走査することになります。
 もう不要になったこの<literal>CHECK</literal>制約は<command>ATTACH PARTITION</command>が終わった後に削除することを推奨します。
 アタッチされるテーブル自体がパーティションテーブルなら、適切な<literal>CHECK</literal>制約が見つかるか、リーフパーティションに到達するまで個々のサブパーティションは再帰的にロックされ走査されます。
@@ -6437,7 +6437,7 @@ ALTER INDEX measurement_city_id_logdate_key
         exclusion is unable to prune child tables effectively, query performance
         might be poor.)
 -->
-宣言的パーティショニングではリストパーティショニング、範囲パーティショニングとハッシュパーティショニングしかサポートされませんが、テーブルの継承ではユーザが選択した方法に従ってデータを分割することができます。
+宣言的パーティショニングではリストパーティショニング、範囲パーティショニングとハッシュパーティショニングしかサポートされませんが、テーブルの継承ではユーザが選択した方法に従ってデータを分割できます。
 （ただし、制約による除外が子テーブルを効果的に分離できない場合、問い合わせのパフォーマンスが悪くなるかもしれないことに注意してください。）
        </para>
       </listitem>
@@ -6473,7 +6473,7 @@ ALTER INDEX measurement_city_id_logdate_key
 -->
 <quote>root</quote>テーブルを作成します。
 すべての<quote>子</quote>テーブルはこれを継承します。
-このテーブルにはデータは含まれません。
+このテーブルにデータは含まれません。
 子テーブルに同じように適用されるのでなければ、このテーブルにチェック制約を定義しないでください。
 このテーブル上にインデックスや一意制約を定義することにも意味はありません。
 以下の例では、rootテーブルは最初に定義したのと同じ<structname>measurement</structname>テーブルです。
@@ -6539,7 +6539,7 @@ CHECK ( outletID &gt;= 100 AND outletID &lt; 200 )
          between the key values permitted in different child tables.  A common
          mistake is to set up range constraints like:
 -->
-制約により、異なる子テーブルで許されるキー値に重なりがないことが保証されるようにします。
+制約により、異なる子テーブルで許されるキー値に重なりがないと保証されるようにします。
 よくある誤りは、次のような範囲制約を設定することです。
 <programlisting>
 CHECK ( outletID BETWEEN 100 AND 200 )
@@ -6606,7 +6606,7 @@ CREATE INDEX measurement_y2008m01_logdate ON measurement_y2008m01 (logdate);
          use a very simple trigger function:
 -->
 アプリケーションで<literal>INSERT INTO measurement ...</literal>を実行することができ、そのときにデータが適切な子テーブルにリダイレクトされることが望ましいです。
-rootテーブルに適当なトリガー関数を追加することでそのような設定にすることができます。
+rootテーブルに適当なトリガー関数を追加することでそのような設定にできます。
 データが最後の子テーブルにしか追加されないなら、次のような非常に単純なトリガー関数を使うことができます。
 
 <programlisting>
@@ -6736,7 +6736,7 @@ DO INSTEAD
          cases, however, the trigger method will offer better performance.
 -->
 ルールはトリガーに比べるとかなり大きなオーバーヘッドがありますが、このオーバーヘッドは一つの問い合わせに対して一度だけで行ごとではないので、この方法にも一括挿入の状況では利点があります。
-ただし、ほとんどの場合はトリガーを使う方法の方が良いパフォーマンスが得られます。
+ただし、ほとんどの場合はトリガーを使う方法の方が良いパフォーマンスを得られます。
         </para>
 
         <para>
@@ -6749,7 +6749,7 @@ DO INSTEAD
 -->
 <command>COPY</command>はルールを無視することに注意してください。
 データの挿入に<command>COPY</command>を使いたい場合は、rootではなく正しい子テーブルにコピーする必要があります。
-トリガーであれば<command>COPY</command>でも起動されるので、トリガーを使う方法であれば通常通りに使用することができます。
+トリガーであれば<command>COPY</command>でも起動されるので、トリガーを使う方法であれば通常通りに使用できます。
         </para>
 
         <para>
@@ -6917,7 +6917,7 @@ ALTER TABLE measurement_y2008m02 INHERIT measurement;
         <command>ANALYZE</command> commands, don't forget that
         you need to run them on each child table individually. A command like:
 -->
-手作業で<command>VACUUM</command>あるいは<command>ANALYZE</command>コマンドを実行している場合、それを個々の子テーブルに対して実行する必要があることを忘れないで下さい。
+手作業で<command>VACUUM</command>あるいは<command>ANALYZE</command>コマンドを実行している場合、それを個々の子テーブルに対して実行する必要があることを忘れないでください。
 次のようなコマンドは、
 <programlisting>
 ANALYZE measurement;
@@ -6937,7 +6937,7 @@ rootテーブルしか処理しません。
         action is only taken in case of unique violations on the specified
         target relation, not its child relations.
 -->
-<literal>ON CONFLICT</literal>句のある<command>INSERT</command>文は恐らく期待通りには動作しないでしょう。
+<literal>ON CONFLICT</literal>句のある<command>INSERT</command>文は恐らく期待通りに動作しないでしょう。
 <literal>ON CONFLICT</literal>の動作は対象となる指定リレーション上での一意制約違反の場合にのみ発生するもので、その子リレーションの場合には発生しないからです。
        </para>
       </listitem>
@@ -7128,7 +7128,7 @@ EXPLAIN SELECT count(*) FROM measurement WHERE logdate &gt;= DATE '2008-01-01';
 問い合わせ計画の実行時。
 パーティション除去では実際に問い合わせの実行をする際にのみ分かる値を用いてパーティションを取り除くことも同様に可能でしょう。
 これは、副問い合わせからの値やネステッドループ結合でパラメータ化されたような実行時のパラメータからの値を含みます。
-それらのパラメータの値は問い合わせの実行時に何回も変わるかもしれないため、パーティション除去はパーティション除去に使われる実行パラメータの値が変るたびに行われます。
+それらのパラメータの値は問い合わせの実行時に何回も変わるかもしれないため、パーティション除去はパーティション除去に使われる実行パラメータの値が変わるたびに行われます。
 この段階で除去されたパーティションを特定するには、<command>EXPLAIN ANALYZE</command>出力中の<literal>loops</literal>プロパティの慎重な調査が必要です。
 異なるパーティションに対応するサブプランは、それぞれ実行時に除去された回数に応じて異なる値を持っているかもしれません。
 毎回パーティションが除去される場合、一部は<literal>(never executed)</literal>と表示されるでしょう。
@@ -7195,7 +7195,7 @@ EXPLAIN SELECT count(*) FROM measurement WHERE logdate &gt;= DATE '2008-01-01';
     to elide additional partitions from the query plan.
 -->
 制約による除外は<literal>CHECK</literal>制約を使用しているためパーティション除去と比べて遅いですが、ときどき利点として使うことができます。
-なぜなら、内部のパーティション境界に加えて宣言的パーティションテーブルにも制約は定義することができるため、制約による除外は問い合わせ計画から追加のパーティションを取り除けるかもしれません。
+なぜなら、内部のパーティション境界に加えて宣言的パーティションテーブルにも制約は定義できるため、制約による除外は問い合わせ計画から追加のパーティションを取り除けるかもしれません。
    </para>
 
    <para>
@@ -7211,7 +7211,7 @@ EXPLAIN SELECT count(*) FROM measurement WHERE logdate &gt;= DATE '2008-01-01';
 -->
 実のところ、<xref linkend="guc-constraint-exclusion"/>のデフォルト（かつ推奨）の設定は、<literal>on</literal>でも<literal>off</literal>でもなく、<literal>partition</literal>という中間の設定です。
 これによりこの技法は、継承パーティションテーブルに対して動作することになる問い合わせのみに適用されるようになります。
-<literal>on</literal>設定にすると、プランナは、効果のなさそうな単純な問い合わせを含め、すべての問い合わせで<literal>CHECK</literal>制約を検証するようになります。
+<literal>on</literal>設定にすると、プランナは、効果のなさそうな単純な問い合わせを含め、すべての問い合わせで<literal>CHECK</literal>制約を検証します。
    </para>
 
    <para>
@@ -7241,7 +7241,7 @@ EXPLAIN SELECT count(*) FROM measurement WHERE logdate &gt;= DATE '2008-01-01';
       planner cannot know which child table the function's value might fall
       into at run time.
 -->
-制約による除外は問い合わせの<literal>WHERE</literal>句が定数(または外部から供給されたパラメータ)を含んでいたときにのみ動作します。例えば、<function>CURRENT_TIMESTAMP</function>のような非immutable関数に対する比較は、関数の結果値がどの子テーブルに該当するかを実行時にプランナが知ることが出来ないため、最適化できません。
+制約による除外は問い合わせの<literal>WHERE</literal>句が定数（または外部から供給されたパラメータ）を含んでいたときにのみ動作します。例えば、<function>CURRENT_TIMESTAMP</function>のような非immutable関数に対する比較は、関数の結果値がどの子テーブルに該当するかを実行時にプランナが知ることが出来ないため、最適化できません。
      </para>
     </listitem>
 
@@ -7362,7 +7362,7 @@ EXPLAIN SELECT count(*) FROM measurement WHERE logdate &gt;= DATE '2008-01-01';
     Either of these can easily lead to excessive numbers of partitions,
     so restraint is advisable.
 -->
-サブパーティショニングは、他のパーティションより巨大になると想定されるパーティションを更に分割するために役立ちます。
+サブパーティショニングは、他のパーティションより巨大になると想定されるパーティションをさらに分割するために役立ちます。
 他の選択は、パーティションキー中に複数の列を含む範囲パーティショニングを使うことです。
 これらのどちらも容易に大量のパーティション数をもたらす結果になるので、自制することをお勧めします。
    </para>
@@ -7383,7 +7383,7 @@ EXPLAIN SELECT count(*) FROM measurement WHERE logdate &gt;= DATE '2008-01-01';
     local memory of each session that touches it.
 -->
 クエリの計画および実行時のパーティショニングのオーバーヘッドを考慮することが重要です。
-典型的なクエリではクエリプランナが少数のパーティションを除いて残り全てのパーティションを除外できるという前提に立てば、クエリプランナは通常最大数千パーティションのパーティション階層を適切に操作することができます。
+典型的なクエリではクエリプランナが少数のパーティションを除いて残り全てのパーティションを除外できるという前提に立てば、クエリプランナは通常最大数千パーティションのパーティション階層を適切に操作できます。
 プランナがパーティション除去を行った後に多くのパーティションが残るほど、計画時間は長くなりメモリ消費は高くなります。
 大量のパーティションを持っていることについて考慮するもうひとつの理由は、特に多くのセッションが大量のパーティションを参照する場合、ある期間にサーバのメモリ消費が著しく増加するかもしれないことです。
 その理由は、各パーティションは参照される各セッションのローカルメモリにメタデータを読み込む必要があるためです。
@@ -7476,7 +7476,7 @@ EXPLAIN SELECT count(*) FROM measurement WHERE logdate &gt;= DATE '2008-01-01';
     to fetch data from the external source, or transmit data to the external
     source in the case of update commands.
 -->
-外部データにアクセスするには、特定の外部データソースへの接続方法をそれを支える外部データラッパが使用するオプションの組み合わせによって定義する<firstterm>外部サーバ</firstterm>オブジェクトを作成する必要があります。その後、外部データの構造を定義する<firstterm>外部テーブル</firstterm>を少なくともひとつ作成する必要があります。外部テーブルは通常のテーブルと同様にクエリの中で使用できますが、外部テーブルはPostgreSQLサーバには格納領域を持ちません。
+外部データにアクセスするには、特定の外部データソースへの接続方法をそれを支える外部データラッパが使用するオプションの組み合わせによって定義する<firstterm>外部サーバ</firstterm>オブジェクトを作成する必要があります。その後、外部データの構造を定義する<firstterm>外部テーブル</firstterm>を少なくともひとつ作成する必要があります。外部テーブルは通常のテーブルと同様にクエリの中で使用できますが、外部テーブルはPostgreSQLサーバに格納領域を持ちません。
 外部テーブルが使われるたびに、<productname>PostgreSQL</productname>は外部ソースからデータを取得することや、更新コマンドの場合には外部ソースへデータを送信することを外部データラッパに依頼します。
    </para>
 
@@ -7488,7 +7488,7 @@ EXPLAIN SELECT count(*) FROM measurement WHERE logdate &gt;= DATE '2008-01-01';
     such as user names and passwords based
     on the current <productname>PostgreSQL</productname> role.
 -->
-外部データへのアクセスは外部データソースからの認証を必要とする場合があります。この情報は、現在の<productname>PostgreSQL</productname>ロールに基づいてユーザ名やパスワードといった追加のデータを提供することができる<firstterm>ユーザマッピング</firstterm>によって提供することができます。
+外部データへのアクセスは外部データソースからの認証を必要とする場合があります。この情報は、現在の<productname>PostgreSQL</productname>ロールに基づいてユーザ名やパスワードといった追加のデータを提供できる<firstterm>ユーザマッピング</firstterm>によって提供できます。
    </para>
 
    <para>
@@ -7659,7 +7659,7 @@ DROP TABLE products CASCADE;
    <literal>CASCADE</literal> to get the default behavior, which is to
    prevent dropping objects that any other objects depend on.
 -->
-<productname>PostgreSQL</productname>では、ほぼ全ての<command>DROP</command>コマンドに<literal>CASCADE</literal>を指定することができます。
+<productname>PostgreSQL</productname>では、ほぼ全ての<command>DROP</command>コマンドに<literal>CASCADE</literal>を指定できます。
 もちろん、どのような依存関係が存在するかは、オブジェクトの種類によって異なります。
 また、<literal>CASCADE</literal>ではなく<literal>RESTRICT</literal>と記述することもできます。
 これは、他のオブジェクトが依存しているオブジェクトの削除を禁止するというデフォルトの振舞いになります。


### PR DESCRIPTION
・冗長表現の見直し（例：使用することができます⇒使用できます）
　　ただし、原文のニュアンスを踏まえて、修正していない箇所もあります。
・助詞の見直し（例：存在するかどうか関係なく⇒存在するかどうかに関係なく）
・送り仮名の見直し（例：割当てられます⇒割り当てられます）
・漢字の開きの見直し（例：以下の通り⇒以下のとおり）
・（）を全角に統一した
・数字を半角に統一した