### PR TITLE
翻訳形式を統一するための修正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -469,11 +469,10 @@ SET configuration_parameter TO DEFAULT;
 <!--
        is:
 -->
-は
+は以下と同じです。
 <programlisting>
 UPDATE pg_settings SET setting = reset_val WHERE name = 'configuration_parameter';
 </programlisting>
-と同じです。
       </para>
      </listitem>
     </itemizedlist>
@@ -10973,6 +10972,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 <!--
              <entry>Virtual transaction ID (backendID/localXID);  see
              <xref linkend="transaction-id"/></entry>
+             <entry>no</entry>
 -->
              <entry>仮想トランザクションID（backendID/localXID）。
               <xref linkend="transaction-id"/>参照</entry>
@@ -10983,6 +10983,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 <!--
              <entry>Transaction ID (0 if none is assigned);  see
              <xref linkend="transaction-id"/></entry>
+             <entry>no</entry>
 -->
              <entry>トランザクションID（何もアサインされていない場合0）。
              <xref linkend="transaction-id"/>参照</entry>

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -17452,7 +17452,6 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
         can only be set in the <filename>postgresql.conf</filename> file or on
         the server command line.
 -->
-
 デフォルトである<literal>on</literal>に設定すると、<productname>PostgreSQL</productname>はバックエンドがクラッシュした後に自動的に一時ファイルを削除します。
 無効にすると、ファイルは保存され、たとえばデバッグ目的で使用できます。
 しかしクラッシュを繰り返すと不要なファイルが溜まっていくかもしれません。

--- a/doc/src/sgml/config0.sgml
+++ b/doc/src/sgml/config0.sgml
@@ -477,11 +477,10 @@ SET configuration_parameter TO DEFAULT;
 <!--
        is:
 -->
-は
+は以下と同じです。
 <programlisting>
 UPDATE pg_settings SET setting = reset_val WHERE name = 'configuration_parameter';
 </programlisting>
-と同じです。
       </para>
      </listitem>
     </itemizedlist>

--- a/doc/src/sgml/config2.sgml
+++ b/doc/src/sgml/config2.sgml
@@ -1896,6 +1896,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 <!--
              <entry>Virtual transaction ID (backendID/localXID);  see
              <xref linkend="transaction-id"/></entry>
+             <entry>no</entry>
 -->
              <entry>仮想トランザクションID（backendID/localXID）。
               <xref linkend="transaction-id"/>参照</entry>
@@ -1906,6 +1907,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 <!--
              <entry>Transaction ID (0 if none is assigned);  see
              <xref linkend="transaction-id"/></entry>
+             <entry>no</entry>
 -->
              <entry>トランザクションID（何もアサインされていない場合0）。
              <xref linkend="transaction-id"/>参照</entry>

--- a/doc/src/sgml/plpython.sgml
+++ b/doc/src/sgml/plpython.sgml
@@ -574,7 +574,7 @@ $$ LANGUAGE plpython3u;
    function. The following examples assume we have:
 -->
 Python関数から行または複合型を返す方法は複数存在します。
-以下の例では
+以下の例はそれを前提とします。
 
 <programlisting>
 CREATE TYPE named_value AS (
@@ -582,7 +582,6 @@ CREATE TYPE named_value AS (
   value  integer
 );
 </programlisting>
-を前提とします。
 
 <!--
    A composite result can be returned as a:

--- a/doc/src/sgml/ref/pg_waldump.sgml
+++ b/doc/src/sgml/ref/pg_waldump.sgml
@@ -461,7 +461,7 @@ WALレコードで見つかったページ全体のイメージを<replaceable>s
 
            <row>
             <entry>BLKNO</entry>
-<!---
+<!--
             <entry>block number of the block</entry>
 -->
             <entry>ブロックのブロック番号</entry>

--- a/doc/src/sgml/ref/release_savepoint.sgml
+++ b/doc/src/sgml/ref/release_savepoint.sgml
@@ -147,7 +147,6 @@ COMMIT;
    A more complex example with multiple nested subtransactions:
 -->
 複数の入れ子になったサブトランザクションを持つ、より複雑な例。
-
 <programlisting>
 BEGIN;
     INSERT INTO table1 VALUES (1);

--- a/doc/src/sgml/xfunc.sgml
+++ b/doc/src/sgml/xfunc.sgml
@@ -1041,7 +1041,7 @@ LANGUAGE SQL;
      the same end result as
 -->
 これは基本的に、関数結果用の無名の複合型の作成を行います。
-上の例では、
+上の例では、以下と同じ最終結果になります。
 
 <screen>
 CREATE TYPE sum_prod AS (sum int, product int);
@@ -1050,7 +1050,6 @@ CREATE FUNCTION sum_n_product (int, int) RETURNS sum_prod
 AS 'SELECT $1 + $2, $1 * $2'
 LANGUAGE SQL;
 </screen>
-と同じ最終結果になります。
 
 <!--
      but not having to bother with the separate composite type definition
@@ -1302,7 +1301,7 @@ variadicパラメータが少なくとも1つの実引数と一致しなけれ�
 variadicパラメータから生成される配列要素パラメータは、それ自身にはまったく名前を持たないものとして扱われます。
 これは、名前付き引数（<xref linkend="sql-syntax-calling-funcs"/>）を使用して可変長の関数を呼び出すことができないことを意味します。
 ただし、<literal>VARIADIC</literal>を指定する場合は例外です。
-たとえば、
+たとえば、以下は動作しますが、
 
 <screen>
 SELECT mleast(VARIADIC arr =&gt; ARRAY[10, -1, 5, 4.4]);
@@ -1311,13 +1310,12 @@ SELECT mleast(VARIADIC arr =&gt; ARRAY[10, -1, 5, 4.4]);
 <!--
      but not these:
 -->
-は動作しますが、
+以下は動作しません。
 
 <screen>
 SELECT mleast(arr =&gt; 10);
 SELECT mleast(arr =&gt; ARRAY[10, -1, 5, 4.4]);
 </screen>
-は動作しません。
     </para>
    </sect2>
 


### PR DESCRIPTION
原文がないところに日本語翻訳を追加している箇所を
「原文」、「翻訳」の形式に修正しました。

コメント閉じタグのハイフン数を修正

原文が削られていた箇所の復活