### PR TITLE
sources.sgmlで気になる点の修正です。

### DIFF
--- a/doc/src/sgml/sources.sgml
+++ b/doc/src/sgml/sources.sgml
@@ -79,7 +79,7 @@
     as though they were plain text.  If you want to preserve the line breaks
     in an indented block, add dashes like this:
 -->
-列1で始まるコメントブロックは<application>pgindent</application>によりそのまま維持されますが、字下げされたコメントブロックを、あたかも平文テキストのように還流します。
+列1で始まるコメントブロックは<application>pgindent</application>によりそのまま維持されますが、字下げされたコメントブロックは、あたかも平文テキストのように再整形されることに注意してください。
 ある字下げブロックの中で改行を維持したい場合は以下のようにダッシュを追加します。
 <programlisting>
     /*----------


### PR DESCRIPTION
"re-flow"が「還流」と訳されていますが、ここで言っているのは、結果とし
てテキストの再折返しが起こることであり、「還流」は意味が違うと思います。
そこで、「再整形」としてみました。
また、分の前半が受け身形なのに、後半はそうでないので主語が不明になって
います。全体を受け身形に統一しました。
"Note"が訳出されていなかったのも修正しました。