### PR TITLE
update datetime for 17.0

### DIFF
--- a/doc/src/sgml/datetime.sgml
+++ b/doc/src/sgml/datetime.sgml
@@ -1072,7 +1072,7 @@ POSIX時間帯の指定には以下の形式があります。
    of UTC; daylight savings time begins on the last Sunday in March at 2AM
    CET and ends on the last Sunday in October at 3AM CEST.
 -->
-《マッチ度[95.198330]》例えば、<literal>CET-1CEST,M3.5.0,M10.5.0/3</literal>は(2020年時点の)パリの現時点の時計方法を表しています。
+例えば、<literal>CET-1CEST,M3.5.0,M10.5.0/3</literal>は(2020年時点の)パリの現時点の時計方法を表しています。
 この指定では、標準時間は<literal>CET</literal>という略語を持ち、UTCより１時間(東)進んでいます。また、夏時間には、<literal>CEST</literal>という略語を持ち、暗黙的にUTCより２時間進んでいます。夏時間は3月の最終日曜のAM2時に始まり、10月の最終日曜日の3AM CESTに終わります。
   </para>
 


### PR DESCRIPTION
datetime.sgml の 17.0 対応です。

が、マッチ度をとっただけです。（原文では the が追加されただけのため。）