### PR TITLE
consumerの訳を消費者に統一

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -6737,7 +6737,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
 物理レプリケーションスタンバイでは、<varname>primary_conninfo</varname>設定です。
 デフォルトは<xref linkend="guc-cluster-name"/>の設定で、さもなければ<literal>walreceiver</literal>です。
 論理レプリケーションでは、サブスクリプションの接続情報で設定でき、デフォルトはサブスクリプション名です。
-それ以外のレプリケーションストリームコンシューマーについては、それぞれのドキュメントをご覧ください。
+それ以外のレプリケーションストリームの消費者については、それぞれのドキュメントをご覧ください。
        </para>
        <para>
 <!--

--- a/doc/src/sgml/config1.sgml
+++ b/doc/src/sgml/config1.sgml
@@ -2582,7 +2582,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
 物理レプリケーションスタンバイでは、<varname>primary_conninfo</varname>設定です。
 デフォルトは<xref linkend="guc-cluster-name"/>の設定で、さもなければ<literal>walreceiver</literal>です。
 論理レプリケーションでは、サブスクリプションの接続情報で設定でき、デフォルトはサブスクリプション名です。
-それ以外のレプリケーションストリームコンシューマーについては、それぞれのドキュメントをご覧ください。
+それ以外のレプリケーションストリームの消費者については、それぞれのドキュメントをご覧ください。
        </para>
        <para>
 <!--

--- a/doc/src/sgml/logicaldecoding.sgml
+++ b/doc/src/sgml/logicaldecoding.sgml
@@ -16,7 +16,7 @@
    via SQL to external consumers.  This functionality can be used for a
    variety of purposes, including replication solutions and auditing.
 -->
-PostgreSQLは、SQLによって実行された更新結果を外部のコンシューマにストリーミングする基盤を提供しています。
+PostgreSQLは、SQLによって実行された更新結果を外部の消費者にストリーミングする基盤を提供しています。
 この機能は、レプリケーションソリューションや監査など、さまざまな目的に使用できます。
   </para>
 


### PR DESCRIPTION
consumersの訳にコンシューマとコンシューマーが一つづつありましたが、他は「消費者」だったので統一しました。