### PR TITLE
段落の文の共通化（４）

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -1658,7 +1658,7 @@ UNIXドメインソケットで接続しているセッションではこのパ�
 これはハングしたクライアントが接続を永久に占有することを防ぎます。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
 デフォルトは1分（<literal>1m</literal>）です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1756,7 +1756,7 @@ Kerberosサーバキーファイルの場所を設定します。
 （ディレクトリ部分は構築時に<varname>sysconfdir</varname>で指定されたものです。
 <literal>pg_config --sysconfdir</literal>を使って確認してください。）
 このパラメータが空文字列に設定されると、それは無視されてシステム依存のデフォルトが使用されます。
-このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 詳細は<xref linkend="gssapi-auth"/>をご覧ください。
        </para>
       </listitem>
@@ -1781,7 +1781,7 @@ Kerberosサーバキーファイルの場所を設定します。
 -->
 GSSAPIユーザ名を大文字小文字の区別なく取り扱うかどうかを設定します。
 デフォルトは<literal>off</literal>（大文字小文字を区別する）です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1808,7 +1808,7 @@ GSSAPIユーザ名を大文字小文字の区別なく取り扱うかどうか�
 デフォルトは<literal>off</literal>です。
 これは、クライアントからの資格証明が受け入れ<emphasis>られない</emphasis>ことを意味します。
 これを<literal>on</literal>に変更すると、サーバは、クライアントから委任された資格証明を受け入れます。
-このパラメータは、<filename>postgresql.conf</filename>ファイルまたはサーバコマンドラインでのみ設定できます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1831,7 +1831,7 @@ GSSAPIユーザ名を大文字小文字の区別なく取り扱うかどうか�
 -->
 このパラメータはデータベース毎のユーザ名を可能にします。
 デフォルトはオフです。
-このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
 
        <para>
@@ -2476,7 +2476,7 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -2514,7 +2514,7 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -3019,7 +3019,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
 この値が単位なしで指定された場合は、キロバイト単位であるとみなします。
 デフォルトは-1で、<xref linkend="guc-maintenance-work-mem"/>が代わりに使われる設定になります。
 別の文脈で実行される<command>VACUUM</command>にはこの設定は影響しません。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        <para>
 <!--
@@ -3646,7 +3646,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
 デフォルトの値は200ミリ秒（<literal>200ms</literal>）です。
 多くのシステムで、スリープ遅延の実精度は10ミリ秒です。
 <varname>bgwriter_delay</varname>の値の設定を10の倍数としない場合、次に大きい10の倍数に設定した結果と同一になるかもしれないことを覚えておいてください。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
         </para>
        </listitem>
       </varlistentry>
@@ -3675,7 +3675,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
 ゼロに設定することでバックグラウンド書き込みは無効になります。
 （分離し、そして専用の補助プロセスにより管理されるチェックポイントは影響を受けません。）
 デフォルト値は100バッファです。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
         </para>
        </listitem>
       </varlistentry>
@@ -3717,7 +3717,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
 より大きな値は突発的な要求に対する多少の緩衝材を提供します。
 より小さな値はサーバプロセスでなされる書き込みを意図的に残します。
 デフォルトは2.0です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
         </para>
        </listitem>
       </varlistentry>
@@ -3763,7 +3763,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
 有効な設定値は、この強制書き込み機能が無効になる<literal>0</literal>から、<literal>2MB</literal>までです。
 デフォルト値は、Linuxでは<literal>512kB</literal>で、それ以外は<literal>0</literal>です。
 (<symbol>BLCKSZ</symbol>が8kBでなければ、この設定のデフォルト値と最大値が<symbol>BLCKSZ</symbol>に比例して変更されます。)
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
         </para>
        </listitem>
       </varlistentry>
@@ -4749,7 +4749,7 @@ WALの更新をディスクへ強制するのに使用される方法です。
 デフォルトは必ずしも理想的なものではありません。
 クラッシュに適応した構成にする、あるいはアーカイブの最適性能を導くためには、この設定あるいはシステム構成の他の部分を変更することが必要かもしれません。
 これらの側面は <xref linkend="wal-reliability"/>で解説されます。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -4817,7 +4817,7 @@ WALの更新をディスクへ強制するのに使用される方法です。
         file or on the server command line.
         The default is <literal>on</literal>.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
@@ -5050,7 +5050,7 @@ WALをフラッシュしたあと、非同期コミットしているトラン�
 デフォルト値は200ミリ秒（<literal>200ms</literal>）です。
 多くのシステムでは、待機間隔の実質的な分解能は10ミリ秒です。
 10の倍数以外の値を<varname>wal_writer_delay</varname>に設定しても、その次に大きい10の倍数を設定した場合と同じ結果となります。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -5085,7 +5085,7 @@ WALライタがWALをフラッシュする頻度を量で指定します。
 <varname>wal_writer_flush_after</varname>が<literal>0</literal>に設定されている場合は、WALデータが書かれるたびにWALが即時にフラッシュされます。
 この値が単位なしで指定された場合は、WALブロック単位であるとみなします。すなわち、<symbol>XLOG_BLCKSZ</symbol>バイト、一般的には8kBです。
 デフォルト値は<literal>1MB</literal>です。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -5237,7 +5237,7 @@ WALライタがWALをフラッシュする頻度を量で指定します。
 有効な範囲は、30秒から1日の間です。
 デフォルトは5分（<literal>5min</literal>）です。
 このパラメータを増やすと、クラッシュリカバリで必要となる時間が増加します。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -5269,7 +5269,7 @@ WALライタがWALをフラッシュする頻度を量で指定します。
 デフォルトは0.9で、可能な限りの間隔のほとんどにチェックポイントを拡散し、かなり一定のI/O負荷をもたらしますが、チェックポイントが完了するにあたってオーバーヘッドをもたらします。
 チェックポイントの完了を早くするので、このパラメータを小さくするのはお勧めできません。
 これにより、チェックポイント中はI/Oの割合が大きくなり、チェックポイントの完了から次のチェックポイントまでの間はより少ないI/Oとなります。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -5315,7 +5315,7 @@ WALライタがWALをフラッシュする頻度を量で指定します。
 有効な設定値は、この強制書き込み機能が無効になる<literal>0</literal>から、<literal>2MB</literal>までです。
 デフォルト値は、Linuxでは<literal>256kB</literal>で、それ以外は<literal>0</literal>です。
 (<symbol>BLCKSZ</symbol>が8kbでなければ、この設定のデフォルト値と最大値が<symbol>BLCKSZ</symbol>に比例して変更されます。)
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -5350,7 +5350,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
 デフォルトは30秒（<literal>30s</literal>）です。
 零の場合は警告を出しません。
 <varname>checkpoint_timeout</varname>が<varname>checkpoint_warning</varname>より小さい場合は警告を出しません。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -5384,7 +5384,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
 この値が単位なしで指定された場合は、メガバイト単位であるとみなします。
 デフォルトは1GBです。
 このパラメータを大きくすると、クラッシュリカバリに必要な時間が長くなります。
