### PR TITLE
protocol.sgmlの16.3対応です

### DIFF
--- a/doc/src/sgml/protocol.sgml
+++ b/doc/src/sgml/protocol.sgml
@@ -2037,7 +2037,7 @@ ParameterStatusメッセージは、任意のパラメータの実際の値が�
 9.0より前のリリースでは、<varname>application_name</varname>は送信されませんでした。
 14より前のリリースでは、<varname>default_transaction_read_only</varname>と<varname>in_hot_standby</varname>は送信されませんでした。
 16より前のリリースでは、<varname>scram_iterations</varname>は送信されませんでした。）
-<varname>server_version</varname>、<varname>server_encoding</varname>および<varname>integer_datetimes</varname>は仮想的なパラメータであり、起動後に変更することができないことに注意してください。
+<varname>server_version</varname>、<varname>server_encoding</varname>および<varname>integer_datetimes</varname>は仮想的なパラメータであり、起動後に変更できないことに注意してください。
 これは今後変更される、あるいは設定変更可能になる可能性があります。
 したがって、フロントエンドは未知または注目していないParameterStatusを単に無視すべきです。
    </para>

--- a/doc/src/sgml/protocol.sgml
+++ b/doc/src/sgml/protocol.sgml
@@ -1992,8 +1992,8 @@ ParameterStatusメッセージは、任意のパラメータの実際の値が�
     At present there is a hard-wired set of parameters for which
     ParameterStatus will be generated.  They are:
 -->
-《機械翻訳》現在、ParameterStatusが生成されるパラメータのハードワイヤードセットがあります。
-それらは次のとおりです。
+現時点では、ParameterStatusを生成するパラメータ群は固定されています。
+それらは次の通りです。
     <simplelist type="vert" columns="2">
      <member><varname>application_name</varname></member>
      <member><varname>client_encoding</varname></member>
@@ -2031,15 +2031,15 @@ ParameterStatusメッセージは、任意のパラメータの実際の値が�
     Accordingly, a frontend should simply ignore ParameterStatus for
     parameters that it does not understand or care about.
 -->
-《機械翻訳》（<varname>server_encoding</varname>, <varname>timezone</varname>, <varname>integer_datetimes</varname>は8.0より前のリリースでは報告されませんでした。
-<varname>standard_conforming_strings</varname>は8.1より前のリリースでは報告されませんでした。
-<varname>IntervalStyle</varname>は8.4より前のリリースでは報告されませんでした。
-<varname>application_name</varname>は9.0より前のリリースでは報告されませんでした。
-<varname>default_transaction_read_only</varname>と<varname>in_hot_standby</varname>は14より前のリリースでは報告されませんでした。
-<varname>scram_iterations</varname>は16より前のリリースでは報告されませんでした。）
-<varname>server_version</varname>, <varname>server_encoding</varname>および<varname>integer_datetimes</varname>は起動後に変更できない擬似パラメータです。
-このセットは将来変更されるかもしれないし、設定可能になるかもしれません。
-したがって、フロントエンドは、理解していない、あるいは気にかけていないパラメータに対しては、ParameterStatusを単純に無視すべきである。
+（8.0より前までのリリースでは、<varname>server_encoding</varname>、<varname>TimeZone</varname>および<varname>integer_datetimes</varname>は送信されませんでした。
+8.1より前までのリリースでは、<varname>standard_conforming_strings</varname>は送信されませんでした。
+8.4より前のリリースでは、<varname>IntervalStyle</varname>は送信されませんでした。
+9.0より前のリリースでは、<varname>application_name</varname>は送信されませんでした。
+14より前のリリースでは、<varname>default_transaction_read_only</varname>と<varname>in_hot_standby</varname>は送信されませんでした。
+16より前のリリースでは、<varname>scram_iterations</varname>は送信されませんでした。）
+<varname>server_version</varname>、<varname>server_encoding</varname>および<varname>integer_datetimes</varname>は仮想的なパラメータであり、起動後に変更することができないことに注意してください。
+これは今後変更される、あるいは設定変更可能になる可能性があります。
+したがって、フロントエンドは未知または注目していないParameterStatusを単に無視すべきです。
    </para>
 
    <para>
