### PR TITLE
第10章の文章表現を見直しました。

### DIFF
--- a/doc/src/sgml/typeconv.sgml
+++ b/doc/src/sgml/typeconv.sgml
@@ -177,7 +177,7 @@ Value Storage
 expressions into a table. The expressions in the statement must be matched up
 with, and perhaps converted to, the types of the target columns.
 -->
-<acronym>SQL</acronym>の<command>INSERT</command>と<command>UPDATE</command>文は式の結果をテーブルの中に格納します。
+<acronym>SQL</acronym>の<command>INSERT</command>と<command>UPDATE</command>文は式の結果をテーブルに格納します。
 文内の式は対象となる列の型に一致する、または、変換できるものである必要があります。
 </para>
 </listitem>
@@ -255,9 +255,9 @@ resolved in a useful way.
 -->
 暗黙のキャストを持つデータ型間の処理において、適切なキャスト処理のより良い決定を行えるようパーサは追加の自律機構を備えています。
 データ型は、<type>boolean</type>、<type>numeric</type>、<type>string</type>、<type>bitstring</type>、<type>datetime</type>、<type>timespan</type>、<type>geometric</type>、<type>network</type>、及びユーザ定義を含むいくつかの基本的な<firstterm>型カテゴリ</firstterm>に分けられます。
-(一覧は<xref linkend="catalog-typcategory-table"/>を参照してください。ですが、独自の型カテゴリを作成するのも可能なことに注意して下さい。)
+（一覧は<xref linkend="catalog-typcategory-table"/>を参照してください。ですが、独自の型カテゴリを作成するのも可能なことに注意してください。)
 各カテゴリには、候補となる型の選択があった場合に、優先される1つ以上の<firstterm>優先される型</firstterm>がある場合があります。
-優先される型と利用可能な暗黙のキャストを注意して選択すれば、曖昧な式(複数の解析結果候補を持つもの)が有効な方法で解決されることを保証することが可能です。
+優先される型と利用可能な暗黙のキャストを注意して選択すれば、曖昧な式（複数の解析結果候補を持つもの）が有効な方法で解決されることを保証することが可能です。
 </para>
 
 <para>
@@ -297,7 +297,7 @@ Additionally, if a query usually requires an implicit conversion for a function,
 if then the user defines a new function with the correct argument types, the parser
 should use this new function and no longer do implicit conversion to use the old function.
 -->
-さらに、もし問い合わせが関数のために暗黙的な変換を通常要求しており、そして、ユーザが正しい引数型を持つ関数を新しく定義した場合、パーサはこの新しい関数を使うべきであり、もはや古い関数を使うために暗黙的な変換を行わないようすべきです。
+さらに、もし問い合わせが関数のために暗黙的な変換を通常要求しており、そして、ユーザが正しい引数型を持つ関数を新しく定義した場合、パーサはこの新しい関数を使うべきであり、もはや古い関数を使うために暗黙的な変換を行わないようにすべきです。
 </para>
 </listitem>
 </itemizedlist>
@@ -330,7 +330,7 @@ should use this new function and no longer do implicit conversion to use the old
    See <xref linkend="sql-precedence"/> for more information.
 -->
 演算式に参照される特定の演算子は、以下の手順を用いて決定されます。
-関連する演算子の優先順位によりどの下位式をどの演算子の入力と見なすかが決定されますので、この手順はこの優先順位により間接的な影響を受けることに注意して下さい。
+関連する演算子の優先順位によりどの下位式をどの演算子の入力と見なすかが決定されますので、この手順はこの優先順位により間接的な影響を受けることに注意してください。
 詳細は<xref linkend="sql-precedence"/>を参照してください。
   </para>
 
@@ -414,7 +414,7 @@ Invocations involving two <type>unknown</type> inputs, or a prefix operator
 with an <type>unknown</type> input, will never find a match at this step.
 -->
 二項演算子の1つの引数が<type>unknown</type>型であった場合、この検査のもう片方の引数と同一の型であると仮定します。
-2つの<type>unknown</type>入力、もしくは<type>unknown</type>入力を伴う前置演算子が呼び出された場合、この段階では対を見つけることはありません。
+2つの<type>unknown</type>入力、もしくは<type>unknown</type>入力を伴う前置演算子が呼び出された場合、この段階で対を見つけることはありません。
 </para>
 </step>
 <step id="op-resol-exact-domain" performance="optional">
