### PR TITLE
第17章の文章表現を見直しました。

### DIFF
--- a/doc/src/sgml/installation.sgml
+++ b/doc/src/sgml/installation.sgml
@@ -182,7 +182,7 @@ su - postgres
 これは非常に役に立ちますので、強く推奨します。
 使用したくない場合は、<filename>configure</filename>に<option>--without-readline</option>オプションを指定する必要があります。
 その代わりとして、BSDライセンスの<filename>libedit</filename>ライブラリを使用することもできます。
-このライブラリは元々<productname>NetBSD</productname>で開発されていました。
+このライブラリはもともと<productname>NetBSD</productname>で開発されていました。
 <filename>libedit</filename>ライブラリはGNUの<productname>Readline</productname>と互換性があり、<filename>libreadline</filename>を認識できなかった場合や<filename>configure</filename>のオプションに<option>--with-libedit-preferred</option>が使用された場合に使用されます。
 パッケージベースのLinuxディストリビューションを使用し、そのディストリビューションの中で<literal>readline</literal>と<literal>readline-devel</literal>パッケージが別個に存在していた場合、両方とも必要ですので注意してください。
      </para>
@@ -295,7 +295,7 @@ su - postgres
 <application>PL/Python</application>は共有ライブラリになりますので、ほとんどのプラットフォームでは、<indexterm><primary>libpython</primary></indexterm><filename>libpython</filename>もまた共有ライブラリである必要があります。
 ソースから構築した<productname>Python</productname>のインストレーションでは、これはデフォルトではありませんが、共有ライブラリは多くのオペレーティングシステムのディストリビューションで入手可能です。
 <application>PL/Python</application>を構築することを選択したのに共有の<filename>libpython</filename>が見つからなければ、<filename>configure</filename>は失敗するでしょう。
-それは、この共有ライブラリを提供するために追加のパッケージをインストールするか、<productname>Python</productname>のインストレーション(の一部)を再構築しなればならないということを意味しているかもしれません。
+それは、この共有ライブラリを提供するために追加のパッケージをインストールするか、<productname>Python</productname>のインストレーション（の一部）を再構築しなければならないということを意味しているかもしれません。
 ソースから構築する場合、<literal>--enable-shared</literal>フラグを付けて<productname>Python</productname>のconfigureを実行してください。
      </para>
     </listitem>
@@ -333,7 +333,7 @@ su - postgres
 -->
 各国語サポート（<acronym>NLS</acronym>）、つまり、英語以外の言語によるプログラムメッセージの表示機能を有効にするには、<application>Gettext</application> <acronym>API</acronym>の実装が必要です。
 オペレーティングシステムの中には（例えば、<systemitem class="osname">Linux</systemitem>、<systemitem class="osname">NetBSD</systemitem>、<systemitem class="osname">Solaris</systemitem>など）、組み込み済みのものがあります。
-他のシステムでは、追加パッケージを<ulink url="https://www.gnu.org/software/gettext/"></ulink>からダウンロードすることができます。
+他のシステムでは、追加パッケージを<ulink url="https://www.gnu.org/software/gettext/"></ulink>からダウンロードできます。
 <acronym>GNU</acronym> Cライブラリの<application>gettext</application>の実装を使用する場合、さらにいくつかのユーティリティプログラムのために<productname>GNU Gettext</productname>パッケージが必要となります。
 他の実装の場合には必要ありません。
      </para>
@@ -349,7 +349,7 @@ su - postgres
       required version is 1.0.1.
 -->
 暗号化されたクライアント接続をサポートする場合には<productname>OpenSSL</productname>が必要です。
-<productname>OpenSSL</productname>は、<filename>/dev/urandom</filename>のないプラットフォーム(Windowsを除く)での乱数生成のためにも必要です。
+<productname>OpenSSL</productname>は、<filename>/dev/urandom</filename>のないプラットフォーム（Windowsを除く）での乱数生成のためにも必要です。
 要求される最小のバージョンは1.0.1です。
      </para>
     </listitem>
@@ -399,7 +399,7 @@ su - postgres
       there is a separate set of requirements; see
       <xref linkend="docguide-toolsets"/>.
 -->
-<productname>PostgreSQL</productname>の文書を構築するためには必要なセットは別途記載します。
+<productname>PostgreSQL</productname>の文書を構築するために必要なセットは別途記載します。
 <xref linkend="docguide-toolsets"/>を参照してください。
      </para>
     </listitem>