@@ -2388,10 +2388,10 @@ CancelRequestメッセージは、接続開始段階でフロントエンドに�
     use <acronym>SSL</acronym> encryption instead
     of <acronym>GSSAPI</acronym>.)
 -->
-《マッチ度[91.760300]》<acronym>GSSAPI</acronym>暗号化接続を開始するには、フロントエンドは最初にStartupMessageではなく、GSSENCRequestメッセージを送ります。
+<acronym>GSSAPI</acronym>暗号化接続を開始するには、フロントエンドは最初にStartupMessageではなく、GSSENCRequestメッセージを送ります。
 次にサーバは、それぞれ<acronym>GSSAPI</acronym>暗号化を希望する、しないを意味する<literal>G</literal>または<literal>N</literal>を含む1バイトを送信します。
 このレスポンスに満足できなければ、この時点でフロントエンドは接続を打ち切って構いません。
-<literal>G</literal>の受信後継続するには、<ulink url="https://tools.ietf.org/html/rfc2744">RFC 2744</ulink>あるいは同様の文書で議論されているGSSAPI Cバインディングを使い、ループの中で<function>gss_init_sec_context()</function>を呼び出して<acronym>GSSAPI</acronym>を初期化し、結果をサーバに送信し、空の入力を受け取ることから始めて、サーバが出力を返さなくなるまでサーバからの出力を受け取ります。
+<literal>G</literal>の受信後継続するには、<ulink url="https://datatracker.ietf.org/doc/html/rfc2744">RFC 2744</ulink>あるいは同様の文書で議論されているGSSAPI Cバインディングを使い、ループの中で<function>gss_init_sec_context()</function>を呼び出して<acronym>GSSAPI</acronym>を初期化し、結果をサーバに送信し、空の入力を受け取ることから始めて、サーバが出力を返さなくなるまでサーバからの出力を受け取ります。
 <function>gss_init_sec_context()</function>の結果をサーバに送る際には、ネットワークバイトオーダーで4バイトの整数にメッセージ長を先頭に付与します。
 <literal>N</literal>の後継続するには、通常のStartupMessageを送信し、暗号化せずに続けてください。
 （他に、<acronym>GSSAPI</acronym>の代わりに<acronym>SSL</acronym>暗号化の使用を試行するために、<literal>N</literal>応答の後にSSLRequestメッセージを送信することが認められています。）
@@ -2582,10 +2582,8 @@ AuthenticationSASLFinalにはサーバからクライアントへの追加のデ
     detail in <ulink url="https://datatracker.ietf.org/doc/html/rfc7677">RFC 7677</ulink>
     and <ulink url="https://datatracker.ietf.org/doc/html/rfc5802">RFC 5802</ulink>.
 -->
-《マッチ度[86.167147]》今のところ実装されているSASL機構は<literal>SCRAM-SHA-256</literal>とチャンネルバインディングを伴う変種の<literal>SCRAM-SHA-256-PLUS</literal>です。
-詳細は<ulink url="https://tools.ietf.org/html/rfc7677">RFC 7677</ulink>および<ulink url="https://tools.ietf.org/html/rfc5802">RFC 5802</ulink>で説明されています。
-《機械翻訳》現在実装されているSASLメカニズムは<literal>SCRAM-SHA-256</literal>と、チャネルバインディングを持つその変種<literal>SCRAM-SHA-256-PLUS</literal>です。
-これらについては、<ulink url="https://datatracker.ietf.org/doc/html/rfc7677">RFC 7677</ulink>と<ulink url="https://datatracker.ietf.org/doc/html/rfc5802">RFC 5802</ulink>で詳しく説明されています。
+今のところ実装されているSASL機構は<literal>SCRAM-SHA-256</literal>とチャネルバインディングを伴う変種の<literal>SCRAM-SHA-256-PLUS</literal>です。
+詳細は<ulink url="https://datatracker.ietf.org/doc/html/rfc7677">RFC 7677</ulink>および<ulink url="https://datatracker.ietf.org/doc/html/rfc5802">RFC 5802</ulink>で説明されています。
    </para>
 
    <para>
@@ -3761,7 +3759,7 @@ CopyBothResponse内部のメッセージは、2つのCommandCompleteメッセー
           options that are accepted by the standard (<literal>pgoutput</literal>)
           plugin.
 -->
