### PR TITLE
fix typos

### DIFF
--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -5946,7 +5946,7 @@ PostgreSQLではビット反転に関する準備をしていません。
      in 6 byte format will be stored in 8 byte length format with the
      4th and 5th bytes set to FF and FE, respectively.
 -->
-<type>macaddr8</type>データ型はイーサーネットカードのハードウェアアドレスなどで知られるEUI-64形式でデータを格納します（MACアドレスは他の目的にもよく使用されます。）。
+<type>macaddr8</type>データ型はイーサネットカードのハードウェアアドレスなどで知られるEUI-64形式でデータを格納します（MACアドレスは他の目的にもよく使用されます）。
 このデータ型は６バイト長と８バイト長の両方の長さのMACアドレスを受け入れることがき、８バイト長の形式で格納します。
 6バイト形式で与えられたMACアドレスは8バイト長の形式では、それぞれ、４番目と５番目のバイトをFFとFEとして格納されます。
 

--- a/doc/src/sgml/ref/pgbench.sgml
+++ b/doc/src/sgml/ref/pgbench.sgml
@@ -3280,7 +3280,7 @@ END;
 -->
 <option>--rate</option>と<option>--latency-limit</option>の両方を使用すると、スキップされたトランザクションの<replaceable>time</replaceable>は<literal>skipped</literal>として報告されます。
 トランザクションが失敗で終了した場合、<replaceable>time</replaceable>は<literal>failed</literal>として報告されます。
-<option>--failures-detailed</option>オプションを使用すると、失敗したトランザクションの<replaceable>time</replaceable>は、障害のタイプに応じて<literal>直列化</literal>または<literal>デットロック</literal>として報告されます（詳細は<xref linkend="failures-and-retries"/>を参照してください）。
+<option>--failures-detailed</option>オプションを使用すると、失敗したトランザクションの<replaceable>time</replaceable>は、障害のタイプに応じて<literal>直列化</literal>または<literal>デッドロック</literal>として報告されます（詳細は<xref linkend="failures-and-retries"/>を参照してください）。
   </para>
 
   <para>
@@ -3773,8 +3773,8 @@ statement latencies in milliseconds, failures and retries:
  <refsect2 id="failures-and-retries" xreflabel="Failures and Serialization/Deadlock Retries">
   <title>Failures and Serialization/Deadlock Retries</title>
 -->
- <refsect2 id="failures-and-retries" xreflabel="直列化の失敗／デットロック再試行">
-  <title>直列化の失敗／デットロック再試行</title>
+ <refsect2 id="failures-and-retries" xreflabel="直列化の失敗／デッドロック再試行">
+  <title>直列化の失敗／デッドロック再試行</title>
 
   <para>
 <!--


### PR DESCRIPTION
イーサーネット -> イーサネット
デットロック -> デッドロック

を直しています。どちらも .ng.list に載せても良いかもしれません。