### PR TITLE
update set_transaction for 15.3

### DIFF
--- a/doc/src/sgml/ref/set_transaction.sgml
+++ b/doc/src/sgml/ref/set_transaction.sgml
@@ -180,10 +180,8 @@ SET SESSION CHARACTERISTICS AS TRANSACTION <replaceable class="parameter">transa
    <xref linkend="mvcc"/> for more information about transaction
    isolation and concurrency control.
 -->
-《マッチ度[88.785047]》トランザクション分離レベルは、そのトランザクションにおける最初の問い合わせ文やデータ更新文（<command>SELECT</command>、<command>INSERT</command>、<command>DELETE</command>、<command>UPDATE</command>、<command>FETCH</command>、<command>COPY</command>）が実行された後では変更することができません。
+トランザクション分離レベルは、そのトランザクションにおける最初の問い合わせ文やデータ更新文（<command>SELECT</command>、<command>INSERT</command>、<command>DELETE</command>、<command>UPDATE</command>、<command>MERGE</command>、<command>FETCH</command>、<command>COPY</command>）が実行された後では変更できません。
 トランザクションの分離や同時実行制御についての詳細情報は<xref linkend="mvcc"/>を参照してください。
-《機械翻訳》トランザクション分離レベルの最初のクエリまたはデータ変更ステートメント(<command>セレクト</command>、<command>INSERT</command>、<command>削除</command>、<command>更新</command>、<command>マージ</command>、<command>フェッチ</command>または<command>コピー</command>)が実行された後は、トランザクションを変更できません。
-トランザクションの分離および同時実行制御の詳細は、<xref linkend="mvcc"/>を参照してください。
   </para>
 
   <para>
@@ -203,18 +201,13 @@ SET SESSION CHARACTERISTICS AS TRANSACTION <replaceable class="parameter">transa
    among those listed.  This is a high-level notion of read-only that
    does not prevent all writes to disk.
 -->
-《マッチ度[84.758364]》トランザクションのアクセスモードは、そのトランザクションが読み書き可能か読み取り専用かを決定します。
+トランザクションのアクセスモードは、そのトランザクションが読み書き可能か読み取り専用かを決定します。
 デフォルトは読み書き可能です。
 読み取り専用のトランザクションでは、以下のSQLコマンドの実行が制限されます。
-書き込み対象のテーブルが一時テーブルでない場合、<literal>INSERT</literal>、<literal>UPDATE</literal>、<literal>DELETE</literal>、<literal>COPY FROM</literal>などのSQLコマンドを実行できません。
+書き込み対象のテーブルが一時テーブルでない場合、<literal>INSERT</literal>、<literal>UPDATE</literal>、<literal>DELETE</literal>、<command>MERGE</command>、<literal>COPY FROM</literal>などのSQLコマンドを実行できません。
 すべての<literal>CREATE</literal>、<literal>ALTER</literal>、<literal>DROP</literal>系のSQLコマンド、<literal>COMMENT</literal>、<literal>GRANT</literal>、<literal>REVOKE</literal>、<literal>TRUNCATE</literal>は、実行できません。
 さらに、上述のコマンドが含まれる<literal>EXPLAIN ANALYZE</literal>と<literal>EXECUTE</literal>コマンドも実行できません。
-この方法ではディスクへの書き込みをすべて防ぐわけではないので、読み取り専用の高レベルの概念です。
-《機械翻訳》トランザクションアクセスモードは、トランザクションが読み取り/書き込みか読み取り専用かを決定します。
-読み取り/書き込みはデフォルトです。
-トランザクションが読み取り専用の場合、書き込み先のテーブルが一時テーブルでない場合、<literal>INSERT</literal>、<literal>UPDATE</literal>、<literal>DELETE</literal>、 <command>MERGE</command>、および<command>COPY FROM</command>SQLコマンドは使用できません。
-すべての<literal>CREATE</literal>、<literal>ALTER</literal>、および<literal>DROP</literal>コマンド、<literal>COMMENT</literal>、<literal>GRANT</literal>、<literal>REVOKE</literal>、<literal>TRUNCATE</literal>、およびコマンドが実行である場合、<literal>EXPLAIN ANALYZE</literal>と<literal>EXECUTE</literal>の場合は、自動的に記録されます。
-これは読み取り専用の上位レベルの概念であり、すべての書き込みがディスクに対して禁止されるわけではありません。
+これは読み取り専用の高レベルの概念であり、ディスクへの書き込みをすべて防ぐわけではありません。
   </para>
 
   <para>
@@ -262,12 +255,12 @@ SET SESSION CHARACTERISTICS AS TRANSACTION <replaceable class="parameter">transa
    non-read-only serializable transaction cannot import a snapshot from a
    read-only transaction.
 -->
-《マッチ度[93.377049]》<literal>SET TRANSACTION SNAPSHOT</literal>コマンドにより、既存のトランザクションと同じ<firstterm>スナップショット</firstterm>を持つ新しいトランザクションを実行することができます。
+<literal>SET TRANSACTION SNAPSHOT</literal>コマンドにより、既存のトランザクションと同じ<firstterm>スナップショット</firstterm>を持つ新しいトランザクションを実行することができます。
 既存のトランザクションは<literal>pg_export_snapshot</literal>関数(<xref linkend="functions-snapshot-synchronization"/>参照)を使用してそのスナップショットを公開していなければなりません。
 この関数はスナップショット識別子を返します。
 どのスナップショットを取り込むかを指定するために、この識別子を<literal>SET TRANSACTION SNAPSHOT</literal>に渡さなければなりません。
 このコマンドでは、この識別子を例えば<literal>'00000003-0000001B-1'</literal>のようにリテラル文字列として記述しなければなりません。
-<literal>SET TRANSACTION SNAPSHOT</literal>はトランザクションの開始時、つまり、トランザクションの最初の問い合わせまたはデータ変更文(<command>SELECT</command>、<command>INSERT</command>、<command>DELETE</command>、<command>UPDATE</command>、<command>FETCH</command>、<command>COPY</command>)の前でのみ実行できます。
+<literal>SET TRANSACTION SNAPSHOT</literal>はトランザクションの開始時、つまり、トランザクションの最初の問い合わせまたはデータ変更文(<command>SELECT</command>、<command>INSERT</command>、<command>DELETE</command>、<command>UPDATE</command>、<command>MERGE</command>、<command>FETCH</command>、<command>COPY</command>)の前でのみ実行できます。
 さらに、そのトランザクションを前もって<literal>SERIALIZABLE</literal>または<literal>REPEATABLE READ</literal>分離レベルに設定していなければなりません。
 (さもないと、<literal>READ COMMITTED</literal>ではコマンドそれぞれに対して新しいスナップショットを取りますので、このスナップショットは即座に破棄されます。)
 取り込むトランザクションが<literal>SERIALIZABLE</literal>分離レベルを使用している場合、スナップショットを公開したトランザクションもこの分離レベルを使用しなければなりません。


### PR DESCRIPTION
ref/set_transaction.sgmlの15.3対応です。
基本的にはMERGEの追加なのですが、

> これは読み取り専用の高レベルの概念であり、ディスクへの書き込みをすべて防ぐわけではありません。

は機械翻訳のほうが自然な気がしたので、機械翻訳に近づける形で変更しました。が、内容をよく分かっているわけではないので、前のほうが正確だとかありましたらお知らせください。