-《機械翻訳》スロットの論理デコード出力プラグインに渡されるオプションの名前です。
+レプリケーションスロットのロジカルデコーディング出力プラグインに渡すオプション名。
 標準(<literal>pgoutput</literal>)プラグインで受け付けられるオプションについては<xref linkend="protocol-logical-replication"/>を参照してください。
          </para>
         </listitem>
@@ -4470,10 +4468,8 @@ PostgreSQLサーバの操作中に作成される種々の一時ファイルお�
           device and operating system files, are skipped.  (Symbolic links
           in <filename>pg_tblspc</filename> are maintained.)
 -->
-《マッチ度[77.777778]》シンボリックリンク（上記で列挙したディレクトリは除きます）や特殊デバイスファイルなど、通常のファイルとディレクトリ以外のものは省略されます。
+シンボリックリンク（上記で列挙したディレクトリは除きます）や特殊デバイスファイル、オペレーティングシステムのファイルなど、通常のファイルとディレクトリ以外のものは省略されます。
 （<filename>pg_tblspc</filename>中のシンボリックリンクは保持されます。）
-《機械翻訳》通常のファイルとディレクトリ以外のファイル、例えばシンボリックリンク（上記のディレクトリ以外のもの）や特殊なデバイスやオペレーティングシステムのファイルはスキップされます。
-（<filename>pg_tblspc</filename>内のシンボリックリンクは保持されます。）
          </para>
         </listitem>
        </itemizedlist>
@@ -4520,8 +4516,8 @@ PostgreSQLサーバの操作中に作成される種々の一時ファイルお�
   plugins.  <literal>pgoutput</literal> is the standard one used for
   the built-in logical replication.
 -->
-《機械翻訳》<productname>PostgreSQL</productname>論理デコードは出力プラグインをサポートしています。
-組み込み論理レプリケーションに使用される標準のものは<literal>pgoutput</literal>です。
+<productname>PostgreSQL</productname>ロジカルデコーディングは出力プラグインをサポートしています。
+組み込み論理レプリケーションに使用される標準のプラグインは<literal>pgoutput</literal>です。
  </para>
 
  <sect2 id="protocol-logical-replication-params">
@@ -4535,7 +4531,7 @@ PostgreSQLサーバの操作中に作成される種々の一時ファイルお�
    Using the <literal>START_REPLICATION</literal> command,
    <literal>pgoutput</literal> accepts the following options:
 -->
-《機械翻訳》<literal>START_REPLICATION</literal>コマンドでは、<literal>pgoutput</literal>は以下のオプションを受け付けます。
+<literal>START_REPLICATION</literal>コマンドを使用する際、<literal>pgoutput</literal>は以下のオプションを受け付けます。
 
    <variablelist>
     <varlistentry>
@@ -4549,10 +4545,8 @@ PostgreSQLサーバの操作中に作成される種々の一時ファイルお�
        <literal>3</literal>, and <literal>4</literal> are supported.  A valid
        version is required.
 -->
-《マッチ度[74.853801]》プロトコルバージョン。現在<literal>1</literal>、<literal>2</literal>、<literal>3</literal>、および<literal>4</literal>がサポートされています。
-《機械翻訳》プロトコルバージョン。
-現在、<literal>1</literal>、<literal>2</literal>、<literal>3</literal>、<literal>4</literal>のバージョンがサポートされています。
-有効なバージョンが必要です。
+プロトコルバージョン。現在<literal>1</literal>、<literal>2</literal>、<literal>3</literal>、および<literal>4</literal>がサポートされています。
+有効なバージョンを指定する必要があります。
       </para>
       <para>
 <!--
@@ -4591,11 +4585,9 @@ PostgreSQLサーバの操作中に作成される種々の一時ファイルお�
        as standard objects names and can be quoted the same as needed.
        At least one publication name is required.
 -->
-《マッチ度[72.765957]》サブスクライブする（変更を受け取る）対象となるパブリケーション名をカンマで区切ったリストです。
+サブスクライブする（変更を受け取る）対象となるパブリケーション名をカンマで区切ったリストです。
 個々のパブリケーション名は標準的なオブジェクト名と扱われ、必要に応じて引用符で括ることができます。
