### PR TITLE
fix traslation of 'commutator'

### DIFF
--- a/doc/src/sgml/xoper.sgml
+++ b/doc/src/sgml/xoper.sgml
@@ -226,7 +226,7 @@ SELECT (a + b) AS c FROM test_complex;
 オプティマイザは、この句を<literal>tab2.y = tab1.x</literal>という形にひっくり返す方法を知らない限り、インデックススキャンを生成できません。
 インデックススキャン機構は演算子の左側にインデックス付けされた列があることを想定しているためです。
 <productname>PostgreSQL</productname>は簡単にこの変形が有効であると前提<emphasis>しません</emphasis>。
-<literal>=</literal>演算子の作成者がこれが有効であることを、交換演算子情報を持つ演算子であると印付けて指定しなければなりません。
+<literal>=</literal>演算子の作成者がこれが有効であることを、交代演算子情報を持つ演算子であると印付けて指定しなければなりません。
     </para>
 
     <para>


### PR DESCRIPTION
「交代演算子」を「交換演算子」と訳しているところを見つけました。

誤字の指摘としては以上なのですが、もやもやしているのでここで吐き出しておきます。
●「交代演算子」
一般的な言葉ではないと思いますが、以下で定義しているようですから、よし、とすべきなのだと思います。
https://www.postgresql.jp/document/16/html/xoper-optimization.html#XOPER-COMMUTATOR
●「交換演算子」
exchange operator の訳語として物理の界隈で使われている言葉です。なので、もし使うのであればPostgreSQLとしては〜な意味で使うという説明が必要でしょう。
●commutator
「交代演算子」と訳している単語です。数学的には「交換子」という訳があるようです。ただ、交換子というと https://www.postgresql.jp/document/16/html/xoper-optimization.html#XOPER-COMMUTATOR にある定義とは異なり（そこにある定義の記号を使って書くなら）「 (x A y) - (y A x)」のことを言います。