@@ -688,7 +688,7 @@ Here the system has implicitly resolved the unknown-type literal as type
 <type>float8</type> and not some other type was used:
 -->
 ここでシステムは、選択した演算子を適用する前に、unknown型のリテラルを<type>float8</type>へ暗黙的に型変換します。
-以下のように<type>float8</type>が使用され、他の型が使用されていないことを検証することができます。
+以下のように<type>float8</type>が使用され、他の型が使用されていないことを検証できます。
 <screen>
 SELECT @ '-4.5e500' AS "abs";
 
@@ -786,7 +786,7 @@ This is possible but is not nearly as useful as it might seem, because the
 operator resolution rules are designed to select operators applying to the
 domain's base type.  As an example consider
 -->
-利用者は時々ドメイン型にのみ適用される演算子を宣言しようとします。
+利用者はときどきドメイン型にのみ適用される演算子を宣言しようとします。
 これは可能ですが、思ったほど便利ではありません。演算子の解決規則がドメイン基本型に適用される演算子を選ぶように設計されているからです。
 例として、以下を考えてください。
 <screen>
@@ -809,8 +809,8 @@ uses the <type>text</type> <literal>=</literal> <type>text</type> operator.
 The only way to get the custom operator to be used is to explicitly cast
 the literal:
 -->
-この問い合わせは独自の演算子を使いません．
-パーサはまず<type>mytext</type> <literal>=</literal> <type>mytext</type>演算子(<xref linkend="op-resol-exact-unknown"/>)があるか確認しますが、ありません。次にドメイン基本型<type>text</type>を考慮して<type>text</type> <literal>=</literal> <type>text</type>演算子(<xref linkend="op-resol-exact-domain"/>)があるか確認すると、あります。そのため<type>unknown</type>型は<type>text</type>として解決され、<type>text</type> <literal>=</literal> <type>text</type>演算子が使われます。
+この問い合わせには独自の演算子を使いません。
+パーサはまず<type>mytext</type> <literal>=</literal> <type>mytext</type>演算子（<xref linkend="op-resol-exact-unknown"/>）があるか確認しますが、ありません。次にドメイン基本型<type>text</type>を考慮して<type>text</type> <literal>=</literal> <type>text</type>演算子（<xref linkend="op-resol-exact-domain"/>）があるか確認すると、あります。そのため<type>unknown</type>型は<type>text</type>として解決され、<type>text</type> <literal>=</literal> <type>text</type>演算子が使われます。
 独自の演算子を使う唯一の方法は、リテラルを明示的にキャストすることだけです。
 <screen>
 SELECT * FROM mytable WHERE val = text 'foo';
@@ -937,8 +937,8 @@ to create objects.
 呼び出す時にセキュリティの危険が発生します。
 悪意のあるユーザは、支配権を奪い、あたかもあなたが実行したかのように任意のSQL関数を実行できます。
 <literal>VARIADIC</literal>キーワードを持つ呼び出しを代わりに使ってください。そうすればこの危険は避けられます。
-<literal>VARIADIC "any"</literal>パラメータにデータを入れての呼び出しには、しばしば同等の<literal>VARIADIC</literal>キーワード含む定式化がありません。
-この呼び出しを安全に行なうには、関数のスキーマは信用できるユーザだけがオブジェクトを作成できるようにしなければなりません。
+<literal>VARIADIC "any"</literal>パラメータにデータを入れての呼び出しには、しばしば同等の<literal>VARIADIC</literal>キーワードを含む定式化がありません。
+この呼び出しを安全に行うには、関数のスキーマは信用できるユーザだけがオブジェクトを作成できるようにしなければなりません。
 </para>
 </step>
 <step performance="optional">
@@ -956,7 +956,7 @@ found.
 -->
 パラメータにデフォルト値を持つ関数は、デフォルト指定可能なパラメータ位置のうち、0以上が省略されたどのような呼び出しに対しても適合すると見なされます。
 もし呼び出し時にこのような関数が2つ以上適合した場合、検索パスで先に見つかったものが使用されます。
