### PR TITLE
マッチ度文と機械翻訳文の追加

### DIFF
--- a/doc/src/sgml/bgworker.sgml
+++ b/doc/src/sgml/bgworker.sgml
@@ -278,6 +278,7 @@ Windowsの（どこか他の場所で<literal>EXEC_BACKEND</literal>が定義さ
 それ以外の場合は、<literal>MyProcPid</literal>で初期化する必要があります。
   </para>
 
+<!--
   <para>Once running, the process can connect to a database by calling
    <function>BackgroundWorkerInitializeConnection(<parameter>char *dbname</parameter>, <parameter>char *username</parameter>, <parameter>uint32 flags</parameter>)</function> or
    <function>BackgroundWorkerInitializeConnectionByOid(<parameter>Oid dboid</parameter>, <parameter>Oid useroid</parameter>, <parameter>uint32 flags</parameter>)</function>.
@@ -295,6 +296,24 @@ Windowsの（どこか他の場所で<literal>EXEC_BACKEND</literal>が定義さ
    role used to connect to databases.
    A background worker can only call one of these two functions, and only
    once.  It is not possible to switch databases.
+-->
+  <para>
+《マッチ度[83.491600]》ひとたび実行すると、このプロセスは<function>BackgroundWorkerInitializeConnection(<parameter>char *dbname</parameter>, <parameter>char *username</parameter>, <parameter>uint32 flags</parameter>)</function>または<function>BackgroundWorkerInitializeConnectionByOid(<parameter>Oid dboid</parameter>, <parameter>Oid useroid</parameter>, <parameter>uint32 flags</parameter>)</function>を呼び出すことによって、データベースに接続できます。
+これはプロセスに<literal>SPI</literal>インタフェースを使用してのトランザクションとクエリの実行を許します。
+もし、<varname>dbname</varname>がNULLであった場合、または<varname>dboid</varname>が<literal>InvalidOid</literal>であった場合には、そのセッションは特定のデータベースに接続しません。しかし、共有カタログにはアクセス出来ます。
+もし、<varname>username</varname>がNULLの場合、または<varname>useroid</varname>が<literal>InvalidOid</literal>の場合には、そのプロセスは<command>initdb</command>時に作成されたスーパーユーザとして実行されます。
+<varname>flags</varname>として<literal>BGWORKER_BYPASS_ALLOWCONN</literal>が設定されている場合、データベースへ接続する際のユーザ接続を許可しない制約を回避することが出来ます。
+バックグラウンドワーカーはこれら２つの関数をどちらかを一度だけ呼ぶことが出来ます。
+データベースを切り替えることができません。
+  </para>
+《機械翻訳》<para>実行後、プロセスは<function>BackgroundWorkerInitializeConnection（<parameter>char*dbname</parameter>,<parameter>char*username</parameter>,<parameter>uint32 flags</parameter></function>または<function>BackgroundWorkerInitializeConnectionByOid(<parameter>データベースdboid</parameter>,<parameter>oid useroid</parameter>,<parameter>uint32 flags</parameter>）</function>を呼び出すことで、oidに接続できます。
+これにより、プロセスは<literal>SPI</literal>インタフェースを使用してトランザクションとクエリを実行できるようになります。
+<varname>dbname</varname>がnull、または<varname>dboid</varname>が<literal>InvalidOid</literal>の場合、セッションは特定のデータベースに接続されていませんが、共有カタログにはアクセスできます。
+<varname>username</varname>がnullまたは<varname>useroid</varname>が<literal>InvalidOid</literal>の場合、プロセスは<command>initdb</command>時に作成されたスーパーユーザとして実行されます。
+<literal>BGWORKER_バイパス_ALLOWCONN</literal>を<varname>flags</varname>として指定すると、制限をバイパスして、ユーザ接続を許可していないデータベースに接続できます。
+<literal>BGWORKER_バイパス_ROLELOGINCHECK</literal>が<varname>flags</varname>として指定されている場合、データベースへの接続に使用されるログインのチェックをバイパスすることができます。
+ロールバックグラウンドワーカーは、これら2つの機能のうちの1つを1回だけ呼び出しできます。
+データベースをスイッチすることはできません。
   </para>
 
   <para>

--- a/doc/src/sgml/bgworker.sgml
+++ b/doc/src/sgml/bgworker.sgml
@@ -305,8 +305,7 @@ Windowsの（どこか他の場所で<literal>EXEC_BACKEND</literal>が定義さ
 <varname>flags</varname>として<literal>BGWORKER_BYPASS_ALLOWCONN</literal>が設定されている場合、データベースへ接続する際のユーザ接続を許可しない制約を回避することが出来ます。
 バックグラウンドワーカーはこれら２つの関数をどちらかを一度だけ呼ぶことが出来ます。
 データベースを切り替えることができません。
-  </para>
-《機械翻訳》<para>実行後、プロセスは<function>BackgroundWorkerInitializeConnection（<parameter>char*dbname</parameter>,<parameter>char*username</parameter>,<parameter>uint32 flags</parameter></function>または<function>BackgroundWorkerInitializeConnectionByOid(<parameter>データベースdboid</parameter>,<parameter>oid useroid</parameter>,<parameter>uint32 flags</parameter>）</function>を呼び出すことで、oidに接続できます。
+《機械翻訳》実行後、プロセスは<function>BackgroundWorkerInitializeConnection（<parameter>char*dbname</parameter>,<parameter>char*username</parameter>,<parameter>uint32 flags</parameter></function>または<function>BackgroundWorkerInitializeConnectionByOid(<parameter>データベースdboid</parameter>,<parameter>oid useroid</parameter>,<parameter>uint32 flags</parameter>）</function>を呼び出すことで、oidに接続できます。
 これにより、プロセスは<literal>SPI</literal>インタフェースを使用してトランザクションとクエリを実行できるようになります。
 <varname>dbname</varname>がnull、または<varname>dboid</varname>が<literal>InvalidOid</literal>の場合、セッションは特定のデータベースに接続されていませんが、共有カタログにはアクセスできます。
 <varname>username</varname>がnullまたは<varname>useroid</varname>が<literal>InvalidOid</literal>の場合、プロセスは<command>initdb</command>時に作成されたスーパーユーザとして実行されます。

--- a/doc/src/sgml/docguide.sgml
+++ b/doc/src/sgml/docguide.sgml
@@ -633,8 +633,11 @@ LOGLEVEL=-Dorg.apache.commons.logging.simplelog.defaultlog=WARN
 <screen>
 <prompt>build$ </prompt><userinput>ninja html</userinput>
 </screen>
+<!--
     For a list of other documentation targets see
     <xref linkend="targets-meson-documentation"/>.
+-->
+《機械翻訳》他のドキュメントのターゲットのリストについては<xref linkend="targets-meson-documentation"/>を参照してください。
 
 <!--
     The output appears in the

--- a/doc/src/sgml/monitoring.sgml
+++ b/doc/src/sgml/monitoring.sgml
@@ -404,11 +404,15 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
 歪みを最小化するには、<varname>stats_fetch_consistency</varname>を<literal>snapshot</literal>に設定します。
 ただし、不要な統計データをキャッシュするためのメモリ使用量が増加します。逆に、統計が一度しかアクセスされないことがわかっている場合は、アクセスされた統計のキャッシュは不要であり、<varname>stats_fetch_consistency</varname>を<literal>none</literal>に設定することで回避できます。
 
+<!--
    You can invoke <function>pg_stat_clear_snapshot()</function> to discard the
    current transaction's statistics snapshot or cached values (if any).  The
    next use of statistical information will (when in snapshot mode) cause a
    new snapshot to be built or (when in cache mode) accessed statistics to be
    cached.
+-->
+《マッチ度[93.421053]》<function>pg_stat_clear_snapshot</function>()を呼び出して、現在のトランザクションの統計スナップショットまたはキャッシュされた値（もしあれば）を破棄することができます。
+次に統計情報を使用すると（スナップショットモードの場合）新しいスナップショットが作成され、（キャッシュモードの場合）アクセスされた統計がキャッシュされます。
   </para>
 
   <para>
@@ -695,10 +699,19 @@ WALアーカイバプロセスの活動状況に関する統計情報を1行の�
 
      <row>
       <entry><structname>pg_stat_checkpointer</structname><indexterm><primary>pg_stat_checkpointer</primary></indexterm></entry>
+<!--
       <entry>One row only, showing statistics about the
        checkpointer process's activity. See
        <link linkend="monitoring-pg-stat-checkpointer-view">
        <structname>pg_stat_checkpointer</structname></link> for details.
+-->
+      <entry>
+《マッチ度[74.271845]》
+WALアーカイバプロセスの活動状況に関する統計情報を1行のみで表示します。
+詳細については<link linkend="monitoring-pg-stat-archiver-view"><structname>pg_stat_archiver</structname></link>を参照してください。
+《機械翻訳》1つの行のみ。
+チェックポインタ統計処理の活動についてプロセスを表示します。
+詳細は<link linkend="monitoring-pg-stat-checkpointer-view"><structname>pg_stat_checkpointer</structname></link>を参照してください。
      </entry>
      </row>
 
@@ -1597,13 +1610,13 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
      </row>
      <row>
       <entry><literal>InjectionPoint</literal></entry>
-      <entry>
 <!--
       <entry>The server process is waiting for an injection point to reach an
        outcome defined in a test.  See
        <xref linkend="xfunc-addin-injection-points"/> for more details.  This
        type has no predefined wait points.
 -->
+      <entry>
 《機械翻訳》サーバプロセスは、インジェクションポイントがテストで定義された結果に達するのを待機しています。
 詳細は、<xref linkend="xfunc-addin-injection-points"/>を参照してください。
 このタイプには事前定義された待機ポイントはありません。
@@ -9539,6 +9552,7 @@ arg2は書き出されるであろうと見積もられたバッファ数(<liter
     <row>
      <entry><literal>buffer-extend-start</literal></entry>
      <entry><literal>(ForkNumber, BlockNumber, Oid, Oid, Oid, int, unsigned int)</literal></entry>
+<!--
      <entry>Probe that fires when a relation extension starts.
        arg0 contains the fork to be extended. arg1, arg2, and arg3 contain the
        tablespace, database, and relation OIDs identifying the relation.  arg4
@@ -9546,10 +9560,26 @@ arg2は書き出されるであろうと見積もられたバッファ数(<liter
        local buffer, or <symbol>INVALID_PROC_NUMBER</symbol> (-1) for a shared
        buffer. arg5 is the number of blocks the caller would like to extend
        by.</entry>
+-->
+      <entry>
+《マッチ度[84.323040]》
+リレーションの拡張が開始された時を捕捉するプローブです。
+arg0は拡張されるフォークを示します。
+arg1、arg2、arg3は対象のリレーションを識別するテーブル空間、データベース、そしてリレーションのOIDです。
+arg4はローカルバッファのために一時的なリレーションを作成したバックエンドのID、<symbol>InvalidBackendId</symbol>(-1)であれは共有バッファを指します。
+arg5は呼び出し元が拡張したいブロックの数です。
+《機械翻訳》プローブextensionが開始されたときに起動するリレーション。
+arg0包含フォークが拡張になります。
+arg1、arg2、およびarg3には、リレーションを識別するテーブルスペース、データベース、およびリレーションのOIDが含まれます。
+arg4は、ローカルバッファの一時的リレーションを作成したバックエンドのIDです。
+または、共有バッファの場合は<symbol>INVALID_PROC_NUMBER</symbol>(-1)です。
+arg5は、呼び出し元が拡張するブロック数です。
+      </entry>
     </row>
     <row>
      <entry><literal>buffer-extend-done</literal></entry>
      <entry><literal>(ForkNumber, BlockNumber, Oid, Oid, Oid, int, unsigned int, BlockNumber)</literal></entry>
+<!--
      <entry>Probe that fires when a relation extension is complete.
        arg0 contains the fork to be extended. arg1, arg2, and arg3 contain the
        tablespace, database, and relation OIDs identifying the relation.  arg4
@@ -9560,21 +9590,53 @@ arg2は書き出されるであろうと見積もられたバッファ数(<liter
        <literal>buffer-extend-start</literal> due to resource
        constraints. arg6 contains the BlockNumber of the first new
        block.</entry>
+-->
+     <entry>
+《マッチ度[85.051546]》
+リレーションの拡張が完了した時を捕捉するプローブです。
+arg0は拡張されるフォークを示します。
+arg1、arg2、arg3は対象のリレーションを識別するテーブル空間、データベース、そしてリレーションのOIDです。
+arg4はローカルバッファのために一時的なリレーションを作成したバックエンドのID、<symbol>InvalidBackendId</symbol>(-1)であれは共有バッファを指します。
+arg5はリレーションが拡張されたブロック数です。これはリソース制約により<literal>buffer-extend-start</literal>で指定された数より少ない場合があります。
+arg6は最初の新しいブロックのブロック番号です。
+《機械翻訳》リレーションextensionが完成したときに点火するプローブ。
+arg0包含フォークを拡張にします。
+arg1、arg2、およびarg3には、リレーションを識別するテーブルスペース、データベース、およびリレーションのOIDが含まれます。
+arg4は、バックエンドの一時的リレーションを作成したローカルバッファのIDです。
+共有バッファの場合は、<symbol>INVALID_PROC_NUMBER</symbol>(-1)です。
+arg5は、リレーションが拡張されたブロックの数です。
+これは、リソースの制約により、<literal>より小さい-拡張-バッファ</literal>内のスタートの数になる可能性があります。
+arg6包含最初の新しいブロックのブロック番号です。
+      </entry>
     </row>
     <row>
      <entry><literal>buffer-read-start</literal></entry>
      <entry><literal>(ForkNumber, BlockNumber, Oid, Oid, Oid, int)</literal></entry>
+<!--
      <entry>Probe that fires when a buffer read is started.
       arg0 and arg1 contain the fork and block numbers of the page.
       arg2, arg3, and arg4 contain the tablespace, database, and relation OIDs
       identifying the relation.
       arg5 is the ID of the backend which created the temporary relation for a
       local buffer, or <symbol>INVALID_PROC_NUMBER</symbol> (-1) for a shared buffer.
+-->
+     <entry>
+《マッチ度[81.521739]》
+バッファ読み込みの開始を捕捉するプローブです。
+arg0とarg1は読み込みページのフォーク番号とブロック番号です。
+arg2、arg3、arg4は対象のリレーションを識別するテーブル空間、データベース、そしてリレーションのOIDです。
+arg5は一時テーブルをローカルバッファに作成していればそのバックエンドのIDであり、<symbol>InvalidBackendId</symbol>(-1)であれは共有バッファを指します。
+《機械翻訳》プローブの読み取りが開始されたときに起動するバッファ。
+arg0とarg1には、フォークのページ番号とブロック番号が含まれます。
+arg2、arg3、およびarg4には、テーブルスペースを識別するリレーション、データベース、およびリレーションのOIDが含まれます。
+arg5は、ローカルバッファの一時的リレーションを作成したバックエンドのIDです。
+共有バッファの場合は<symbol>INVALID_PROC_NUMBER</symbol>(-1)です。
       </entry>
     </row>
     <row>
      <entry><literal>buffer-read-done</literal></entry>
      <entry><literal>(ForkNumber, BlockNumber, Oid, Oid, Oid, int, bool)</literal></entry>
+<!--
      <entry>Probe that fires when a buffer read is complete.
       arg0 and arg1 contain the fork and block numbers of the page.
       arg2, arg3, and arg4 contain the tablespace, database, and relation OIDs
@@ -9582,6 +9644,21 @@ arg2は書き出されるであろうと見積もられたバッファ数(<liter
       arg5 is the ID of the backend which created the temporary relation for a
       local buffer, or <symbol>INVALID_PROC_NUMBER</symbol> (-1) for a shared buffer.
       arg6 is true if the buffer was found in the pool, false if not.</entry>
+-->
+     <entry>
+《マッチ度[86.621315]》
+バッファ読み込みの終了を捕捉するプローブです。
+arg0とarg1はそのページのフォーク番号とブロック番号です。
+arg2、arg3、arg4は対象のリレーションを識別するテーブル空間、データベース、そしてリレーションのOIDです。
+arg5はローカルバッファのために一時的なリレーションを作成したバックエンドのID、<symbol>InvalidBackendId</symbol>(-1)であれは共有バッファを指します。
+arg6はtrueならばバッファがプール内にある、falseはプール内に無かったことを示します。
+《機械翻訳》プローブの読み込みが完了したときに起動するバッファです。
+arg0とarg1には、フォークのページ番号とブロック番号が格納されます。
+arg2、arg3、およびarg4には、テーブルスペースを識別するリレーション、データベース、およびリレーションのOIDが格納されます。
+arg5には、ローカルバッファの一時的リレーションを作成したバックエンドのID、または共有バッファの場合は<symbol>INVALID_PROC_NUMBER</symbol>(-1)が格納されます。
+arg6には、がで見つかった場合は真、見つからなかった場合はが格納されます。
+バッファプール偽
+     </entry>
     </row>
     <row>
      <entry><literal>buffer-flush-start</literal></entry>
@@ -9661,16 +9738,31 @@ arg1は情報フラグです。
     <row>
      <entry><literal>smgr-md-read-start</literal></entry>
      <entry><literal>(ForkNumber, BlockNumber, Oid, Oid, Oid, int)</literal></entry>
+<!--
      <entry>Probe that fires when beginning to read a block from a relation.
       arg0 and arg1 contain the fork and block numbers of the page.
       arg2, arg3, and arg4 contain the tablespace, database, and relation OIDs
       identifying the relation.
       arg5 is the ID of the backend which created the temporary relation for a
       local buffer, or <symbol>INVALID_PROC_NUMBER</symbol> (-1) for a shared buffer.</entry>
+-->
+     <entry>
+《マッチ度[86.513995]》
+リレーションからのブロック読み込みの開始を捕捉するプローブ。
+arg0とarg1はそのページのフォーク番号とブロック番号です。
+arg2、arg3、arg4は対象のリレーションを識別するテーブル空間、データベース、そしてリレーションのOIDです。
+arg5は一時テーブルをローカルバッファに作成していればそのバックエンドのIDであり、<symbol>InvalidBackendId</symbol>(-1)であれは共有バッファを指します。
+《機械翻訳》リレーションからプローブの読み込みを開始したときに起動するブロックです。
+arg0とarg1には、そのページのフォーク番号とブロック番号が格納されます。
+arg2、arg3、およびarg4には、そのリレーションを識別するテーブルスペース、データベース、およびリレーションのOIDが格納されます。
+arg5には、ローカルバッファの一時的リレーションを作成したバックエンドのID、または<symbol>INVALID_PROC_NUMBER</symbol>(-1)が格納されます。
+バッファ
+     </entry>
     </row>
     <row>
      <entry><literal>smgr-md-read-done</literal></entry>
      <entry><literal>(ForkNumber, BlockNumber, Oid, Oid, Oid, int, int, int)</literal></entry>
+<!--
      <entry>Probe that fires when a block read is complete.
       arg0 and arg1 contain the fork and block numbers of the page.
       arg2, arg3, and arg4 contain the tablespace, database, and relation OIDs
@@ -9679,20 +9771,49 @@ arg1は情報フラグです。
       local buffer, or <symbol>INVALID_PROC_NUMBER</symbol> (-1) for a shared buffer.
       arg6 is the number of bytes actually read, while arg7 is the number
       requested (if these are different it indicates a short read).</entry>
+-->
+     <entry>
+《マッチ度[85.177866]》
+ブロックの読み込み終了を捕捉するプローブです。
+arg0とarg1はそのページのフォーク番号とブロック番号です。
+arg2、arg3、arg4は対象のリレーションを識別するテーブル空間、データベース、そしてリレーションのOIDです。
+arg5は一時テーブルをローカルバッファに作成していればそのバックエンドのIDであり、<symbol>InvalidBackendId</symbol>(-1)であれは共有バッファを指します。
+arg6は実際に読み込んだバイト数、arg7はリクエストされた読み込みバイト数です(もし、これらに差異があった場合、何らかの問題があることを示します)。
+《機械翻訳》プローブの読み込みが完了したときに起動するブロックです。
+arg0とarg1には、フォークのページ番号とブロック番号が格納されます。
+arg2、arg3、およびarg4には、テーブルスペースを識別するリレーション、データベース、およびリレーションのOIDが格納されます。
+arg5には、ローカルバッファの一時的リレーションを作成したバックエンドのID、または<symbol>INVALID_PROC_NUMBER</symbol>(-1)には共有バッファが格納されます。
+arg6には実際に読み込まれたバイト数、arg7には要求されたバイト数が格納されます（これらが異なる場合は、短い読み込みを意味します）。
+     </entry>
     </row>
     <row>
      <entry><literal>smgr-md-write-start</literal></entry>
      <entry><literal>(ForkNumber, BlockNumber, Oid, Oid, Oid, int)</literal></entry>
+<!--
      <entry>Probe that fires when beginning to write a block to a relation.
       arg0 and arg1 contain the fork and block numbers of the page.
       arg2, arg3, and arg4 contain the tablespace, database, and relation OIDs
       identifying the relation.
       arg5 is the ID of the backend which created the temporary relation for a
       local buffer, or <symbol>INVALID_PROC_NUMBER</symbol> (-1) for a shared buffer.</entry>
+-->
+     <entry>
+《マッチ度[86.479592]》
+リレーションへのブロック書き出しの開始を捕捉するプローブです。
+arg0とarg1はそのページのフォーク番号とブロック番号です。
+arg2、arg3、arg4は対象のリレーションを識別するテーブル空間、データベース、そしてリレーションのOIDです。
+arg5は一時テーブルをローカルバッファに作成していればそのバックエンドのIDであり、<symbol>InvalidBackendId</symbol>(-1)であれは共有バッファを指します。
+《機械翻訳》プローブへのブロックの書き込みを開始したときに起動するリレーション。
+arg0とarg1には、そのページのフォーク番号とブロック番号が格納されます。
+arg2、arg3、およびarg4には、そのリレーションを識別するテーブルスペース、データベース、およびリレーションのOIDが格納されます。
+arg5には、ローカルバッファの一時的リレーションを作成したバックエンドのID、または<symbol>INVALID_PROC_NUMBER</symbol>(-1)が格納されます。
+バッファ
+     </entry>
     </row>
     <row>
      <entry><literal>smgr-md-write-done</literal></entry>
      <entry><literal>(ForkNumber, BlockNumber, Oid, Oid, Oid, int, int, int)</literal></entry>
+<!--
      <entry>Probe that fires when a block write is complete.
       arg0 and arg1 contain the fork and block numbers of the page.
       arg2, arg3, and arg4 contain the tablespace, database, and relation OIDs
@@ -9701,6 +9822,21 @@ arg1は情報フラグです。
       local buffer, or <symbol>INVALID_PROC_NUMBER</symbol> (-1) for a shared buffer.
       arg6 is the number of bytes actually written, while arg7 is the number
       requested (if these are different it indicates a short write).</entry>
+-->
+     <entry>
+《マッチ度[85.127202]》
+ブロックの書き出し終了を捕捉するプローブです。
+arg0とarg1はそのページのフォーク番号とブロック番号です。
+arg2、arg3、arg4は対象のリレーションを識別するテーブル空間、データベース、そしてリレーションのOIDです。
+arg5は一時テーブルをローカルバッファに作成していればそのバックエンドのIDであり、<symbol>InvalidBackendId</symbol>(-1)であれは共有バッファを指します。
+arg6は実際に書き出したバイト数、arg7はリクエストされた書き出しバイト数です(もし、これらに差異があった場合、何らかの問題があることを示します)。
+《機械翻訳》（プローブの書き込みが完了したときに起動するブロック。
+arg0とarg1には、ページのフォーク番号とブロック番号が含まれます。
+arg2、arg3、およびarg4には、リレーションを識別するテーブルスペース、データベース、およびリレーションのOIDが含まれます。
+arg5は、バックエンドの一時的リレーションを作成したローカルバッファのIDです。
+共有バッファの場合は<symbol>INVALID_PROC_NUMBER</symbol>(-1）です。
+arg6は実際に書き込まれたバイト数であり、arg7は要求されたバイト数ですこれらが異なる場合は、短い書き込みを示します。
+     </entry>
     </row>
     <row>
      <entry><literal>sort-start</literal></entry>


### PR DESCRIPTION
翻訳範囲でミスっていた箇所を手動で指定して入れ直しました。