@@ -456,7 +456,7 @@ su - postgres
       <application>Perl</application> in any case.  <application>Perl</application> is
       also required to run some test suites.
 -->
-Gitからチェックアウトしたものから構築する場合や、構築時にPerlスクリプトを使用して作成されるファイルの入力となるファイルを変更する場合には<application>Perl</application>5.8.3以降が必要です。
+Gitからチェックアウトしたもので構築する場合や、構築時にPerlスクリプトを使用して作成されるファイルの入力となるファイルを変更する場合には<application>Perl</application>5.8.3以降が必要です。
 Windows上で構築する場合、いずれにしても<application>Perl</application>は必要です。
 <application>Perl</application>はテストスイートのいくつかを実行するのにも必要です。
      </para>
@@ -588,7 +588,7 @@ Windows上で構築する場合、いずれにしても<application>Perl</applic
 -->
 構築用のディレクトリを別の場所にしたい場合は、ソースツリーの外のディレクトリで<filename>configure</filename>を実行することもできます。
 この処理は<indexterm><primary>VPATH</primary></indexterm><firstterm>VPATH</firstterm>構築と呼ばれます。
-どのように行うかは下記を参照して下さい。
+どのように行うかは下記を参照してください。
 <screen>
 <userinput>mkdir build_dir</userinput>
 <userinput>cd build_dir</userinput>
@@ -620,8 +620,8 @@ Windows上で構築する場合、いずれにしても<application>Perl</applic
     has a large number of options, which are described in
     <xref linkend="configure-options"/>.
 -->
-<filename>configure</filename>にコマンドラインオプションを1つ以上指定することで、構築処理やインストール処理を変更することができます。
-よくあるのは、インストールの位置や構築するオプションの機能の設定を変更することでしょう。
+<filename>configure</filename>にコマンドラインオプションを1つ以上指定することで、構築処理やインストール処理を変更できます。
+よくあるのは、インストール位置や構築するオプションの機能の設定を変更することでしょう。
 <filename>configure</filename>には数多くのオプションがあり、それは<xref linkend="configure-options"/>に書かれています。
    </para>
 
@@ -678,7 +678,7 @@ Windows上で構築する場合、いずれにしても<application>Perl</applic
    additional modules (<filename>contrib</filename>), but without
    the documentation, type instead:
 -->
-もし、追加モジュール(<filename>contrib</filename>)は含めるがドキュメントは含めずに、構築可能なものすべてを構築したい場合、次のように入力します。
+もし、追加モジュール(<filename>contrib</filename>)は含めるがドキュメントを含めずに、構築可能なものすべてを構築したい場合、次のように入力します。
 <screen>
 <userinput>make world-bin</userinput>
 </screen>
@@ -779,7 +779,7 @@ build-postgresql:
 -->
 これは、ファイルを<xref linkend="configure"/>で指定されたディレクトリにインストールします。
 その領域に書き込むための権限を持っていることを確認してください。
-通常はこのステップはrootで行う必要があります。
+通常はこのステップをrootで行う必要があります。
 代わりに対象とするディレクトリを前もって作成し、適切に権限を調整することも可能です。
    </para>
 
@@ -787,7 +787,7 @@ build-postgresql:
 <!--
     To install the documentation (HTML and man pages), enter:
 -->
-ドキュメント(HTMLやman)をインストールするには、以下を入力して下さい。
+ドキュメント（HTMLやman）をインストールするには、以下を入力してください。
 <screen>
 <userinput>make install-docs</userinput>
 </screen>
@@ -797,7 +797,7 @@ build-postgresql:
 <!--
     If you built the world above, type instead:
 -->
-上記のようにすべてを(worldを付けて)構築していた場合には、代わりに以下を入力してください。
+上記のようにすべてを（worldを付けて）構築していた場合には、代わりに以下を入力してください。
 <screen>
 <userinput>make install-world</userinput>
 </screen>
@@ -830,7 +830,7 @@ build-postgresql:
     executable file, so if you want to save all the disk space you
     possibly can, you will have to do manual work.
 -->
-<literal>make install</literal>の代わりに<literal>make install-strip</literal>を使用することで、インストール時に実行可能ファイルやライブラリをストリップ（strip）することができます。
+<literal>make install</literal>の代わりに<literal>make install-strip</literal>を使用することで、インストール時に実行可能ファイルやライブラリをストリップ（strip）できます。
 これにより、多少の容量を節約できます。
 デバッグをサポートするように構築している場合でも、ストリップするとデバッグのサポートは実質、除去されてしまいます。
 したがって、これはデバッグが必要なくなった場合にのみ実行すべきです。
