### PR TITLE
indextermのインデントを変更

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -19949,18 +19949,18 @@ table2-mapping
    <primary>JSON</primary>
    <secondary>functions and operators</secondary>
   </indexterm>
-  <indexterm zone="functions-json">
-   <primary>JSON</primary>
-   <secondary>関数と演算子</secondary>
-  </indexterm>
+ <indexterm zone="functions-json"> /* diff誤作動を防ぐためインデント変更 */
+  <primary>JSON</primary>
+  <secondary>関数と演算子</secondary>
+ </indexterm>
    <indexterm zone="functions-json">
     <primary>SQL/JSON</primary>
     <secondary>functions and expressions</secondary>
    </indexterm>
-  <indexterm zone="functions-json">
-   <primary>SQL/JSON</primary>
-   <secondary>関数と式</secondary>
-  </indexterm>
+ <indexterm zone="functions-json">  /* diff誤作動を防ぐためインデント変更 */
+  <primary>SQL/JSON</primary>
+  <secondary>関数と式</secondary>
+ </indexterm>
 
   <para>
 <!--

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -19949,7 +19949,7 @@ table2-mapping
    <primary>JSON</primary>
    <secondary>functions and operators</secondary>
   </indexterm>
- <indexterm zone="functions-json"> /* diff誤作動を防ぐためインデント変更 */
+ <indexterm zone="functions-json"> <!-- diff誤作動を防ぐためインデント変更 -->
   <primary>JSON</primary>
   <secondary>関数と演算子</secondary>
  </indexterm>
@@ -19957,7 +19957,7 @@ table2-mapping
     <primary>SQL/JSON</primary>
     <secondary>functions and expressions</secondary>
    </indexterm>
- <indexterm zone="functions-json">  /* diff誤作動を防ぐためインデント変更 */
+ <indexterm zone="functions-json">  <!-- diff誤作動を防ぐためインデント変更 -->
   <primary>SQL/JSON</primary>
   <secondary>関数と式</secondary>
  </indexterm>

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -17,18 +17,18 @@
    <primary>JSON</primary>
    <secondary>functions and operators</secondary>
   </indexterm>
-  <indexterm zone="functions-json">
-   <primary>JSON</primary>
-   <secondary>関数と演算子</secondary>
-  </indexterm>
+ <indexterm zone="functions-json"> /* diff誤作動を防ぐためインデント変更 */
+  <primary>JSON</primary>
+  <secondary>関数と演算子</secondary>
+ </indexterm>
    <indexterm zone="functions-json">
     <primary>SQL/JSON</primary>
     <secondary>functions and expressions</secondary>
    </indexterm>
-  <indexterm zone="functions-json">
-   <primary>SQL/JSON</primary>
-   <secondary>関数と式</secondary>
-  </indexterm>
+ <indexterm zone="functions-json">  /* diff誤作動を防ぐためインデント変更 */
+  <primary>SQL/JSON</primary>
+  <secondary>関数と式</secondary>
+ </indexterm>
 
   <para>
 <!--

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -17,7 +17,7 @@
    <primary>JSON</primary>
    <secondary>functions and operators</secondary>
   </indexterm>
- <indexterm zone="functions-json"> /* diff誤作動を防ぐためインデント変更 */
+ <indexterm zone="functions-json"> <!-- diff誤作動を防ぐためインデント変更 -->
   <primary>JSON</primary>
   <secondary>関数と演算子</secondary>
  </indexterm>
@@ -25,7 +25,7 @@
     <primary>SQL/JSON</primary>
     <secondary>functions and expressions</secondary>
    </indexterm>
- <indexterm zone="functions-json">  /* diff誤作動を防ぐためインデント変更 */
+ <indexterm zone="functions-json">  <!-- diff誤作動を防ぐためインデント変更 -->
   <primary>SQL/JSON</primary>
   <secondary>関数と式</secondary>
  </indexterm>


### PR DESCRIPTION
indextrmが追加されたときに近いところに同一行が追加されるため
diffが中身のみになってしまうのを防ぐためにインデントを変更しました。

ここだけ連続しているので、diffが以下のように`</indexterm>`始まりの追加のようになってしまってしまいます。
これが解析の妨げになっているので変更させてください。

```diff
   <indexterm zone="functions-json">
    <primary>JSON</primary>
    <secondary>functions and operators</secondary>
+  </indexterm>
+  <indexterm zone="functions-json">
+   <primary>JSON</primary>
+   <secondary>関数と演算子</secondary>
   </indexterm>
    <indexterm zone="functions-json">
     <primary>SQL/JSON</primary>
     <secondary>functions and expressions</secondary>
    </indexterm>
+  <indexterm zone="functions-json">
+   <primary>SQL/JSON</primary>
+   <secondary>関数と式</secondary>
+  </indexterm>
 ```