### PR TITLE
commandは訳さないように修正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -6378,9 +6378,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      about logical replication configuration settings refer to
      <xref linkend="logical-replication-config"/>.
 -->
-<emphasis>ロジカルレプリケーション</emphasis>の場合、<firstterm>パブリッシャ（</firstterm><link linkend="sql-createpublication"><command>パブリケーションの作成</command></link>を実行するサーバ）は、データを<firstterm>サブスクライバ</firstterm>（<link linkend="sql-createsubscription"><command>サブスクリプションの作成</command></link>を実行するサーバ）に複製します。
-サーバは、パブリッシャとサブスクライバを同時に兼ねることもできます。
-次の項でパブリッシャを「送信者」と呼ぶことに注意してください。
+<emphasis>ロジカルレプリケーション</emphasis>の場合、<firstterm>パブリッシャー（</firstterm><link linkend="sql-createpublication"><command>CREATE PUBLICATION</command></link>を実行するサーバ）は、データを<firstterm>サブスクライバー</firstterm>（<link linkend="sql-createsubscription"><command>CREATE SUBSCRIPTION</command></link>を実行するサーバ）に複製します。
+サーバは、パブリッシャーとサブスクライバーを同時に兼ねることもできます。
+次の項でパブリッシャーを「送信者」と呼ぶことに注意してください。
 ロジカルレプリケーション設定設定の詳細は、<xref linkend="logical-replication-config"/>を参照してください。
     </para>
 
@@ -7482,7 +7482,7 @@ WALレコードは、適用される準備が整うまでスタンバイに保�
 サブスクライバー側ではレプリケーション原点(origin)（<xref linkend="replication-origins"/>参照）をいくつ並行して追跡できるかを指定します。
 これは実質的に論理レプリケーションのサブスクリプションをサーバ上にいくつ作ることができるかを制限します。
 現在追跡しているレプリケーション原点の数（<link linkend="view-pg-replication-origin-status">pg_replication_origin_status</link>に反映されます）よりも小さい値を設定すると、サーバが起動しなくなります。
-<literal>max_replication_slots</literal>は、少なくともサブスクライバに追加されるサブスクリプションの数に、テーブル同期用の予備を加えた数に設定する必要があります。
+<literal>max_replication_slots</literal>は、少なくともサブスクライバーに追加されるサブスクリプションの数に、テーブル同期用の予備を加えた数に設定する必要があります。
 <xref linkend="replication-origins"/>
        </para>
 
@@ -17579,7 +17579,7 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
         changes when <varname>logical_decoding_work_mem</varname> is reached.
 -->
 パブリッシャー側では、<varname>debug_logical_replication_streaming</varname>を使用すると、ロジカルデコーディングでただちに変更をストリーミングまたはシリアル化できます。
-<literal>immediate</literal>に設定すると、<link linkend="sql-createsubscription"><command>CREATEサブスクリプション</command></link>の<link linkend="sql-createsubscription-with-streaming"><literal>ストリーミング</literal></link>オプションが有効になっている場合は各変更をストリームし、それ以外の場合は各変更をシリアル化します。
+<literal>immediate</literal>に設定すると、<link linkend="sql-createsubscription"><command>CREATE SUBSCRIPTION</command></link>の<link linkend="sql-createsubscription-with-streaming"><literal>ストリーミング</literal></link>オプションが有効になっている場合は各変更をストリームし、それ以外の場合は各変更をシリアル化します。
 <literal>buffered</literal>に設定すると、<varname>logical_decoding_work_mem</varname>に達したときに、デコーディング処理がストリームまたはシリアル化します。
        </para>
 

--- a/doc/src/sgml/config1.sgml
+++ b/doc/src/sgml/config1.sgml
@@ -2235,9 +2235,9 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
      about logical replication configuration settings refer to
      <xref linkend="logical-replication-config"/>.
 -->