@@ -851,7 +851,7 @@ build-postgresql:
 <!--
     <title>Client-only installation:</title>
 -->
-    <title>クライアント側のみのインストール:</title>
+    <title>クライアント側のみのインストール：</title>
     <para>
 <!--
      If you want to install only the client applications and
@@ -878,7 +878,7 @@ build-postgresql:
 <!--
    <title>Uninstallation:</title>
 -->
-   <title>アンインストール:</title>
+   <title>アンインストール：</title>
    <para>
 <!--
     To undo the installation use the command <command>make
@@ -893,7 +893,7 @@ build-postgresql:
 <!--
    <title>Cleaning:</title>
 -->
-   <title>クリーニング:</title>
+   <title>クリーニング：</title>
 
    <para>
 <!--
@@ -951,7 +951,7 @@ build-postgresql:
     the standard Autoconf documentation.
 -->
 <command>configure</command>のコマンドラインオプションを以下で説明します。
-この一覧は完全なものではありません(完全なものを得るには<literal>./configure --help</literal>を使ってください)。
+この一覧は完全なものではありません（完全なものを得るには<literal>./configure --help</literal>を使ってください）。
 ここで取り上げていないオプションはクロスコンパイルのような高度なユースケースのためのもので、標準のAutoconfのドキュメントに書かれています。
    </para>
 
@@ -977,7 +977,7 @@ build-postgresql:
 -->
 このオプションは<literal>make install</literal>がファイルをどこに置くかを制御します。
 たいていの場合<option>--prefix</option>オプションで十分です。
-特別な必要性があるのであれば、この節に書かれた他のオプションを使用して個々のインストレーションサブディレクトリを変更できます。
+特別な必要があるのであれば、この節に書かれた他のオプションを使用して個々のインストレーションサブディレクトリを変更できます。
 しかし、異なるサブディレクトリの相対的な位置を変更した場合、インストレーションは再配置不能になります。つまり、インストールの後にディレクトリを移動できないことに注意してください。
 （<literal>man</literal>と<literal>doc</literal>の場所はこの制限の影響を受けません。）
 再配置可能インストールのために、後述の<literal>--disable-rpath</literal>を使用しようと考えるかもしれません。
@@ -1205,7 +1205,7 @@ CおよびC++のヘッダファイルをインストールするディレクト�
        also be created, if appropriate, under <varname>libdir</varname>
        for dynamically loadable modules.
 -->
-（<filename>/usr/local/include</filename>といった）共用のインストール場所に、システムの他の名前空間に影響を与えることなく<productname>PostgreSQL</productname>をインストールすることができるような配慮がなされています。
+（<filename>/usr/local/include</filename>といった）共用のインストール場所に、システムの他の名前空間に影響を与えることなく<productname>PostgreSQL</productname>をインストールできるような配慮がなされています。
 まず、完全に展開したディレクトリ名に<quote><literal>postgres</literal></quote>か<quote><literal>pgsql</literal></quote>という文字列が含まれていない場合、<quote><literal>/postgresql</literal></quote>という文字列が自動的に<varname>datadir</varname>、<varname>sysconfdir</varname>、<varname>docdir</varname>に追加されます。
 例えば、接頭辞として<filename>/usr/local</filename>を使用する場合、文書は<filename>/usr/local/doc/postgresql</filename>にインストールされますが、接頭辞が<filename>/opt/postgres</filename>の場合は<filename>/opt/postgres/doc</filename>にインストールされます。
 クライアントインタフェース用の外部向けCヘッダファイルは<varname>includedir</varname>にインストールされ、名前空間の問題はありません。
@@ -1339,7 +1339,7 @@ Tclは、Tclへのインタフェースモジュールを構築するために�
 -->
 <productname>ICU</productname><indexterm><primary>ICU</primary></indexterm>ライブラリのサポートを有効にして構築します。これによりICU照合機能が使用できるようになります。
 <phrase condition="standalone-ignore"> (<xref linkend="collation"/>を参照してください。)</phrase>
-これには、<productname>ICU4C</productname>パッケージがインストールされていることが必要です。
+これには、<productname>ICU4C</productname>パッケージをインストールされていることが必要です。
 <productname>ICU4C</productname>の要求される最小のバージョンは現在4.2です。
         </para>
 