-このパラメータは、<filename>postgresql.conf</filename>ファイルで設定するか、サーバのコマンドラインでのみ指定できます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -5415,7 +5415,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
 この設定は、たとえば大きなバッチジョブを走らせる際のWALの利用スパイクを取り扱うために、十分なWALのスペースが予約されていることを保証するために使用できます。
 この値が単位なしで指定された場合は、メガバイト単位であるとみなします。
 デフォルトは80MBです。
-このパラメータは、<filename>postgresql.conf</filename>ファイルで設定するか、サーバのコマンドラインでのみ指定できます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -5527,7 +5527,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
         archiving, but also breaks the chain of WAL files needed for
         archive recovery, so it should only be used in unusual circumstances.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 サーバ起動時に<varname>archive_mode</varname>が有効で、<varname>archive_library</varname>が空文字の時にのみ使用されます。
 <varname>archive_command</varname>と<varname>archive_library</varname>の両方が有効ならばエラーが発生します。
 <varname>archive_mode</varname>が有効であるにもかかわらず、<varname>archive_command</varname>が空文字列（デフォルト）、（そして<varname>archive_library</varname>が空文字列）である場合、WALアーカイブ処理は一時的に無効になりますが、コマンドが後で提供されることを見越して、サーバはWALセグメントの蓄積を続けます。
@@ -5567,7 +5567,7 @@ WALアーカイバプロセスは、このパラメータが変更されたと�
         This parameter can only be set in the
         <filename>postgresql.conf</filename> file or on the server command line.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -5615,7 +5615,7 @@ WALアーカイバプロセスは、このパラメータが変更されたと�
 したがって、非常に短い<varname>archive_timeout</varname>を使用することは賢明ではなく、アーカイブストレージを膨張させます。
 通常は1分程度の<varname>archive_timeout</varname>設定が妥当です。
 プライマリサーバからデータをより迅速にコピーしたい場合は、アーカイブではなくストリーミングレプリケーションを使用することを検討してください。この値が単位なしで指定された場合、秒として取得されます。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -5868,7 +5868,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-このパラメータは <filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -5937,7 +5937,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -5982,7 +5982,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -6550,7 +6550,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
 もし<varname>wal_keep_size</varname>が（デフォルトの）ゼロの場合、システムはスタンバイサーバのために追加セグメントを保持することはしません。
 従って、スタンバイサーバが使用できる古いWALセグメントの数は、直前のチェックポイントの場所とWALアーカイブの状況によって算出されます。
 この値が単位無しで指定されると、メガバイトであると見なします。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        </listitem>
       </varlistentry>
@@ -6588,7 +6588,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
 そうでなければ、レプリケーションスロットのrestart_lsnが現在のLSNよりも与えられたサイズ分遅れると、そのスロットを使っているスタンバイは必要なWALファイルが削除されたためにレプリケーションを継続できなくなります。
 レプリケーションスロットのWALが存在するかどうかは<link linkend="view-pg-replication-slots">pg_replication_slots</link>を見て確認できます。
 この値が単位無しで指定されると、メガバイトであると見なします。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        </listitem>
       </varlistentry>
@@ -6652,7 +6652,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         command line. The default value is <literal>off</literal>.
 -->
 トランザクションのコミットタイムを記録します。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 デフォルトは<literal>off</literal>です。
        </para>
       </listitem>
@@ -6875,7 +6875,7 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -6960,7 +6960,7 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
           is an empty string).
           This setting has no effect if the server is not in standby mode.
 -->
-このパラメータは<filename>postgresql.conf</filename>か、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 WAL受信プロセスが実行中にこのパラメータが変更されると、そのプロセスにシグナルが送られ、新しい設定で再起動するために停止します（<varname>primary_conninfo</varname>が空文字の場合を除きます。）
 サーバがスタンバイモードでなければこの設定は無効となります。
          </para>
@@ -6991,7 +6991,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
           set or the server is not in standby mode.
 -->
 上流ノードのリソース削除を制御するためにストリーミングレプリケーション経由でプライマリに接続した場合、既存のレプリケーションスロットを使うように、必要に応じて指定します（<xref linkend="streaming-replication-slots"/>を参照）。
-このパラメータは<filename>postgresql.conf</filename>か、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 WAL受信プロセスが実行中にこのパラメータが変更されると、そのプロセスにシグナルが送られ、新しい設定で再起動するために停止します。
 <varname>primary_conninfo</varname>が設定されていない場合、この設定は無効です。
          </para>
@@ -7053,7 +7053,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
 この値が単位なしで指定された場合、ミリ秒単位で取得されます。
 デフォルトは30秒です。
 値-1を指定すると、スタンバイは競合するクエリが完了するまで永遠に待機します。
-このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバコマンドラインからのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        <para>
 <!--
@@ -7101,7 +7101,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
 この値が単位なしで指定された場合、ミリ秒単位で取得されます。
 デフォルトは30秒です。
 値-1を指定すると、スタンバイは競合するクエリが完了するまで永久に待機します。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        <para>
 <!--
@@ -7143,7 +7143,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
 -->
 永続レプリケーションスロットが(<xref linkend="guc-primary-slot-name"/>を使って)作成されない設定になっている時に、WAL受信プロセスがリモートインスタンス上に一時レプリケーションスロットを作るかどうかを指定します。
 デフォルトはoffです。
-このパラメータは<filename>postgresql.conf</filename>か、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 WAL受信プロセスが実行中にこのパラメータが変更されると、そのプロセスにシグナルが送られ、新しい設定で再起動するために停止します。
        </para>
       </listitem>
@@ -7192,7 +7192,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
 従って、適用位置は真の位置よりも少し後ろにずれることがあります。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
 デフォルトの値は10秒です。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
       </para>
       </listitem>
      </varlistentry>
@@ -7224,7 +7224,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
 しかし、いくつかのワークロードに対してはプライマリサーバ上でのデータベース肥大の原因となります。
 フィードバックメッセージは<varname>wal_receiver_status_interval</varname>毎に、2回以上送信されません。
 デフォルトの値は<literal>off</literal>です。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        <para>
 <!--
@@ -7281,7 +7281,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
 デフォルト値は60秒です。
 値ゼロは時間切れメカニズムを無効にします。
-このパラメータは<filename>postgresql.conf</filename>ファイルまたはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -7309,10 +7309,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
         command line.
 -->
 WALデータがソース(ストリーミングレプリケーション、ローカルの<filename>pg_wal</filename>、またはWALアーカイブ)から取得できない時に、スタンバイサーバがWALデータ受信をリトライするまでにどの位の時間待つべきかを指定します。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
 デフォルト値は5秒です。
-このパラメータは、<filename>postgresql.conf</filename>ファイルで設定するか、サーバのコマンドラインでのみ指定できます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        <para>
 <!--
