### PR TITLE
更新されてなかった訳の修正

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -8118,7 +8118,7 @@ regexp_substr('ABCDEFGHI', '(c..)(...)', 1, 1, 'i', 2)
        <replaceable>bound</replaceable> (see below) </entry>
 -->
        <entry>直後に数字以外がある場合、左中括弧<literal>{</literal>にマッチします。
-直後に数字が続く場合、<replaceable>bound</replaceable>（後述）の始まりです。</entry>
+直後に数字が続く場合、<replaceable>バウンド</replaceable>（後述）の始まりです。</entry>
        </row>
 
        <row>
@@ -9761,6 +9761,7 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
 <literal>$</literal>は、REの末尾にある場合や括弧内の副式の末尾の場合を除き、普通の文字です。
 また、<literal>*</literal>はREの先頭にある場合や括弧内の副式の先頭にある場合には普通の文字になります（その前に<literal>^</literal>が付いている可能性もあります）。
 最後に、1桁の後方参照を使用することができ、また、BREにおいては、<literal>\&lt;</literal>と<literal>\&gt;</literal>はそれぞれ<literal>[[:&lt;:]]</literal>と<literal>[[:&gt;:]]</literal>と同義です。
+その他のエスケープはBREでは使用できません。
    </para>
    </sect3>
 
@@ -24449,8 +24450,7 @@ nullあるいは空の配列の結合は無処理です。そうでない場合�
         is <literal>NULL</literal>; if the value is not found in the array, an
         empty array is returned.
 -->
-2番目の引数が配列に現れるすべての添字を配列で返します。存在しなければ<literal>NULL</literal>を返します。
-3番目の引数が与えられるとその添字から検索が始まります。
+2番目の引数が最初の引数として与えられた配列に現れるすべての添字を配列で返します。
 配列は一次元でなければなりません。
 比較は<literal>IS NOT DISTINCT FROM</literal>の意味論で行われるので、<literal>NULL</literal>を検索することができます。
 配列が<literal>NULL</literal>のときのみ<literal>NULL</literal>が返ります。
@@ -29951,7 +29951,7 @@ SELECT * FROM pg_ls_dir('.') WITH ORDINALITY AS t(ls,n);
         be used for any tables or other named objects that are created without
         specifying a target schema.
 -->
-サーチパスの先頭にあるスキーマの名前を返します。（サーチパスが空ならNULL値を返します。）
+検索パスの先頭にあるスキーマの名前を返します。（検索パスが空ならNULL値を返します。）
 これはターゲットスキーマを指定せずに作成されるすべてのテーブルあるいは名前付きのオブジェクトで使われるスキーマです。
        </para></entry>
       </row>
@@ -37072,7 +37072,6 @@ SELECT pg_size_pretty(sum(pg_relation_size(relid))) AS total_size
 これらの関数の一部はオプションで<parameter>missing_ok</parameter>パラメータをとり、ファイルまたはディレクトリが存在しない場合の動作を指定できます。
 <literal>true</literal>の場合、関数は<literal>NULL</literal>を返すか、適切な場合には空の結果集合を返します。
 <literal>false</literal>の場合はエラーが発生します。
-デフォルトは<literal>false</literal>です。
 （<quote>ファイルが見つかりません</quote>以外の失敗条件は、どのケースでもエラーとして報告されます。）
 デフォルトは<literal>false</literal>です。
    </para>

--- a/doc/src/sgml/func1.sgml
+++ b/doc/src/sgml/func1.sgml
@@ -8049,7 +8049,7 @@ regexp_substr('ABCDEFGHI', '(c..)(...)', 1, 1, 'i', 2)
        <replaceable>bound</replaceable> (see below) </entry>
 -->
        <entry>直後に数字以外がある場合、左中括弧<literal>{</literal>にマッチします。
-直後に数字が続く場合、<replaceable>bound</replaceable>（後述）の始まりです。</entry>
+直後に数字が続く場合、<replaceable>バウンド</replaceable>（後述）の始まりです。</entry>
        </row>
 
        <row>
@@ -9692,6 +9692,7 @@ BREにおいては、<literal>|</literal>、<literal>+</literal>、<literal>?</l
 <literal>$</literal>は、REの末尾にある場合や括弧内の副式の末尾の場合を除き、普通の文字です。
 また、<literal>*</literal>はREの先頭にある場合や括弧内の副式の先頭にある場合には普通の文字になります（その前に<literal>^</literal>が付いている可能性もあります）。
 最後に、1桁の後方参照を使用することができ、また、BREにおいては、<literal>\&lt;</literal>と<literal>\&gt;</literal>はそれぞれ<literal>[[:&lt;:]]</literal>と<literal>[[:&gt;:]]</literal>と同義です。
+その他のエスケープはBREでは使用できません。
    </para>
    </sect3>
 

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -4511,8 +4511,7 @@ nullあるいは空の配列の結合は無処理です。そうでない場合�
         is <literal>NULL</literal>; if the value is not found in the array, an
         empty array is returned.
 -->
-2番目の引数が配列に現れるすべての添字を配列で返します。存在しなければ<literal>NULL</literal>を返します。
-3番目の引数が与えられるとその添字から検索が始まります。
+2番目の引数が最初の引数として与えられた配列に現れるすべての添字を配列で返します。
 配列は一次元でなければなりません。
 比較は<literal>IS NOT DISTINCT FROM</literal>の意味論で行われるので、<literal>NULL</literal>を検索することができます。
 配列が<literal>NULL</literal>のときのみ<literal>NULL</literal>が返ります。

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -1510,7 +1510,7 @@ SELECT * FROM pg_ls_dir('.') WITH ORDINALITY AS t(ls,n);
         be used for any tables or other named objects that are created without
         specifying a target schema.
 -->
-サーチパスの先頭にあるスキーマの名前を返します。（サーチパスが空ならNULL値を返します。）
+検索パスの先頭にあるスキーマの名前を返します。（検索パスが空ならNULL値を返します。）
 これはターゲットスキーマを指定せずに作成されるすべてのテーブルあるいは名前付きのオブジェクトで使われるスキーマです。
        </para></entry>
       </row>
@@ -8631,7 +8631,6 @@ SELECT pg_size_pretty(sum(pg_relation_size(relid))) AS total_size
 これらの関数の一部はオプションで<parameter>missing_ok</parameter>パラメータをとり、ファイルまたはディレクトリが存在しない場合の動作を指定できます。
 <literal>true</literal>の場合、関数は<literal>NULL</literal>を返すか、適切な場合には空の結果集合を返します。
 <literal>false</literal>の場合はエラーが発生します。
-デフォルトは<literal>false</literal>です。
 （<quote>ファイルが見つかりません</quote>以外の失敗条件は、どのケースでもエラーとして報告されます。）
 デフォルトは<literal>false</literal>です。
    </para>


### PR DESCRIPTION
func.sgmlではサーチパスは修正箇所だけで他は検索パスでした。
boundは後述と書いてありましたが、後述では「バウンド」と訳していました。
third argumentは別の箇所にありますが、修正箇所にはありませんでした。