### PR TITLE
discussedの訳語を「説明」に変更

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -14518,7 +14518,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
          see <xref linkend="datatype-float"/> for further discussion.
 -->
 このパラメータの意味とデフォルト値は<productname>PostgreSQL</productname> 12で変更されました。
-更なる議論については<xref linkend="datatype-float"/>をご覧ください。
+更なる説明については<xref linkend="datatype-float"/>をご覧ください。
         </para>
        </note>
       </listitem>

--- a/doc/src/sgml/config3.sgml
+++ b/doc/src/sgml/config3.sgml
@@ -1114,7 +1114,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
          see <xref linkend="datatype-float"/> for further discussion.
 -->
 このパラメータの意味とデフォルト値は<productname>PostgreSQL</productname> 12で変更されました。
-更なる議論については<xref linkend="datatype-float"/>をご覧ください。
+更なる説明については<xref linkend="datatype-float"/>をご覧ください。
         </para>
        </note>
       </listitem>

--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -5125,7 +5125,7 @@ SELECT name, elevation
    <literal>ONLY</literal> keyword.
 -->
 ここで<literal>ONLY</literal>キーワードは、問い合わせが<structname>cities</structname>テーブルのみを対象にし<structname>cities</structname>以下の継承の階層にあるテーブルは対象としないことを意味します。
-これまで議論したコマンドの多く&mdash;<command>SELECT</command>、<command>UPDATE</command>そして<command>DELETE</command> &mdash;が<literal>ONLY</literal>キーワードをサポートしています。
+これまで説明したコマンドの多く&mdash;<command>SELECT</command>、<command>UPDATE</command>そして<command>DELETE</command> &mdash;が<literal>ONLY</literal>キーワードをサポートしています。
   </para>
 
   <para>

--- a/doc/src/sgml/event-trigger.sgml
+++ b/doc/src/sgml/event-trigger.sgml
@@ -21,7 +21,7 @@
    event triggers are global to a particular database and are capable of
    capturing DDL events.
 -->
