### PR TITLE
func.sgmlの15.3対応です

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -12953,25 +12953,21 @@ SELECT (DATE '2001-10-30', DATE '2001-10-30') OVERLAPS
    does not necessarily equal <literal>interval '24 hours'</literal>.
    For example, with the session time zone set
    to <literal>America/Denver</literal>:
-<screen>
-SELECT timestamp with time zone '2005-04-02 12:00:00-07' + interval '1 day';
-<lineannotation>Result: </lineannotation><computeroutput>2005-04-03 12:00:00-06</computeroutput>
-SELECT timestamp with time zone '2005-04-02 12:00:00-07' + interval '24 hours';
-<lineannotation>Result: </lineannotation><computeroutput>2005-04-03 13:00:00-06</computeroutput>
-</screen>
-   This happens because an hour was skipped due to a change in daylight saving
-   time at <literal>2005-04-03 02:00:00</literal> in time zone
-   <literal>America/Denver</literal>.
 -->
 <type>timestamp with time zone</type>の値に<type>interval</type>の値を加える時（または<type>interval</type>の値を引く時）、日にちの部分は、<type>timestamp with time zone</type>の日付を指定された日数だけ先に進める、もしくは後に戻し、時刻は同じに保ちます。
 （セッションの時間帯がDSTを認識する設定の場合）夏時間の移行に跨っての変化に関しては、<literal>interval '1 day'</literal>が<literal>interval '24 hours'</literal>に等しいとは限りません。
 例えば、セッションの時間帯が <literal>America/Denver</literal>に設定されている時には以下のようになります。
 <screen>
 SELECT timestamp with time zone '2005-04-02 12:00:00-07' + interval '1 day';
-<lineannotation>結果: </lineannotation><computeroutput>2005-04-03 12:00:00-06</computeroutput>
+<lineannotation>Result: </lineannotation><computeroutput>2005-04-03 12:00:00-06</computeroutput>
 SELECT timestamp with time zone '2005-04-02 12:00:00-07' + interval '24 hours';
-<lineannotation>結果: </lineannotation><computeroutput>2005-04-03 13:00:00-06</computeroutput>
+<lineannotation>Result: </lineannotation><computeroutput>2005-04-03 13:00:00-06</computeroutput>
 </screen>
+<!--
+   This happens because an hour was skipped due to a change in daylight saving
+   time at <literal>2005-04-03 02:00:00</literal> in time zone
+   <literal>America/Denver</literal>.
+-->
 その理由は<literal>America/Denver</literal>時間帯で<literal>2005-04-03 02:00:00</literal>に夏時間への変更があるからです。
   </para>
 
