### PR TITLE
fix translation of 'streaming replication'

### DIFF
--- a/doc/src/sgml/logicaldecoding.sgml
+++ b/doc/src/sgml/logicaldecoding.sgml
@@ -550,7 +550,7 @@ postgres=# select * from pg_logical_slot_get_changes('regression_slot', NULL, NU
 <!--
    <title>Streaming Replication Protocol Interface</title>
 -->
-   <title>ストリームレプリケーションプロトコルインタフェース</title>
+   <title>ストリーミングレプリケーションプロトコルインタフェース</title>
 
    <para>
 <!--


### PR DESCRIPTION
streaming replicationの訳が「ストリームレプリケーション」になっていたので、「ストリーミングレプリケーション」に修正しました。

「ストリームレプリケーション」というのは他には見当たらないですし、原文も"streaming"なので原文に忠実な「ストリーミング」で良いと思うのですが、もし意図的に「ストリーム」としているのならご指摘ください。