### PR TITLE
func.sgmlのチェックで見つけた問題の修正です

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -32361,7 +32361,7 @@ SELECT collation for ('foo' COLLATE "de_DE");
 -->
 テキスト形式の演算子名をOIDに変換します。
 同様の結果はその文字列を<type>regoper</type>型にキャストすることによっても得られます。（<xref linkend="datatype-oid"/>参照。）
-しかしこの関数は名前が見つからない場合にエラーを起こすのではなく、<literal>NULL</literal>を返します。
+しかしこの関数は名前が見つからない、あるいは曖昧な場合にエラーを起こすのではなく、<literal>NULL</literal>を返します。
        </para></entry>
       </row>
 
@@ -32405,7 +32405,7 @@ SELECT collation for ('foo' COLLATE "de_DE");
 -->
 テキスト形式の関数名またはプロシージャ名をOIDに変換します。
 同様の結果はその文字列を<type>regproc</type>型にキャストすることによっても得られます。（<xref linkend="datatype-oid"/>参照。）
-しかしこの関数は名前が見つからないか、あるいは曖昧な場合にエラーを起こすのではなく、<literal>NULL</literal>を返します。
+しかしこの関数は名前が見つからない、あるいは曖昧な場合にエラーを起こすのではなく、<literal>NULL</literal>を返します。
        </para></entry>
       </row>
 

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -3605,7 +3605,7 @@ POSIX正規表現にマッチする最初の部分文字列を返します。<xr
         start, end, or both ends (<literal>BOTH</literal> is the default)
         of <parameter>string</parameter>.
 -->
-<parameter>string</parameter>から<parameter>characters</parameter>（空白一文字がデフォルト）に現れる文字のみを含む最長の文字列を先頭、末尾、あるいはその両方（BOTHがデフォルト）から取り除きます。
+<parameter>string</parameter>から<parameter>characters</parameter>（空白一文字がデフォルト）に現れる文字のみを含む最長の文字列を先頭、末尾、あるいはその両方（<literal>BOTH</literal>がデフォルト）から取り除きます。
        </para>
        <para>
         <literal>trim(both 'xyz' from 'yxTomxx')</literal>
@@ -5424,7 +5424,7 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
         end, or both ends (<literal>BOTH</literal> is the default)
         of <parameter>bytes</parameter>.
 -->
-<parameter>bytes</parameter>から<parameter>bytesremoved</parameter>に現れるバイトのみを含む最長の文字列を先頭、末尾、あるいはその両方（BOTHがデフォルト）から取り除きます。
+<parameter>bytes</parameter>から<parameter>bytesremoved</parameter>に現れるバイトのみを含む最長の文字列を先頭、末尾、あるいはその両方（<literal>BOTH</literal>がデフォルト）から取り除きます。
        </para>
        <para>
         <literal>trim('\x9012'::bytea from '\x1234567890'::bytea)</literal>
@@ -13097,7 +13097,7 @@ SELECT (DATE '2001-10-30', DATE '2001-10-30') OVERLAPS
    For example, with the session time zone set
    to <literal>America/Denver</literal>:
 -->
-<type>timestamp with time zone</type>の値に<type>interval</type>の値を加える際には（あるいは<type>interval</type>の値を引く際には）、<type>interval</type>値の月、日、マイクロ秒のフィールドが順に適用されます。
+<type>timestamp</type>または<type>timestamp with time zone</type>の値に<type>interval</type>の値を加える際には（あるいは<type>interval</type>の値を引く際には）、<type>interval</type>値の月、日、マイクロ秒のフィールドが順に適用されます。
 まず、非ゼロの月フィールドが示す日数の分だけtimestampの日付を先に進める、もしくは後に戻し、新しい月の最終日を超えてしまわない限り月内の日付を同じに保ちます。月の最後の日を超えてしまうようなら、その月の最終日が使われます。
 （たちえば、3月31日に1ヶ月を加えると4月30日になりますが、3月31日に2ヶ月を加えると5月31日になります。）
 次に、日フィールド分だけtimestampの日付を先に進める、もしくは後に戻します。
@@ -26676,7 +26676,7 @@ NULLも含めてすべての入力値を収集し、JSON配列に格納します
 -->
 すべてのキー／値ペアをJSONオブジェクトに格納します。
 キー引数はテキストに変換されます。値は<function>to_json</function>あるいは<function>to_jsonb</function>にしたがって変換されます。
