### PR TITLE
update for 17.0 - part 2

### DIFF
--- a/src/backend/catalog/sql_features.txt.ja
+++ b/src/backend/catalog/sql_features.txt.ja
@@ -33,7 +33,7 @@ B128	ルーチン言語 SQL			YES
 B200	多相型テーブル関数(PTF)			NO	
 B201	2つ以上のPTFジェネリックテーブルパラメータ			NO	
 B202	PTFコパーティション			NO	
-B203	2つ以上のパーティション指定			NO	
+B203	2つ以上のコパーティション指定			NO	
 B204	PRUNE WHEN EMPTY			NO	
 B205	パススルー列			NO	
 B206	PTF記述子パラメータ			NO	
@@ -633,7 +633,7 @@ X034	XMLAgg			YES
 X035	XMLAgg: ORDER BYオプション			YES	
 X036	XMLComment			YES	
 X037	XMLPI			YES	
-X038	XMLText			YES	supported except for RETURNING
+X038	XMLText			YES	RETURNINGを除いてサポート
 X040	基本テーブル対応付け			YES	
 X041	基本テーブル対応付け: NULLがない			YES	
 X042	基本テーブル対応付け: NULLをnilとして扱う			YES	

--- a/src/backend/utils/errcodes.txt.ja
+++ b/src/backend/utils/errcodes.txt.ja
@@ -2,7 +2,7 @@
 # errcodes.txt
 #      PostgreSQL error codes
 #
-# Copyright (c) 2003-2023, PostgreSQL Global Development Group
+# Copyright (c) 2003-2024, PostgreSQL Global Development Group
 #
 # This list serves as the basis for generating source files containing error
 # codes. It is kept in a common format to make sure all these source files have
@@ -251,6 +251,7 @@ Section: クラス 25 - 無効なトランザクション状態
 25P01    E    ERRCODE_NO_ACTIVE_SQL_TRANSACTION                              no_active_sql_transaction
 25P02    E    ERRCODE_IN_FAILED_SQL_TRANSACTION                              in_failed_sql_transaction
 25P03    E    ERRCODE_IDLE_IN_TRANSACTION_SESSION_TIMEOUT                    idle_in_transaction_session_timeout
+25P04    E    ERRCODE_TRANSACTION_TIMEOUT                                    transaction_timeout
 
 Section: クラス 26 - 無効なSQL文の名前
 
@@ -437,10 +438,6 @@ Section: クラス 58 - システムエラー(PostgreSQL自体の外部のエラ
 58030    E    ERRCODE_IO_ERROR                                               io_error
 58P01    E    ERRCODE_UNDEFINED_FILE                                         undefined_file
 58P02    E    ERRCODE_DUPLICATE_FILE                                         duplicate_file
-
-Section: クラス 72 - スナップショット失敗
-# (class borrowed from Oracle)
-72000    E    ERRCODE_SNAPSHOT_TOO_OLD                                       snapshot_too_old
 
 Section: クラス F0 - 設定ファイルエラー
 


### PR DESCRIPTION
以下のファイルの 17.0対応です。

- src/backend/catalog/sql_features.txt.ja
- src/backend/utils/errcodes.txt.ja

sql_features.txt.jaですが、YES/NOについては対応済みだったので、それ以外の部分の対応です。