### PR TITLE
pgstatstatements.sgmlでの括弧の修正です。

### DIFF
--- a/doc/src/sgml/pgstatstatements.sgml
+++ b/doc/src/sgml/pgstatstatements.sgml
@@ -754,7 +754,7 @@ SQL文のコードを出力するのに費やした総時間（ミリ秒単位�
    Furthermore, it is not safe to assume that <structfield>queryid</structfield>
    will be stable across major versions of <productname>PostgreSQL</productname>.
 -->
-<structname>pg_stat_statements</structname>の消費者は、問い合わせテキストよりもより安定で信頼できる各項目への識別子として(おそらく<structfield>dbid</structfield>や<structfield>userid</structfield>と組み合わせて)<structfield>queryid</structfield>を使いたいかもしれません。
+<structname>pg_stat_statements</structname>の消費者は、問い合わせテキストよりもより安定で信頼できる各項目への識別子として（おそらく<structfield>dbid</structfield>や<structfield>userid</structfield>と組み合わせて）<structfield>queryid</structfield>を使いたいかもしれません。
 しかし、<structfield>queryid</structfield>ハッシュ値の安定性には限定された保証しかないのを理解することは重要です。
 識別子は解析後の木から得られますので、その値は、とりわけ、この表現に現れる内部オブジェクト識別子の関数です。
 これは少々直観に反する結果です。


### PR DESCRIPTION
PostgreSQL 15.4固有の修正ではなく、以前からあった、ASCII "()"を、全角に置き換える修正です。