-キーはNULLにはできません。
+<parameter>key</parameter>はNULLにはできません。
 <parameter>value</parameter>がNULLなら、そのエントリはスキップされます。
 重複キーがある場合、エラーが発生します。
        </para></entry>
@@ -31203,8 +31203,7 @@ PUBLIC仮想ロールは実在するロールのメンバには決してなれ�
         names.)
 -->
 与えられた属性で<type>aclitem</type>を作成します。
-<parameter>privileges</parameter>は、結果中に設定される<literal>SELECT</literal>、<literal>INSERT</literal>などのカ
-ンマで区切られた権限名のリストです。
+<parameter>privileges</parameter>は、結果中に設定される<literal>SELECT</literal>、<literal>INSERT</literal>などのカンマで区切られた権限名のリストです。
 （権限文字列の大文字小文字の区別は無視されます。権限文字の間に余分な空白が合っても構いませんが、権限文字列中に空白があってはいけません。）
        </para></entry>
       </row>
@@ -32360,9 +32359,9 @@ SELECT collation for ('foo' COLLATE "de_DE");
         <literal>NULL</literal> rather than throwing an error if the name is
         not found or is ambiguous.
 -->
-テキスト形式のリレーション名をOIDに変換します。
-同様の結果はその文字列を<type>regclass</type>型にキャストすることによっても得られます。（<xref linkend="datatype-oid"/>参照。）
-しかしこの関数は名前が見つからない、あるいは曖昧な場合にエラーを起こすのではなく、<literal>NULL</literal>を返します。
+テキスト形式の演算子名をOIDに変換します。
+同様の結果はその文字列を<type>regoper</type>型にキャストすることによっても得られます。（<xref linkend="datatype-oid"/>参照。）
+しかしこの関数は名前が見つからない場合にエラーを起こすのではなく、<literal>NULL</literal>を返します。
        </para></entry>
       </row>
 

--- a/doc/src/sgml/func1.sgml
+++ b/doc/src/sgml/func1.sgml
@@ -3536,7 +3536,7 @@ POSIX正規表現にマッチする最初の部分文字列を返します。<xr
         start, end, or both ends (<literal>BOTH</literal> is the default)
         of <parameter>string</parameter>.
 -->
-<parameter>string</parameter>から<parameter>characters</parameter>（空白一文字がデフォルト）に現れる文字のみを含む最長の文字列を先頭、末尾、あるいはその両方（BOTHがデフォルト）から取り除きます。
+<parameter>string</parameter>から<parameter>characters</parameter>（空白一文字がデフォルト）に現れる文字のみを含む最長の文字列を先頭、末尾、あるいはその両方（<literal>BOTH</literal>がデフォルト）から取り除きます。
        </para>
        <para>
         <literal>trim(both 'xyz' from 'yxTomxx')</literal>
@@ -5355,7 +5355,7 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
         end, or both ends (<literal>BOTH</literal> is the default)
         of <parameter>bytes</parameter>.
 -->
-<parameter>bytes</parameter>から<parameter>bytesremoved</parameter>に現れるバイトのみを含む最長の文字列を先頭、末尾、あるいはその両方（BOTHがデフォルト）から取り除きます。
+<parameter>bytes</parameter>から<parameter>bytesremoved</parameter>に現れるバイトのみを含む最長の文字列を先頭、末尾、あるいはその両方（<literal>BOTH</literal>がデフォルト）から取り除きます。
        </para>
        <para>
         <literal>trim('\x9012'::bytea from '\x1234567890'::bytea)</literal>

--- a/doc/src/sgml/func2.sgml
+++ b/doc/src/sgml/func2.sgml
@@ -3046,7 +3046,7 @@ SELECT (DATE '2001-10-30', DATE '2001-10-30') OVERLAPS
    For example, with the session time zone set
    to <literal>America/Denver</literal>:
 -->
