### PR TITLE
update pgcrypto for 16.3

### DIFF
--- a/doc/src/sgml/pgcrypto.sgml
+++ b/doc/src/sgml/pgcrypto.sgml
@@ -680,10 +680,8 @@ Intel Mobile Core i3のマシンを使用しました。
    (<ulink url="https://datatracker.ietf.org/doc/html/rfc4880">RFC 4880</ulink>)
    standard.  Supported are both symmetric-key and public-key encryption.
 -->
-《マッチ度[88.625592]》ここで示す関数はOpenPGP（<ulink url="https://tools.ietf.org/html/rfc4880">RFC 4880</ulink>）標準の暗号処理部分を実装します。
+ここで示す関数はOpenPGP（(<ulink url="https://datatracker.ietf.org/doc/html/rfc4880">RFC 4880</ulink>）標準の暗号処理部分を実装します。
 対称鍵および公開鍵暗号化がサポートされます。
-《機械翻訳》ここで提供する関数は、OpenPGP (<ulink url="https://datatracker.ietf.org/doc/html/rfc4880">RFC 4880</ulink>)標準の暗号化部分を実装します。
-対称鍵暗号化と公開鍵暗号化の両方をサポートしています。
   </para>
 
   <para>


### PR DESCRIPTION
pgcrypto.sgml の 16.3 対応です。

差分がたくさんあるように見えたのですが、参考資料の削除がほとんどでした、、、