### PR TITLE
fix translation of 'exclamation mark'

### DIFF
--- a/doc/src/sgml/isn.sgml
+++ b/doc/src/sgml/isn.sgml
@@ -464,7 +464,7 @@ weakモードの現在の状態を返します。
    the <function>is_valid</function> function and cleared with the
    <function>make_valid</function> function.
 -->
-weakモードを使用して無効な番号をテーブルに挿入する時、番号は修正されたチェックディジット付きで挿入されますが、最後にイクスクラメーション印（<literal>!</literal>）付きで、例えば<literal>0-11-000322-5!</literal>と表示されます。
+weakモードを使用して無効な番号をテーブルに挿入する時、番号は修正されたチェックディジット付きで挿入されますが、最後に感嘆符（<literal>!</literal>）付きで、例えば<literal>0-11-000322-5!</literal>と表示されます。
 この無効印は<function>is_valid</function>関数を使って検査することができ、また、 <function>make_valid</function>関数で消去することができます。
   </para>
 


### PR DESCRIPTION
元の訳は流石に、ねぇ。
（直後に記号が書いてあるので誤解は生じないとは思いますが、、、、）