@@ -7589,7 +7588,7 @@ WALレコードは、適用される準備が整うまでスタンバイに保�
         line.
 -->
 デフォルト値は2です。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -7628,7 +7627,7 @@ WALレコードは、適用される準備が整うまでスタンバイに保�
         line.
 -->
 デフォルト値は2です。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -9312,7 +9311,7 @@ SELECT * FROM parent WHERE key = 2400;
 Windowsでは、<systemitem>eventlog</systemitem>も同時に提供します。
 このパラメータを設定するには、カンマ区切りでお好みのログ出力先を記載します。
 デフォルトでは、ログは<systemitem>stderr</systemitem>のみに出力されます。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        <para>
 <!--
@@ -9508,7 +9507,7 @@ Windowsで<varname>log_destination</varname>に対し<literal>eventlog</literal>
 -->
 <varname>logging_collector</varname>を有効と設定した場合、このパラメータはログファイルが作成されるディレクトリを確定します。
 ディレクトリは、絶対パス、もしくはデータベースクラスタのディレクトリに対する相対パスで指定することができます。
-このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバコマンドラインからのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 デフォルトは<literal>log</literal>です。
        </para>
       </listitem>
@@ -9672,7 +9671,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 この値が単位なしで指定された場合は、分単位であるとみなします。
 デフォルトは24時間です。
 ゼロに設定することで、時間に基づいた新しいログファイルの生成は無効になります。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -9704,7 +9703,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 この値が単位なしで指定された場合は、キロバイト単位であるとみなします。
 デフォルトは10メガバイトです。
 ゼロに設定することで、サイズに基づいた新しいログファイルの生成は無効になります。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -9738,7 +9737,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 しかし、切り詰めは時間を基にしたローテーションのために新規にファイルが開かれた時にのみ発生し、サーバ起動時やサイズを基にしたローテーションでは発生しません。
 偽の場合、全ての場合において既存のファイルは追記されます。
 例えば、この設定を<literal>postgresql-%H.log</literal>のような<varname>log_filename</varname>と組み合わせて使用すると、24個の時別のログファイルが生成され、それらは周期的に上書きされることになります。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        <para>
 <!--
@@ -9798,7 +9797,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 <literal>LOCAL0</literal>、<literal>LOCAL1</literal>、<literal>LOCAL2</literal>、<literal>LOCAL3</literal>、<literal>LOCAL4</literal>、<literal>LOCAL5</literal>、<literal>LOCAL6</literal>、<literal>LOCAL7</literal>の中から選んでください。
 デフォルトは<literal>LOCAL0</literal>です。
 使用しているシステムの<application>syslog</application>デーモンの文書を同時に参照してください。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -9824,7 +9823,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
          file or on the server command line.
 -->
 <application>syslog</application>にログ取得が有効な場合、このパラメータは<application>syslog</application>ログ内の<productname>PostgreSQL</productname>メッセージを特定するのに使用するプログラム名を確定します。デフォルトは<literal>postgres</literal>です。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
         </para>
        </listitem>
       </varlistentry>
@@ -9864,7 +9863,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
          This parameter can only be set in the <filename>postgresql.conf</filename>
          file or on the server command line.
 -->
-このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
         </para>
       </listitem>
      </varlistentry>
@@ -9915,7 +9914,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -9939,7 +9938,8 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-<application>event log</application>へのログ取得が有効になっていると、このパラメータはログ中の<productname>PostgreSQL</productname>メッセージを特定するのに使用されるプログラム名を決定します。デフォルトは<literal>PostgreSQL</literal>です。このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+<application>event log</application>へのログ取得が有効になっていると、このパラメータはログ中の<productname>PostgreSQL</productname>メッセージを特定するのに使用されるプログラム名を決定します。デフォルトは<literal>PostgreSQL</literal>です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -10272,7 +10272,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 デフォルトは10秒です。
 <literal>0</literal>に設定すると、この機能は無効になります。この値を単位なしで指定すると、ミリ秒とみなされます。
 この設定は、各操作に個別に適用されます。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
         </para>
 
         <para>
@@ -10582,7 +10582,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 さらに、<literal>-1</literal>以外の値にこのパラメータが設定された場合、競合するロックや並行して削除されたリレーションによりautovacuum動作がスキップされるとメッセージはログに記録されます。
 デフォルトは<literal>10min</literal>です。
 このパラメータを有効にすることは、autovacuum活動の追跡に役に立ちます。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
@@ -10608,7 +10608,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 -->
 チェックポイントおよびリスタートポイントをサーバログに記録するようにします。
 書き出されたバッファ数や書き出しに要した時間など、いくつかの統計情報がこのログメッセージに含まれます。
-このパラメータは<filename>postgresql.conf</filename>ファイルまたはサーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 デフォルトはonです。
        </para>
       </listitem>
@@ -10788,7 +10788,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 デフォルトでは、接続ログメッセージは接続元ホストのIPアドレスのみを表示します。
 このパラメータを有効にすると、ホスト名もログに残るようになります。
 ホスト名解決方法の設定に依存しますが、これが無視できないほどの性能劣化を起こす可能性があることに注意してください。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -10836,7 +10836,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
          file or on the server command line. The default is
          <literal>'%m [%p] '</literal> which logs a time stamp and the process ID.
 -->
-このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定することができます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 デフォルトは、タイムスタンプとプロセスIDをログ出力する<literal>'%m [%p] '</literal>です。
        </para>
 
@@ -11204,7 +11204,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
         command line.
 -->
 デフォルトは<literal>off</literal>です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -11458,7 +11458,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
 <xref linkend="guc-timezone"/>と異なり、すべてのセッションで一貫性を持ってタイムスタンプが報告されるようにこの値はクラスタ全体に適用されます。
 組み込まれているデフォルトは<literal>GMT</literal>ですが、<filename>postgresql.conf</filename>により通常は上書きされます。<application>initdb</application>によりこれらと関連した設定をシステム環境にインストールされます。
 詳細は<xref linkend="datatype-timezones"/>を参照してください。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -12492,7 +12492,7 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 サーバがautovacuumランチャデーモンを実行すべきかどうかを管理します。
 デフォルトでは有効です。
 しかしautovacuumを作動させるためには<xref linkend="guc-track-counts"/>も有効でなければなりません。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 ただし、テーブルストレージパラメータを変更することにより、autovacuumは個々のテーブルに対して無効にできます。
        </para>
        <para>
@@ -12556,7 +12556,7 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 それぞれの周期で、デーモンはそのデータベースを試験し、そしてそのデータベース内のテーブルで必要性が認められると、<command>VACUUM</command>および<command>ANALYZE</command>コマンドを発行します。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
 デフォルトは1分（<literal>1min</literal>）です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -12585,7 +12585,7 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 -->
 どのテーブルに対しても<command>VACUUM</command>を起動するために必要な、更新もしくは削除されたタプルの最小数を指定します。
 デフォルトは50タプルです。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
@@ -12618,7 +12618,7 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 あるテーブルで<command>VACUUM</command>を起動するきっかけとなるのに必要な挿入タプル数を設定します。
 デフォルトは1000タプルです。
 -1が指定されると、自動VACUUMが挿入タプル数に基づいて<command>VACUUM</command>操作を引き起こすことはなくなります。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
