### PR TITLE
update pgcrypto for 16.0

### DIFF
--- a/doc/src/sgml/pgcrypto.sgml
+++ b/doc/src/sgml/pgcrypto.sgml
@@ -1,7 +1,10 @@
 <!-- doc/src/sgml/pgcrypto.sgml -->
 
 <sect1 id="pgcrypto" xreflabel="pgcrypto">
+<!--
  <title>pgcrypto &mdash; cryptographic functions</title>
+-->
+ <title>pgcrypto &mdash; 暗号関数</title>
 
  <indexterm zone="pgcrypto">
   <primary>pgcrypto</primary>
@@ -640,10 +643,10 @@ Intel Mobile Core i3のマシンを使用しました。
       <literal>crypt-bf</literal> implementation in <filename>pgcrypto</filename>
       is the same one used in John the Ripper.)
 -->
-《機械翻訳》<literal>crypt-bf</literal>の数値は、単純なプログラムを使って取得されます。 このプログラムは、1000個の8文字のパスワードをループして実行します。
-このようにして、異なる反復回数での速度を示すことができます。
-参考までに、<literal>john -test</literal>は<literal>crypt-bf/5</literal>の13506ループ/秒を示します。
-（結果の差が非常に小さいのは、<filename>pgcrypto</filename>の<literal>crypt-bf</literal>実装が、<filename>john the ripper</filename>で使用されているものと同じであるという事実にあります。）
+<literal>crypt-bf</literal>の数は、1000個の8文字パスワードをループする単純なプログラムを使用して得たものです。
+こうして、異なる回数の速度を示すことができました。
+参考までに、<literal>john -test</literal>は<literal>crypt-bf/5</literal>で13506 loops/secでした。
+（結果の差異が非常に小さいことは、<filename>pgcrypto</filename>における<literal>crypt-bf</literal>実装がJohn the Ripperで使用されるものと同じであるという事実と一致します。）
      </para>
     </listitem>
    </itemizedlist>


### PR DESCRIPTION
pgcrypto.sgml の16.0対応です。

機械翻訳のところを書き換えているように見えますが、実際は15.4のものに戻しただけです。（原文の変更がI can showからcan be shownという訳に影響しないものでしたので。）