@@ -1366,7 +1366,7 @@ Tclは、Tclへのインタフェースモジュールを構築するために�
          order to avoid use of <productname>pkg-config</productname>, for
          example, <literal>ICU_CFLAGS=' '</literal>.)
 -->
-(<productname>ICU4C</productname>がコンパイラのデフォルトの検索パスにあるのなら、<productname>pkg-config</productname>の使用を避けるため、例えば<literal>ICU_CFLAGS=' '</literal>のような空でない文字列を指定することも必要です。)
+（<productname>ICU4C</productname>がコンパイラのデフォルトの検索パスにあるのなら、<productname>pkg-config</productname>の使用を避けるため、例えば<literal>ICU_CFLAGS=' '</literal>のような空でない文字列を指定することも必要です。）
         </para>
        </listitem>
       </varlistentry>
@@ -1384,8 +1384,8 @@ Tclは、Tclへのインタフェースモジュールを構築するために�
          The minimum required version of <productname>LLVM</productname> is
          currently 3.9.
 -->
-<productname>LLVM</productname>に基づいた<acronym>JIT</acronym>コンパイル<phrase condition="standalone-ignore"> (<xref linkend="jit"/>を参照)</phrase>のサポート有効にして構築します。
-これには、<productname>LLVM</productname>ライブラリがインストールされていることが必要です。
+<productname>LLVM</productname>に基づいた<acronym>JIT</acronym>コンパイル<phrase condition="standalone-ignore">（<xref linkend="jit"/>を参照）</phrase>のサポートを有効にして構築します。
+これには、<productname>LLVM</productname>ライブラリをインストールされていることが必要です。
 <productname>LLVM</productname>の要求される最小のバージョンは現在3.9です。
         </para>
         <para>
@@ -1402,7 +1402,7 @@ Tclは、Tclへのインタフェースモジュールを構築するために�
 要求されるコンパイルオプションを見つけるために<command>llvm-config</command><indexterm><primary>llvm-config</primary></indexterm>が使われます。
 <command>llvm-config</command>、それからサポートされるバージョンすべての<command>llvm-config-$major-$minor</command>を<envar>PATH</envar>で探します。
 それで正しいバイナリが見つからなければ、正しい<command>llvm-config</command>へのパスを指定するために<envar>LLVM_CONFIG</envar>を使ってください。
-例えば、以下の通りです。
+例えば、以下のとおりです。
 <programlisting>
 ./configure ... --with-llvm LLVM_CONFIG='/path/to/llvm/bin/llvm-config'
 </programlisting>
@@ -1416,7 +1416,7 @@ Tclは、Tclへのインタフェースモジュールを構築するために�
          compiler (specified, if necessary, using the <envar>CXX</envar>
          environment variable).
 -->
-<productname>LLVM</productname>サポートは<command>clang</command>互換のコンパイラ(必要なら環境変数<envar>CLANG</envar>で指定してください)と動作するC++コンパイラ(必要なら環境変数<envar>CXX</envar>で指定してください)を要求します。
+<productname>LLVM</productname>サポートは<command>clang</command>互換のコンパイラ（必要なら環境変数<envar>CLANG</envar>で指定してください）と動作するC++コンパイラ（必要なら環境変数<envar>CXX</envar>で指定してください）を要求します。
         </para>
        </listitem>
       </varlistentry>
@@ -1466,7 +1466,7 @@ Tclは、Tclへのインタフェースモジュールを構築するために�
 -->
 <acronym>SSL</acronym>（暗号化）接続のサポートを有効にして構築します。
 サポートされている唯一の<replaceable>LIBRARY</replaceable>は<option>openssl</option>です。
-これには、<productname>OpenSSL</productname>パッケージがインストールされていることが必要です。
+これには、<productname>OpenSSL</productname>パッケージをインストールされていることが必要です。
 <filename>configure</filename>は、処理を進める前に<productname>OpenSSL</productname>のインストールを確認するために、必要なヘッダファイルとライブラリを検査します。
         </para>
        </listitem>
@@ -1525,7 +1525,7 @@ GSSAPI認証のサポートを構築します。
 -->
 認証および接続パラメータ検索用の<acronym>LDAP</acronym><indexterm><primary>LDAP</primary></indexterm>サポートを有効にして構築します。
 （詳細は<phrase id="install-ldap-links"><xref linkend="libpq-ldap"/>および<xref linkend="auth-ldap"/></phrase>を参照してください。）