@@ -13027,15 +13023,9 @@ SELECT (EXTRACT(EPOCH FROM timestamptz '2013-07-01 12:00:00') -
         / 60 / 60 / 24;
 <lineannotation>Result: </lineannotation><computeroutput>121.9583333333333333</computeroutput>
 SELECT timestamptz '2013-07-01 12:00:00' - timestamptz '2013-03-01 12:00:00';
-<!--
 <lineannotation>Result: </lineannotation><computeroutput>121 days 23:00:00</computeroutput>
--->
-<lineannotation>結果: </lineannotation><computeroutput>121 days 23:00:00</computeroutput>
 SELECT age(timestamptz '2013-07-01 12:00:00', timestamptz '2013-03-01 12:00:00');
-<!--
 <lineannotation>Result: </lineannotation><computeroutput>4 mons</computeroutput>
--->
-<lineannotation>結果: </lineannotation><computeroutput>4 mons</computeroutput>
 </screen>
 
   <sect2 id="functions-datetime-extract">
@@ -19873,13 +19863,10 @@ SQL/JSON標準を更に学ぶためには、<xref linkend="sqltr-19075-6"/>を�
    into a JSON object, and their <type>jsonb</type> equivalents,
    <function>jsonb_agg</function> and <function>jsonb_object_agg</function>.
 -->
-《マッチ度[51.231527]》<xref linkend="functions-json-op-table"/>にJSONデータ型(<xref linkend="datatype-json"/>を参照)で使用可能な演算子を示します。
+<xref linkend="functions-json-op-table"/>にJSONデータ型(<xref linkend="datatype-json"/>を参照)で使用可能な演算子を示します。
 加えて<xref linkend="functions-comparison-op-table"/>で示す通常の比較演算子が<type>jsonb</type>で利用できますが、<type>json</type>では利用できません。
 比較演算子は<xref linkend="json-indexing"/>で概要が示されているように示すBツリー操作用の順序付け規則にしたがいます。
-《機械翻訳》<xref linkend="functions-json-op-table"/>に、JSONデータタイプで使用可能な演算子を示します(<xref linkend="datatype-json"/>を参照)。
-また、<xref linkend="functions-comparison-op-table"/>で使用可能な通常の比較演算子は<type>jsonb</type>で使用できますが、<type>JSON</type>では使用できません。
-比較演算子は、<xref linkend="json-indexing"/>で説明されているB-ツリー操作の順序付けルールに従います。
-レコード値をJSONとして集計する集約関数<function>JSON_agg</function>の<xref linkend="functions-aggregate"/>、値のペアをJSONオブジェクトに集計する集約関数<function>JSON_オブジェクト_agg</function>、およびこれらに相当する<type>jsonb</type>の<function>jsonb_agg</function>および<function>jsonb_オブジェクト_agg</function>も参照してください。
+レコードの値をJSONに集約する<function>json_agg</function>集約関数、値の対をJSONオブジェクトに集約する<function>json_object_agg</function>集約関数、およびそれらの<type>jsonb</type>版の<function>jsonb_agg</function>と<function>jsonb_object_agg</function>については<xref linkend="functions-aggregate"/>を参照して下さい。
   </para>
 
   <table id="functions-json-op-table">
@@ -31382,12 +31369,8 @@ OIDで指定されるロール名を返します。
         Only the most useful flags listed in
         <xref linkend="functions-pg-settings-flags"/> are exposed.
 -->
-《マッチ度[68.661972]》指定されたGUCに関連付けられたフラグの配列を返します。
+指定されたGUCに関連付けられたフラグの配列を返します。
 存在しない場合は<literal>NULL</literal>を返します。
-GUCが存在しても表示するフラグがない場合、結果は空の配列になります。
-次のような最も有用なフラグのみが公開されます:
-《機械翻訳》指定されたGUCに関連付けられているフラグの配列を戻します。
-GUCが存在しない場合は<literal>null</literal>を戻します。
 GUCが存在しても表示するフラグがない場合、結果は空の配列になります。
 <xref linkend="functions-pg-settings-flags"/>にリストされている最も有用なフラグのみが公開されます。
        </para></entry>
@@ -31959,36 +31942,54 @@ SELECT collation for ('foo' COLLATE "de_DE");
    <title>GUC Flags</title>
    <tgroup cols="2">
     <thead>
+<!--
      <row><entry>Flag</entry><entry>Description</entry></row>
+-->
+     <row><entry>フラグ</entry><entry>説明</entry></row>
     </thead>
     <tbody>
      <row>
       <entry><literal>EXPLAIN</literal></entry>
+<!--
       <entry>Parameters with this flag are included in
        <command>EXPLAIN (SETTINGS)</command> commands.
+-->
+      <entry>このフラグを持つパラメータは<command>EXPLAIN (SETTINGS)</command>コマンドに含まれます。
       </entry>
      </row>
      <row>
       <entry><literal>NO_SHOW_ALL</literal></entry>
+<!--
       <entry>Parameters with this flag are excluded from
        <command>SHOW ALL</command> commands.
+-->
+      <entry>このフラグを持つパラメータは<command>SHOW ALL</command>コマンドから除外されます。
       </entry>
      </row>
      <row>
       <entry><literal>NO_RESET_ALL</literal></entry>
+<!--
       <entry>Parameters with this flag are excluded from
        <command>RESET ALL</command> commands.
+-->
+      <entry>このフラグを持つパラメータは<command>RESET ALL</command>コマンドから除外されます。
       </entry>
      </row>
      <row>
       <entry><literal>NOT_IN_SAMPLE</literal></entry>
+<!--
       <entry>Parameters with this flag are not included in
        <filename>postgresql.conf</filename> by default.
+-->
+      <entry>このフラグを持つパラメータはデフォルトでは<filename>postgresql.conf</filename>に含まれません。
       </entry>
      </row>
      <row>
       <entry><literal>RUNTIME_COMPUTED</literal></entry>
+<!--
       <entry>Parameters with this flag are runtime-computed ones.
+-->
+      <entry>このフラグを持つパラメータは実行時に計算されます。
       </entry>
      </row>
     </tbody>
@@ -35338,10 +35339,8 @@ postgres=# SELECT * FROM pg_walfile_name_offset((pg_backup_stop()).lsn);
         units are powers of 2 rather than powers of 10, so 1kB is 1024 bytes,
         1MB is 1024<superscript>2</superscript> = 1048576 bytes, and so on.
 -->
-《マッチ度[86.071429]》バイトサイズを、サイズ単位(バイト、kB、MB、GB、TBのうちの適切なもの)を使ったより人間が読みやすい形式に変換します。
+バイトサイズを、サイズ単位(バイト、kB、MB、GB、TB、PBのうちの適切なもの)を使った、より人間が読みやすい形式に変換します。
 単位は10のべき乗ではなく、2のべき乗であることに注意してください。ですから1kBは1024バイトで、1MBは1024<superscript>2</superscript> = 1048576バイト、などとなります。
-《機械翻訳》バイト単位のサイズを、フォーマット単位(バイト、キロバイト、メガバイト、ギガバイト、TBまたはPB)を使用して、人間が読みやすいサイズに変換します。
-ノートでは、単位は10の累乗ではなく2の累乗であるため、1キロバイトは1024バイト、1メガバイトは1024<superscript>2</superscript>=1048576バイトなどになります。
        </para></entry>
       </row>
 

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -12968,7 +12968,7 @@ SELECT timestamp with time zone '2005-04-02 12:00:00-07' + interval '24 hours';
    time at <literal>2005-04-03 02:00:00</literal> in time zone
    <literal>America/Denver</literal>.
 -->
-その理由は<literal>America/Denver</literal>時間帯で<literal>2005-04-03 02:00:00</literal>に夏時間への変更があるからです。
+その理由は<literal>America/Denver</literal>時間帯で<literal>2005-04-03 02:00:00</literal>に夏時間への変更され、1時間スキップされたためです。
   </para>
 
   <para>
@@ -19866,7 +19866,7 @@ SQL/JSON標準を更に学ぶためには、<xref linkend="sqltr-19075-6"/>を�
 <xref linkend="functions-json-op-table"/>にJSONデータ型(<xref linkend="datatype-json"/>を参照)で使用可能な演算子を示します。
 加えて<xref linkend="functions-comparison-op-table"/>で示す通常の比較演算子が<type>jsonb</type>で利用できますが、<type>json</type>では利用できません。
 比較演算子は<xref linkend="json-indexing"/>で概要が示されているように示すBツリー操作用の順序付け規則にしたがいます。
-レコードの値をJSONに集約する<function>json_agg</function>集約関数、値の対をJSONオブジェクトに集約する<function>json_object_agg</function>集約関数、およびそれらの<type>jsonb</type>版の<function>jsonb_agg</function>と<function>jsonb_object_agg</function>については<xref linkend="functions-aggregate"/>を参照して下さい。
+レコードの値をJSONに集約する<function>json_agg</function>集約関数、値の対をJSONオブジェクトに集約する<function>json_object_agg</function>集約関数、およびそれらの<type>jsonb</type>版の<function>jsonb_agg</function>と<function>jsonb_object_agg</function>については<xref linkend="functions-aggregate"/>も参照して下さい。
   </para>
 
   <table id="functions-json-op-table">

--- a/doc/src/sgml/func2.sgml
+++ b/doc/src/sgml/func2.sgml
@@ -2987,7 +2987,7 @@ SELECT timestamp with time zone '2005-04-02 12:00:00-07' + interval '24 hours';
    time at <literal>2005-04-03 02:00:00</literal> in time zone
    <literal>America/Denver</literal>.
 -->
-その理由は<literal>America/Denver</literal>時間帯で<literal>2005-04-03 02:00:00</literal>に夏時間への変更があるからです。
+その理由は<literal>America/Denver</literal>時間帯で<literal>2005-04-03 02:00:00</literal>に夏時間への変更され、1時間スキップされたためです。
   </para>
 
   <para>

--- a/doc/src/sgml/func2.sgml
+++ b/doc/src/sgml/func2.sgml
@@ -2972,25 +2972,21 @@ SELECT (DATE '2001-10-30', DATE '2001-10-30') OVERLAPS
    does not necessarily equal <literal>interval '24 hours'</literal>.
    For example, with the session time zone set
    to <literal>America/Denver</literal>:
-<screen>
-SELECT timestamp with time zone '2005-04-02 12:00:00-07' + interval '1 day';
-<lineannotation>Result: </lineannotation><computeroutput>2005-04-03 12:00:00-06</computeroutput>
-SELECT timestamp with time zone '2005-04-02 12:00:00-07' + interval '24 hours';
-<lineannotation>Result: </lineannotation><computeroutput>2005-04-03 13:00:00-06</computeroutput>
-</screen>
-   This happens because an hour was skipped due to a change in daylight saving
-   time at <literal>2005-04-03 02:00:00</literal> in time zone
-   <literal>America/Denver</literal>.
 -->
 <type>timestamp with time zone</type>の値に<type>interval</type>の値を加える時（または<type>interval</type>の値を引く時）、日にちの部分は、<type>timestamp with time zone</type>の日付を指定された日数だけ先に進める、もしくは後に戻し、時刻は同じに保ちます。
 （セッションの時間帯がDSTを認識する設定の場合）夏時間の移行に跨っての変化に関しては、<literal>interval '1 day'</literal>が<literal>interval '24 hours'</literal>に等しいとは限りません。
 例えば、セッションの時間帯が <literal>America/Denver</literal>に設定されている時には以下のようになります。
 <screen>
 SELECT timestamp with time zone '2005-04-02 12:00:00-07' + interval '1 day';
-<lineannotation>結果: </lineannotation><computeroutput>2005-04-03 12:00:00-06</computeroutput>
+<lineannotation>Result: </lineannotation><computeroutput>2005-04-03 12:00:00-06</computeroutput>
 SELECT timestamp with time zone '2005-04-02 12:00:00-07' + interval '24 hours';
-<lineannotation>結果: </lineannotation><computeroutput>2005-04-03 13:00:00-06</computeroutput>
+<lineannotation>Result: </lineannotation><computeroutput>2005-04-03 13:00:00-06</computeroutput>
 </screen>
+<!--
+   This happens because an hour was skipped due to a change in daylight saving
+   time at <literal>2005-04-03 02:00:00</literal> in time zone
+   <literal>America/Denver</literal>.
+-->
 その理由は<literal>America/Denver</literal>時間帯で<literal>2005-04-03 02:00:00</literal>に夏時間への変更があるからです。
   </para>
 
@@ -3046,15 +3042,9 @@ SELECT (EXTRACT(EPOCH FROM timestamptz '2013-07-01 12:00:00') -
         / 60 / 60 / 24;
 <lineannotation>Result: </lineannotation><computeroutput>121.9583333333333333</computeroutput>
 SELECT timestamptz '2013-07-01 12:00:00' - timestamptz '2013-03-01 12:00:00';
-<!--
 <lineannotation>Result: </lineannotation><computeroutput>121 days 23:00:00</computeroutput>
--->
-<lineannotation>結果: </lineannotation><computeroutput>121 days 23:00:00</computeroutput>
 SELECT age(timestamptz '2013-07-01 12:00:00', timestamptz '2013-03-01 12:00:00');
-<!--
 <lineannotation>Result: </lineannotation><computeroutput>4 mons</computeroutput>
--->
-<lineannotation>結果: </lineannotation><computeroutput>4 mons</computeroutput>
 </screen>
 
   <sect2 id="functions-datetime-extract">

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -85,7 +85,7 @@ SQL/JSON標準を更に学ぶためには、<xref linkend="sqltr-19075-6"/>を�
 <xref linkend="functions-json-op-table"/>にJSONデータ型(<xref linkend="datatype-json"/>を参照)で使用可能な演算子を示します。
 加えて<xref linkend="functions-comparison-op-table"/>で示す通常の比較演算子が<type>jsonb</type>で利用できますが、<type>json</type>では利用できません。
 比較演算子は<xref linkend="json-indexing"/>で概要が示されているように示すBツリー操作用の順序付け規則にしたがいます。
-レコードの値をJSONに集約する<function>json_agg</function>集約関数、値の対をJSONオブジェクトに集約する<function>json_object_agg</function>集約関数、およびそれらの<type>jsonb</type>版の<function>jsonb_agg</function>と<function>jsonb_object_agg</function>については<xref linkend="functions-aggregate"/>を参照して下さい。
+レコードの値をJSONに集約する<function>json_agg</function>集約関数、値の対をJSONオブジェクトに集約する<function>json_object_agg</function>集約関数、およびそれらの<type>jsonb</type>版の<function>jsonb_agg</function>と<function>jsonb_object_agg</function>については<xref linkend="functions-aggregate"/>も参照して下さい。
   </para>
 
   <table id="functions-json-op-table">

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -82,13 +82,10 @@ SQL/JSON標準を更に学ぶためには、<xref linkend="sqltr-19075-6"/>を�
    into a JSON object, and their <type>jsonb</type> equivalents,
    <function>jsonb_agg</function> and <function>jsonb_object_agg</function>.
 -->
-《マッチ度[51.231527]》<xref linkend="functions-json-op-table"/>にJSONデータ型(<xref linkend="datatype-json"/>を参照)で使用可能な演算子を示します。
+<xref linkend="functions-json-op-table"/>にJSONデータ型(<xref linkend="datatype-json"/>を参照)で使用可能な演算子を示します。
 加えて<xref linkend="functions-comparison-op-table"/>で示す通常の比較演算子が<type>jsonb</type>で利用できますが、<type>json</type>では利用できません。
 比較演算子は<xref linkend="json-indexing"/>で概要が示されているように示すBツリー操作用の順序付け規則にしたがいます。
-《機械翻訳》<xref linkend="functions-json-op-table"/>に、JSONデータタイプで使用可能な演算子を示します(<xref linkend="datatype-json"/>を参照)。
-また、<xref linkend="functions-comparison-op-table"/>で使用可能な通常の比較演算子は<type>jsonb</type>で使用できますが、<type>JSON</type>では使用できません。
-比較演算子は、<xref linkend="json-indexing"/>で説明されているB-ツリー操作の順序付けルールに従います。
-レコード値をJSONとして集計する集約関数<function>JSON_agg</function>の<xref linkend="functions-aggregate"/>、値のペアをJSONオブジェクトに集計する集約関数<function>JSON_オブジェクト_agg</function>、およびこれらに相当する<type>jsonb</type>の<function>jsonb_agg</function>および<function>jsonb_オブジェクト_agg</function>も参照してください。
+レコードの値をJSONに集約する<function>json_agg</function>集約関数、値の対をJSONオブジェクトに集約する<function>json_object_agg</function>集約関数、およびそれらの<type>jsonb</type>版の<function>jsonb_agg</function>と<function>jsonb_object_agg</function>については<xref linkend="functions-aggregate"/>を参照して下さい。
   </para>
 
   <table id="functions-json-op-table">

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -3632,12 +3632,8 @@ OIDで指定されるロール名を返します。
         Only the most useful flags listed in
         <xref linkend="functions-pg-settings-flags"/> are exposed.
 -->
-《マッチ度[68.661972]》指定されたGUCに関連付けられたフラグの配列を返します。
+指定されたGUCに関連付けられたフラグの配列を返します。
 存在しない場合は<literal>NULL</literal>を返します。
-GUCが存在しても表示するフラグがない場合、結果は空の配列になります。
-次のような最も有用なフラグのみが公開されます:
-《機械翻訳》指定されたGUCに関連付けられているフラグの配列を戻します。
-GUCが存在しない場合は<literal>null</literal>を戻します。
 GUCが存在しても表示するフラグがない場合、結果は空の配列になります。
 <xref linkend="functions-pg-settings-flags"/>にリストされている最も有用なフラグのみが公開されます。
        </para></entry>
@@ -4209,36 +4205,54 @@ SELECT collation for ('foo' COLLATE "de_DE");
    <title>GUC Flags</title>
    <tgroup cols="2">
     <thead>
+<!--
      <row><entry>Flag</entry><entry>Description</entry></row>
+-->
+     <row><entry>フラグ</entry><entry>説明</entry></row>
     </thead>
     <tbody>
      <row>
       <entry><literal>EXPLAIN</literal></entry>
+<!--
       <entry>Parameters with this flag are included in
        <command>EXPLAIN (SETTINGS)</command> commands.
+-->
+      <entry>このフラグを持つパラメータは<command>EXPLAIN (SETTINGS)</command>コマンドに含まれます。
       </entry>
      </row>
      <row>
       <entry><literal>NO_SHOW_ALL</literal></entry>
+<!--
       <entry>Parameters with this flag are excluded from
        <command>SHOW ALL</command> commands.
+-->
+      <entry>このフラグを持つパラメータは<command>SHOW ALL</command>コマンドから除外されます。
       </entry>
      </row>
      <row>
       <entry><literal>NO_RESET_ALL</literal></entry>
+<!--
       <entry>Parameters with this flag are excluded from
        <command>RESET ALL</command> commands.
+-->
+      <entry>このフラグを持つパラメータは<command>RESET ALL</command>コマンドから除外されます。
       </entry>
      </row>
      <row>
       <entry><literal>NOT_IN_SAMPLE</literal></entry>
+<!--
       <entry>Parameters with this flag are not included in
        <filename>postgresql.conf</filename> by default.
+-->
+      <entry>このフラグを持つパラメータはデフォルトでは<filename>postgresql.conf</filename>に含まれません。
       </entry>
      </row>
      <row>
       <entry><literal>RUNTIME_COMPUTED</literal></entry>
+<!--
       <entry>Parameters with this flag are runtime-computed ones.
+-->
+      <entry>このフラグを持つパラメータは実行時に計算されます。
       </entry>
      </row>
     </tbody>
@@ -7588,10 +7602,8 @@ postgres=# SELECT * FROM pg_walfile_name_offset((pg_backup_stop()).lsn);
         units are powers of 2 rather than powers of 10, so 1kB is 1024 bytes,
         1MB is 1024<superscript>2</superscript> = 1048576 bytes, and so on.
 -->
-《マッチ度[86.071429]》バイトサイズを、サイズ単位(バイト、kB、MB、GB、TBのうちの適切なもの)を使ったより人間が読みやすい形式に変換します。
+バイトサイズを、サイズ単位(バイト、kB、MB、GB、TB、PBのうちの適切なもの)を使った、より人間が読みやすい形式に変換します。
 単位は10のべき乗ではなく、2のべき乗であることに注意してください。ですから1kBは1024バイトで、1MBは1024<superscript>2</superscript> = 1048576バイト、などとなります。
-《機械翻訳》バイト単位のサイズを、フォーマット単位(バイト、キロバイト、メガバイト、ギガバイト、TBまたはPB)を使用して、人間が読みやすいサイズに変換します。
-ノートでは、単位は10の累乗ではなく2の累乗であるため、1キロバイトは1024バイト、1メガバイトは1024<superscript>2</superscript>=1048576バイトなどになります。
        </para></entry>
       </row>
 


### PR DESCRIPTION
Result:が結果としているところとそのままのとろころがあったので、
Resultに統一しました。