### PR TITLE
Translate create_subscription.sgml for PG17

### DIFF
--- a/doc/src/sgml/ref/create_subscription.sgml
+++ b/doc/src/sgml/ref/create_subscription.sgml
@@ -188,7 +188,7 @@ CREATE SUBSCRIPTION <replaceable class="parameter">subscription_name</replaceabl
           for examples.
 -->
 このオプションが<literal>false</literal>に設定されると接続が行われないため、テーブルはサブスクライブされません。
-レプリケーションを開始するには、レプリケーションスロットを手動で作成し、必要に応じてフェイルオーバーオプションを有効にしたうえで、サブスクリプションを有効にして、サブスクリプションをリフレッシュする必要があります。
+レプリケーションを開始するには、レプリケーションスロットを手動で作成し、必要に応じてfailoverオプションを有効にしたうえで、サブスクリプションを有効にして、サブスクリプションをリフレッシュする必要があります。
 例については<xref linkend="logical-replication-subscription-examples-deferred-slot"/>を参照してください。
          </para>
         </listitem>

--- a/doc/src/sgml/ref/create_subscription.sgml
+++ b/doc/src/sgml/ref/create_subscription.sgml
@@ -607,7 +607,7 @@ falseの場合、レプリケーションワーカーは各テーブルでその
           replication can be resumed from the new primary after failover.
           The default is <literal>false</literal>.
 -->
-フェイルオーバー後に新しいプライマリから論理レプリケーションを再開できるように、サブスクリプションに関連付けられたレプリケーションスロットが物理スタンバイと同期できるようにするかどうかを指定します。
+フェイルオーバー後に新しいプライマリから論理レプリケーションを再開できるように、サブスクリプションに関連付けられたレプリケーションスロットがスタンバイと同期できるようにするかどうかを指定します。
 デフォルトは<literal>false</literal>です。
          </para>
         </listitem>

--- a/doc/src/sgml/ref/create_subscription.sgml
+++ b/doc/src/sgml/ref/create_subscription.sgml
@@ -77,7 +77,7 @@ CREATE SUBSCRIPTION <replaceable class="parameter">subscription_name</replaceabl
    the <literal>pg_create_subscription</literal> role, as well as
    <literal>CREATE</literal> privileges on the current database.
 -->
-《マッチ度[93.264249]》サブスクリプションを作成するには、現在のデータベースに対する<literal>CREATE</literal>権限に加えて、<literal>pg_create_subscription</literal>ロールの権限が必要です。
+サブスクリプションを作成するには、現在のデータベースに対する<literal>CREATE</literal>権限に加えて、<literal>pg_create_subscription</literal>ロールの権限が必要です。
   </para>
 
   <para>
@@ -187,11 +187,8 @@ CREATE SUBSCRIPTION <replaceable class="parameter">subscription_name</replaceabl
           <xref linkend="logical-replication-subscription-examples-deferred-slot"/>
           for examples.
 -->
-《マッチ度[77.492877]》このオプションが<literal>false</literal>に設定されると接続が行われないため、テーブルはサブスクライブされません。
-レプリケーションを開始するには、レプリケーションスロットを手動で作成し、サブスクリプションを有効にして、サブスクリプションをリフレッシュする必要があります。
-例については<xref linkend="logical-replication-subscription-examples-deferred-slot"/>を参照してください。
-《機械翻訳》このオプションが<literal>false</literal>の場合は接続が行われないため、テーブルはサブスクライブされません。
-レプリケーションを開始するには、レプリケーションスロットを手動で作成し、必要に応じてフェイルオーバーを有効にし、サブスクリプションを有効にし、サブスクリプションを更新する必要があります。
+このオプションが<literal>false</literal>に設定されると接続が行われないため、テーブルはサブスクライブされません。
+レプリケーションを開始するには、レプリケーションスロットを手動で作成し、必要に応じてフェイルオーバーオプションを有効にしたうえで、サブスクリプションを有効にして、サブスクリプションをリフレッシュする必要があります。
 例については<xref linkend="logical-replication-subscription-examples-deferred-slot"/>を参照してください。
          </para>
         </listitem>
@@ -280,11 +277,10 @@ CREATE SUBSCRIPTION <replaceable class="parameter">subscription_name</replaceabl
           option is disabled or could be disabled for sync even when the
           subscription's <literal>failover</literal> option is enabled.
 -->