-Unixでは、<productname>OpenLDAP</productname>パッケージがインストールされていることが必要です。
+Unixでは、<productname>OpenLDAP</productname>パッケージをインストールされていることが必要です。
 Windowsではデフォルトの<productname>WinLDAP</productname>ライブラリが使用されます。
 <filename>configure</filename>は、処理を進める前に<productname>OpenLDAP</productname>のインストールが十分されているかどうかを確認するために、必要なヘッダファイルとライブラリを検査します。
         </para>
@@ -1591,7 +1591,7 @@ BSD認証のサポートを有効にして構築します。
 -->
 Bonjour自動サービス検出のサポートを有効にして構築します。
 これには、オペレーティングシステムがBonjourをサポートしていることが必要です。
-macOSでは推奨します。
+macOSで推奨します。
         </para>
        </listitem>
       </varlistentry>
@@ -1697,7 +1697,7 @@ pkg-configがインストールされていて、かつそれがlibxml2につい
          nonempty strings.)
 -->
 通常以外の場所にインストールしたlibxml2インストレーションを使用するためには、<command>pkg-config</command>関連の環境変数を設定するか(そのドキュメントを参照してください)、環境変数<envar>XML2_CONFIG</envar>がそのインストレーション用の<command>xml2-config</command>プログラムを指し示すように設定するか、変数<envar>XML2_CFLAGS</envar>と<envar>XML2_LIBS</envar>を設定します。
-(<command>pkg-config</command>がインストールされていて、libxml2がどこにあるかについてのその認識を覆したいのであれば、<envar>XML2_CONFIG</envar>を、もしくは<envar>XML2_CFLAGS</envar>と<envar>XML2_LIBS</envar>の両方を空でない文字列に設定しなければなりません。)
+（<command>pkg-config</command>がインストールされていて、libxml2がどこにあるかについてのその認識を覆したいのであれば、<envar>XML2_CONFIG</envar>を、もしくは<envar>XML2_CFLAGS</envar>と<envar>XML2_LIBS</envar>の両方を空でない文字列に設定しなければなりません。）
         </para>
        </listitem>
       </varlistentry>
@@ -1945,7 +1945,7 @@ CPU不可分操作の使用を無効にします。
 このオプションが使用されると、<replaceable>DIRECTORY</replaceable>にあるシステムが提供する時間帯データベースがPostgreSQLソース配布物に含まれるものの代わりに使用されます。
 <replaceable>DIRECTORY</replaceable>は絶対パスで指定しなければなりません。
 <filename>/usr/share/zoneinfo</filename>がオペレーティングシステムの一部でよく使われます。
-インストール処理が時間帯データが一致しない、またはエラーがあることを検知しないことに注意してください。
+インストール処理が時間帯データの不一致、またはエラーがあることを検知しないことに注意してください。
 このオプションを使用する場合、指定した時間帯データが<productname>PostgreSQL</productname>で正しく動作するかどうかを検証するためにリグレッションテストを実行することが推奨されています。
         </para>
 
@@ -2049,7 +2049,7 @@ PostgreSQLバージョン番号に<replaceable>STRING</replaceable>を追加し�
 -->
 サーバとクライアントのデフォルトのポート番号を<replaceable>NUMBER</replaceable>に設定します。
 デフォルトは5432です。
-このポートは後でいつでも変更することができますが、ここで指定した場合、サーバとクライアントはコンパイル時に同じデフォルト値を持つようになります。
+このポートは後でいつでも変更できますが、ここで指定した場合、サーバとクライアントはコンパイル時に同じデフォルト値を持つようになります。
 これは非常に便利です。
 通常、デフォルト以外の値を選択すべき唯一の理由は、同じマシンで複数の<productname>PostgreSQL</productname>を稼働させることです。
         </para>
@@ -2103,7 +2103,7 @@ Windows環境のために構築している場合は大文字の<literal>POSTGRE
 大規模なテーブルはこのセグメントサイズと同じサイズの複数のオペレーティングシステムのファイルに分割されます。
 これにより多くのプラットフォームで存在するファイルサイズ上限に関する問題を防ぎます。
 デフォルトのセグメントサイズは1ギガバイトで、サポートされるすべてのプラットフォームで安全です。
-使用するオペレーティングシステムが<quote>ラージファイル</quote>をサポートしていれば（最近はほとんどサポートしています）、より大きなセグメントサイズを使用することができます。
+使用するオペレーティングシステムが<quote>ラージファイル</quote>をサポートしていれば（最近はほとんどサポートしています）、より大きなセグメントサイズを使用できます。
 非常に大規模なテーブルで作業する時のファイル記述子の消費数を減らすために、これが役に立つでしょう。
 しかし、プラットフォーム、または使用予定のファイルシステムでサポートされる値以上に大きな値を指定しないように注意してください。
 <application>tar</application>などの、使用したいその他のツールにも使用できるファイルサイズに制限があることがあります。
