### PR TITLE
make check-ngのパス変更対応の修正

### DIFF
--- a/doc/src/sgml/Makefile
+++ b/doc/src/sgml/Makefile
@@ -285,6 +285,7 @@ check-tabs:
 
 # words to avoid as pgsql-jp
 check-ng:
+	@ln -sf $(top_builddir)/.ng.list .ng.list
 	@if git --no-pager grep -E --color=always -f .ng.list *sgml ref/*sgml; \
 	then \
 	  echo "使用NGな語が見つかりました。";\


### PR DESCRIPTION
git 2.43からgit grep -f のパスがトップから現在のパスに変更されたため、
.ng.listが見つからずにエラーになっていました。
それより古いgitバージョンと非互換対応のため、
シンボリックリンクを作成するようにしました。