### PR TITLE
翻訳の分割単位を厳格化

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -4,7 +4,7 @@
 <!--
   <title>Server Configuration</title>
 -->
-  <title>サーバの設定</title>
+  <title>サーバ設定</title>
 
   <indexterm>
    <primary>configuration</primary>
@@ -5888,7 +5888,15 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         The <xref linkend="pgarchivecleanup"/> module
         is often used in <varname>archive_cleanup_command</varname> for
         single-standby configurations, for example:
+-->
+オプションのパラメータは、すべてのリスタートポイントで実行されるシェルコマンドを指定します。
+<varname>archive_cleanup_command</varname>の目的は、スタンバイサーバにとって必要とされない古いアーカイブWALファイルをクリーンアップする仕組みを提供することです。
+<literal>%r</literal>は最後の有効なリスタートポイントを含むファイル名に置換されます。
+これはリストアが再開可能であるために<emphasis>保持</emphasis>しなければならない最古のファイルで、<literal>%r</literal>よりも前のすべてのファイルは安全に削除できます。
+これは現在のリストアからの再開をサポートするのに最小限必要なアーカイブを残して切り詰めるのに必要な情報として利用できます。
+単一のスタンバイ構成用の<varname>archive_cleanup_command</varname>で、たとえば以下のように、しばしば<xref linkend="pgarchivecleanup"/>モジュールが使われます。
 <programlisting>archive_cleanup_command = 'pg_archivecleanup /mnt/server/archivedir %r'</programlisting>
+<!--
         Note however that if multiple standby servers are restoring from the
         same archive directory, you will need to ensure that you do not delete
         WAL files until they are no longer needed by any of the servers.
@@ -5897,12 +5905,6 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         Write <literal>%%</literal> to embed an actual <literal>%</literal> character in the
         command.
 -->
-オプションのパラメータは、すべてのリスタートポイントで実行されるシェルコマンドを指定します。
-<varname>archive_cleanup_command</varname>の目的は、スタンバイサーバにとって必要とされない古いアーカイブWALファイルをクリーンアップする仕組みを提供することです。
-<literal>%r</literal>は最後の有効なリスタートポイントを含むファイル名に置換されます。
-これはリストアが再開可能であるために<emphasis>保持</emphasis>しなければならない最古のファイルで、<literal>%r</literal>よりも前のすべてのファイルは安全に削除できます。
-これは現在のリストアからの再開をサポートするのに最小限必要なアーカイブを残して切り詰めるのに必要な情報として利用できます。
-単一のスタンバイ構成用の<varname>archive_cleanup_command</varname>で、たとえば<programlisting>archive_cleanup_command = 'pg_archivecleanup /mnt/server/archivedir %r'</programlisting>のようにして、しばしば<xref linkend="pgarchivecleanup"/>モジュールが使われます。
 だたし、複数のスタンバイサーバが同じアーカイブディレクトリからリストアしている場合は、どのサーバにおいてももはや必要がなくなるまでWALファイルが削除されることのないようにする必要があることに留意してください。
 <varname>archive_cleanup_command</varname>は通常ウォームスタンバイ構成で使用されます。
 （<xref linkend="warm-standby"/>参照。）

--- a/doc/src/sgml/config0.sgml
+++ b/doc/src/sgml/config0.sgml
@@ -12,7 +12,7 @@
 <!--
   <title>Server Configuration</title>
 -->
-  <title>サーバの設定</title>
+  <title>サーバ設定</title>
 
   <indexterm>
    <primary>configuration</primary>

--- a/doc/src/sgml/config1.sgml
+++ b/doc/src/sgml/config1.sgml
@@ -1745,7 +1745,15 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         The <xref linkend="pgarchivecleanup"/> module
         is often used in <varname>archive_cleanup_command</varname> for
         single-standby configurations, for example:
+-->
+オプションのパラメータは、すべてのリスタートポイントで実行されるシェルコマンドを指定します。
+<varname>archive_cleanup_command</varname>の目的は、スタンバイサーバにとって必要とされない古いアーカイブWALファイルをクリーンアップする仕組みを提供することです。
+<literal>%r</literal>は最後の有効なリスタートポイントを含むファイル名に置換されます。
+これはリストアが再開可能であるために<emphasis>保持</emphasis>しなければならない最古のファイルで、<literal>%r</literal>よりも前のすべてのファイルは安全に削除できます。
+これは現在のリストアからの再開をサポートするのに最小限必要なアーカイブを残して切り詰めるのに必要な情報として利用できます。
+単一のスタンバイ構成用の<varname>archive_cleanup_command</varname>で、たとえば以下のように、しばしば<xref linkend="pgarchivecleanup"/>モジュールが使われます。
 <programlisting>archive_cleanup_command = 'pg_archivecleanup /mnt/server/archivedir %r'</programlisting>
+<!--
         Note however that if multiple standby servers are restoring from the
         same archive directory, you will need to ensure that you do not delete
         WAL files until they are no longer needed by any of the servers.
@@ -1754,12 +1762,6 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         Write <literal>%%</literal> to embed an actual <literal>%</literal> character in the
         command.
 -->
-オプションのパラメータは、すべてのリスタートポイントで実行されるシェルコマンドを指定します。
-<varname>archive_cleanup_command</varname>の目的は、スタンバイサーバにとって必要とされない古いアーカイブWALファイルをクリーンアップする仕組みを提供することです。
-<literal>%r</literal>は最後の有効なリスタートポイントを含むファイル名に置換されます。
-これはリストアが再開可能であるために<emphasis>保持</emphasis>しなければならない最古のファイルで、<literal>%r</literal>よりも前のすべてのファイルは安全に削除できます。
-これは現在のリストアからの再開をサポートするのに最小限必要なアーカイブを残して切り詰めるのに必要な情報として利用できます。
-単一のスタンバイ構成用の<varname>archive_cleanup_command</varname>で、たとえば<programlisting>archive_cleanup_command = 'pg_archivecleanup /mnt/server/archivedir %r'</programlisting>のようにして、しばしば<xref linkend="pgarchivecleanup"/>モジュールが使われます。
 だたし、複数のスタンバイサーバが同じアーカイブディレクトリからリストアしている場合は、どのサーバにおいてももはや必要がなくなるまでWALファイルが削除されることのないようにする必要があることに留意してください。
 <varname>archive_cleanup_command</varname>は通常ウォームスタンバイ構成で使用されます。
 （<xref linkend="warm-standby"/>参照。）

--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -51,7 +51,7 @@
 <!--
     <title>Data Types</title>
 -->