-もし、デフォルト指定のない位置に同じパラメータ型を持つ関数(もしそれらが異なるデフォルト指定のあるパラメータのセットを持っていればあり得ます)が同じスキーマに2つ以上あった時は、システムはどの関数を使うべきか決定できず、呼び出しにより適合するものが見つからなければ<quote>ambiguous function call</quote>エラーが結果として返るでしょう。
+もし、デフォルト指定のない位置に同じパラメータ型を持つ関数（もしそれらが異なるデフォルト指定のあるパラメータのセットを持っていればあり得ます）が同じスキーマに2つ以上あった時は、システムはどの関数を使うべきか決定できず、呼び出しにより適合するものが見つからなければ<quote>ambiguous function call</quote>エラーが結果として返るでしょう。
 </para>
 <para>
 <!--
@@ -1063,7 +1063,7 @@ domain's base type for all subsequent steps.  This ensures that domains
 act like their base types for purposes of ambiguous-function resolution.
 -->
 入力引数のいずれかがドメイン型であれば、以降の段階すべてでドメインの基本型であるかのように扱います。
-これにより、曖昧な関数を解決するのを目的としてその基本型であるかのようにドメインが振る舞うことが確実になります。
+これにより、曖昧な関数を解決するのを目的としてその基本型であるかのようにドメインが振る舞うことを確実にします。
 </para>
 </step>
 <step performance="required">
@@ -1409,7 +1409,7 @@ the literal string will be fed to the input conversion routine for the target
 type.
 -->
 なければ、式を対象の型に変換してみます。
-もし2つの型の間の<firstterm>代入キャスト</firstterm>が<structname>pg_cast</structname>カタログ(<xref linkend="sql-createcast"/>を参照してください)に登録されている場合、これは可能です。
+もし2つの型の間の<firstterm>代入キャスト</firstterm>が<structname>pg_cast</structname>カタログ（<xref linkend="sql-createcast"/>を参照してください）に登録されている場合、これは可能です。
 あるいは、もし式がunknown型リテラルの場合、リテラル文字列の内容は対象の型の入力変換ルーチンに与えられます。
 </para>
 </step>
@@ -1484,7 +1484,7 @@ type-specific function performs the required length check and addition of
 padding spaces.
 -->
 ここで実際に起こったのは、デフォルトで<literal>||</literal>演算子が<type>text</type>の連結として解決できるように、2つのunknownリテラルが<type>text</type>に解決されたということです。
-そして演算子の<type>text</type>型の結果は対象の列の型に合うように<type>bpchar</type>(<quote>空白が埋められる文字</quote>, <type>character</type>データ型の内部名)に変換されます
+そして演算子の<type>text</type>型の結果は対象の列の型に合うように<type>bpchar</type>（<quote>空白が埋められる文字</quote>, <type>character</type>データ型の内部名）に変換されます
 （しかし、<type>text</type>から<type>bpchar</type>へバイナリ変換可能ですので、この型変換のために実際の関数呼び出しは挿入されません）。
 最後に、<literal>bpchar(bpchar, integer, boolean)</literal>サイズ調整関数がシステムカタログの中から見つかり、演算子の結果と格納する列の長さを適用します。
 この型特有の関数は必要とされる長さを検査し、空白の埋め込みを行います。
@@ -1621,7 +1621,7 @@ Otherwise, <type>unknown</type> inputs are ignored for the purposes
 of the remaining rules.
 -->
 もし全ての入力値が<type>unknown</type>型だった場合、<type>text</type>型（文字列カテゴリの優先される型）として解決されます。
-そうでない場合は<type>unknown</type>入力は残りの規則のために無視されます。
+そうでない場合、<type>unknown</type>入力は残りの規則のために無視されます。
 </para>
 </step>
 
@@ -1802,7 +1802,7 @@ likewise resolved pairwise.  However, the other constructs described in this
 section consider all of their inputs in one resolution step.
 -->
 <literal>INTERSECT</literal>と<literal>EXCEPT</literal>操作は同様に二項演算として解決されます。
-しかしながら、この節のその他の構文は入力をすべて解決の段階1つで考慮します。
+しかしながら、この節のその他の構文は入力をすべて解決の段階の1つで考慮します。
 </para>
 </example>
 </sect1>


### PR DESCRIPTION
・漢字の開きの見直し（例：して下さい⇒してください）
・（）を全角に統一した
・句点を「。」に統一した
・助詞の見直し（例：行わないようすべきです⇒行わないようにすべきです）
・冗長表現の見直し（例：検証することができます⇒検証できます）
　　ただし、原文のニュアンスを踏まえて、修正していない箇所もあります。
・送り仮名の修正（例：行なうには⇒行うには）