@@ -12648,8 +12648,8 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 -->
 どのテーブルに対しても<command>ANALYZE</command>を起動するのに必要な、挿入、更新、もしくは削除されたタプルの最小数を指定します。
 デフォルトは50タプルです。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
-この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
+ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
      </varlistentry>
@@ -12679,7 +12679,8 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 -->
 <command>VACUUM</command>を起動するか否かを決定するときに、<varname>autovacuum_vacuum_threshold</varname>に足し算するテーブル容量の割合を指定します。
 デフォルトは0.2（テーブルサイズの20%）です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されますが、テーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
+ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
      </varlistentry>
@@ -12709,7 +12710,8 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 -->
 <command>VACUUM</command>を起動するかどうか決める際の<varname>autovacuum_vacuum_insert_threshold</varname>に追加するテーブルサイズの割合を指定します。
 デフォルトは0.2（テーブルサイズの20%）です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されますが、テーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
+ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
      </varlistentry>
@@ -12739,8 +12741,8 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 -->
 <command>ANALYZE</command>を起動するか否かを決定するときに、<varname>autovacuum_analyze_threshold</varname>に足し算するテーブル容量の割合を指定します。
 デフォルトは0.1（テーブルサイズの10%）です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
-この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きされます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
+ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
      </varlistentry>
@@ -12861,8 +12863,8 @@ vacuumは同時に<filename>pg_xact</filename>サブディレクトリから古�
 -1に指定されると、一定の <xref linkend="guc-vacuum-cost-delay"/>の値が使用されます。
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
 デフォルト値は2ミリ秒です。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
-この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
+ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
      </varlistentry>
@@ -12897,8 +12899,8 @@ vacuumは同時に<filename>pg_xact</filename>サブディレクトリから古�
 （デフォルトの）-1が指定されると、一定の <xref linkend="guc-vacuum-cost-limit"/>の値が使用されます。
 この値は、実行中の自動バキュームワーカーが複数存在する場合ワーカーすべてに比例分配されることに注意してください。
 したがって各ワーカーの制限を足し合わせてもこの変数による制限を超えることはありません。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインのみで設定可能です。
-この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
+ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
      </varlistentry>
@@ -15417,7 +15419,7 @@ GINインデックススキャンにより返されるセットのソフトな�
 リレーション全体をカバーするロックに昇格する前に、一つリレーションの中で述語ロックできるページ数あるいはタプル数を指定します。
 0以上の値は、絶対的な制限を表し、負の数は<xref linkend="guc-max-pred-locks-per-transaction"/>をその絶対値で割ったものを表します。
 デフォルトは-2で、以前のバージョンの<productname>PostgreSQL</productname>の振る舞いを維持します。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -15441,7 +15443,7 @@ GINインデックススキャンにより返されるセットのソフトな�
 -->
 ページ全体をカバーするロックに昇格する前に、一つページの中で述語ロックできる行数を指定します。
 デフォルトは2です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -15972,7 +15974,7 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
         This parameter can only be set in the
         <filename>postgresql.conf</filename> file or on the server command line.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -16853,7 +16855,7 @@ WALディスクブロックの容量を報告します。
 これは、認証における誤動作を追跡するために、デバッガを使用してサーバプロセスに接続する機会を開発者に提供することを目的としたものです。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
 値がゼロ（デフォルト）の場合、この機能は無効になります。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -16916,7 +16918,7 @@ WALディスクブロックの容量を報告します。
 デフォルトの<literal>LOG</literal>はロギングの決定にまったく影響しません。
 その他の値を指定すると、その優先度以上のリカバリ関連のデバッグ・メッセージが<literal>LOG</literal>優先であるかのようにロギングされます。
 <varname>log_min_messages</varname>の一般的な設定では、無条件にサーバ・ログに送信されます。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -17515,7 +17517,7 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
 デフォルトである<literal>on</literal>に設定すると、<productname>PostgreSQL</productname>はバックエンドがクラッシュした後に自動的に一時ファイルを削除します。
 無効にすると、ファイルは保存され、たとえばデバッグ目的で使用できます。
 しかしクラッシュを繰り返すと不要なファイルが溜まっていくかもしれません。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -17556,7 +17558,7 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
 これは、クラッシュの後の他のプロセスの状態を調査するのに便利です。
 また、クラッシュが繰り返されるイベントで大量のディスクスペースを消費する可能性があるため、注意深く監視していないシステムではこれを有効にしないでください。
 自動的にコアファイルを削除する機能は提供されていないことに注意してください。
-このパラメータは<filename>postgresql.conf</filename>ファイルまたはサーバコマンドラインでのみ設定できます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -17596,7 +17598,7 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
 これは、<quote>スタックした</quote>子プロセスの状態を調査するのに便利です。
 また、クラッシュが繰り返されるイベントで大量のディスクスペースを消費する可能性があるため、注意深く監視していないシステムではこれを有効にしないでください。
 自動的にコアファイルを削除する機能は提供されていないことに注意してください。
-このパラメータは<filename>postgresql.conf</filename>ファイルまたはサーバコマンドラインでのみ設定できます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/config0.sgml
+++ b/doc/src/sgml/config0.sgml
@@ -1666,7 +1666,7 @@ UNIXドメインソケットで接続しているセッションではこのパ�
 これはハングしたクライアントが接続を永久に占有することを防ぎます。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
 デフォルトは1分（<literal>1m</literal>）です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1764,7 +1764,7 @@ Kerberosサーバキーファイルの場所を設定します。
 （ディレクトリ部分は構築時に<varname>sysconfdir</varname>で指定されたものです。
 <literal>pg_config --sysconfdir</literal>を使って確認してください。）
 このパラメータが空文字列に設定されると、それは無視されてシステム依存のデフォルトが使用されます。
-このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 詳細は<xref linkend="gssapi-auth"/>をご覧ください。
        </para>
       </listitem>
@@ -1789,7 +1789,7 @@ Kerberosサーバキーファイルの場所を設定します。
 -->
 GSSAPIユーザ名を大文字小文字の区別なく取り扱うかどうかを設定します。
 デフォルトは<literal>off</literal>（大文字小文字を区別する）です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1816,7 +1816,7 @@ GSSAPIユーザ名を大文字小文字の区別なく取り扱うかどうか�
 デフォルトは<literal>off</literal>です。
 これは、クライアントからの資格証明が受け入れ<emphasis>られない</emphasis>ことを意味します。
 これを<literal>on</literal>に変更すると、サーバは、クライアントから委任された資格証明を受け入れます。
-このパラメータは、<filename>postgresql.conf</filename>ファイルまたはサーバコマンドラインでのみ設定できます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1839,7 +1839,7 @@ GSSAPIユーザ名を大文字小文字の区別なく取り扱うかどうか�
 -->
 このパラメータはデータベース毎のユーザ名を可能にします。
 デフォルトはオフです。
-このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
 
        <para>