-<title>データ型</title>
+    <title>データ型</title>
     <tgroup cols="3">
      <colspec colname="col1" colwidth="2*"/>
      <colspec colname="col2" colwidth="1*"/>
@@ -466,7 +466,7 @@
 <!--
    <title>Compatibility</title>
 -->
-<title>互換性</title>
+   <title>互換性</title>
    <para>
 <!--
     The following types (or spellings thereof) are specified by
@@ -513,7 +513,7 @@
 <!--
    <title>Numeric Types</title>
 -->
-<title>数値データ型</title>
+   <title>数値データ型</title>
 
    <indexterm zone="datatype-numeric">
     <primary>data type</primary>
@@ -539,7 +539,7 @@
 <!--
      <title>Numeric Types</title>
 -->
-<title>数値データ型</title>
+     <title>数値データ型</title>
      <tgroup cols="4">
       <colspec colname="col1" colwidth="2*"/>
       <colspec colname="col2" colwidth="1*"/>
@@ -698,7 +698,7 @@
 <!--
     <title>Integer Types</title>
 -->
-<title>整数データ型</title>
+    <title>整数データ型</title>
 
     <indexterm zone="datatype-int">
      <primary>integer</primary>
@@ -770,7 +770,7 @@
 <!--
     <title>Arbitrary Precision Numbers</title>
 -->
-<title>任意の精度を持つ数</title>
+    <title>任意の精度を持つ数</title>
 
     <indexterm>
      <primary>numeric (data type)</primary>
@@ -1133,7 +1133,7 @@ FROM generate_series(-3.5, 3.5, 1) as x;
 <!--
     <title>Floating-Point Types</title>
 -->
-<title>浮動小数点データ型</title>
+    <title>浮動小数点データ型</title>
 
     <indexterm zone="datatype-float">
      <primary>real</primary>
@@ -1570,7 +1570,7 @@ ALTER SEQUENCE <replaceable class="parameter">tablename</replaceable>_<replaceab
 <!--
    <title>Monetary Types</title>
 -->
-<title>通貨型</title>
+   <title>通貨型</title>
 
    <para>
 <!--
@@ -1595,7 +1595,7 @@ ALTER SEQUENCE <replaceable class="parameter">tablename</replaceable>_<replaceab
 <!--
      <title>Monetary Types</title>
 -->
-<title>通貨型</title>
+     <title>通貨型</title>
      <tgroup cols="4">
       <colspec colname="col1" colwidth="2*"/>
       <colspec colname="col2" colwidth="1*"/>
@@ -1699,7 +1699,7 @@ SELECT '52093.89'::money::numeric::float8;
 <!--
    <title>Character Types</title>
 -->
-<title>文字型</title>
+   <title>文字型</title>
 
    <indexterm zone="datatype-character">
     <primary>character string</primary>
@@ -1747,7 +1747,7 @@ SELECT '52093.89'::money::numeric::float8;
 <!--
      <title>Character Types</title>
 -->
-<title>文字型</title>
+     <title>文字型</title>
      <tgroup cols="2">
       <thead>
        <row>
@@ -1978,7 +1978,7 @@ SELECT '52093.89'::money::numeric::float8;
 <!--
     <title>Using the Character Types</title>
 -->
-<title>文字データ型の使用</title>
+    <title>文字データ型の使用</title>
 
 <programlisting>
 CREATE TABLE test1 (a character(4));
@@ -2097,7 +2097,7 @@ SELECT b, char_length(b) FROM test2;
 <!--
   <title>Binary Data Types</title>
 -->
-<title>バイナリ列データ型</title>
+  <title>バイナリ列データ型</title>
 
   <indexterm zone="datatype-binary">
    <primary>binary data</primary>
@@ -2123,7 +2123,7 @@ SELECT b, char_length(b) FROM test2;
 <!--
     <title>Binary Data Types</title>
 -->
-<title>バイナリ列データ型</title>
+    <title>バイナリ列データ型</title>
     <tgroup cols="3">
      <colspec colname="col1" colwidth="1*"/>
      <colspec colname="col2" colwidth="3*"/>
@@ -2571,7 +2571,7 @@ SELECT 'abc \153\154\155 \052\251\124'::bytea;
 <!--
    <title>Date/Time Types</title>
 -->
-<title>日付/時刻データ型</title>
+   <title>日付/時刻データ型</title>
 
    <indexterm zone="datatype-datetime">
     <primary>date</primary>
@@ -2627,7 +2627,7 @@ SELECT 'abc \153\154\155 \052\251\124'::bytea;
 <!--
      <title>Date/Time Types</title>
 -->
-<title>日付/時刻データ型</title>
+     <title>日付/時刻データ型</title>
      <tgroup cols="6">
       <thead>
        <row>
@@ -2821,7 +2821,7 @@ MINUTE TO SECOND
 <!--
     <title>Date/Time Input</title>
 -->
-<title>日付/時刻の入力</title>
+    <title>日付/時刻の入力</title>
 
     <para>
 <!--
@@ -2906,7 +2906,7 @@ MINUTE TO SECOND
 <!--
       <title>Date Input</title>
 -->
-<title>日付入力</title>
+      <title>日付入力</title>
       <tgroup cols="2">
        <colspec colname="col1" colwidth="1*"/>
        <colspec colname="col2" colwidth="2*"/>
@@ -3362,47 +3362,48 @@ January 8 04:05:06 1999 PST
       and <type>timestamp with time zone</type> literals by the presence of a
       <quote>+</quote> or <quote>-</quote> symbol and time zone offset after
       the time.  Hence, according to the standard,
+-->
+標準<acronym>SQL</acronym>では、<type>timestamp without time zone</type>のリテラルと<type>timestamp with time zone</type>のリテラルを、時刻の後の<quote>+</quote>もしくは<quote>-</quote>記号と時間帯補正の有無により区別します。
+そのため、標準に従うと、
 
 <programlisting>
 TIMESTAMP '2004-10-19 10:23:54'
 </programlisting>
 
+<!--
       is a <type>timestamp without time zone</type>, while
+-->
+は<type>timestamp without time zone</type>に、
 
 <programlisting>
 TIMESTAMP '2004-10-19 10:23:54+02'
 </programlisting>
 
+<!--
       is a <type>timestamp with time zone</type>.
       <productname>PostgreSQL</productname> never examines the content of a
       literal string before determining its type, and therefore will treat
       both of the above as <type>timestamp without time zone</type>.  To
       ensure that a literal is treated as <type>timestamp with time
       zone</type>, give it the correct explicit type:
+-->
+は<type>timestamp with time zone</type>になります。
+<productname>PostgreSQL</productname>では、その型を決める前に文字列リテラルの内容を検証しません。
+そのため上の例はいずれも<type>timestamp without time zone</type>として扱います。
+リテラルが確実に<type>timestamp with time zone</type>として扱われるようにするには、例えば、
 
 <programlisting>
 TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54+02'
 </programlisting>
 
+<!--
       In a literal that has been determined to be <type>timestamp without time
       zone</type>, <productname>PostgreSQL</productname> will silently ignore
       any time zone indication.
       That is, the resulting value is derived from the date/time
       fields in the input value, and is not adjusted for time zone.
 -->
-標準<acronym>SQL</acronym>では、<type>timestamp without time zone</type>のリテラルと<type>timestamp with time zone</type>のリテラルを、時刻の後の<quote>+</quote>もしくは<quote>-</quote>記号と時間帯補正の有無により区別します。
-そのため、標準に従うと、
-
-<programlisting>TIMESTAMP '2004-10-19 10:23:54'</programlisting>
-
-は<type>timestamp without time zone</type>に、
-
-<programlisting>TIMESTAMP '2004-10-19 10:23:54+02'</programlisting>
-
-は<type>timestamp with time zone</type>になります。
-<productname>PostgreSQL</productname>では、その型を決める前に文字列リテラルの内容を検証しません。
-そのため上の例はいずれも<type>timestamp without time zone</type>として扱います。
-リテラルが確実に<type>timestamp with time zone</type>として扱われるようにするには、例えば、<programlisting>TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54+02'</programlisting>のように正しい明示的な型を指定してください。
+のように正しい明示的な型を指定してください。
 <type>timestamp without time zone</type>と決定済みのリテラルでは、<productname>PostgreSQL</productname>は警告なく時間帯情報をすべて無視します。
 つまり、結果の値は明示された入力値の日付/時刻フィールドから持ち込まれますが、時間帯の調整はなされません。
      </para>
@@ -3454,7 +3455,7 @@ TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54+02'
 <!--
      <title>Special Values</title>
 -->
-<title>特別な値</title>
+     <title>特別な値</title>
 
      <indexterm>
       <primary>time</primary>
@@ -3867,7 +3868,7 @@ ISO 8601の仕様では日付と時刻を区切るために大文字の<literal>
 <!--
     <title>Time Zones</title>
 -->
-<title>時間帯</title>
+    <title>時間帯</title>
 
     <indexterm zone="datatype-timezones">
      <primary>time zone</primary>
@@ -4610,7 +4611,7 @@ SELECT EXTRACT(days from '80 hours'::interval);
 <!--
    <title>Boolean Type</title>
 -->
-<title>論理値データ型</title>
+   <title>論理値データ型</title>
 
    <indexterm zone="datatype-boolean">
     <primary>Boolean</primary>
@@ -4736,7 +4737,7 @@ SELECT EXTRACT(days from '80 hours'::interval);
 <!--
     <title>Using the <type>boolean</type> Type</title>
 -->
-<title><type>boolean</type>型の使用</title>
+    <title><type>boolean</type>型の使用</title>
 
 <programlisting>
 CREATE TABLE test1 (a boolean, b text);
@@ -5016,7 +5017,7 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
 <!--
    <title>Geometric Types</title>
 -->
-<title>幾何データ型</title>
+   <title>幾何データ型</title>
 
    <para>
 <!--
@@ -5032,7 +5033,7 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
 <!--
      <title>Geometric Types</title>
 -->
-<title>幾何データ型</title>
+     <title>幾何データ型</title>
      <tgroup cols="4">
       <colspec colname="col1" colwidth="1*"/>
       <colspec colname="col2" colwidth="1*"/>
@@ -5291,7 +5292,7 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
 <!--
     <title>Boxes</title>
 -->
-<title>矩形</title>
+    <title>矩形</title>
 
     <indexterm>
      <primary>box (data type)</primary>
@@ -5510,7 +5511,7 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
 <!--
    <title>Network Address Types</title>
 -->
-<title>ネットワークアドレス型</title>
+   <title>ネットワークアドレス型</title>
 
    <indexterm zone="datatype-net-types">
     <primary>network</primary>
@@ -5540,7 +5541,7 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
 <!--
      <title>Network Address Types</title>
 -->
-<title>ネットワークアドレスデータ型</title>
+     <title>ネットワークアドレスデータ型</title>
      <tgroup cols="3">
       <colspec colname="col1" colwidth="1*"/>
       <colspec colname="col2" colwidth="1*"/>
@@ -5814,7 +5815,7 @@ IPv6ではアドレス長は128ビットですので、128ビットが一意な�
 <!--
     <title><type>inet</type> vs. <type>cidr</type></title>
 -->
-<title><type>inet</type>と<type>cidr</type>データ型の違い</title>
+    <title><type>inet</type>と<type>cidr</type>データ型の違い</title>
 
     <para>
 <!--
@@ -6031,7 +6032,7 @@ SELECT macaddr8_set7bit('08:00:2b:01:02:03');
 <!--
    <title>Bit String Types</title>
 -->
-<title>ビット列データ型</title>
+   <title>ビット列データ型</title>
 
    <indexterm zone="datatype-bit">
     <primary>bit string</primary>
@@ -6107,7 +6108,7 @@ SQLのビット型には2つあります。
 <!--
     <title>Using the Bit String Types</title>
 -->
-<title>ビット列データ型の使用</title>
+    <title>ビット列データ型の使用</title>
 
 <programlisting>
 CREATE TABLE test (a BIT(3), b BIT VARYING(5));
@@ -7379,12 +7380,6 @@ nextval('foo')              <lineannotation><literal>foo</literal>のサーチ�
      want <quote>late binding</quote> where the object reference is resolved
      at run time.  To get late-binding behavior, force the constant to be
      stored as a <type>text</type> constant instead of <type>regclass</type>:
-<programlisting>
-nextval('foo'::text)      <lineannotation><literal>foo</literal> is looked up at runtime</lineannotation>
-</programlisting>
-     The <function>to_regclass()</function> function and its siblings
-     can also be used to perform run-time lookups.  See
-     <xref linkend="functions-info-catalog-table"/>.
 -->
 そのような関数の引数を装飾のない文字列として記載した場合、それは<type>regclass</type>型(もしくは適切な型)の定数になります。
 これは実際には単にOIDなので、スキーマの再割り当てなどで後からリネームされたとしても最初に識別されたオブジェクトを追跡します。