-<xref linkend="triggers"/>で議論されたトリガの機能を補完するために、<productname>PostgreSQL</productname>はイベントトリガを提供します。
+<xref linkend="triggers"/>で説明されたトリガの機能を補完するために、<productname>PostgreSQL</productname>はイベントトリガを提供します。
 一つのテーブルに付与され、DMLイベントのみ対象にしたこれまでのトリガと違い、イベントトリガは特定のデータベースに大域的であり、DDLイベントを対象に実行できます。
   </para>
 

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -18958,7 +18958,7 @@ SELECT xmlexists('//town[text() = ''Toronto'']' PASSING BY VALUE '<towns><town>T
      are accepted in <productname>PostgreSQL</productname>, but are ignored,
      as discussed in <xref linkend="functions-xml-limits-postgresql"/>.
 -->
-<productname>PostgreSQL</productname>は<literal>BY REF</literal>句と<literal>BY VALUE</literal>句を受け付けますが、<xref linkend="functions-xml-limits-postgresql"/>で議論されているように無視します。
+<productname>PostgreSQL</productname>は<literal>BY REF</literal>句と<literal>BY VALUE</literal>句を受け付けますが、<xref linkend="functions-xml-limits-postgresql"/>で説明されているように無視します。
     </para>
 
     <para>
@@ -18969,7 +18969,7 @@ SELECT xmlexists('//town[text() = ''Toronto'']' PASSING BY VALUE '<towns><town>T
      expression, as discussed in
      <xref linkend="functions-xml-limits-xpath1"/>.
 -->
-SQL標準では<function>xmlexists</function>関数はXML問い合わせ言語における式を評価しますが、<xref linkend="functions-xml-limits-xpath1"/>で議論されているように、<productname>PostgreSQL</productname>はXPath 1.0の式だけを受け付けます。
+SQL標準では<function>xmlexists</function>関数はXML問い合わせ言語における式を評価しますが、<xref linkend="functions-xml-limits-xpath1"/>で説明されているように、<productname>PostgreSQL</productname>はXPath 1.0の式だけを受け付けます。
     </para>
    </sect3>
 
@@ -19290,7 +19290,7 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
 -->
 <replaceable>document_expression</replaceable>は<replaceable>row_expression</replaceable>のためのコンテキスト項目を提供します。
 それは整形式XMLの文書でなければならず、フラグメントやフォレストは受け付けられません。
-<xref linkend="functions-xml-limits-postgresql"/>で議論されているように、<literal>BY REF</literal>句と<literal>BY VALUE</literal>句は受け付けられますが、無視されます。
+<xref linkend="functions-xml-limits-postgresql"/>で説明されているように、<literal>BY REF</literal>句と<literal>BY VALUE</literal>句は受け付けられますが、無視されます。
     </para>
 
     <para>
@@ -19301,7 +19301,7 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
      expressions, as discussed in
      <xref linkend="functions-xml-limits-xpath1"/>.
 -->
-SQL標準では<function>xmltable</function>関数はXML問い合わせ言語の式を評価しますが、<xref linkend="functions-xml-limits-xpath1"/>で議論されているように<productname>PostgreSQL</productname>ではXPath 1.0式だけを受け付けます。
+SQL標準では<function>xmltable</function>関数はXML問い合わせ言語の式を評価しますが、<xref linkend="functions-xml-limits-xpath1"/>で説明されているように<productname>PostgreSQL</productname>ではXPath 1.0式だけを受け付けます。
     </para>
 
     <para>
@@ -19439,7 +19439,7 @@ XPath 1.0 <function>string</function>関数が、他のXMLノード型と非XML�
      The conversion rules presented here are not exactly those of the SQL
      standard, as discussed in <xref linkend="functions-xml-limits-casts"/>.
 -->
-ここで示した変換ルールは、<xref linkend="functions-xml-limits-casts"/>で議論されているように、正確にSQL標準に従っているわけではありません。
+ここで示した変換ルールは、<xref linkend="functions-xml-limits-casts"/>で説明されているように、正確にSQL標準に従っているわけではありません。
     </para>
 
     <para>

--- a/doc/src/sgml/func2.sgml
+++ b/doc/src/sgml/func2.sgml
@@ -8907,7 +8907,7 @@ SELECT xmlexists('//town[text() = ''Toronto'']' PASSING BY VALUE '<towns><town>T
      are accepted in <productname>PostgreSQL</productname>, but are ignored,
      as discussed in <xref linkend="functions-xml-limits-postgresql"/>.
 -->
-<productname>PostgreSQL</productname>は<literal>BY REF</literal>句と<literal>BY VALUE</literal>句を受け付けますが、<xref linkend="functions-xml-limits-postgresql"/>で議論されているように無視します。
+<productname>PostgreSQL</productname>は<literal>BY REF</literal>句と<literal>BY VALUE</literal>句を受け付けますが、<xref linkend="functions-xml-limits-postgresql"/>で説明されているように無視します。
     </para>
 
     <para>
@@ -8918,7 +8918,7 @@ SELECT xmlexists('//town[text() = ''Toronto'']' PASSING BY VALUE '<towns><town>T
      expression, as discussed in
      <xref linkend="functions-xml-limits-xpath1"/>.
 -->
-SQL標準では<function>xmlexists</function>関数はXML問い合わせ言語における式を評価しますが、<xref linkend="functions-xml-limits-xpath1"/>で議論されているように、<productname>PostgreSQL</productname>はXPath 1.0の式だけを受け付けます。
+SQL標準では<function>xmlexists</function>関数はXML問い合わせ言語における式を評価しますが、<xref linkend="functions-xml-limits-xpath1"/>で説明されているように、<productname>PostgreSQL</productname>はXPath 1.0の式だけを受け付けます。
     </para>
    </sect3>
 
@@ -9239,7 +9239,7 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
 -->
 <replaceable>document_expression</replaceable>は<replaceable>row_expression</replaceable>のためのコンテキスト項目を提供します。
 それは整形式XMLの文書でなければならず、フラグメントやフォレストは受け付けられません。
-<xref linkend="functions-xml-limits-postgresql"/>で議論されているように、<literal>BY REF</literal>句と<literal>BY VALUE</literal>句は受け付けられますが、無視されます。
+<xref linkend="functions-xml-limits-postgresql"/>で説明されているように、<literal>BY REF</literal>句と<literal>BY VALUE</literal>句は受け付けられますが、無視されます。
     </para>
 
     <para>
@@ -9250,7 +9250,7 @@ SELECT xpath_exists('/my:a/text()', '<my:a xmlns:my="http://example.com">test</m
      expressions, as discussed in
      <xref linkend="functions-xml-limits-xpath1"/>.
 -->
-SQL標準では<function>xmltable</function>関数はXML問い合わせ言語の式を評価しますが、<xref linkend="functions-xml-limits-xpath1"/>で議論されているように<productname>PostgreSQL</productname>ではXPath 1.0式だけを受け付けます。
+SQL標準では<function>xmltable</function>関数はXML問い合わせ言語の式を評価しますが、<xref linkend="functions-xml-limits-xpath1"/>で説明されているように<productname>PostgreSQL</productname>ではXPath 1.0式だけを受け付けます。
     </para>
 
     <para>
@@ -9388,7 +9388,7 @@ XPath 1.0 <function>string</function>関数が、他のXMLノード型と非XML�
      The conversion rules presented here are not exactly those of the SQL
      standard, as discussed in <xref linkend="functions-xml-limits-casts"/>.
 -->
-ここで示した変換ルールは、<xref linkend="functions-xml-limits-casts"/>で議論されているように、正確にSQL標準に従っているわけではありません。
+ここで示した変換ルールは、<xref linkend="functions-xml-limits-casts"/>で説明されているように、正確にSQL標準に従っているわけではありません。
     </para>
 
     <para>

--- a/doc/src/sgml/mvcc.sgml
+++ b/doc/src/sgml/mvcc.sgml
@@ -1863,7 +1863,7 @@ ERROR:  could not serialize access due to read/write dependencies among transact
 これにより、それらは現在のトランザクションが終わるまで、他のトランザクションがロック、変更、削除できなくなります。
 すなわち、これらの行に対して<command>UPDATE</command>、<command>DELETE</command>、<command>SELECT FOR UPDATE</command>、<command>SELECT FOR NO KEY UPDATE</command>、<command>SELECT FOR SHARE</command>、<command>SELECT FOR KEY SHARE</command>をしようとする他のトランザクションは現在のトランザクションが終わるまでブロックされます。逆に言えば、<command>SELECT FOR UPDATE</command>は同じ行に対して上記のコマンドを実行している同時実行トランザクションを待ち、それから更新された行をロックして返します(行が削除されていれば、行は返しません)。
 しかし、<literal>REPEATABLE READ</literal>もしくは<literal>SERIALIZABLE</literal>トランザクション内では、ロックする行がトランザクションの開始した後に変更された場合にはエラーが返ります。
-これ以上の議論は<xref linkend="applevel-consistency"/>を参照してください。
+これ以上の説明は<xref linkend="applevel-consistency"/>を参照してください。
         </para>
         <para>
 <!--

--- a/doc/src/sgml/parallel.sgml
+++ b/doc/src/sgml/parallel.sgml
@@ -273,7 +273,7 @@ EXPLAIN SELECT * FROM pgbench_accounts WHERE filler LIKE '%x%';
 クエリが<literal>PARALLEL UNSAFE</literal>とマーク付されている関数を使っています。
 ほとんどのシステム定義の関数は<literal>PARALLEL SAFE</literal>です。
 しかし、ユーザ定義関数はデフォルトで<literal>PARALLEL UNSAFE</literal>とマーク付されます。
-<xref linkend="parallel-safety"/>の議論をご覧ください。
+<xref linkend="parallel-safety"/>の説明をご覧ください。
       </para>
     </listitem>
 
@@ -347,7 +347,7 @@ EXPLAIN SELECT * FROM pgbench_accounts WHERE filler LIKE '%x%';
         that may be suboptimal when run serially.
 -->
 クライアントが0ではないフェッチカウント付きのExecuteメッセージを送信した場合。
-<link linkend="protocol-flow-ext-query">拡張問い合わせプロトコル</link>の議論をご覧ください。
+<link linkend="protocol-flow-ext-query">拡張問い合わせプロトコル</link>の説明をご覧ください。
 現在の<link linkend="libpq">libpq</link>にはそのようなメッセージを送る方法がないため、これはlibpqに依存しないクライアントを使った時にだけ起こります。
 これが頻繁に起こるようなら、順次実行したときに最適ではないプランが生成されるのを防ぐために、それが起こりそうなセッションの中で、<xref linkend="guc-max-parallel-workers-per-gather"/>を0に設定すると良いかもしれません。
       </para>

--- a/doc/src/sgml/protocol.sgml
+++ b/doc/src/sgml/protocol.sgml
@@ -2391,7 +2391,7 @@ CancelRequestメッセージは、接続開始段階でフロントエンドに�
 <acronym>GSSAPI</acronym>暗号化接続を開始するには、フロントエンドは最初にStartupMessageではなく、GSSENCRequestメッセージを送ります。
 次にサーバは、それぞれ<acronym>GSSAPI</acronym>暗号化を希望する、しないを意味する<literal>G</literal>または<literal>N</literal>を含む1バイトを送信します。
 このレスポンスに満足できなければ、この時点でフロントエンドは接続を打ち切って構いません。
-<literal>G</literal>の受信後継続するには、<ulink url="https://datatracker.ietf.org/doc/html/rfc2744">RFC 2744</ulink>あるいは同様の文書で議論されているGSSAPI Cバインディングを使い、ループの中で<function>gss_init_sec_context()</function>を呼び出して<acronym>GSSAPI</acronym>を初期化し、結果をサーバに送信し、空の入力を受け取ることから始めて、サーバが出力を返さなくなるまでサーバからの出力を受け取ります。
+<literal>G</literal>の受信後継続するには、<ulink url="https://datatracker.ietf.org/doc/html/rfc2744">RFC 2744</ulink>あるいは同様の文書で説明されているGSSAPI Cバインディングを使い、ループの中で<function>gss_init_sec_context()</function>を呼び出して<acronym>GSSAPI</acronym>を初期化し、結果をサーバに送信し、空の入力を受け取ることから始めて、サーバが出力を返さなくなるまでサーバからの出力を受け取ります。
 <function>gss_init_sec_context()</function>の結果をサーバに送る際には、ネットワークバイトオーダーで4バイトの整数にメッセージ長を先頭に付与します。
 <literal>N</literal>の後継続するには、通常のStartupMessageを送信し、暗号化せずに続けてください。
 （他に、<acronym>GSSAPI</acronym>の代わりに<acronym>SSL</acronym>暗号化の使用を試行するために、<literal>N</literal>応答の後にSSLRequestメッセージを送信することが認められています。）

--- a/doc/src/sgml/ref/alter_table.sgml
+++ b/doc/src/sgml/ref/alter_table.sgml
@@ -1436,7 +1436,7 @@ fillfactor、TOAST、およびautovacuumのストレージパラメータおよ�
       constraints on the foreign table.)
 -->
 新しいパーティションが外部テーブルの場合、外部テーブルのすべての行がパーティションの制約に従うかどうかの確認は何も行われません。
-（外部テーブルの制約については<xref linkend="sql-createforeigntable"/>の議論を参照してください。）
+（外部テーブルの制約については<xref linkend="sql-createforeigntable"/>の説明を参照してください。）
      </para>
 
      <para>

--- a/doc/src/sgml/ref/create_table.sgml
+++ b/doc/src/sgml/ref/create_table.sgml
@@ -650,7 +650,7 @@ Bツリー演算子クラスがない場合はエラーが報告されます。
       See <xref linkend="ddl-partitioning"/> for more discussion on table
       partitioning.
 -->
-テーブルパーティショニングに関するより詳しい議論は<xref linkend="ddl-partitioning"/>を参照してください。
+テーブルパーティショニングに関するより詳しい説明は<xref linkend="ddl-partitioning"/>を参照してください。
      </para>
 
     </listitem>

--- a/doc/src/sgml/spgist.sgml
+++ b/doc/src/sgml/spgist.sgml
@@ -289,7 +289,7 @@
   not discussed further here.
 -->
 <acronym>SP-GiST</acronym>インデックスが<literal>INCLUDE</literal>列を付けて作成された場合には、その列の値もリーフタプルに格納されます。
-<literal>INCLUDE</literal>列は<acronym>SP-GiST</acronym>演算子クラスとは関係ありませんので、ここではこれ以上議論しません。
+<literal>INCLUDE</literal>列は<acronym>SP-GiST</acronym>演算子クラスとは関係ありませんので、ここではこれ以上説明しません。
  </para>
 
  <para>
@@ -354,7 +354,7 @@
 <acronym>SP-GiST</acronym>のコアのコードはnullエントリについても対応しています。
 <acronym>SP-GiST</acronym>のインデックスはインデックス列がnullのエントリについても格納しますが、これはインデックスの演算子クラスのコードからは隠されているので、nullのインデックスエントリや検索条件が演算子クラスのメソッドに渡されることはありません。
 (<acronym>SP-GiST</acronym>の演算子は厳格なのでNULL値について成功を返すことはできないと想定されています。)
-従って、ここではこれ以上、NULLについて議論しません。
+従って、ここではこれ以上、NULLについて説明しません。
   </para>
  </note>
 


### PR DESCRIPTION
discusedでマニュアルを指している場合等は「説明」に変更しました。

#2984 の対応です。