### PR TITLE
SQL descriptorをSQL記述子に統一

### DIFF
--- a/doc/src/sgml/ecpg.sgml
+++ b/doc/src/sgml/ecpg.sgml
@@ -1054,7 +1054,7 @@ EXEC SQL DEALLOCATE PREPARE <replaceable>name</replaceable>;
    applications is the use of SQL descriptors, described
    in <xref linkend="ecpg-descriptors"/>.
 -->
-PostgreSQLバックエンドとECPGアプリケーションの間で値をやり取りするその他の方法は、 <xref linkend="ecpg-descriptors"/> で説明されているSQLデスクリプタを使う方法です。
+PostgreSQLバックエンドとECPGアプリケーションの間で値をやり取りするその他の方法は、<xref linkend="ecpg-descriptors"/>で説明されているSQL記述子を使う方法です。
   </para>
 
   <sect2 id="ecpg-variables-overview">


### PR DESCRIPTION
「デスクリプタ」が使われているのが1箇所のみで「ディスクリプタ」にしようかと思いましたが、
他では「SQL記述子」だったので統一しました。