@@ -2130,7 +2130,7 @@ Windows環境のために構築している場合は大文字の<literal>POSTGRE
 キロバイト単位で<firstterm>ブロック容量</firstterm>を設定します。
 これはテーブル内でのストレージとI/Oの単位です。
 8キロバイトのデフォルトはほとんどの場合適切ですが、特別な場合は他の値が役立ちます。
-値は1から32（キロバイト）の範囲の２のべき乗でなければなりません。
+値は1から32（キロバイト）の範囲の2のべき乗でなければなりません。
 この値を変更するとディスク上でのデータベースの互換性を壊すことに注意してください。すなわち、<command>pg_upgrade</command>を使ってブロック容量の異なるビルドにはアップグレードできません。
         </para>
        </listitem>
@@ -2153,7 +2153,7 @@ Windows環境のために構築している場合は大文字の<literal>POSTGRE
 キロバイト単位で<firstterm>WALブロック容量</firstterm>を設定します。
 これはWALログ内でのストレージとI/Oの単位です。
 8キロバイトのデフォルトはほとんどの場合適切ですが、特別な場合は大きめの値が役立ちます。
-値は1から64（キロバイト）の範囲の２のべき乗でなければなりません。
+値は1から64（キロバイト）の範囲の2のべき乗でなければなりません。
 この値を変更するとディスク上でのデータベースの互換性を壊すことに注意してください。すなわち、<command>pg_upgrade</command>を使ってWALブロック容量の異なるビルドにはアップグレードできません。
         </para>
        </listitem>
@@ -2348,7 +2348,7 @@ GCCを使用する場合、すべてのプログラムとライブラリがプ�
          typically installed under <filename>/usr/sbin</filename>,
          which might not be in your <envar>PATH</envar>.
 -->
-<command>dtrace</command>プログラムを指し示すために<envar>DTRACE</envar>環境変数を設定することができます。
+<command>dtrace</command>プログラムを指し示すために<envar>DTRACE</envar>環境変数を設定できます。
 <command>dtrace</command>は通常、<envar>PATH</envar>内に存在しない可能性がある<filename>/usr/sbin</filename>以下にインストールされていますので、この設定はよく必要になります。
         </para>
 
@@ -2441,7 +2441,7 @@ Sunのコンパイラを使用する場合は以下のようにします。
      default compiler flags if needed with the <envar>CFLAGS</envar> variable.
 -->
 これらの環境変数の中で最も一般的に使用されているのは、<envar>CC</envar>と<envar>CFLAGS</envar>です。
-<filename>configure</filename>が選ぶものと違うCコンパイラを使いたいという場合には、<envar>CC</envar> 環境変数をその使用したいプログラムに設定することができます。
+<filename>configure</filename>が選ぶものと違うCコンパイラを使いたいという場合には、<envar>CC</envar> 環境変数をその使用したいプログラムに設定できます。
 デフォルトでは、<filename>configure</filename>は利用できるのであれば<filename>gcc</filename>を、利用できなければプラットフォームのデフォルト（通常<filename>cc</filename>）を選択します。
 同様に、デフォルトのコンパイラフラグは必要に応じて<envar>CFLAGS</envar>変数で上書きすることもできます。
     </para>
@@ -2909,7 +2909,7 @@ libpq.so.2.1: cannot open shared object file: No such file or directory
 -->
 （または同等のディレクトリ）をインストール後に実行して、実行時リンカが共有ライブラリを素早く検索できるようにできます。
 より詳細については<command>ldconfig</command>のマニュアルページを参照してください。
-<systemitem class="osname">FreeBSD</systemitem>、<systemitem class="osname">NetBSD</systemitem>および<systemitem class="osname">OpenBSD</systemitem>の場合のコマンドは以下の通りです。
+<systemitem class="osname">FreeBSD</systemitem>、<systemitem class="osname">NetBSD</systemitem>および<systemitem class="osname">OpenBSD</systemitem>の場合のコマンドは以下のとおりです。
 <programlisting>
 /sbin/ldconfig -m /usr/local/pgsql/lib
 </programlisting>