-《機械翻訳》<literal>slot_name</literal>を有効な名前に設定し、<literal>create_slot</literal>を偽に設定した場合、指定されたスロットの<literal>failover</literal>プロパティ値は、サブスクリプションで指定された対応する<literal>failover</literal>パラメータとは異なる可能性があります。
-スロットプロパティ<literal>failover</literal>がサブスクリプションの対応するパラメータと一致すること、およびその逆も常に確認してください。
-そうでない場合、パブリッシャ上のスロットは、これらのサブスクリプションオプションが示す動作とは異なる動作をする可能性があります。
-たとえば、サブスクリプションの<literal>failover</literal>オプションが無効になっている場合でも、パブリッシャ上のスロットはスタンバイに同期される可能性があります。
-また、サブスクリプションの<literal>failover</literal>オプションが有効になっている場合でも、同期に対して無効にされる可能性があります。
+<literal>slot_name</literal>に有効な名前を設定し、かつ<literal>create_slot</literal>をfalseに設定した場合、指定されたスロットに設定された<literal>failover</literal>の値はサブスクリプションで指定した<literal>failover</literal>パラメータの値と異なる場合があります。
+スロットの<literal>failover</literal>がサブスクリプションのパラメータと一致すること、およびその逆も常に確認してください。
+そうしないと、パブリッシャー上のスロットがこれらサブスクリプションオプションので指定されている内容とは異なる動作をする場合があります。
+例えば、サブスクリプションオプションの<literal>failover</literal>が無効になっていても、パブリッシャー上のスロットがスタンバイと同期されたり、逆にサブスクリプションオプションの<literal>failover</literal>が有効になっている場合でも、同期が行われなかったりする可能性があります。
          </para>
         </listitem>
        </varlistentry>
@@ -611,7 +607,7 @@ falseの場合、レプリケーションワーカーは各テーブルでその
           replication can be resumed from the new primary after failover.
           The default is <literal>false</literal>.
 -->
-《機械翻訳》フェイルオーバー後に新しいプライマリから論理レプリケーションを再開できるように、サブスクリプションに関連付けられたレプリケーションスロットをスタンバイに同期できるようにするかどうかを指定します。
+フェイルオーバー後に新しいプライマリから論理レプリケーションを再開できるように、サブスクリプションに関連付けられたレプリケーションスロットが物理スタンバイと同期できるようにするかどうかを指定します。
 デフォルトは<literal>false</literal>です。
          </para>
         </listitem>
@@ -706,7 +702,7 @@ falseの場合、レプリケーションワーカーは各テーブルでその
    would not be replicated using DML. See
    <xref linkend="logical-replication-subscription-examples"/> for examples.
 -->
-《マッチ度[94.514502]》パブリケーション内のテーブルに<literal>WHERE</literal>句がある場合、<replaceable class="parameter">expression</replaceable>が偽またはNULLと評価される行はパブリッシュされません。
+パブリケーション内のテーブルに<literal>WHERE</literal>句がある場合、<replaceable class="parameter">expression</replaceable>が偽またはNULLと評価される行はパブリッシュされません。
 サブスクリプションに、同じテーブルが異なる<literal>WHERE</literal>句でパブリッシュされた複数のパブリケーションがある場合、(パブリッシュ操作を参照する)式のいずれかが満たされると行がパブリッシュされます。
 <literal>WHERE</literal>句が異なる場合、パブリケーションのいずれかに<literal>WHERE</literal>句がないか(パブリッシュ操作を参照する)パブリケーションが<link linkend="sql-createpublication-params-for-all-tables"><literal>FOR ALL TABLES</literal></link>または<link linkend="sql-createpublication-params-for-tables-in-schema"><literal>FOR TABLES IN SCHEMA</literal></link>として宣言されている場合、行は他の式の定義に関係なく常にパブリッシュされます。
 サブスクライバーのバージョンが<productname>PostgreSQL</productname> 15より前の場合、最初のデータ同期フェーズでは行のフィルタリングは無視されます。


### PR DESCRIPTION
## 迷ったところ

以下の文章の`failover`の語訳に少し迷いました。

> To initiate replication, you must manually create the replication slot, enable
> the failover if required, enable the subscription, and refresh the subscription.

ここで言及しているのは、サーバを切り替える行為ではなく、新たに追加されたスロットおよびサブスクリプションオプションに関してです。
そのため「フェイルオーバーオプション」と訳しています。