@@ -2484,7 +2484,7 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -2522,7 +2522,7 @@ TLS 1.0より前のプロトコルバージョン、すなわちSSLバージョ�
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -3027,7 +3027,7 @@ Linuxでは、これは<quote>transparent huge pages</quote><indexterm><primary>
 この値が単位なしで指定された場合は、キロバイト単位であるとみなします。
 デフォルトは-1で、<xref linkend="guc-maintenance-work-mem"/>が代わりに使われる設定になります。
 別の文脈で実行される<command>VACUUM</command>にはこの設定は影響しません。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        <para>
 <!--
@@ -3654,7 +3654,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
 デフォルトの値は200ミリ秒（<literal>200ms</literal>）です。
 多くのシステムで、スリープ遅延の実精度は10ミリ秒です。
 <varname>bgwriter_delay</varname>の値の設定を10の倍数としない場合、次に大きい10の倍数に設定した結果と同一になるかもしれないことを覚えておいてください。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
         </para>
        </listitem>
       </varlistentry>
@@ -3683,7 +3683,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
 ゼロに設定することでバックグラウンド書き込みは無効になります。
 （分離し、そして専用の補助プロセスにより管理されるチェックポイントは影響を受けません。）
 デフォルト値は100バッファです。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
         </para>
        </listitem>
       </varlistentry>
@@ -3725,7 +3725,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
 より大きな値は突発的な要求に対する多少の緩衝材を提供します。
 より小さな値はサーバプロセスでなされる書き込みを意図的に残します。
 デフォルトは2.0です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
         </para>
        </listitem>
       </varlistentry>
@@ -3771,7 +3771,7 @@ vacuumを掛けるプロセスをスリープさせることになる累計さ�
 有効な設定値は、この強制書き込み機能が無効になる<literal>0</literal>から、<literal>2MB</literal>までです。
 デフォルト値は、Linuxでは<literal>512kB</literal>で、それ以外は<literal>0</literal>です。
 (<symbol>BLCKSZ</symbol>が8kBでなければ、この設定のデフォルト値と最大値が<symbol>BLCKSZ</symbol>に比例して変更されます。)
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
         </para>
        </listitem>
       </varlistentry>

--- a/doc/src/sgml/config1.sgml
+++ b/doc/src/sgml/config1.sgml
@@ -594,7 +594,7 @@ WALの更新をディスクへ強制するのに使用される方法です。
 デフォルトは必ずしも理想的なものではありません。
 クラッシュに適応した構成にする、あるいはアーカイブの最適性能を導くためには、この設定あるいはシステム構成の他の部分を変更することが必要かもしれません。
 これらの側面は <xref linkend="wal-reliability"/>で解説されます。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -662,7 +662,7 @@ WALの更新をディスクへ強制するのに使用される方法です。
         file or on the server command line.
         The default is <literal>on</literal>.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 デフォルトは<literal>on</literal>です。
        </para>
       </listitem>
@@ -895,7 +895,7 @@ WALをフラッシュしたあと、非同期コミットしているトラン�
 デフォルト値は200ミリ秒（<literal>200ms</literal>）です。
 多くのシステムでは、待機間隔の実質的な分解能は10ミリ秒です。
 10の倍数以外の値を<varname>wal_writer_delay</varname>に設定しても、その次に大きい10の倍数を設定した場合と同じ結果となります。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -930,7 +930,7 @@ WALライタがWALをフラッシュする頻度を量で指定します。
 <varname>wal_writer_flush_after</varname>が<literal>0</literal>に設定されている場合は、WALデータが書かれるたびにWALが即時にフラッシュされます。
 この値が単位なしで指定された場合は、WALブロック単位であるとみなします。すなわち、<symbol>XLOG_BLCKSZ</symbol>バイト、一般的には8kBです。
 デフォルト値は<literal>1MB</literal>です。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1082,7 +1082,7 @@ WALライタがWALをフラッシュする頻度を量で指定します。
 有効な範囲は、30秒から1日の間です。
 デフォルトは5分（<literal>5min</literal>）です。
 このパラメータを増やすと、クラッシュリカバリで必要となる時間が増加します。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1114,7 +1114,7 @@ WALライタがWALをフラッシュする頻度を量で指定します。
 デフォルトは0.9で、可能な限りの間隔のほとんどにチェックポイントを拡散し、かなり一定のI/O負荷をもたらしますが、チェックポイントが完了するにあたってオーバーヘッドをもたらします。
 チェックポイントの完了を早くするので、このパラメータを小さくするのはお勧めできません。
 これにより、チェックポイント中はI/Oの割合が大きくなり、チェックポイントの完了から次のチェックポイントまでの間はより少ないI/Oとなります。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1160,7 +1160,7 @@ WALライタがWALをフラッシュする頻度を量で指定します。
 有効な設定値は、この強制書き込み機能が無効になる<literal>0</literal>から、<literal>2MB</literal>までです。
 デフォルト値は、Linuxでは<literal>256kB</literal>で、それ以外は<literal>0</literal>です。
 (<symbol>BLCKSZ</symbol>が8kbでなければ、この設定のデフォルト値と最大値が<symbol>BLCKSZ</symbol>に比例して変更されます。)
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1195,7 +1195,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
 デフォルトは30秒（<literal>30s</literal>）です。
 零の場合は警告を出しません。
 <varname>checkpoint_timeout</varname>が<varname>checkpoint_warning</varname>より小さい場合は警告を出しません。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1229,7 +1229,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
 この値が単位なしで指定された場合は、メガバイト単位であるとみなします。
 デフォルトは1GBです。
 このパラメータを大きくすると、クラッシュリカバリに必要な時間が長くなります。
-このパラメータは、<filename>postgresql.conf</filename>ファイルで設定するか、サーバのコマンドラインでのみ指定できます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1260,7 +1260,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
 この設定は、たとえば大きなバッチジョブを走らせる際のWALの利用スパイクを取り扱うために、十分なWALのスペースが予約されていることを保証するために使用できます。
 この値が単位なしで指定された場合は、メガバイト単位であるとみなします。
 デフォルトは80MBです。
-このパラメータは、<filename>postgresql.conf</filename>ファイルで設定するか、サーバのコマンドラインでのみ指定できます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1372,7 +1372,7 @@ WALセグメントファイルが溢れることが原因で起きるチェッ�
         archiving, but also breaks the chain of WAL files needed for
         archive recovery, so it should only be used in unusual circumstances.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 サーバ起動時に<varname>archive_mode</varname>が有効で、<varname>archive_library</varname>が空文字の時にのみ使用されます。
 <varname>archive_command</varname>と<varname>archive_library</varname>の両方が有効ならばエラーが発生します。
 <varname>archive_mode</varname>が有効であるにもかかわらず、<varname>archive_command</varname>が空文字列（デフォルト）、（そして<varname>archive_library</varname>が空文字列）である場合、WALアーカイブ処理は一時的に無効になりますが、コマンドが後で提供されることを見越して、サーバはWALセグメントの蓄積を続けます。
