### PR TITLE
update psql-ref for 15.4

### DIFF
--- a/doc/src/sgml/ref/psql-ref.sgml
+++ b/doc/src/sgml/ref/psql-ref.sgml
@@ -6759,7 +6759,7 @@ Unixシステム上のデフォルトは<literal>+</literal>です。
       If neither of them is set, the default is to use <literal>more</literal> on most
       platforms, but <literal>less</literal> on Cygwin.
 -->
-《マッチ度[88.454707]》問い合わせ結果が画面に入り切らない場合、このコマンドによって結果をパイプします。
+問い合わせ結果が画面に入り切らない場合、このコマンドによって結果をパイプします。
 一般的に指定される値は、<literal>more</literal>、または<literal>less</literal>です。
 ページャの使用を無効にするには<envar>PSQL_PAGER</envar>や<envar>PAGER</envar>を空文字列にするか、<command>\pset</command>コマンドのページャ関連のオプションを調整します。
 これらの変数は列挙した順で検査され、最初の設定されているものが使われます。


### PR DESCRIPTION
ref/psql-ref.sgml の15.4対応です。

と言っても、差分は大きいように見えたのですが、実態は移動であり（マージの段階で対応されていました）、唯一あった変更も
none of -> neither of
であり、「いずれも〜ない」という既存の訳で対応できると考えたので、結果的に訳には影響がありませんでした。