### PR TITLE
fix "firewall"

### DIFF
--- a/doc/src/sgml/runtime.sgml
+++ b/doc/src/sgml/runtime.sgml
@@ -1025,7 +1025,7 @@ psql: error: connection to server on socket "/tmp/.s.PGSQL.5432" failed: No such
 もしそこを接続待ちしているサーバがない場合、典型的なカーネルエラーメッセージは、表示されているように<computeroutput>Connection refused</computeroutput>もしくは<computeroutput>No such file or directory</computeroutput>となります。
 （この場合の<computeroutput>Connection refused</computeroutput>はサーバが接続要求を受け付けた後に拒否したわけでは<emphasis>ない</emphasis>ということを理解しておくことが大切です。
 もしそうだった場合は<xref linkend="client-authentication-problems"/>で示されるような別のメッセージが表示されます。）
-<computeroutput>Connection timed out</computeroutput>のような他のメッセージは、例えばネットワーク接続の欠如、あるいはファイアーウォールが接続をブロックしているようなもっと根本的な問題を表しています。
+<computeroutput>Connection timed out</computeroutput>のような他のメッセージは、例えばネットワーク接続の欠如、あるいはファイアウォールが接続をブロックしているようなもっと根本的な問題を表しています。
     </para>
    </sect2>
   </sect1>


### PR DESCRIPTION
ファイアーウォール -> ファイアウォール

Googleさん今回は検索数を表示してくれませんでしたが、Geminiさんに尋ねたところ

> 「ファイアウォール」の方が一般的によく使われています。
>
> インターネット上での検索結果や、書籍、論文などを調べたところ、「ファイアウォール」が約2倍、「ファイアーウォール」が約1倍という結果が出ています。
>
>    「ファイアウォール」：約6億件
>    「ファイアーウォール」：約3億件

とのことでした。PostgreSQL文書中では他にはlibpqの一箇所しかなくて、そちらはファイアウォールでした。