@@ -2996,7 +2996,7 @@ export MANPATH
 環境変数<envar>PGHOST</envar>と<envar>PGPORT</envar>は、クライアントアプリケーションにデータベースサーバのホストとポートを指定し、コンパイル時に決定されたデフォルト値を無効にします。
 クライアントアプリケーションをリモートで実行する場合、データベースを使用する予定の全てのユーザが<envar>PGHOST</envar>を設定していると便利です。
 しかしこれは必須ではありません。
-この設定は、ほとんどのクライアントプログラムのコマンドラインオプションでも設定することができます。
+この設定は、ほとんどのクライアントプログラムのコマンドラインオプションでも設定できます。
    </para>
   </sect2>
  </sect1>
@@ -3021,7 +3021,7 @@ export MANPATH
    or can be made to work, you are strongly encouraged to set up a build
    farm member machine so that continued compatibility can be assured.
 -->
-プラットフォーム（CPUアーキテクチャとオペレーティングシステムの組合せ）は、そのプラットフォーム上で動作する仕組みがコード内に存在し、かつ、そのプラットフォーム上で構築およびリグレッションテストに合格することが最近検証できた場合に、<productname>PostgreSQL</productname>開発者コミュニティによってサポートされたものとみなされます。
+プラットフォーム（CPUアーキテクチャとオペレーティングシステムの組み合わせ）は、そのプラットフォーム上で動作する仕組みがコード内に存在し、かつ、そのプラットフォーム上で構築およびリグレッションテストに合格することが最近検証できた場合に、<productname>PostgreSQL</productname>開発者コミュニティによってサポートされたものとみなされます。
 現在、プラットフォームの互換性に関するほとんどの試験は<ulink url="https://buildfarm.postgresql.org/">PostgreSQLビルドファーム</ulink>中の試験マシンによって自動的に行われます。
 ビルドファームに存在しないが、コードが動作するあるいは動作させることができたプラットフォームにおける<productname>PostgreSQL</productname>の使用に興味のあるかたは、継続した互換性を確実にするために、ビルドファームのメンバマシンとして設定することを強く勧めます。
   </para>
@@ -3055,7 +3055,7 @@ M68K、M32R、VAXをサポートするコードは存在しますが、これら
    specific to your operating system, particularly if using an older system.
 -->
 <productname>PostgreSQL</productname>は次のオペレーティングシステムで動作することを期待できます。
-Linux (最近のディストリビューションすべて), Windows (XP以降), FreeBSD, OpenBSD, NetBSD, macOS, AIX, HP/UX, Solaris。
+Linux（最近のディストリビューションすべて）, Windows（XP以降）, FreeBSD, OpenBSD, NetBSD, macOS, AIX, HP/UX, Solaris。
 他のUnixに似たシステムでも動作するかもしれませんが、最近試験されていません。
 ほとんどの場合、指定されたオペレーティングシステムでサポートされるCPUアーキテクチャはすべて動作するでしょう。
 特に古めのシステムを使用している場合、以下の<xref linkend="installation-platform-notes"/>を参照し、使用するオペレーティングシステム固有の情報がないか確認してください。
@@ -3238,7 +3238,7 @@ ERROR:  could not load library "/opt/dbs/pgsql/lib/plperl.so": Bad address
 -->
 32-ビットバイナリを要求する場合、PostgreSQLサーバを起動する前に<symbol>LDR_CNTRL</symbol>を<literal>MAXDATA=0x<replaceable>n</replaceable>0000000</literal>に設定します。ここで、1 &lt;= n &lt;= 8です。そして異なる値と<filename>postgresql.conf</filename>設定で満足に稼動する構成を見つけ出します。
 このように<symbol>LDR_CNTRL</symbol>を使用すると、AIXに対してサーバがヒープにかかわらず、256 MBセグメントに割り当てられた<symbol>MAXDATA</symbol>バイトセットを持つようにさせたい意図を表明します。
-稼動する構成を見つけたとき、意図したヒープ容量をデフォルトで使用するように<command>ldedit</command>を使用してバイナリを変更することができます。
+稼働する構成を見つけたとき、意図したヒープ容量をデフォルトで使用するように<command>ldedit</command>を使用してバイナリを変更できます。
 同じ効果を得るため、<literal>configure LDFLAGS="-Wl,-bmaxdata:0x<replaceable>n</replaceable>0000000"</literal>を渡してPostgreSQLを再構築することもできます。
     </para>
 