@@ -1412,7 +1412,7 @@ WALアーカイバプロセスは、このパラメータが変更されたと�
         This parameter can only be set in the
         <filename>postgresql.conf</filename> file or on the server command line.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1460,7 +1460,7 @@ WALアーカイバプロセスは、このパラメータが変更されたと�
 したがって、非常に短い<varname>archive_timeout</varname>を使用することは賢明ではなく、アーカイブストレージを膨張させます。
 通常は1分程度の<varname>archive_timeout</varname>設定が妥当です。
 プライマリサーバからデータをより迅速にコピーしたい場合は、アーカイブではなくストリーミングレプリケーションを使用することを検討してください。この値が単位なしで指定された場合、秒として取得されます。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1713,7 +1713,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-このパラメータは <filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1782,7 +1782,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1827,7 +1827,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -2395,7 +2395,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
 もし<varname>wal_keep_size</varname>が（デフォルトの）ゼロの場合、システムはスタンバイサーバのために追加セグメントを保持することはしません。
 従って、スタンバイサーバが使用できる古いWALセグメントの数は、直前のチェックポイントの場所とWALアーカイブの状況によって算出されます。
 この値が単位無しで指定されると、メガバイトであると見なします。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        </listitem>
       </varlistentry>
@@ -2433,7 +2433,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
 そうでなければ、レプリケーションスロットのrestart_lsnが現在のLSNよりも与えられたサイズ分遅れると、そのスロットを使っているスタンバイは必要なWALファイルが削除されたためにレプリケーションを継続できなくなります。
 レプリケーションスロットのWALが存在するかどうかは<link linkend="view-pg-replication-slots">pg_replication_slots</link>を見て確認できます。
 この値が単位無しで指定されると、メガバイトであると見なします。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        </listitem>
       </varlistentry>
@@ -2497,7 +2497,7 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         command line. The default value is <literal>off</literal>.
 -->
 トランザクションのコミットタイムを記録します。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 デフォルトは<literal>off</literal>です。
        </para>
       </listitem>
@@ -2720,7 +2720,7 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -2805,7 +2805,7 @@ ANY <replaceable class="parameter">num_sync</replaceable> ( <replaceable class="
           is an empty string).
           This setting has no effect if the server is not in standby mode.
 -->
-このパラメータは<filename>postgresql.conf</filename>か、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 WAL受信プロセスが実行中にこのパラメータが変更されると、そのプロセスにシグナルが送られ、新しい設定で再起動するために停止します（<varname>primary_conninfo</varname>が空文字の場合を除きます。）
 サーバがスタンバイモードでなければこの設定は無効となります。
          </para>
@@ -2836,7 +2836,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
           set or the server is not in standby mode.
 -->
 上流ノードのリソース削除を制御するためにストリーミングレプリケーション経由でプライマリに接続した場合、既存のレプリケーションスロットを使うように、必要に応じて指定します（<xref linkend="streaming-replication-slots"/>を参照）。
-このパラメータは<filename>postgresql.conf</filename>か、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 WAL受信プロセスが実行中にこのパラメータが変更されると、そのプロセスにシグナルが送られ、新しい設定で再起動するために停止します。
 <varname>primary_conninfo</varname>が設定されていない場合、この設定は無効です。
          </para>
@@ -2898,7 +2898,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
 この値が単位なしで指定された場合、ミリ秒単位で取得されます。
 デフォルトは30秒です。
 値-1を指定すると、スタンバイは競合するクエリが完了するまで永遠に待機します。
-このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバコマンドラインからのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        <para>
 <!--
@@ -2946,7 +2946,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
 この値が単位なしで指定された場合、ミリ秒単位で取得されます。
 デフォルトは30秒です。
 値-1を指定すると、スタンバイは競合するクエリが完了するまで永久に待機します。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        <para>
 <!--
@@ -2988,7 +2988,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
 -->
 永続レプリケーションスロットが(<xref linkend="guc-primary-slot-name"/>を使って)作成されない設定になっている時に、WAL受信プロセスがリモートインスタンス上に一時レプリケーションスロットを作るかどうかを指定します。
 デフォルトはoffです。
-このパラメータは<filename>postgresql.conf</filename>か、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 WAL受信プロセスが実行中にこのパラメータが変更されると、そのプロセスにシグナルが送られ、新しい設定で再起動するために停止します。
        </para>
       </listitem>
@@ -3037,7 +3037,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
 従って、適用位置は真の位置よりも少し後ろにずれることがあります。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
 デフォルトの値は10秒です。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
       </para>
       </listitem>
      </varlistentry>
@@ -3069,7 +3069,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
 しかし、いくつかのワークロードに対してはプライマリサーバ上でのデータベース肥大の原因となります。
 フィードバックメッセージは<varname>wal_receiver_status_interval</varname>毎に、2回以上送信されません。
 デフォルトの値は<literal>off</literal>です。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        <para>
 <!--
@@ -3126,7 +3126,7 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
 デフォルト値は60秒です。
 値ゼロは時間切れメカニズムを無効にします。
-このパラメータは<filename>postgresql.conf</filename>ファイルまたはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -3154,10 +3154,9 @@ WAL受信プロセスが実行中にこのパラメータが変更されると�
         command line.
 -->
 WALデータがソース(ストリーミングレプリケーション、ローカルの<filename>pg_wal</filename>、またはWALアーカイブ)から取得できない時に、スタンバイサーバがWALデータ受信をリトライするまでにどの位の時間待つべきかを指定します。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
 デフォルト値は5秒です。
-このパラメータは、<filename>postgresql.conf</filename>ファイルで設定するか、サーバのコマンドラインでのみ指定できます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        <para>
 <!--
@@ -3434,7 +3433,7 @@ WALレコードは、適用される準備が整うまでスタンバイに保�
         line.
 -->
 デフォルト値は2です。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -3473,7 +3472,7 @@ WALレコードは、適用される準備が整うまでスタンバイに保�
         line.
 -->
 デフォルト値は2です。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、もしくはサーバコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/config2.sgml
+++ b/doc/src/sgml/config2.sgml
@@ -205,7 +205,7 @@
 Windowsでは、<systemitem>eventlog</systemitem>も同時に提供します。
 このパラメータを設定するには、カンマ区切りでお好みのログ出力先を記載します。
 デフォルトでは、ログは<systemitem>stderr</systemitem>のみに出力されます。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        <para>
 <!--
@@ -401,7 +401,7 @@ Windowsで<varname>log_destination</varname>に対し<literal>eventlog</literal>
 -->
 <varname>logging_collector</varname>を有効と設定した場合、このパラメータはログファイルが作成されるディレクトリを確定します。
 ディレクトリは、絶対パス、もしくはデータベースクラスタのディレクトリに対する相対パスで指定することができます。
-このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバコマンドラインからのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 デフォルトは<literal>log</literal>です。
        </para>
       </listitem>
