### PR TITLE
update information_schema for 16.3

### DIFF
--- a/doc/src/sgml/information_schema.sgml
+++ b/doc/src/sgml/information_schema.sgml
@@ -987,14 +987,10 @@ PostgreSQLはひとつのデータベース内で複数の文字セットをサ�
        all supported by PostgreSQL).  Encoding forms are not exposed
        as an SQL object, but are visible in this view.
 -->
-《マッチ度[87.103594]》文字集合の符号化方式です。
-ほとんどの古い文字集合はひとつの符号化形式を使うため、それらについては分離した名称はありません(たとえば、<literal>LATIN1</literal>は<literal>LATIN1</literal>集合に適用可能な符号化形式です)。
+文字集合の符号化方式です。
+ほとんどの古い文字集合はひとつの符号化形式を使うため、それらについては分離した名称はありません(たとえば、<literal>LATIN2</literal>は<literal>LATIN2</literal>集合に適用可能な符号化形式です)。
 しかし例えばUnicodeには<literal>UTF8</literal>、<literal>UTF16</literal>などの符号化形式があります（PostgreSQLでは一部だけサポートしています）。
 符号化形式はSQLオブジェクトとして表にでませんが、このビューで参照できます。
-《機械翻訳》いくつかの文字レパートリのエンコーディング。
-古い文字レパートリのほとんどは、1 つのエンコーディング形式しか使用しないため、それらに対して個別の名前はありません （例えば、<literal>LATIN2</literal> は <literal>LATIN2</literal> レパートリに適用可能なエンコーディング形式です）。
-しかし、例えば、Unicode には <literal>UTF8</literal>、<literal>UTF16</literal> などのエンコーディング形式があります （すべて PostgreSQL でサポートされています）。
-エンコーディング形式は SQL オブジェクトとして公開されていませんが、このビューでは表示されます。
       </para>
      </listitem>
     </varlistentry>
@@ -6657,13 +6653,9 @@ PostgreSQLではデータ型は実際の権限を持たず、<literal>PUBLIC</li
    not quoted bodies or functions in other languages.)  A column is only
    included if its table is owned by a currently enabled role.
 -->
-《マッチ度[62.500000]》<literal>routine_sequence_usage</literal>ビューは、本体またはパラメータのデフォルト式のいずれかで関数またはプロシージャによって使用される全てのシーケンスを識別することを目的としています。
-現在、パラメータのデフォルト式で使用されるシーケンスのみが追跡されます。
-シーケンスが含まれるのは、そのシーケンスが現在有効なロールによって所有されている場合のみです。
-《機械翻訳》<literal>routine_column_usage</literal>ビューは、SQL本体またはプロシージャのパラメータのデフォルト式のいずれかで、関数またはプロシージャによって使用されるすべての列を識別します。
-（これは、引用符で囲まれていないSQL本体に対してのみ機能します。
-引用符で囲まれた本文や他の言語の関数では機能しません。
-列は、そのテーブルが現在有効なロールによって所有されている場合にのみ含まれます。
+<literal>routine_column_usage</literal>ビューは、SQL本体またはパラメータのデフォルト式のいずれかで関数またはプロシージャによって使用されるすべての列を識別します。
+（これは、引用符で囲まれていないSQL本体に対してのみ機能し、引用符で囲まれた本文や他の言語の関数では機能しません。）
+列が含まれるのは、その列が現在有効なロールによって所有されている場合のみです。
   </para>
 
   <table>
@@ -6990,12 +6982,10 @@ PostgreSQLではデータ型は実際の権限を持たず、<literal>PUBLIC</li
    by a currently enabled role.  (There is no such restriction on the using
    function.)
 -->
-《マッチ度[76.339286]》<literal>routine_routine_usage</literal>ビューは、本体またはパラメータのデフォルト式のいずれかで、別の（または同じ）関数またはプロシージャによって使用される、全ての関数またはプロシージャを識別することを目的としています。
-現在、パラメータのデフォルト式で使用される関数のみが追跡されます。
+<literal>routine_routine_usage</literal>ビューは、SQL本体またはパラメータのデフォルト式のいずれかで、別の（または同じ）関数またはプロシージャによって使用される、すべての関数またはプロシージャを識別します。
+（これは、引用符で囲まれていないSQL本体に対してのみ機能し、引用符で囲まれた本文や他の言語の関数では機能しません。）
 ここにエントリが含まれるのは、使用される関数が現在使用可能なロールによって所有されている場合のみです。
 （使用する関数にこのような制限はありません。）
-《機械翻訳》<literal>routine_routine_usage</literal>ビューは、SQL本体またはパラメータのデフォルト式の中で、別の（または同じ）関数またはプロシージャによって使用されるすべての関数またはプロシージャを識別します（これは、引用符で囲まれていないSQL本体または他の言語の関数に対してのみ機能します）。
-ここには、現在使用可能なロールによって所有されている関数が含まれます（使用する関数にそのような制限はありません）。
   </para>
 
   <para>
@@ -7124,13 +7114,9 @@ PostgreSQLではデータ型は実際の権限を持たず、<literal>PUBLIC</li
    not quoted bodies or functions in other languages.)  A sequence is only
    included if that sequence is owned by a currently enabled role.
 -->
-《マッチ度[71.468927]》<literal>routine_sequence_usage</literal>ビューは、本体またはパラメータのデフォルト式のいずれかで関数またはプロシージャによって使用される全てのシーケンスを識別することを目的としています。
-現在、パラメータのデフォルト式で使用されるシーケンスのみが追跡されます。
+<literal>routine_sequence_usage</literal>ビューは、SQL本体またはパラメータのデフォルト式のいずれかで関数またはプロシージャによって使用されるすべてのシーケンスを識別します。
+（これは、引用符で囲まれていないSQL本体に対してのみ機能し、引用符で囲まれた本文や他の言語の関数では機能しません。）
 シーケンスが含まれるのは、そのシーケンスが現在有効なロールによって所有されている場合のみです。
-《機械翻訳》<literal>routine_sequence_usage</literal>ビューは、SQL本体またはパラメータのデフォルト式のいずれかで、関数またはプロシージャによって使用されるすべてのシーケンスを識別します。
-（これは、引用符で囲まれていないSQL本体に対してのみ機能します。
-引用符で囲まれた本文や他の言語の関数では機能しません。
-シーケンスが現在有効なロールによって所有されている場合にのみ、シーケンスが含まれます。
   </para>
 
   <table>


### PR DESCRIPTION
information_schema.sgml の 16.3 対応です。

character repertoireの訳は「文字レパートリ（ー）」とすべきなのでは、という議論がありましたが、今回はそこには手をつけていません。