@@ -3298,8 +3298,8 @@ ERROR:  could not load library "/opt/dbs/pgsql/lib/plperl.so": Bad address
     <phrase condition="standalone-ignore">(see <xref linkend="install-windows"/>)</phrase> and
     running a server under Cygwin is no longer recommended.
 -->
-Windowsに対するLinux的環境である、Cygwinを使ってPostgreSQLを構築することが可能です。
-しかし、この手法はWindowsネイティブビルド<phrase condition="standalone-ignore">(<xref linkend="install-windows"/>を参照)</phrase>には及ばないので、もはや推奨されません。
+Windowsに対するLinux的環境である、Cygwinを使ってPostgreSQLを構築できます。
+しかし、この手法はWindowsネイティブビルド<phrase condition="standalone-ignore">（<xref linkend="install-windows"/>を参照）</phrase>には及ばないので、もはや推奨されません。
    </para>
 
    <para>
@@ -3424,7 +3424,7 @@ make MAX_CONNECTIONS=5 check
     It is installed in the
     directory <filename>/usr/share/doc/Cygwin</filename>.
 -->
-Windows NTサービスとして<command>cygserver</command>とPostgreSQLサーバをインストールすることができます。
+Windows NTサービスとして<command>cygserver</command>とPostgreSQLサーバをインストールできます。
 これを実現する方法は、CygwinのPostgreSQLバイナリパッケージに含まれる<filename>README</filename>文書を参照してください。
 それは<filename>/usr/share/doc/Cygwin</filename>ディレクトリにインストールされます。
    </para>
@@ -3587,7 +3587,7 @@ MinGW版の構築は本章で記述されている通常の構築システムを
     creating the binaries.
 -->
 ネイティブに移植されたWindows版ではWindows 2000以降の32ビットまたは64ビット版が必要です。
-これより前のオペレーティングシステムには充分な構造基盤がありません（ただし、Cygwinはそれら上で使える可能性があります）。
+これより前のオペレーティングシステムには十分な構造基盤がありません（ただし、Cygwinはそれら上で使える可能性があります）。
 Unixに似た構築ツールであるMinGWと、<command>configure</command>のようなシェルスクリプトを実行するために必要なUnixツール群であるMSYSは、<ulink url="http://www.mingw.org/"></ulink>からダウンロード可能です。
 作成されたバイナリの実行にはいずれも必要ありません。バイナリの作成のためのみ必要です。
    </para>
@@ -3631,7 +3631,7 @@ MSYSコンソールはバッファリングに問題があるので、すべて�
      into this directory with a unique name based on the identifier of
      the crashing process and the current time of the crash.
 -->
-もしWindows上のPostgreSQLがクラッシュした場合、Unixにおけるコアダンプと似た、クラッシュの原因を追跡するために使用できる<productname>minidumps</productname>を生成することができます。
+もしWindows上のPostgreSQLがクラッシュした場合、Unixにおけるコアダンプと似た、クラッシュの原因を追跡するために使用できる<productname>minidumps</productname>を生成できます。
 このダンプは<productname>Windows Debugger Tools</productname>や<productname>Visual Studio</productname>を使うことで解析できます。Windowsにてダンプを生成できるように、<filename>crashdumps</filename>という名前のサブディレクトリをデータベースクラスタディレクトリの中に作成します。
 ダンプは、クラッシュ時の現在時間と原因となったプロセスの識別子を元にした一意な名前としてこのディレクトリの中に生成されます。
     </para>
@@ -3723,7 +3723,7 @@ configure ... LDFLAGS="-R /usr/sfw/lib:/opt/sfw/lib:/usr/local/lib"
      the <citerefentry><refentrytitle>ld</refentrytitle><manvolnum>1</manvolnum></citerefentry>
      man page for more information.
 -->
-より詳細な情報は<citerefentry><refentrytitle>ld</refentrytitle><manvolnum>1</manvolnum></citerefentry>マニュアルページを参照ください。
+より詳細な情報は<citerefentry><refentrytitle>ld</refentrytitle><manvolnum>1</manvolnum></citerefentry>マニュアルページを参照してください。
     </para>
    </sect3>
 


### PR DESCRIPTION
・漢字の開きの見直し（例：元々⇒もともと）
・冗長表現の見直し（例：することができます⇒できます）
・送り仮名の見直し（例：組合せ⇒組み合わせ）
・表記の見直し（例：充分⇒十分）
・必要性⇒必要
・稼動⇒稼働
・助詞の繰り返しの見直し
・（）を全角に統一した
・数字を半角に統一した
・：を全角に統一した