@@ -565,7 +565,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 この値が単位なしで指定された場合は、分単位であるとみなします。
 デフォルトは24時間です。
 ゼロに設定することで、時間に基づいた新しいログファイルの生成は無効になります。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -597,7 +597,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 この値が単位なしで指定された場合は、キロバイト単位であるとみなします。
 デフォルトは10メガバイトです。
 ゼロに設定することで、サイズに基づいた新しいログファイルの生成は無効になります。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -631,7 +631,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 しかし、切り詰めは時間を基にしたローテーションのために新規にファイルが開かれた時にのみ発生し、サーバ起動時やサイズを基にしたローテーションでは発生しません。
 偽の場合、全ての場合において既存のファイルは追記されます。
 例えば、この設定を<literal>postgresql-%H.log</literal>のような<varname>log_filename</varname>と組み合わせて使用すると、24個の時別のログファイルが生成され、それらは周期的に上書きされることになります。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
        <para>
 <!--
@@ -691,7 +691,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 <literal>LOCAL0</literal>、<literal>LOCAL1</literal>、<literal>LOCAL2</literal>、<literal>LOCAL3</literal>、<literal>LOCAL4</literal>、<literal>LOCAL5</literal>、<literal>LOCAL6</literal>、<literal>LOCAL7</literal>の中から選んでください。
 デフォルトは<literal>LOCAL0</literal>です。
 使用しているシステムの<application>syslog</application>デーモンの文書を同時に参照してください。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -717,7 +717,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
          file or on the server command line.
 -->
 <application>syslog</application>にログ取得が有効な場合、このパラメータは<application>syslog</application>ログ内の<productname>PostgreSQL</productname>メッセージを特定するのに使用するプログラム名を確定します。デフォルトは<literal>postgres</literal>です。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
         </para>
        </listitem>
       </varlistentry>
@@ -757,7 +757,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
          This parameter can only be set in the <filename>postgresql.conf</filename>
          file or on the server command line.
 -->
-このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
         </para>
       </listitem>
      </varlistentry>
@@ -808,7 +808,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -832,7 +832,8 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
         This parameter can only be set in the <filename>postgresql.conf</filename>
         file or on the server command line.
 -->
-<application>event log</application>へのログ取得が有効になっていると、このパラメータはログ中の<productname>PostgreSQL</productname>メッセージを特定するのに使用されるプログラム名を決定します。デフォルトは<literal>PostgreSQL</literal>です。このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+<application>event log</application>へのログ取得が有効になっていると、このパラメータはログ中の<productname>PostgreSQL</productname>メッセージを特定するのに使用されるプログラム名を決定します。デフォルトは<literal>PostgreSQL</literal>です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1165,7 +1166,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 デフォルトは10秒です。
 <literal>0</literal>に設定すると、この機能は無効になります。この値を単位なしで指定すると、ミリ秒とみなされます。
 この設定は、各操作に個別に適用されます。
-このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
         </para>
 
         <para>
@@ -1475,7 +1476,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 さらに、<literal>-1</literal>以外の値にこのパラメータが設定された場合、競合するロックや並行して削除されたリレーションによりautovacuum動作がスキップされるとメッセージはログに記録されます。
 デフォルトは<literal>10min</literal>です。
 このパラメータを有効にすることは、autovacuum活動の追跡に役に立ちます。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
@@ -1501,7 +1502,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 -->
 チェックポイントおよびリスタートポイントをサーバログに記録するようにします。
 書き出されたバッファ数や書き出しに要した時間など、いくつかの統計情報がこのログメッセージに含まれます。
-このパラメータは<filename>postgresql.conf</filename>ファイルまたはサーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 デフォルトはonです。
        </para>
       </listitem>
@@ -1681,7 +1682,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
 デフォルトでは、接続ログメッセージは接続元ホストのIPアドレスのみを表示します。
 このパラメータを有効にすると、ホスト名もログに残るようになります。
 ホスト名解決方法の設定に依存しますが、これが無視できないほどの性能劣化を起こす可能性があることに注意してください。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -1729,7 +1730,7 @@ Unixシステムにおいては、<varname>logging_collector</varname>が有効�
          file or on the server command line. The default is
          <literal>'%m [%p] '</literal> which logs a time stamp and the process ID.
 -->
-このパラメータは、<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定することができます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 デフォルトは、タイムスタンプとプロセスIDをログ出力する<literal>'%m [%p] '</literal>です。
        </para>
 
@@ -2097,7 +2098,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
         command line.
 -->
 デフォルトは<literal>off</literal>です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -2351,7 +2352,7 @@ log_line_prefix = '%m [%p] %q%u@%d/%a '
 <xref linkend="guc-timezone"/>と異なり、すべてのセッションで一貫性を持ってタイムスタンプが報告されるようにこの値はクラスタ全体に適用されます。
 組み込まれているデフォルトは<literal>GMT</literal>ですが、<filename>postgresql.conf</filename>により通常は上書きされます。<application>initdb</application>によりこれらと関連した設定をシステム環境にインストールされます。
 詳細は<xref linkend="datatype-timezones"/>を参照してください。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -3385,7 +3386,7 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 サーバがautovacuumランチャデーモンを実行すべきかどうかを管理します。
 デフォルトでは有効です。
 しかしautovacuumを作動させるためには<xref linkend="guc-track-counts"/>も有効でなければなりません。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 ただし、テーブルストレージパラメータを変更することにより、autovacuumは個々のテーブルに対して無効にできます。
        </para>
        <para>
@@ -3449,7 +3450,7 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 それぞれの周期で、デーモンはそのデータベースを試験し、そしてそのデータベース内のテーブルで必要性が認められると、<command>VACUUM</command>および<command>ANALYZE</command>コマンドを発行します。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
 デフォルトは1分（<literal>1min</literal>）です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -3478,7 +3479,7 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 -->
 どのテーブルに対しても<command>VACUUM</command>を起動するために必要な、更新もしくは削除されたタプルの最小数を指定します。
 デフォルトは50タプルです。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
@@ -3511,7 +3512,7 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 あるテーブルで<command>VACUUM</command>を起動するきっかけとなるのに必要な挿入タプル数を設定します。
 デフォルトは1000タプルです。
 -1が指定されると、自動VACUUMが挿入タプル数に基づいて<command>VACUUM</command>操作を引き起こすことはなくなります。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
 ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
@@ -3541,8 +3542,8 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 -->
 どのテーブルに対しても<command>ANALYZE</command>を起動するのに必要な、挿入、更新、もしくは削除されたタプルの最小数を指定します。
 デフォルトは50タプルです。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
-この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
+ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
      </varlistentry>
@@ -3572,7 +3573,8 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 -->
 <command>VACUUM</command>を起動するか否かを決定するときに、<varname>autovacuum_vacuum_threshold</varname>に足し算するテーブル容量の割合を指定します。
 デフォルトは0.2（テーブルサイズの20%）です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されますが、テーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
+ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
      </varlistentry>
@@ -3602,7 +3604,8 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 -->
 <command>VACUUM</command>を起動するかどうか決める際の<varname>autovacuum_vacuum_insert_threshold</varname>に追加するテーブルサイズの割合を指定します。
 デフォルトは0.2（テーブルサイズの20%）です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されますが、テーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
+ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
      </varlistentry>
@@ -3632,8 +3635,8 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 -->
 <command>ANALYZE</command>を起動するか否かを決定するときに、<varname>autovacuum_analyze_threshold</varname>に足し算するテーブル容量の割合を指定します。
 デフォルトは0.1（テーブルサイズの10%）です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみで設定されます。
-この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きされます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
+ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
      </varlistentry>
@@ -3754,8 +3757,8 @@ vacuumは同時に<filename>pg_xact</filename>サブディレクトリから古�
 -1に指定されると、一定の <xref linkend="guc-vacuum-cost-delay"/>の値が使用されます。
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
 デフォルト値は2ミリ秒です。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
-この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
+ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
      </varlistentry>
@@ -3790,8 +3793,8 @@ vacuumは同時に<filename>pg_xact</filename>サブディレクトリから古�
 （デフォルトの）-1が指定されると、一定の <xref linkend="guc-vacuum-cost-limit"/>の値が使用されます。
 この値は、実行中の自動バキュームワーカーが複数存在する場合ワーカーすべてに比例分配されることに注意してください。
 したがって各ワーカーの制限を足し合わせてもこの変数による制限を超えることはありません。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインのみで設定可能です。
-この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
+ただし、この設定はテーブルストレージパラメータの変更により、それぞれのテーブルに対して上書きすることができます。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/config3.sgml
+++ b/doc/src/sgml/config3.sgml
@@ -1996,7 +1996,7 @@ GINインデックススキャンにより返されるセットのソフトな�
 リレーション全体をカバーするロックに昇格する前に、一つリレーションの中で述語ロックできるページ数あるいはタプル数を指定します。
 0以上の値は、絶対的な制限を表し、負の数は<xref linkend="guc-max-pred-locks-per-transaction"/>をその絶対値で割ったものを表します。
 デフォルトは-2で、以前のバージョンの<productname>PostgreSQL</productname>の振る舞いを維持します。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -2020,7 +2020,7 @@ GINインデックススキャンにより返されるセットのソフトな�
 -->
 ページ全体をカバーするロックに昇格する前に、一つページの中で述語ロックできる行数を指定します。
 デフォルトは2です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -2551,7 +2551,7 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
         This parameter can only be set in the
         <filename>postgresql.conf</filename> file or on the server command line.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイル、または、サーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -3432,7 +3432,7 @@ WALディスクブロックの容量を報告します。
 これは、認証における誤動作を追跡するために、デバッガを使用してサーバプロセスに接続する機会を開発者に提供することを目的としたものです。
 この値が単位なしで指定された場合は、秒単位であるとみなします。
 値がゼロ（デフォルト）の場合、この機能は無効になります。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -3495,7 +3495,7 @@ WALディスクブロックの容量を報告します。
 デフォルトの<literal>LOG</literal>はロギングの決定にまったく影響しません。
 その他の値を指定すると、その優先度以上のリカバリ関連のデバッグ・メッセージが<literal>LOG</literal>優先であるかのようにロギングされます。
 <varname>log_min_messages</varname>の一般的な設定では、無条件にサーバ・ログに送信されます。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -4094,7 +4094,7 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
 デフォルトである<literal>on</literal>に設定すると、<productname>PostgreSQL</productname>はバックエンドがクラッシュした後に自動的に一時ファイルを削除します。
 無効にすると、ファイルは保存され、たとえばデバッグ目的で使用できます。
 しかしクラッシュを繰り返すと不要なファイルが溜まっていくかもしれません。
-このパラメータは<filename>postgresql.conf</filename>ファイル内、またはサーバのコマンドラインのみで設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -4135,7 +4135,7 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
 これは、クラッシュの後の他のプロセスの状態を調査するのに便利です。
 また、クラッシュが繰り返されるイベントで大量のディスクスペースを消費する可能性があるため、注意深く監視していないシステムではこれを有効にしないでください。
 自動的にコアファイルを削除する機能は提供されていないことに注意してください。
-このパラメータは<filename>postgresql.conf</filename>ファイルまたはサーバコマンドラインでのみ設定できます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>
@@ -4175,7 +4175,7 @@ JITコンパイルが有効な時にタプルデフォーミングがJITコン�
 これは、<quote>スタックした</quote>子プロセスの状態を調査するのに便利です。
 また、クラッシュが繰り返されるイベントで大量のディスクスペースを消費する可能性があるため、注意深く監視していないシステムではこれを有効にしないでください。
 自動的にコアファイルを削除する機能は提供されていないことに注意してください。
-このパラメータは<filename>postgresql.conf</filename>ファイルまたはサーバコマンドラインでのみ設定できます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/pgstatstatements.sgml
+++ b/doc/src/sgml/pgstatstatements.sgml
@@ -1183,7 +1183,7 @@ SQL文のコードを出力するのに費やした総時間（ミリ秒単位�
 <varname>pg_stat_statements.save</varname>は、サーバを終了させる際に文の統計情報を保存するかどうかを指定します。
 <literal>off</literal>の場合、統計情報は終了時に保存されず、サーバ開始時に再読み込みもされません。
 デフォルト値は<literal>on</literal>です。
-このパラメータは<filename>postgresql.conf</filename>ファイル、またはサーバコマンドラインでのみ設定できます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
      </para>
     </listitem>
    </varlistentry>

--- a/doc/src/sgml/plperl.sgml
+++ b/doc/src/sgml/plperl.sgml
@@ -2087,7 +2087,7 @@ DO 'elog(WARNING, join ", ", sort keys %INC)' LANGUAGE plperl;
 <!--
        This parameter can only be set in the <filename>postgresql.conf</filename> file or on the server command line.
 -->
-このパラメータは<filename>postgresql.conf</filename>ファイルまたはサーバのコマンドラインでのみ設定可能です。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/sepgsql.sgml
+++ b/doc/src/sgml/sepgsql.sgml
@@ -401,7 +401,7 @@ $ sudo semodule -r sepgsql-regtest
 -->
 このパラメータにより、オペレーティングシステムの設定に関わらず、<filename>sepgsql</filename>をパーミッシブモードで動作させる事ができます。
 デフォルトの設定値はoffです。
-<filename>postgresql.conf</filename>内、およびサーバ起動時のコマンドラインでのみ、このパラメータを設定する事ができます。
+このパラメータは、<filename>postgresql.conf</filename>ファイルか、サーバのコマンドラインでのみ設定可能です。
      </para>
 
      <para>


### PR DESCRIPTION
fileの訳でファイルが入っていない #3123 関連で、共通化の修正が関連しているため、
This parameter can only be set in the
<filename>postgresql.conf</filename> file or on the server command line. の入っている文を共通化しました。

関連して、改行の関係で修正する必要があったため、
but the setting can be overridden for
individual tables by changing table storage parameters. の入っている文も共通化しました。

また、一箇所重複していた文を削除しました。