@@ -7392,8 +7387,13 @@ nextval('foo'::text)      <lineannotation><literal>foo</literal> is looked up at
 しかし、オブジェクトの参照を実行時に行う<quote>遅延バインディング(late binding)</quote>が望ましいこともあります。
 遅延バインディングの動作とするためには、定数は<type>regclass</type>の代わりに<type>text</type>の定数として配置してください。
 <programlisting>
-nextval('foo'::text)      <lineannotation><literal>foo</literal>は実行時に参照されます。</lineannotation>
+nextval('foo'::text)      <lineannotation><literal>foo</literal> is looked up at runtime</lineannotation>
 </programlisting>
+<!--
+     The <function>to_regclass()</function> function and its siblings
+     can also be used to perform run-time lookups.  See
+     <xref linkend="functions-info-catalog-table"/>.
+-->
 <function>to_regclass()</function>関数とその兄弟は実行時に参照させるために使用することもできます。
 詳細は<xref linkend="functions-info-catalog-table"/>を参照ください。
     </para>
@@ -7408,23 +7408,6 @@ nextval('foo'::text)      <lineannotation><literal>foo</literal>は実行時に�
     the <function>pg_relation_size()</function> function, which requires
     the table OID.  Taking the above rules into account, the correct way
     to do that is
-<programlisting>
-SELECT table_schema, table_name,
-       pg_relation_size((quote_ident(table_schema) || '.' ||
-                         quote_ident(table_name))::regclass)
-FROM information_schema.tables
-WHERE ...
-</programlisting>
-    The <function>quote_ident()</function> function will take care of
-    double-quoting the identifiers where needed.  The seemingly easier
-<programlisting>
-SELECT pg_relation_size(table_name)
-FROM information_schema.tables
-WHERE ...
-</programlisting>
-    is <emphasis>not recommended</emphasis>, because it will fail for
-    tables that are outside your search path or have names that require
-    quoting.
 -->
 <type>regclass</type>のもう一つの実用的な使用例はそのようなOIDを直接提供しない<literal>information_schema</literal>ビューにリストされたテーブルのOIDを参照することです。
 例えば、テーブルのOIDを必要とする<function>pg_relation_size()</function>関数を呼び出したい場合を考えます。
@@ -7436,6 +7419,10 @@ SELECT table_schema, table_name,
 FROM information_schema.tables
 WHERE ...
 </programlisting>
+<!--
+    The <function>quote_ident()</function> function will take care of
+    double-quoting the identifiers where needed.  The seemingly easier
+-->
 <function>quote_ident()</function>関数は必要に応じて二重引用符をつけます。
 より簡単そうに思われる
 <programlisting>
@@ -7443,6 +7430,11 @@ SELECT pg_relation_size(table_name)
 FROM information_schema.tables
 WHERE ...
 </programlisting>
+<!--
+    is <emphasis>not recommended</emphasis>, because it will fail for
+    tables that are outside your search path or have names that require
+    quoting.
+-->
 という方法は<emphasis>推奨されません</emphasis>。
 テーブルがサーチパスの範囲外にあったり、引用符付けを必要とする名前であった場合に失敗するためです。
    </para>

--- a/doc/src/sgml/jit.sgml
+++ b/doc/src/sgml/jit.sgml
@@ -277,9 +277,11 @@ SET
 
 <!--
  <sect1 id="jit-configuration" xreflabel="JIT Configuration">
-  <title>Configuration</title>
 -->
  <sect1 id="jit-configuration" xreflabel="JIT設定">
+<!--
+  <title>Configuration</title>
+-->
   <title>設定</title>
 
   <para>

--- a/doc/src/sgml/pltcl.sgml
+++ b/doc/src/sgml/pltcl.sgml
@@ -4,7 +4,7 @@
 <!--
   <title>PL/Tcl &mdash; Tcl Procedural Language</title>
 -->
-<title>PL/Tcl &mdash; Tcl手続き言語</title>
+  <title>PL/Tcl &mdash; Tcl手続き言語</title>
 
   <indexterm zone="pltcl">
    <primary>PL/Tcl</primary>
@@ -31,7 +31,7 @@ PL/Tclとは、<productname>PostgreSQL</productname>データベースシステ�
 <!--
    <title>Overview</title>
 -->
-<title>概要</title>
+   <title>概要</title>
 
    <para>
 <!--
@@ -114,7 +114,7 @@ C関数では可能ですが、PL/Tclにはデータベースサーバ内部に�
 <!--
     <title>PL/Tcl Functions and Arguments</title>
 -->
-<title>PL/Tcl関数と引数</title>
+    <title>PL/Tcl関数と引数</title>
 
     <para>
 <!--
@@ -342,7 +342,7 @@ $$ LANGUAGE pltcl;
 <!--
     <title>Data Values in PL/Tcl</title>
 -->
-<title>PL/Tclにおけるデータの値</title>
+    <title>PL/Tclにおけるデータの値</title>
 
     <para>
 <!--
@@ -363,7 +363,7 @@ PL/Tcl関数コードに与えられる引数の値は、単に、テキスト�
 <!--
     <title>Global Data in PL/Tcl</title>
 -->
-<title>PL/Tclにおけるグローバルデータ</title>
+    <title>PL/Tclにおけるグローバルデータ</title>
 
     <indexterm zone="pltcl-global">
      <primary>global data</primary>
@@ -461,7 +461,7 @@ PL/Tcl関数が予期しない相互作用に巻き込まれないようにす�
 <!--
     <title>Database Access from PL/Tcl</title>
 -->
-<title>PL/Tclからのデータベースアクセス</title>
+    <title>PL/Tclからのデータベースアクセス</title>
 
     <para>
 <!--
@@ -528,16 +528,12 @@ PL/Tcl関数が予期しない相互作用に巻き込まれないようにす�
         No storing occurs if the query returns no rows.  (This case can be
         detected by checking the result of <function>spi_exec</function>.)
         For example:
-<programlisting>
-spi_exec "SELECT count(*) AS cnt FROM pg_proc"
-</programlisting>
 -->
 問い合わせ文が<command>SELECT</command>文、かつ、<replaceable>loop-body</replaceable>スクリプトが付与されなかった場合、結果のうち最初の行だけがTclの変数または配列要素に格納されます。
 他にも行があったとしても、それらは無視されます。
 問い合わせが行を返さなかった場合は、変数への格納は発生しません
 （<function>spi_exec</function>の戻り値を検査することで、これを検出することができます）。
 以下に例を示します。
-
 <programlisting>
 spi_exec "SELECT count(*) AS cnt FROM pg_proc"
 </programlisting>
@@ -849,7 +845,7 @@ SELECT 'doesn''t' AS ret
 <!--
     <title>Trigger Functions in PL/Tcl</title>
 -->
