### PR TITLE
第6章の文章表現を見直しました。

### DIFF
--- a/doc/src/sgml/dml.sgml
+++ b/doc/src/sgml/dml.sgml
@@ -50,7 +50,7 @@
 テーブルは、作成時にはデータを含んでいません。
 データベースを利用価値のあるものにするには、まずデータを挿入する必要があります。
 データは一度に1行ずつ挿入されます。
-ユーザは1つのコマンドで複数行を挿入することもできますが、完全な行ではないものを挿入することはできません。
+ユーザは1つのコマンドで複数行を挿入することもできますが、完全な行でないものを挿入することはできません。
 列の値が一部しかわかっていない場合でも、1行全体を作成しなければなりません。
   </para>
 
@@ -159,7 +159,7 @@ INSERT INTO products (product_no, name, price) VALUES
    It is also possible to insert the result of a query (which might be no
    rows, one row, or many rows):
 -->
-また、問い合わせの結果（０行かも、１行かも、複数行かもしれない）を挿入することもできます。
+また、問い合わせの結果（0行か、1行か、複数行かもしれない）を挿入することもできます。
 <programlisting>
 INSERT INTO products (product_no, name, price)
   SELECT product_no, name, price FROM new_products
@@ -214,8 +214,8 @@ INSERT INTO products (product_no, name, price)
    updated separately; the other columns are not affected.
 -->
 既にデータベースに入っているデータを変更することを「更新(update)する」と言います。
-個別の行、テーブル内の全ての行、あるいは全ての行のサブセットを更新することができます。
-各列は、他の列に影響を及ぼすことなく個別に更新することができます。
+個別の行、テーブル内の全ての行、あるいは全ての行のサブセットを更新できます。
+各列は、他の列に影響を及ぼすことなく個別に更新できます。
   </para>
 
   <para>
@@ -263,9 +263,9 @@ INSERT INTO products (product_no, name, price)
    update rows individually.
 -->
 <xref linkend="ddl"/>で説明した、一般にSQLでは行に対して一意のIDを指定しないことを思い出してください。
-従って、どの行を更新するかを直接指定することができない場合があります。
+従って、どの行を更新するかを直接指定できない場合があります。
 その代わりに、更新される行が満たすべき条件を指定します。
-テーブルに主キーを設定している場合に限り（ユーザが宣言したのかどうかには関係なく）、主キーと一致する条件を選択することで確実に個別の行を指定することができます。
+テーブルに主キーを設定している場合に限り（ユーザが宣言したのかどうかには関係なく）、主キーと一致する条件を選択することで確実に個別の行を指定できます。
 グラフィカルなデータベースアクセスツールは、この方法を使用して行を個別に更新することを可能にしています。
   </para>
 
@@ -466,7 +466,7 @@ DELETE FROM products;
    all columns of the target table in order.
 -->
 <literal>RETURNING</literal>句で使用できる項目は<command>SELECT</command>コマンドの出力リスト（<xref linkend="queries-select-lists"/>参照）と同じです。
-コマンドの対象となっているテーブルの列の名前、あるいはそれらの列を使った値の式を入れることができます。
+コマンドの対象となっているテーブルの列名、あるいはそれらの列を使った値の式を入れることができます。
 よく使われる省略記法は<literal>RETURNING *</literal>で、これは対象テーブルのすべての列を順に返します。
   </para>
 


### PR DESCRIPTION
・助詞の見直し（例：完全な行ではないものを⇒完全な行でないものを）
・冗長表現の見直し（例：することができます⇒できます）
　　ただし、原文のニュアンスを踏まえて、修正していない箇所もあります。
・数字を半角に統一した
・column names を「列名」と訳した
　　他の章の訳を参考にしました。