-<emphasis>ロジカルレプリケーション</emphasis>の場合、<firstterm>パブリッシャ（</firstterm><link linkend="sql-createpublication"><command>パブリケーションの作成</command></link>を実行するサーバ）は、データを<firstterm>サブスクライバ</firstterm>（<link linkend="sql-createsubscription"><command>サブスクリプションの作成</command></link>を実行するサーバ）に複製します。
-サーバは、パブリッシャとサブスクライバを同時に兼ねることもできます。
-次の項でパブリッシャを「送信者」と呼ぶことに注意してください。
+<emphasis>ロジカルレプリケーション</emphasis>の場合、<firstterm>パブリッシャー（</firstterm><link linkend="sql-createpublication"><command>CREATE PUBLICATION</command></link>を実行するサーバ）は、データを<firstterm>サブスクライバー</firstterm>（<link linkend="sql-createsubscription"><command>CREATE SUBSCRIPTION</command></link>を実行するサーバ）に複製します。
+サーバは、パブリッシャーとサブスクライバーを同時に兼ねることもできます。
+次の項でパブリッシャーを「送信者」と呼ぶことに注意してください。
 ロジカルレプリケーション設定設定の詳細は、<xref linkend="logical-replication-config"/>を参照してください。
     </para>
 
@@ -3339,7 +3339,7 @@ WALレコードは、適用される準備が整うまでスタンバイに保�
 サブスクライバー側ではレプリケーション原点(origin)（<xref linkend="replication-origins"/>参照）をいくつ並行して追跡できるかを指定します。
 これは実質的に論理レプリケーションのサブスクリプションをサーバ上にいくつ作ることができるかを制限します。
 現在追跡しているレプリケーション原点の数（<link linkend="view-pg-replication-origin-status">pg_replication_origin_status</link>に反映されます）よりも小さい値を設定すると、サーバが起動しなくなります。
-<literal>max_replication_slots</literal>は、少なくともサブスクライバに追加されるサブスクリプションの数に、テーブル同期用の予備を加えた数に設定する必要があります。
+<literal>max_replication_slots</literal>は、少なくともサブスクライバーに追加されるサブスクリプションの数に、テーブル同期用の予備を加えた数に設定する必要があります。
 <xref linkend="replication-origins"/>
        </para>
 

--- a/doc/src/sgml/config3.sgml
+++ b/doc/src/sgml/config3.sgml
@@ -3047,7 +3047,7 @@ WALディスクブロックの容量を報告します。
 <!--
     <title>Developer Options</title>
 -->
-    <title>開発者向けのオプション</title>
+    <title>開発者向けオプション</title>
 
     <para>
 <!--
@@ -4068,7 +4068,6 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
         can only be set in the <filename>postgresql.conf</filename> file or on
         the server command line.
 -->
-
 デフォルトである<literal>on</literal>に設定すると、<productname>PostgreSQL</productname>はバックエンドがクラッシュした後に自動的に一時ファイルを削除します。
 無効にすると、ファイルは保存され、たとえばデバッグ目的で使用できます。
 しかしクラッシュを繰り返すと不要なファイルが溜まっていくかもしれません。
@@ -4196,7 +4195,7 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
         changes when <varname>logical_decoding_work_mem</varname> is reached.
 -->
 パブリッシャー側では、<varname>debug_logical_replication_streaming</varname>を使用すると、ロジカルデコーディングでただちに変更をストリーミングまたはシリアル化できます。
-<literal>immediate</literal>に設定すると、<link linkend="sql-createsubscription"><command>CREATEサブスクリプション</command></link>の<link linkend="sql-createsubscription-with-streaming"><literal>ストリーミング</literal></link>オプションが有効になっている場合は各変更をストリームし、それ以外の場合は各変更をシリアル化します。
+<literal>immediate</literal>に設定すると、<link linkend="sql-createsubscription"><command>CREATE SUBSCRIPTION</command></link>の<link linkend="sql-createsubscription-with-streaming"><literal>ストリーミング</literal></link>オプションが有効になっている場合は各変更をストリームし、それ以外の場合は各変更をシリアル化します。
 <literal>buffered</literal>に設定すると、<varname>logical_decoding_work_mem</varname>に達したときに、デコーディング処理がストリームまたはシリアル化します。
        </para>
 

--- a/doc/src/sgml/release-16.sgml
+++ b/doc/src/sgml/release-16.sgml
@@ -2423,7 +2423,7 @@ Author: Amit Kapila <akapila@postgresql.org>
        Allow logical replication subscribers to process only changes that
        have no origin (Vignesh C, Amit Kapila)
 -->
-論理レプリケーションのサブスクライバが、オリジンを持たない変更のみを処理できるようにしました。
+論理レプリケーションのサブスクライバーが、オリジンを持たない変更のみを処理できるようにしました。
 (Vignesh C, Amit Kapila)
       </para>
 


### PR DESCRIPTION
パブリッシャーとサブスクライバーの長音を統一。
split-config.shの実行（前回漏れがあった）。