-<title>PL/Tclのトリガ関数</title>
+    <title>PL/Tclのトリガ関数</title>
 
     <indexterm>
      <primary>trigger</primary>
@@ -1610,7 +1606,7 @@ Tcl内でそれまでに行われた操作は取り消されません。
 <!--
     <title>Tcl Procedure Names</title>
 -->
-<title>Tclプロシージャ名</title>
+    <title>Tclプロシージャ名</title>
 
     <para>
 <!--

--- a/doc/src/sgml/ref/alter_collation.sgml
+++ b/doc/src/sgml/ref/alter_collation.sgml
@@ -140,9 +140,11 @@ ALTER COLLATION <replaceable>name</replaceable> SET SCHEMA <replaceable>new_sche
 
 <!--
  <refsect1 id="sql-altercollation-notes" xreflabel="Notes">
-  <title>Notes</title>
 -->
  <refsect1 id="sql-altercollation-notes" xreflabel="注釈">
+<!--
+  <title>Notes</title>
+-->
   <title>注釈</title>
 
   <para>

--- a/doc/src/sgml/ref/alter_database.sgml
+++ b/doc/src/sgml/ref/alter_database.sgml
@@ -57,7 +57,7 @@ ALTER DATABASE <replaceable class="parameter">name</replaceable> RESET ALL
 <!--
   <title>Description</title>
 -->
-<title>説明</title>
+  <title>説明</title>
 
   <para>
 <!--

--- a/doc/src/sgml/ref/alter_default_privileges.sgml
+++ b/doc/src/sgml/ref/alter_default_privileges.sgml
@@ -97,7 +97,7 @@ REVOKE [ GRANT OPTION FOR ]
 <!--
   <title>Description</title>
 -->
-<title>説明</title>
+  <title>説明</title>
 
   <para>
 <!--

--- a/doc/src/sgml/ref/alter_table.sgml
+++ b/doc/src/sgml/ref/alter_table.sgml
@@ -1915,9 +1915,11 @@ fillfactor、TOAST、およびautovacuumのストレージパラメータおよ�
 
 <!--
  <refsect1 id="sql-altertable-notes" xreflabel="Notes">
-  <title>Notes</title>
 -->
  <refsect1 id="sql-altertable-notes" xreflabel="注釈">
+<!--
+  <title>Notes</title>
+-->
   <title>注釈</title>
 
    <para>

--- a/doc/src/sgml/ref/create_aggregate.sgml
+++ b/doc/src/sgml/ref/create_aggregate.sgml
@@ -921,9 +921,11 @@ SELECT col FROM tab ORDER BY col USING sortop LIMIT 1;
 
 <!--
  <refsect1 id="sql-createaggregate-notes" xreflabel="Notes">
-  <title>Notes</title>
 -->
  <refsect1 id="sql-createaggregate-notes" xreflabel="注釈">
+<!--
+  <title>Notes</title>
+-->
   <title>注釈</title>
 
    <para>

--- a/doc/src/sgml/ref/create_index.sgml
+++ b/doc/src/sgml/ref/create_index.sgml
@@ -549,9 +549,11 @@ NULLを非NULLより後にソートすることを指定します。
 
 <!--
   <refsect2 id="sql-createindex-storage-parameters" xreflabel="Index Storage Parameters">
-   <title>Index Storage Parameters</title>
 -->
   <refsect2 id="sql-createindex-storage-parameters" xreflabel="インデックス格納パラメータ">
+<!--
+   <title>Index Storage Parameters</title>
+-->
    <title>インデックス格納パラメータ</title>
 
    <para>
@@ -857,9 +859,11 @@ GINインデックスでは以下の異なるパラメータを受け付けま�
 
 <!--
   <refsect2 id="sql-createindex-concurrently" xreflabel="Building Indexes Concurrently">
-   <title>Building Indexes Concurrently</title>
 -->
   <refsect2 id="sql-createindex-concurrently" xreflabel="インデックスの同時作成">
+<!--
+   <title>Building Indexes Concurrently</title>
+-->
    <title>インデックスの同時作成</title>
 
    <indexterm zone="sql-createindex-concurrently">

--- a/doc/src/sgml/ref/create_subscription.sgml
+++ b/doc/src/sgml/ref/create_subscription.sgml
@@ -592,9 +592,11 @@ falseの場合、レプリケーションワーカーは各テーブルでその
 
 <!--
  <refsect1 id="sql-createsubscription-notes" xreflabel="Notes">
-  <title>Notes</title>
 -->
  <refsect1 id="sql-createsubscription-notes" xreflabel="注釈">
+<!--
+  <title>Notes</title>
+-->
   <title>注釈</title>
 
   <para>

--- a/doc/src/sgml/ref/postgres-ref.sgml
+++ b/doc/src/sgml/ref/postgres-ref.sgml
@@ -1034,9 +1034,11 @@ PostgreSQL documentation
 
 <!--
  <refsect1 id="app-postgres-single-user" xreflabel="Single-User Mode">
-  <title>Single-User Mode</title>
 -->
  <refsect1 id="app-postgres-single-user" xreflabel="シングルユーザモード">
+<!--
+  <title>Single-User Mode</title>
+-->
   <title>シングルユーザモード</title>
 
    <para>

--- a/doc/src/sgml/ref/psql-ref.sgml
+++ b/doc/src/sgml/ref/psql-ref.sgml
@@ -40,7 +40,7 @@ PostgreSQL documentation
 <!--
   <title>Description</title>
 -->
-<title>説明</title>
+  <title>説明</title>
 
     <para>
 <!--
@@ -64,7 +64,7 @@ PostgreSQL documentation
 <!--
   <title>Options</title>
 -->
-<title>オプション</title>
+  <title>オプション</title>
 
   <variablelist>
     <varlistentry id="app-psql-option-echo-all">
@@ -879,13 +879,13 @@ EOF
 <!--
   <title>Usage</title>
 -->
-<title>使用方法</title>
+  <title>使用方法</title>
 
   <refsect2 id="r2-app-psql-connecting">
 <!--
     <title>Connecting to a Database</title>
 -->
-<title>データベースへの接続</title>
+    <title>データベースへの接続</title>
 
     <para>
 <!--
@@ -1011,7 +1011,7 @@ $ <userinput>psql postgresql://dbmaster:5433/mydb?sslmode=require</userinput>
 <!--
     <title>Entering SQL Commands</title>
 -->
-<title>SQLコマンドの入力</title>
+    <title>SQLコマンドの入力</title>
 
     <para>
 <!--
@@ -1278,7 +1278,10 @@ Cの形式のブロックコメントは、サーバに送信され、サーバ�
         </para>
 
         <para>