-《機械翻訳》サブスクライブ （変更を受信） するパブリケーション名のカンマ区切りリスト。
-個々のパブリケーション名は標準オブジェクト名として扱われ、必要に応じて引用符で囲むことができます。
-少なくとも 1 つのパブリケーション名が必要です。
+少なくとも１つのパブリケーション名が必要です。
       </para>
      </listitem>
     </varlistentry>
@@ -4610,8 +4602,8 @@ PostgreSQLサーバの操作中に作成される種々の一時ファイルお�
        Boolean option to use binary transfer mode.  Binary mode is faster
        than the text mode but slightly less robust.
 -->
-《機械翻訳》バイナリ転送モードを使用するためのブールオプション。
-バイナリモードはテキストモードより高速ですが、やや堅牢性が低くなります。
+バイナリ転送モードを使用するブールオプションです。
+バイナリモードはテキストモードより高速ですが、堅牢性が少し低くなります。
       </para>
      </listitem>
     </varlistentry>
@@ -4626,7 +4618,7 @@ PostgreSQLサーバの操作中に作成される種々の一時ファイルお�
        Boolean option to enable sending the messages that are written
        by <function>pg_logical_emit_message</function>.
 -->
-《機械翻訳》<function>pg_logical_slot_peek_message</function>が書き込むメッセージの送信を有効にするブールオプションです。
+<function>pg_logical_slot_peek_message</function>によって書き込まれたメッセージの送信を有効にするブールオプションです。
       </para>
      </listitem>
     </varlistentry>
@@ -4644,10 +4636,10 @@ PostgreSQLサーバの操作中に作成される種々の一時ファイルお�
        Minimum protocol version 2 is required to turn it on.  Minimum protocol
        version 4 is required for the "parallel" option.
 -->
-《機械翻訳》進行中のトランザクションのストリーミングを有効にするブールオプションです。
-追加情報を送信するために、並列化で使用されるメッセージに追加情報を送信するための追加値「parallel」を受け入れます。
-最小プロトコルバージョン2が必要です。
-「parallel」オプションには最小プロトコルバージョン4が必要です。
+進行中のトランザクションのストリーミングを有効にするブールオプションです。
+並列処理に使用される追加情報の送信を有効にするため、追加の値「parallel」を受け付けます。
+本パラメータを有効化するには、プロトコルバージョンが2以上である必要があります。
+「parallel」に指定する場合は、プロトコルバージョンが4以上である必要があります。
       </para>
      </listitem>
     </varlistentry>
@@ -4662,8 +4654,8 @@ PostgreSQLサーバの操作中に作成される種々の一時ファイルお�
        Boolean option to enable two-phase transactions.   Minimum protocol
        version 3 is required to turn it on.
 -->
-《機械翻訳》2 フェーズ・トランザクションを有効にするためのブール・オプション。
-これをオンにするには、最低プロトコル・バージョン 3 が必要です。
+2相コミットを有効にするブールオプションです。
+本パラメータを有効化するには、プロトコルバージョンが3以上である必要があります。
       </para>
      </listitem>
     </varlistentry>
@@ -4681,9 +4673,9 @@ PostgreSQLサーバの操作中に作成される種々の一時ファイルお�
        to avoid loops (infinite replication of the same data) among
        replication nodes.
 -->
-《機械翻訳》変更を発生元別に送信するオプションです。
-値は、変更を発生元に関連付けない場合は「なし」、発生元に関係なく変更を送信する場合は「任意」です。
-これは、複製ノード間でループ （同じデータの無限の複製） を回避するために使用できます。
+オリジンに応じて変更を送信するオプションです。
+取りうる値はオリジンのない変更のみを送信する「none」か、オリジンに関係なく変更を送信する「any」です。
+本パラメータはレプリケーションノード間でループ（同じデータの無限の複製）を回避するために使用できます。
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
## 迷ったところ

`Boolean option`をどのように訳すのかで迷いました。
file-fdw.sgmlには以下のような記載がありますが、9年前のcommitなので現在も参考にしてよいのか分かりませんでした。

```
<!--
     This is a Boolean option.  ...
-->
これはbooleanオプションです。
```

とりあえず「ブールオプション」と翻訳しています。