-<type>timestamp with time zone</type>の値に<type>interval</type>の値を加える際には（あるいは<type>interval</type>の値を引く際には）、<type>interval</type>値の月、日、マイクロ秒のフィールドが順に適用されます。
+<type>timestamp</type>または<type>timestamp with time zone</type>の値に<type>interval</type>の値を加える際には（あるいは<type>interval</type>の値を引く際には）、<type>interval</type>値の月、日、マイクロ秒のフィールドが順に適用されます。
 まず、非ゼロの月フィールドが示す日数の分だけtimestampの日付を先に進める、もしくは後に戻し、新しい月の最終日を超えてしまわない限り月内の日付を同じに保ちます。月の最後の日を超えてしまうようなら、その月の最終日が使われます。
 （たちえば、3月31日に1ヶ月を加えると4月30日になりますが、3月31日に2ヶ月を加えると5月31日になります。）
 次に、日フィールド分だけtimestampの日付を先に進める、もしくは後に戻します。

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -6747,7 +6747,7 @@ NULLも含めてすべての入力値を収集し、JSON配列に格納します
 -->
 すべてのキー／値ペアをJSONオブジェクトに格納します。
 キー引数はテキストに変換されます。値は<function>to_json</function>あるいは<function>to_jsonb</function>にしたがって変換されます。
-キーはNULLにはできません。
+<parameter>key</parameter>はNULLにはできません。
 <parameter>value</parameter>がNULLなら、そのエントリはスキップされます。
 重複キーがある場合、エラーが発生します。
        </para></entry>

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -3933,7 +3933,7 @@ SELECT collation for ('foo' COLLATE "de_DE");
 -->
 テキスト形式の演算子名をOIDに変換します。
 同様の結果はその文字列を<type>regoper</type>型にキャストすることによっても得られます。（<xref linkend="datatype-oid"/>参照。）
-しかしこの関数は名前が見つからない場合にエラーを起こすのではなく、<literal>NULL</literal>を返します。
+しかしこの関数は名前が見つからない、あるいは曖昧な場合にエラーを起こすのではなく、<literal>NULL</literal>を返します。
        </para></entry>
       </row>
 
@@ -3977,7 +3977,7 @@ SELECT collation for ('foo' COLLATE "de_DE");
 -->
 テキスト形式の関数名またはプロシージャ名をOIDに変換します。
 同様の結果はその文字列を<type>regproc</type>型にキャストすることによっても得られます。（<xref linkend="datatype-oid"/>参照。）
-しかしこの関数は名前が見つからないか、あるいは曖昧な場合にエラーを起こすのではなく、<literal>NULL</literal>を返します。
+しかしこの関数は名前が見つからない、あるいは曖昧な場合にエラーを起こすのではなく、<literal>NULL</literal>を返します。
        </para></entry>
       </row>
 

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -2775,8 +2775,7 @@ PUBLIC仮想ロールは実在するロールのメンバには決してなれ�
         names.)
 -->
 与えられた属性で<type>aclitem</type>を作成します。
-<parameter>privileges</parameter>は、結果中に設定される<literal>SELECT</literal>、<literal>INSERT</literal>などのカ
-ンマで区切られた権限名のリストです。
+<parameter>privileges</parameter>は、結果中に設定される<literal>SELECT</literal>、<literal>INSERT</literal>などのカンマで区切られた権限名のリストです。
 （権限文字列の大文字小文字の区別は無視されます。権限文字の間に余分な空白が合っても構いませんが、権限文字列中に空白があってはいけません。）
        </para></entry>
       </row>
@@ -3932,9 +3931,9 @@ SELECT collation for ('foo' COLLATE "de_DE");
         <literal>NULL</literal> rather than throwing an error if the name is
         not found or is ambiguous.
 -->
-テキスト形式のリレーション名をOIDに変換します。
-同様の結果はその文字列を<type>regclass</type>型にキャストすることによっても得られます。（<xref linkend="datatype-oid"/>参照。）
-しかしこの関数は名前が見つからない、あるいは曖昧な場合にエラーを起こすのではなく、<literal>NULL</literal>を返します。
+テキスト形式の演算子名をOIDに変換します。
+同様の結果はその文字列を<type>regoper</type>型にキャストすることによっても得られます。（<xref linkend="datatype-oid"/>参照。）
+しかしこの関数は名前が見つからない場合にエラーを起こすのではなく、<literal>NULL</literal>を返します。
        </para></entry>
       </row>
 


### PR DESCRIPTION
タグの数があってなかったのでタグを補完

timestampが足りてなかったのを補完

不要な改行を削除

類似文が上にあったためにツールが上の類似文を出してしまったのが原因の修正。
→テキスト形式の演算子名をOIDに変換します。