+<!--
          Example:
+-->
+例:
 <programlisting>
 INSERT INTO tbl1 VALUES ($1, $2) \bind 'first value' 'second value' \g
 </programlisting>
@@ -5244,9 +5247,11 @@ select 1\; select 2\; select 3;
 
 <!--
   <refsect3 id="app-psql-patterns" xreflabel="Patterns">
-   <title>Patterns</title>
 -->
   <refsect3 id="app-psql-patterns" xreflabel="パターン">
+<!--
+   <title>Patterns</title>
+-->
    <title>パターン</title>
 
    <indexterm>
@@ -5405,13 +5410,15 @@ SQLの名前と異なり、パターンの一部を二重引用符で括るこ�
 <!--
   <title>Advanced Features</title>
 -->
-<title>高度な機能</title>
+  <title>高度な機能</title>
 
 <!--
    <refsect3 id="app-psql-variables" xreflabel="Variables">
-    <title>Variables</title>
 -->
    <refsect3 id="app-psql-variables" xreflabel="変数">
+<!--
+    <title>Variables</title>
+-->
     <title>変数</title>
 
     <para>
@@ -6283,9 +6290,11 @@ offの動作は古いバージョンのpsqlとの互換性のためです。
 
 <!--
    <refsect3 id="app-psql-interpolation" xreflabel="SQL Interpolation">
-    <title><acronym>SQL</acronym> Interpolation</title>
 -->
    <refsect3 id="app-psql-interpolation" xreflabel="SQL差し替え">
+<!--
+    <title><acronym>SQL</acronym> Interpolation</title>
+-->
     <title><acronym>SQL</acronym>差し替え</title>
 
     <para>
@@ -6418,9 +6427,11 @@ SQLリテラルまたは識別子として変数の値をエスケープさせ�
 
 <!--
    <refsect3 id="app-psql-prompting" xreflabel="Prompting">
-    <title>Prompting</title>
 -->
    <refsect3 id="app-psql-prompting" xreflabel="プロンプト">
+<!--
+    <title>Prompting</title>
+-->
     <title>プロンプト</title>
 
     <para>
@@ -6834,9 +6845,11 @@ $endif
 
 <!--
  <refsect1 id="app-psql-environment" xreflabel="Environment">
-  <title>Environment</title>
 -->
  <refsect1 id="app-psql-environment" xreflabel="環境">
+<!--
+  <title>Environment</title>
+-->
   <title>環境</title>
 
   <variablelist>
@@ -7074,7 +7087,7 @@ Unixシステム上のデフォルトは<literal>+</literal>です。
 <!--
   <title>Files</title>
 -->
-<title>ファイル</title>
+  <title>ファイル</title>
 
  <variablelist>
   <varlistentry id="app-psql-files-psqlrc">
@@ -7292,9 +7305,11 @@ Cygwinを使用しているのであれば、このコマンドを<filename>/etc
 
 <!--
  <refsect1 id="app-psql-examples" xreflabel="Examples">
-  <title>Examples</title>
 -->
  <refsect1 id="app-psql-examples" xreflabel="例">
+<!--
+  <title>Examples</title>
+-->
   <title>例</title>
 
   <para>

--- a/doc/src/sgml/ref/select.sgml
+++ b/doc/src/sgml/ref/select.sgml
@@ -310,9 +310,11 @@ TABLE [ ONLY ] <replaceable class="parameter">table_name</replaceable> [ * ]
 
 <!--
   <refsect2 id="sql-with" xreflabel="WITH Clause">
-   <title><literal>WITH</literal> Clause</title>
 -->
   <refsect2 id="sql-with" xreflabel="WITH句">
+<!--
+   <title><literal>WITH</literal> Clause</title>
+-->
    <title><literal>WITH</literal>句</title>
 
    <para>
@@ -559,9 +561,11 @@ TABLE [ ONLY ] <replaceable class="parameter">table_name</replaceable> [ * ]
 
 <!--
   <refsect2 id="sql-from" xreflabel="FROM Clause">
-   <title><literal>FROM</literal> Clause</title>
 -->
   <refsect2 id="sql-from" xreflabel="FROM句">
+<!--
+   <title><literal>FROM</literal> Clause</title>
+-->
    <title><literal>FROM</literal>句</title>
 
    <para>
@@ -1122,9 +1126,11 @@ TABLE [ ONLY ] <replaceable class="parameter">table_name</replaceable> [ * ]
 
 <!--
   <refsect2 id="sql-where" xreflabel="WHERE Clause">
-   <title><literal>WHERE</literal> Clause</title>
 -->
   <refsect2 id="sql-where" xreflabel="WHERE句">
+<!--
+   <title><literal>WHERE</literal> Clause</title>
+-->
    <title><literal>WHERE</literal>句</title>
 
    <para>
@@ -1151,9 +1157,11 @@ WHERE <replaceable class="parameter">condition</replaceable>
 
 <!--
   <refsect2 id="sql-groupby" xreflabel="GROUP BY Clause">
-   <title><literal>GROUP BY</literal> Clause</title>
 -->
   <refsect2 id="sql-groupby" xreflabel="GROUP BY句">
+<!--
+   <title><literal>GROUP BY</literal> Clause</title>
+-->
    <title><literal>GROUP BY</literal>句</title>
 
    <para>
@@ -1266,9 +1274,11 @@ GROUP BY [ ALL | DISTINCT ] <replaceable class="parameter">grouping_element</rep
 
 <!--
   <refsect2 id="sql-having" xreflabel="HAVING Clause">
-   <title><literal>HAVING</literal> Clause</title>
 -->
   <refsect2 id="sql-having" xreflabel="HAVING句">
+<!--
+   <title><literal>HAVING</literal> Clause</title>
+-->
    <title><literal>HAVING</literal>句</title>
 
    <para>
@@ -1334,9 +1344,11 @@ HAVING <replaceable class="parameter">condition</replaceable>
 
 <!--
   <refsect2 id="sql-window" xreflabel="WINDOW Clause">
-   <title><literal>WINDOW</literal> Clause</title>
 -->
   <refsect2 id="sql-window" xreflabel="WINDOW句">
+<!--
+   <title><literal>WINDOW</literal> Clause</title>
+-->
    <title><literal>WINDOW</literal>句</title>
 
    <para>
@@ -1620,9 +1632,11 @@ EXCLUDE NO OTHERS
 
 <!--
   <refsect2 id="sql-select-list" xreflabel="SELECT List">
-   <title><command>SELECT</command> List</title>
 -->
   <refsect2 id="sql-select-list" xreflabel="SELECTリスト">
