### PR TITLE
match translation of 'boolean option' with one in protocol

### DIFF
--- a/doc/src/sgml/file-fdw.sgml
+++ b/doc/src/sgml/file-fdw.sgml
@@ -181,7 +181,7 @@
   the value TRUE, since all such options are Booleans.
 -->
 <command>COPY</command>では<literal>HEADER</literal>といったオプションを対応する値なしで指定できるのに対して、外部データラッパーの構文では全ての場合において値を指定する必要がある点に注意してください。
-通常の値なしで指定される<command>COPY</command>オプションを有効にするには、そのようなオプションはすべてbooleanであるため、代わりにTRUEを渡すことができます。
+通常の値なしで指定される<command>COPY</command>オプションを有効にするには、それらはすべてブールオプションであるため、代わりにTRUEを渡すことができます。
  </para>
 
  <para>

--- a/doc/src/sgml/file-fdw.sgml
+++ b/doc/src/sgml/file-fdw.sgml
@@ -206,7 +206,7 @@
      as listing the column in <command>COPY</command>'s
      <literal>FORCE_NOT_NULL</literal> option.
 -->
-これはbooleanオプションです。
+これはブールオプションです。
 真の場合は、このカラムの値はNULL文字列(これはテーブルレベルの<literal>null</literal>オプションです)と比較されません。
 これは、<command>COPY</command>の<literal>FORCE_NOT_NULL</literal>オプションに列名を指定するのと同じ効果があります。
     </para>
@@ -226,7 +226,7 @@
      This has the same effect  as listing the column in
      <command>COPY</command>'s <literal>FORCE_NULL</literal> option.
 -->
-これはbooleanオプションです。
+これはブールオプションです。
 真の場合、NULL文字列と一致するこのカラムの値は、たとえ引用符で括られていたとしても<literal>NULL</literal>と返されます。
 このオプションがなければ、NULL文字列と一致する引用符で括られていない値のみが<literal>NULL</literal>と返されます。
 これは、<command>COPY</command>の<literal>FORCE_NULL</literal>オプションに列名を指定するのと同じ効果があります。


### PR DESCRIPTION
boolean optionの訳をprotocol.sgmlに合わせました。

https://github.com/pgsql-jp/jpug-doc/pull/2966#issuecomment-2228467870 で書いた件です。