### PR TITLE
remove 'nakaten' around 'archive'

### DIFF
--- a/doc/src/sgml/archive-modules.sgml
+++ b/doc/src/sgml/archive-modules.sgml
@@ -80,9 +80,9 @@ PostgreSQLは、継続的アーカイブのためのカスタムモジュール�
    return value needs to be of server lifetime, which is typically achieved by
    defining it as a <literal>static const</literal> variable in global scope.
 -->
-アーカイブ・ライブラリは、<xref linkend="guc-archive-library"/>の名前をライブラリ・ベース名とする共有ライブラリを動的にロードすることによってロードされます。
+アーカイブライブラリは、<xref linkend="guc-archive-library"/>の名前をライブラリ・ベース名とする共有ライブラリを動的にロードすることによってロードされます。
 通常のライブラリ検索パスを使用してライブラリが検索されます。
-必要なアーカイブ・モジュール・コールバックを提供し、ライブラリが実際にアーカイブ・モジュールであることを示すには、<function>_PG_archive_module_init</function>という名前の関数を提供する必要があります。
+必要なアーカイブモジュールコールバックを提供し、ライブラリが実際にアーカイブモジュールであることを示すには、<function>_PG_archive_module_init</function>という名前の関数を提供する必要があります。
 関数の結果は、コアコードがアーカイブモジュールを利用するために必要なすべての情報を含む<structname>ArchiveModuleCallbacks</structname>型の構造体へのポインタである必要があります。
 戻り値は、サーバのライフタイムである必要があります。これは、通常、グローバルスコープで<literal>static const</literal>変数として定義することによって達成されます。
 

--- a/doc/src/sgml/backup.sgml
+++ b/doc/src/sgml/backup.sgml
@@ -1024,10 +1024,10 @@ test ! -f /mnt/server/archivedir/00000001000000A900000065 &amp;&amp; cp pg_wal/0
     useful server resources.  For more information about archive modules, see
     <xref linkend="archive-modules"/>.
 -->
-アーカイブするための別の方法は、<varname>archive_library</varname>としてカスタム・アーカイブ・モジュールを使用することです。
+アーカイブするための別の方法は、<varname>archive_library</varname>としてカスタムアーカイブモジュールを使用することです。
 このようなモジュールは<literal>C</literal>で記述されているため、独自のモジュールを作成するには、シェル・コマンドを記述するよりもかなり多くの労力が必要になる場合があります。
-しかし、アーカイブ・モジュールはシェルを介したアーカイブよりもパフォーマンスが高く、多くの有用なサーバー・リソースにアクセスできます。
-アーカイブ・モジュールの詳細は<xref linkend="archive-modules"/>を参照してください。
+しかし、アーカイブモジュールはシェルを介したアーカイブよりもパフォーマンスが高く、多くの有用なサーバー・リソースにアクセスできます。
+アーカイブモジュールの詳細は<xref linkend="archive-modules"/>を参照してください。
    </para>
 
    <para>


### PR DESCRIPTION
「アーカイブ・モジュール」など「アーカイブ」の前後に「・」があるものについて、「・」を削除しました。

例えば「アーカイブ・モジュール」だと「アーカイブモジュール」と「・」がない方が多数派でしたので。