+<!--
+   <title><command>SELECT</command> List</title>
+-->
    <title><command>SELECT</command>リスト</title>
 
    <para>
@@ -1745,9 +1759,11 @@ EXCLUDE NO OTHERS
 
 <!--
   <refsect2 id="sql-distinct" xreflabel="DISTINCT Clause">
-   <title><literal>DISTINCT</literal> Clause</title>
 -->
   <refsect2 id="sql-distinct" xreflabel="DISTINCT句">
+<!--
+   <title><literal>DISTINCT</literal> Clause</title>
+-->
    <title><literal>DISTINCT</literal>句</title>
 
    <para>
@@ -1816,9 +1832,11 @@ SELECT DISTINCT ON (location) location, time, report
 
 <!--
   <refsect2 id="sql-union" xreflabel="UNION Clause">
-   <title><literal>UNION</literal> Clause</title>
 -->
   <refsect2 id="sql-union" xreflabel="UNION句">
+<!--
+   <title><literal>UNION</literal> Clause</title>
+-->
    <title><literal>UNION</literal>句</title>
 
    <para>
@@ -1899,9 +1917,11 @@ SELECT DISTINCT ON (location) location, time, report
 
 <!--
   <refsect2 id="sql-intersect" xreflabel="INTERSECT Clause">
-   <title><literal>INTERSECT</literal> Clause</title>
 -->
   <refsect2 id="sql-intersect" xreflabel="INTERSECT句">
+<!--
+   <title><literal>INTERSECT</literal> Clause</title>
+-->
    <title><literal>INTERSECT</literal>句</title>
 
    <para>
@@ -1974,9 +1994,11 @@ SELECT DISTINCT ON (location) location, time, report
 
 <!--
   <refsect2 id="sql-except" xreflabel="EXCEPT Clause">
-   <title><literal>EXCEPT</literal> Clause</title>
 -->
   <refsect2 id="sql-except" xreflabel="EXCEPT句">
+<!--
+   <title><literal>EXCEPT</literal> Clause</title>
+-->
    <title><literal>EXCEPT</literal>句</title>
 
    <para>
@@ -2043,9 +2065,11 @@ SELECT DISTINCT ON (location) location, time, report
 
 <!--
   <refsect2 id="sql-orderby" xreflabel="ORDER BY Clause">
-   <title><literal>ORDER BY</literal> Clause</title>
 -->
   <refsect2 id="sql-orderby" xreflabel="ORDER BY句">
+<!--
+   <title><literal>ORDER BY</literal> Clause</title>
+-->
    <title><literal>ORDER BY</literal>句</title>
 
    <para>
@@ -2198,9 +2222,11 @@ SELECT name FROM distributors ORDER BY code;
 
 <!--
   <refsect2 id="sql-limit" xreflabel="LIMIT Clause">
-   <title><literal>LIMIT</literal> Clause</title>
 -->
   <refsect2 id="sql-limit" xreflabel="LIMIT句">
+<!--
+   <title><literal>LIMIT</literal> Clause</title>
+-->
    <title><literal>LIMIT</literal>句</title>
 
    <para>
@@ -2330,9 +2356,11 @@ SQL標準では<literal>OFFSET</literal>句は、<literal>FETCH</literal>句と�
 
 <!--
   <refsect2 id="sql-for-update-share" xreflabel="The Locking Clause">
-   <title>The Locking Clause</title>
 -->
   <refsect2 id="sql-for-update-share" xreflabel="ロック処理句">
+<!--
+   <title>The Locking Clause</title>
+-->
    <title>ロック処理句</title>
 
    <para>

--- a/doc/src/sgml/ref/vacuumdb.sgml
+++ b/doc/src/sgml/ref/vacuumdb.sgml
@@ -126,7 +126,7 @@ PostgreSQL documentation
 <!--
   <title>Options</title>
 -->
-<title>オプション</title>
+  <title>オプション</title>
 
    <para>
 <!--
@@ -731,7 +731,7 @@ PostgreSQL documentation
 <!--
   <title>Environment</title>
 -->
-<title>環境</title>
+  <title>環境</title>
 
   <variablelist>
    <varlistentry>
@@ -826,7 +826,7 @@ PostgreSQL documentation
 <!--
   <title>Examples</title>
 -->
-<title>例</title>
+  <title>例</title>
 
    <para>
 <!--
@@ -878,7 +878,7 @@ PostgreSQL documentation
 <!--
   <title>See Also</title>
 -->
-<title>関連項目</title>
+  <title>関連項目</title>
 
   <simplelist type="inline">
    <member><xref linkend="sql-vacuum"/></member>

--- a/doc/src/sgml/regress.sgml
+++ b/doc/src/sgml/regress.sgml
@@ -254,21 +254,20 @@ make installcheck-world
    limits, you can make things go substantially faster with parallelism.
    The recipe that most PostgreSQL developers actually use for running all
    tests is something like
+-->
+複数のCPUコアがあり、オペレーティングシステムの厳しい制限のない最近のマシンでは、並列処理でかなり速くできます。
+ほとんどのPostgreSQL開発者がテストをすべて実行するのに実際に使っている方法は以下のようなものです。
 <screen>
 make check-world -j8 >/dev/null
 </screen>
+<!--
    with a <option>-j</option> limit near to or a bit more than the number
    of available cores.  Discarding <systemitem>stdout</systemitem>
    eliminates chatter that's not interesting when you just want to verify
    success.  (In case of failure, the <systemitem>stderr</systemitem>
    messages are usually enough to determine where to look closer.)
 -->
-複数のCPUコアがあり、オペレーティングシステムの厳しい制限のない最近のマシンでは、並列処理でかなり速くできます。
-ほとんどのPostgreSQL開発者がテストをすべて実行するのに実際に使っている方法は
-<screen>
-make check-world -j8 >/dev/null
-</screen>
-のようなものです。ここで<option>-j</option>の範囲は利用可能なコアの数に近い、もしくはそれより少し多い値です。
+ここで<option>-j</option>の範囲は利用可能なコアの数に近い、もしくはそれより少し多い値です。
 <systemitem>stdout</systemitem>を捨てることで、成功を検証する時には興味のない出力を除きます。(失敗した場合、どこをより詳細に調べるべきか決めるには<systemitem>stderr</systemitem>メッセージでたいてい十分です。)
   </para>
 

--- a/doc/src/sgml/runtime.sgml
+++ b/doc/src/sgml/runtime.sgml
@@ -4,7 +4,7 @@
 <!--
  <title>Server Setup and Operation</title>
 -->
