### PR TITLE
deleteとupdateの翻訳を原文に沿うように修正

### DIFF
--- a/doc/src/sgml/ref/delete.sgml
+++ b/doc/src/sgml/ref/delete.sgml
@@ -282,7 +282,7 @@ DELETE <replaceable class="parameter">count</replaceable>
 -->
 <replaceable class="parameter">count</replaceable>は削除した行数です。
 この数は、<literal>BEFORE DELETE</literal>トリガによって削除が抑止された場合、<replaceable class="parameter">condition</replaceable>に合致した行より少なくなる可能性があることに注意してください。
-<replaceable class="parameter">count</replaceable>が0の場合、<replaceable class="parameter">condition</replaceable>を満たす行が存在しなかったことを示します
+<replaceable class="parameter">count</replaceable>が0の場合、問い合わせによって行が削除されなかったことを示します
 （これはエラーとはみなされません）。
   </para>
 
@@ -334,7 +334,7 @@ DELETE FROM films
    In some cases the join style is easier to write or faster to
    execute than the sub-select style.
 -->
-副問い合わせ形式より結合形式の方が書き易い、あるいは、実行が速くなることがあります。
+副SELECT形式より結合形式の方が書き易い、あるいは、実行が速くなることがあります。
   </para>
  </refsect1>
 

--- a/doc/src/sgml/ref/delete.sgml
+++ b/doc/src/sgml/ref/delete.sgml
@@ -282,7 +282,7 @@ DELETE <replaceable class="parameter">count</replaceable>
 -->
 <replaceable class="parameter">count</replaceable>は削除した行数です。
 この数は、<literal>BEFORE DELETE</literal>トリガによって削除が抑止された場合、<replaceable class="parameter">condition</replaceable>に合致した行より少なくなる可能性があることに注意してください。
-<replaceable class="parameter">count</replaceable>が0の場合、問い合わせによって行が削除されなかったことを示します
+<replaceable class="parameter">count</replaceable>が0の場合、問い合わせによって削除された行がなかったことを示します
 （これはエラーとはみなされません）。
   </para>
 

--- a/doc/src/sgml/ref/update.sgml
+++ b/doc/src/sgml/ref/update.sgml
@@ -354,7 +354,7 @@ UPDATE <replaceable class="parameter">count</replaceable>
 -->
 <replaceable class="parameter">count</replaceable>は、合致したが変更されなかった行を含む、更新された行数です。
 この数は、<literal>BEFORE UPDATE</literal>トリガにより更新が抑止された場合、<replaceable class="parameter">condition</replaceable>に合致した行より少なくなる可能性があることに注意してください。
-<replaceable class="parameter">count</replaceable>が0の場合、問い合わせによって行が更新されなかったことを示します
+<replaceable class="parameter">count</replaceable>が0の場合、問い合わせによって更新された行がなかったことを示します
 （これはエラーとはみなされません）。
   </para>
 

--- a/doc/src/sgml/ref/update.sgml
+++ b/doc/src/sgml/ref/update.sgml
@@ -352,9 +352,9 @@ UPDATE <replaceable class="parameter">count</replaceable>
    <replaceable class="parameter">count</replaceable> is 0, no rows were
    updated by the query (this is not considered an error).
 -->
-<replaceable class="parameter">count</replaceable>は、合致したが変更されなかった行を含む、更新された行数を意味します。
-<literal>BEFORE UPDATE</literal>トリガにより更新が抑制された場合に、<replaceable class="parameter">condition</replaceable>に合致した行数より少なくなる可能性があることに注意してください。
-<replaceable class="parameter">count</replaceable>が0の場合は<replaceable class="parameter">condition</replaceable>に一致する行がなかったことを意味します
+<replaceable class="parameter">count</replaceable>は、合致したが変更されなかった行を含む、更新された行数です。
+この数は、<literal>BEFORE UPDATE</literal>トリガにより更新が抑止された場合、<replaceable class="parameter">condition</replaceable>に合致した行より少なくなる可能性があることに注意してください。
+<replaceable class="parameter">count</replaceable>が0の場合、問い合わせによって行が更新されなかったことを示します
 （これはエラーとはみなされません）。
   </para>
 


### PR DESCRIPTION
countが0の場合の説明が条件を満たすではなく、結果に対してなので
原文に沿うように修正。
updateとdeleteの類似文を同じ書き方になるように修正。
sub-selectの修正漏れを修正