### PR TITLE
fix translation of 'question mark'

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -22221,7 +22221,7 @@ $.track.segments.size()
    a question mark and provides a condition in parentheses:
 -->
 パスを定義する際にはSQLの<literal>WHERE</literal>節のように働く一つ以上の<firstterm>フィルター式</firstterm>が利用できます。
-フィルター式はクェスチョンマークで始まり、カッコ内に条件を記述します。
+フィルター式は疑問符で始まり、カッコ内に条件を記述します。
 
 <programlisting>
 ? (<replaceable>condition</replaceable>)

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -2283,7 +2283,7 @@ $.track.segments.size()
    a question mark and provides a condition in parentheses:
 -->
 パスを定義する際にはSQLの<literal>WHERE</literal>節のように働く一つ以上の<firstterm>フィルター式</firstterm>が利用できます。
-フィルター式はクェスチョンマークで始まり、カッコ内に条件を記述します。
+フィルター式は疑問符で始まり、カッコ内に条件を記述します。
 
 <programlisting>
 ? (<replaceable>condition</replaceable>)

--- a/doc/src/sgml/ref/ecpg-ref.sgml
+++ b/doc/src/sgml/ref/ecpg-ref.sgml
@@ -261,7 +261,7 @@ libecpgはプリペアド文のキャッシュを保持し、再実行される�
          Allow question mark as placeholder for compatibility reasons.
          This used to be the default long ago.
 -->
-互換性のためにクエスチョンマークをプレースホルダとして許します。
+互換性のために疑問符をプレースホルダとして許します。
 これは大昔にデフォルトでした。
          </para>
          </listitem>


### PR DESCRIPTION
question markの訳が
- クェスチョンマーク
- クエスチョンマーク

でぶれていたのですが、「疑問符」にすれば問題解決！ということで。

ecpg.sgmlでも「疑問符」としているので整合性は取れていると思います。