### PR TITLE
Translate pg_recvlogical for PG17

### DIFF
--- a/doc/src/sgml/ref/pg_recvlogical.sgml
+++ b/doc/src/sgml/ref/pg_recvlogical.sgml
@@ -388,10 +388,8 @@ LSNが<replaceable>lsn</replaceable>と正確に一致するレコードがあ�
         Enables decoding of prepared transactions. This option may only be specified with
         <option>&#45;-create-slot</option>.
 -->
-《マッチ度[84.955752]》プリペアドトランザクションのデコードを有効にします。
+プリペアドトランザクションのデコードを有効にします。
 このオプションは<option>--create-slot</option>でのみ指定できます
-《機械翻訳》準備されたトランザクションのデコードを有効にします。
-このオプションは<option>--create-slot</option>と一緒にしか指定できません。
        </para>
        </listitem>
      </varlistentry>


### PR DESCRIPTION
内容の変更はなかったので、旧バージョンの翻訳文に置き換えました。