### PR TITLE
copartitionの訳見直し

### DIFF
--- a/src/backend/catalog/sql_features.txt.ja
+++ b/src/backend/catalog/sql_features.txt.ja
@@ -33,7 +33,7 @@ B128	ルーチン言語 SQL			YES
 B200	多相型テーブル関数(PTF)			NO	
 B201	2つ以上のPTFジェネリックテーブルパラメータ			NO	
 B202	PTFコパーティション			NO	
-B203	2つ以上のパーティション指定			NO	
+B203	2つ以上のコパーティション指定			NO	
 B204	PRUNE WHEN EMPTY			NO	
 B205	パススルー列			NO	
 B206	PTF記述子パラメータ			NO	

--- a/src/backend/utils/errcodes.txt.ja
+++ b/src/backend/utils/errcodes.txt.ja
@@ -2,7 +2,7 @@
 # errcodes.txt
 #      PostgreSQL error codes
 #
-# Copyright (c) 2003-2021, PostgreSQL Global Development Group
+# Copyright (c) 2003-2023, PostgreSQL Global Development Group
 #
 # This list serves as the basis for generating source files containing error
 # codes. It is kept in a common format to make sure all these source files have


### PR DESCRIPTION
copartitionだったのでパーティションと区別するため。
Copyrightの年の更新漏れを修正。