### PR TITLE
remove extra ","

### DIFF
--- a/doc/src/sgml/ref/create_table.sgml
+++ b/doc/src/sgml/ref/create_table.sgml
@@ -793,7 +793,7 @@ Bツリー演算子クラスがない場合はエラーが報告されます。
       <literal>FROM ('infinity') TO (MAXVALUE)</literal> is not an empty range; it
       allows precisely one value to be stored &mdash; "infinity".
 -->
-<literal>timestamp</literal>,など一部の要素型では、"infinity"（無限）の概念があり、それも保存できる値であることにも注意してください。
+<literal>timestamp</literal>など一部の要素型では、"infinity"（無限）の概念があり、それも保存できる値であることにも注意してください。
 <literal>MINVALUE</literal>と<literal>MAXVALUE</literal>は保存できる真の値ではなく、値に境界がないということを表現するための方法に過ぎないため、これとは違います。
 <literal>MAXVALUE</literal>は"infinity"も含め、他のすべての値より大きいものと考えることができ、また<literal>MINVALUE</literal>は"minus infinity"も含め、他のすべての値より小さいものと考えることができます。
 従って、境界<literal>FROM ('infinity') TO (MAXVALUE)</literal>は空の範囲ではなく、たった1つの値、つまり"infinity"だけを保存します。


### PR DESCRIPTION
timestamp,など一部の要素型では、

と見えますので、「,」を削除しました。