-<title>サーバの準備と運用</title>
+ <title>サーバの準備と運用</title>
 
  <para>
 <!--
@@ -848,7 +848,7 @@ su - postgres -c "/usr/local/pgsql/bin/pg_ctl start -l logfile -D /usr/local/pgs
 <!--
     <title>Server Start-up Failures</title>
 -->
-<title>サーバ起動の失敗</title>
+    <title>サーバ起動の失敗</title>
 
     <para>
 <!--
@@ -954,7 +954,7 @@ DETAIL:  Failed system call was semget(5440126, 17, 03600).
 <!--
     <title>Client Connection Problems</title>
 -->
-<title>クライアント接続の問題</title>
+    <title>クライアント接続の問題</title>
 
     <para>
 <!--
@@ -3322,7 +3322,7 @@ GSSAPI暗号化接続は、問い合わせ及び返却されるデータを含�
 <!--
   <title>Secure TCP/IP Connections with SSL</title>
 -->
-<title>SSLによる安全なTCP/IP接続</title>
+  <title>SSLによる安全なTCP/IP接続</title>
 
   <indexterm zone="ssl-tcp">
    <primary>SSL</primary>
@@ -4125,8 +4125,7 @@ SSHはいろいろな方法でネットワークが制約されているとき�
    <application>event log</application> library with the operating system,
    issue this command:
 -->
-   <systemitem class="osname">Windows</systemitem>の
-   OSの<application>event log</application>ライブラリに登録するには、以下のコマンドを発行します:
+<systemitem class="osname">Windows</systemitem>のOSの<application>event log</application>ライブラリに登録するには、以下のコマンドを発行します:
 <screen>
 <userinput>regsvr32 <replaceable>pgsql_library_directory</replaceable>/pgevent.dll</userinput>
 </screen>
@@ -4134,7 +4133,7 @@ SSHはいろいろな方法でネットワークが制約されているとき�
    This creates registry entries used by the event viewer, under the default
    event source named <literal>PostgreSQL</literal>.
 -->
-   このコマンドは、<literal>PostgreSQL</literal>というデフォルトのイベントソース名で、イベントビューアが使用するレジストリエントリを作成します。
+このコマンドは、<literal>PostgreSQL</literal>というデフォルトのイベントソース名で、イベントビューアが使用するレジストリエントリを作成します。
   </para>
 
   <para>
@@ -4143,7 +4142,7 @@ SSHはいろいろな方法でネットワークが制約されているとき�
    <xref linkend="guc-event-source"/>), use the <literal>/n</literal>
    and <literal>/i</literal> options:
 -->
-   異なるイベントソース名（<xref linkend="guc-event-source"/>参照）を指定するには、<literal>/n</literal>および<literal>/i</literal>オプションを使ってください:
+異なるイベントソース名（<xref linkend="guc-event-source"/>参照）を指定するには、<literal>/n</literal>および<literal>/i</literal>オプションを使ってください:
 <screen>
 <userinput>regsvr32 /n /i:<replaceable>event_source_name</replaceable> <replaceable>pgsql_library_directory</replaceable>/pgevent.dll</userinput>
 </screen>
@@ -4154,7 +4153,7 @@ SSHはいろいろな方法でネットワークが制約されているとき�
    To unregister the <application>event log</application> library from
    the operating system, issue this command:
 -->
-   OSから<application>event log</application>ライブラリを削除するには、以下のコマンドを発行します:
+OSから<application>event log</application>ライブラリを削除するには、以下のコマンドを発行します:
 <screen>
 <userinput>regsvr32 /u [/i:<replaceable>event_source_name</replaceable>] <replaceable>pgsql_library_directory</replaceable>/pgevent.dll</userinput>
 </screen>
@@ -4167,7 +4166,7 @@ SSHはいろいろな方法でネットワークが制約されているとき�
     <xref linkend="guc-log-destination"/> to include
     <literal>eventlog</literal> in <filename>postgresql.conf</filename>.
 -->
-    データベースサーバにおけるイベントロギングを有効にするには、<literal>eventlog</literal>を含むように<filename>postgresql.conf</filename>の<xref linkend="guc-log-destination"/>を変更してください。
+データベースサーバにおけるイベントロギングを有効にするには、<literal>eventlog</literal>を含むように<filename>postgresql.conf</filename>の<xref linkend="guc-log-destination"/>を変更してください。
    </para>
   </note>
  </sect1>

--- a/doc/src/sgml/spgist.sgml
+++ b/doc/src/sgml/spgist.sgml
@@ -1143,9 +1143,6 @@ typedef struct spgInnerConsistentOut
       <para>
 <!--
        The <acronym>SQL</acronym> declaration of the function must look like this:
-<programlisting>
-CREATE FUNCTION my_leaf_consistent(internal, internal) RETURNS bool ...
-</programlisting>
 -->
 関数の<acronym>SQL</acronym>宣言は以下のようになります。
 <programlisting>

--- a/doc/src/sgml/storage.sgml
+++ b/doc/src/sgml/storage.sgml
@@ -1093,24 +1093,25 @@ erased (they will be recreated automatically as needed).
 <!--
 This section provides an overview of the page format used within
 <productname>PostgreSQL</productname> tables and indexes.<footnote>
+-->
+本節では<productname>PostgreSQL</productname>のテーブルおよびインデックスで使われるページ書式の概略について説明します。
+<footnote>
   <para>
+<!--
     Actually, use of this page format is not required for either table or
     index access methods. The <literal>heap</literal> table access method
     always uses this format.  All the existing index methods also use the
     basic format, but the data kept on index metapages usually doesn't follow
     the item layout rules.
-  </para>
-</footnote>
-Sequences and <acronym>TOAST</acronym> tables are formatted just like a regular table.
 -->
-本節では<productname>PostgreSQL</productname>のテーブルおよびインデックスで使われるページ書式の概略について説明します。
-<footnote>
-<para>
 実際には、テーブルアクセスメソッドもインデックスアクセスメソッドも、このページ書式を使用する必要はありません。
 <literal>heap</literal>テーブルアクセスメソッドは常にこの書式を使用します。
 既存のすべてのインデックスメソッドも、この基本書式を使用しています。しかし、インデックスメタページに保持されるデータは通常、アイテムレイアウト規則に従っていません。
   </para>
 </footnote>
+<!--
+Sequences and <acronym>TOAST</acronym> tables are formatted just like a regular table.
+-->
 <acronym>TOAST</acronym>のテーブルとシーケンスは、通常のテーブルと同様に整形されています。
 </para>
 


### PR DESCRIPTION
. #2845の対応です。
タイトルの統一とインデントの統一を含みます。