### PR TITLE
標準SQLに統一（２）と「準拠」に統一

### DIFF
--- a/doc/src/sgml/array.sgml
+++ b/doc/src/sgml/array.sgml
@@ -111,7 +111,7 @@ CREATE TABLE tictactoe (
   <structfield>pay_by_quarter</structfield> could have been defined
   as:
 -->
-SQLに準拠し、<literal>ARRAY</literal>キーワードを使用したもう1つの構文を一次元配列に使うことができます。
+標準SQLに準拠している、<literal>ARRAY</literal>キーワードを使用したもう1つの構文を一次元配列に使うことができます。
 <structfield>pay_by_quarter</structfield>を次のように定義することもできます。
 <programlisting>
     pay_by_quarter  integer ARRAY[4],

--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -963,7 +963,7 @@ NUMERIC(3, 5)
       systems.
 -->
 <productname>PostgreSQL</productname>では、<type>numeric</type>型宣言の位取りを-1000～1000の範囲の任意の値にすることができます。
-しかし、<acronym>SQL</acronym>標準では位取りを0～<replaceable>精度</replaceable>の範囲にする必要があります。
+しかし、標準<acronym>SQL</acronym>では位取りを0～<replaceable>精度</replaceable>の範囲にする必要があります。
 この範囲外の位取りを使用すると、他のデータベースシステムに移植できない可能性があります。
      </para>
     </note>
@@ -1448,7 +1448,7 @@ IEEE 754では、<literal>NaN</literal>は（<literal>NaN</literal>を含む）�
       identity column feature, described at <xref linkend="sql-createtable"/>.
 -->
 この節ではPostgreSQL固有の自動増分列の作成方法について記述します。
-SQL標準の識別列を作成する方法は、<xref linkend="sql-createtable"/>に記述されています。
+標準SQLの識別列を作成する方法は、<xref linkend="sql-createtable"/>に記述されています。
      </para>
     </note>
 
@@ -4550,7 +4550,7 @@ microseconds フィールドは、時間、分、秒、および小数の秒に�
      year-month literal string followed by a day-time literal string,
      with explicit signs added to disambiguate mixed-sign intervals.
 -->
-<literal>sql_standard</literal>形式は、時間間隔値が標準制約（構成要素に正負が混在していない年数と月数のみ、または日数と時間のみ）を満足する場合、時間間隔リテラル文字列に対し標準SQLに準拠する出力を作成します。
+<literal>sql_standard</literal>形式は、時間間隔値が標準制約（構成要素に正負が混在していない年数と月数のみ、または日数と時間のみ）を満足する場合、時間間隔リテラル文字列に対し標準SQLに準拠している出力を作成します。
 それ以外の場合、出力は、標準的な年数-月数のリテラル文字列の後に日数-時間のリテラル文字列が続いたものになり、正負混在した時間間隔のあいまいさを無くすために明示的な符号が付加されます。
     </para>
 

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -972,7 +972,7 @@ NULLを比較可能な値とした上で、等しい。
     NULL</literal> clauses to <literal>x IS NULL</literal>.
 -->
 アプリケーションによっては、<literal><replaceable>expression</replaceable> = NULL</literal>が、<replaceable>expression</replaceable>がNULL値と評価されるのであれば真を返すことを期待することがあります。
-こうしたアプリケーションは標準SQLに従うように改修することを強く推奨します。
+これらのアプリケーションをSQL標準に準拠するように変更することを強くお勧めします。
 しかし、それができなければ<xref linkend="guc-transform-null-equals"/>を使用することで対応することができます。
 これを有効にした場合、<productname>PostgreSQL</productname>は<literal>x = NULL</literal>句を<literal>x IS NULL</literal>に変換します。
    </para>

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -972,7 +972,7 @@ NULLを比較可能な値とした上で、等しい。
     NULL</literal> clauses to <literal>x IS NULL</literal>.
 -->
 アプリケーションによっては、<literal><replaceable>expression</replaceable> = NULL</literal>が、<replaceable>expression</replaceable>がNULL値と評価されるのであれば真を返すことを期待することがあります。
-これらのアプリケーションをSQL標準に準拠するように変更することを強くお勧めします。
+これらのアプリケーションを標準SQLに準拠するように変更することを強くお勧めします。
 しかし、それができなければ<xref linkend="guc-transform-null-equals"/>を使用することで対応することができます。
 これを有効にした場合、<productname>PostgreSQL</productname>は<literal>x = NULL</literal>句を<literal>x IS NULL</literal>に変換します。
    </para>

--- a/doc/src/sgml/func1.sgml
+++ b/doc/src/sgml/func1.sgml
@@ -903,7 +903,7 @@ NULLを比較可能な値とした上で、等しい。
     NULL</literal> clauses to <literal>x IS NULL</literal>.
 -->
 アプリケーションによっては、<literal><replaceable>expression</replaceable> = NULL</literal>が、<replaceable>expression</replaceable>がNULL値と評価されるのであれば真を返すことを期待することがあります。
-こうしたアプリケーションは標準SQLに従うように改修することを強く推奨します。
+これらのアプリケーションを標準SQLに準拠するように変更することを強くお勧めします。
 しかし、それができなければ<xref linkend="guc-transform-null-equals"/>を使用することで対応することができます。
 これを有効にした場合、<productname>PostgreSQL</productname>は<literal>x = NULL</literal>句を<literal>x IS NULL</literal>に変換します。
    </para>

--- a/doc/src/sgml/information_schema.sgml
+++ b/doc/src/sgml/information_schema.sgml
@@ -47,7 +47,7 @@
    same schema, but users can specify such duplicate names.
 -->
 制約情報についてデータベースに問い合わせるとき、一行を返すことが想定される標準に準拠したクエリが数行の結果を返す場合があります。
-これは、制約名がスキーマ内で一意になることをSQL標準が要求しているのに対して、<productname>PostgreSQL</productname>はこの制約を強制しないためです。
+これは、制約名がスキーマ内で一意になることを標準SQLが要求しているのに対して、<productname>PostgreSQL</productname>はこの制約を強制しないためです。
 <productname>PostgreSQL</productname>は自動生成される制約の名前がスキーマ内で重複することを防ぎますが、ユーザは重複する名前を指定できます。
   </para>
 
@@ -950,7 +950,7 @@ PostgreSQLはひとつのデータベース内で複数の文字セットをサ�
 <!--
    Take note of how the following terms are used in the SQL standard:
 -->
-以下の用語のSQL標準での使われ方に注意してください。
+以下の用語の標準SQLでの使われ方に注意してください。
    <variablelist>
     <varlistentry>
 <!--
@@ -6356,7 +6356,7 @@ ORDER BY c.ordinal_position;
        shows <literal>YES</literal> if the privilege
        is <literal>SELECT</literal>, else <literal>NO</literal>.
 -->
-SQL標準では、<literal>WITH HIERARCHY OPTION</literal>は、継承テーブル階層に対するある操作を許可する独立した（副次）権限です。
+標準SQLでは、<literal>WITH HIERARCHY OPTION</literal>は、継承テーブル階層に対するある操作を許可する独立した（副次）権限です。
 PostgreSQLでは、これは<literal>SELECT</literal>権限に含まれているため、この列は権限が<literal>SELECT</literal>の場合は<literal>YES</literal>、それ以外の場合は<literal>NO</literal>です。
       </para></entry>
      </row>
@@ -6998,7 +6998,7 @@ PostgreSQLではデータ型は実際の権限を持たず、<literal>PUBLIC</li
    about specific names.
 -->
 ビュー内の両方の関数のエントリは、ルーチンに関する他の情報スキーマビューと矛盾する方法で列名が使用されていても、ルーチンの<quote>仕様</quote>名称を参照していることに注意してください。
-これはSQL標準に従っていますが、間違いなく設計ミスです。
+これは標準SQLに従っていますが、間違いなく設計ミスです。
 仕様名称の詳細は<xref linkend="infoschema-routines"/>を参照してください。
   </para>
 
@@ -8826,7 +8826,7 @@ PostgreSQLではデータ型は実際の権限を持たず、<literal>PUBLIC</li
    Note that in accordance with the SQL standard, the start, minimum,
    maximum, and increment values are returned as character strings.
 -->
-SQL標準に従い、開始、最小、最大および増加の値が文字列で返されることに注意してください。
+標準SQLに従い、開始、最小、最大および増加の値が文字列で返されることに注意してください。
   </para>
  </sect1>
 
@@ -9599,7 +9599,7 @@ ODBCインタフェースの説明に記載されています。
        shows <literal>YES</literal> if the privilege
        is <literal>SELECT</literal>, else <literal>NO</literal>.
 -->
-SQL標準では、<literal>WITH HIERARCHY OPTION</literal>は、継承テーブル階層に対するある操作を許可する独立した（副次）権限です。
+標準SQLでは、<literal>WITH HIERARCHY OPTION</literal>は、継承テーブル階層に対するある操作を許可する独立した（副次）権限です。
 PostgreSQLでは、これは<literal>SELECT</literal>権限に含まれているため、この列は権限が<literal>SELECT</literal>の場合は<literal>YES</literal>、それ以外の場合は<literal>NO</literal>です。
       </para></entry>
      </row>
@@ -10382,7 +10382,7 @@ PostgreSQLはこれをサポートしていません。
 一方、標準SQLでは1つのみしか許されません。
 トリガが複数のイベントで発行するように定義された場合、それぞれのイベントで1行という形で、情報スキーマ内では複数の行として表現されます。
 これらの2つの問題の結果、<literal>triggers</literal>ビューの主キーは実際、標準SQLで定義された<literal>(trigger_catalog, trigger_schema, trigger_name)</literal>ではなく、<literal>(trigger_catalog, trigger_schema, event_object_table, trigger_name, event_manipulation)</literal>となります。
-それでもなお、標準SQLに従う（スキーマ内でトリガ名を一意とし、トリガに対し1種類のイベントしか持たせないという）手法でトリガを定義していれば、これは影響ありません。
+それでもなお、標準SQLに準拠している（スキーマ内でトリガ名を一意とし、トリガに対し1種類のイベントしか持たせないという）手法でトリガを定義していれば、これは影響ありません。
   </para>
 
   <note>

--- a/doc/src/sgml/json.sgml
+++ b/doc/src/sgml/json.sgml
@@ -1209,7 +1209,7 @@ PL/Python向けの拡張は、<literal>jsonb_plpython3u</literal>と呼ばれま
    At the same time, to provide a natural way of working with JSON data,
    SQL/JSON path syntax uses some JavaScript conventions:
 -->
-SQL/JSONパス述部および演算子のセマンティクスは、SQLに準拠しています。
+SQL/JSONパス述部および演算子のセマンティクスは、SQLに従います。
 同時に、JSONデータを処理する自然な方法を提供するために、SQL/JSONのパス構文ではいくつかのJavaScript規則を使用します。
   </para>
 

--- a/doc/src/sgml/ref/alter_foreign_data_wrapper.sgml
+++ b/doc/src/sgml/ref/alter_foreign_data_wrapper.sgml
@@ -246,7 +246,7 @@ ALTER FOREIGN DATA WRAPPER dbi VALIDATOR bob.myvalidator;
    <literal>VALIDATOR</literal>, <literal>OWNER TO</literal>, and <literal>RENAME</literal>
    clauses are extensions.
 -->
-<command>ALTER FOREIGN DATA WRAPPER</command>はISO/IEC 9075-9 (SQL/MED)に従います。
+<command>ALTER FOREIGN DATA WRAPPER</command>はISO/IEC 9075-9 (SQL/MED)に準拠しています。
 ただし、 <literal>HANDLER</literal>、<literal>VALIDATOR</literal>、<literal>OWNER TO</literal>、<literal>RENAME</literal>句は拡張です。
   </para>
  </refsect1>

--- a/doc/src/sgml/ref/alter_foreign_table.sgml
+++ b/doc/src/sgml/ref/alter_foreign_table.sgml
@@ -737,7 +737,7 @@ ALTER FOREIGN TABLE myschema.distributors OPTIONS (ADD opt1 'value', SET opt2 'v
    Also, the ability to specify more than one manipulation in a single
    <command>ALTER FOREIGN TABLE</command> command is an extension.
 -->
-<literal>ADD</literal>、<literal>DROP</literal>、<literal>SET DATA TYPE</literal>構文は標準SQLに準拠します。
+<literal>ADD</literal>、<literal>DROP</literal>、<literal>SET DATA TYPE</literal>構文は標準SQLに準拠しています。
 他の構文は標準SQLに対する<productname>PostgreSQL</productname>の拡張です。
 単一の<command>ALTER FOREIGN TABLE</command>コマンドに複数の操作を指定する機能も拡張です。
   </para>

--- a/doc/src/sgml/ref/alter_sequence.sgml
+++ b/doc/src/sgml/ref/alter_sequence.sgml
@@ -480,7 +480,7 @@ ALTER SEQUENCE serial RESTART WITH 105;
    <literal>SET SCHEMA</literal> clauses, which are
    <productname>PostgreSQL</productname> extensions.
 -->
-<command>ALTER SEQUENCE</command>は、<productname>PostgreSQL</productname>の拡張である<literal>AS</literal>、<literal>START WITH</literal>、<literal>OWNED BY</literal>、<literal>OWNER TO</literal>、<literal>RENAME TO</literal>、<literal>SET SCHEMA</literal>構文を除いて、標準<acronym>SQL</acronym>に従っています。
+<command>ALTER SEQUENCE</command>は、標準<acronym>SQL</acronym>に準拠していますが、<productname>PostgreSQL</productname>の拡張である<literal>AS</literal>、<literal>START WITH</literal>、<literal>OWNED BY</literal>、<literal>OWNER TO</literal>、<literal>RENAME TO</literal>、<literal>SET SCHEMA</literal>構文を除きます。
   </para>
  </refsect1>
 

--- a/doc/src/sgml/ref/alter_server.sgml
+++ b/doc/src/sgml/ref/alter_server.sgml
@@ -185,7 +185,7 @@ ALTER SERVER foo VERSION '8.4' OPTIONS (SET host 'baz');
    The <literal>OWNER TO</literal> and <literal>RENAME</literal> forms are
    PostgreSQL extensions.
 -->
-   <command>ALTER SERVER</command>はISO/IEC 9075-9 (SQL/MED)に従います。
+<command>ALTER SERVER</command>はISO/IEC 9075-9 (SQL/MED)に準拠しています。
 <literal>OWNER TO</literal>と<literal>RENAME</literal>構文はPostgreSQLの拡張です。
   </para>
  </refsect1>

--- a/doc/src/sgml/ref/alter_table.sgml
+++ b/doc/src/sgml/ref/alter_table.sgml
@@ -2524,7 +2524,7 @@ ALTER TABLE measurement
    Also, the ability to specify more than one manipulation in a single
    <command>ALTER TABLE</command> command is an extension.
 -->
-（<literal>USING INDEX</literal>がない）<literal>ADD</literal>、<literal>DROP [COLUMN]</literal>、<literal>DROP IDENTITY</literal>、<literal>RESTART</literal>、<literal>SET DEFAULT</literal>、（<literal>USING</literal>のない）<literal>SET DATA TYPE</literal>、<literal>SET GENERATED</literal>、<literal>SET <replaceable>sequence_option</replaceable></literal>構文は標準SQLに従います。
+（<literal>USING INDEX</literal>がない）<literal>ADD</literal>、<literal>DROP [COLUMN]</literal>、<literal>DROP IDENTITY</literal>、<literal>RESTART</literal>、<literal>SET DEFAULT</literal>、（<literal>USING</literal>のない）<literal>SET DATA TYPE</literal>、<literal>SET GENERATED</literal>、<literal>SET <replaceable>sequence_option</replaceable></literal>構文は標準SQLに準拠しています。
 他の構文は標準SQLに対する<productname>PostgreSQL</productname>の拡張です。
 また、単一の<command>ALTER TABLE</command>コマンド内に複数の操作を指定する機能も<productname>PostgreSQL</productname>の拡張です。
   </para>

--- a/doc/src/sgml/ref/alter_user_mapping.sgml
+++ b/doc/src/sgml/ref/alter_user_mapping.sgml
@@ -155,7 +155,7 @@ ALTER USER MAPPING FOR bob SERVER foo OPTIONS (SET password 'public');
    the standard here in the interest of consistency and
    interoperability.
 -->
-<command>ALTER USER MAPPING</command>はISO/IEC 9075-9(SQL/MED)に従います。
+<command>ALTER USER MAPPING</command>はISO/IEC 9075-9(SQL/MED)に準拠しています。
 小さな構文上の問題があります。
 標準では<literal>FOR</literal>キーワードを省略します。
 <literal>CREATE USER MAPPING</literal>と<literal>DROP USER MAPPING</literal>では<literal>FOR</literal>を似たような位置で使用し、またIBM DB2（他の主なSQL/MED実装になっています）では<literal>ALTER USER MAPPING</literal>で必要としていますので、PostgreSQLは、一貫性と相互運用性を目的に、標準と違いを持たせています。

--- a/doc/src/sgml/ref/create_foreign_data_wrapper.sgml
+++ b/doc/src/sgml/ref/create_foreign_data_wrapper.sgml
@@ -232,7 +232,7 @@ CREATE FOREIGN DATA WRAPPER mywrapper
    clauses <literal>LIBRARY</literal> and <literal>LANGUAGE</literal>
    are not implemented in <productname>PostgreSQL</productname>.
 -->
-<command>CREATE FOREIGN DATA WRAPPER</command>はISO/IEC 9075-9 (SQL/MED)に従います。
+<command>CREATE FOREIGN DATA WRAPPER</command>はISO/IEC 9075-9 (SQL/MED)に準拠しています。
 ただし、<literal>HANDLER</literal>句と<literal>VALIDATOR</literal>句は拡張であり、<productname>PostgreSQL</productname>では標準の<literal>LIBRARY</literal>句と<literal>LANGUAGE</literal>句は実装されていません。
   </para>
 

--- a/doc/src/sgml/ref/create_sequence.sgml
+++ b/doc/src/sgml/ref/create_sequence.sgml
@@ -546,7 +546,7 @@ END;
    <command>CREATE SEQUENCE</command> conforms to the <acronym>SQL</acronym>
    standard, with the following exceptions:
 -->
-以下の例外を除き、<command>CREATE SEQUENCE</command>は標準<acronym>SQL</acronym>に従います。
+以下の例外を除き、<command>CREATE SEQUENCE</command>は標準<acronym>SQL</acronym>に準拠しています。
    <itemizedlist>
     <listitem>
      <para>

--- a/doc/src/sgml/ref/create_server.sgml
+++ b/doc/src/sgml/ref/create_server.sgml
@@ -227,7 +227,7 @@ CREATE SERVER myserver FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host 'foo', db
 <!--
    <command>CREATE SERVER</command> conforms to ISO/IEC 9075-9 (SQL/MED).
 -->
-<command>CREATE SERVER</command>はISO/IEC 9075-9 (SQL/MED)に従います。
+<command>CREATE SERVER</command>はISO/IEC 9075-9 (SQL/MED)に準拠しています。
   </para>
  </refsect1>
 

--- a/doc/src/sgml/ref/create_table.sgml
+++ b/doc/src/sgml/ref/create_table.sgml
@@ -3122,7 +3122,7 @@ CREATE TABLE cities_partdef
    The <command>CREATE TABLE</command> command conforms to the
    <acronym>SQL</acronym> standard, with exceptions listed below.
 -->
-<command>CREATE TABLE</command>は、以下に挙げるものを除いて、標準<acronym>SQL</acronym>に従います。
+<command>CREATE TABLE</command>は、以下に挙げるものを除いて、標準<acronym>SQL</acronym>に準拠しています。
   </para>
 
   <refsect2>
@@ -3332,7 +3332,7 @@ CREATE TABLE cities_partdef
     constraint, and index names must be unique across all relations within
     the same schema.
 -->
-SQL標準ではテーブルとドメインの制約はテーブルやドメインを含むスキーマ中で一意な名前を持たなければなりません。
+標準SQLではテーブルとドメインの制約はテーブルやドメインを含むスキーマ中で一意な名前を持たなければなりません。
 <productname>PostgreSQL</productname>はより緩やかで、制約名は特定のテーブルやドメインに付加された制約の中で一意であることだけが求められます。
 しかしながら、この追加的な自由はインデックスに基づく制約（<literal>UNIQUE</literal>、<literal>PRIMARY KEY</literal>、および<literal>EXCLUDE</literal>制約）にはありません。なぜなら、関連付けられたインデックスは制約と同じに命名されて、インデックス名は同スキーマ内の全てのリレーションの中で一意でなければならないからです。
    </para>
@@ -3429,7 +3429,7 @@ SQL:1999以降では、異なる構文と意味体系による単一継承を定
     other SQL implementations.  The SQL standard does not specify the storage
     of generated columns.
 -->
-オプション<literal>STORED</literal>は標準ではありませんが他のSQL実装でも使われています。SQL標準は生成列の格納を規定していません。
+オプション<literal>STORED</literal>は標準ではありませんが他のSQL実装でも使われています。標準SQLは生成列の格納を規定していません。
    </para>
   </refsect2>
 

--- a/doc/src/sgml/ref/create_table_as.sgml
+++ b/doc/src/sgml/ref/create_table_as.sgml
@@ -425,7 +425,7 @@ CREATE TEMP TABLE films_recent ON COMMIT DROP AS
    <command>CREATE TABLE AS</command> conforms to the <acronym>SQL</acronym>
    standard.  The following are nonstandard extensions:
 -->
-<command>CREATE TABLE AS</command>は標準<acronym>SQL</acronym>に従います。
+<command>CREATE TABLE AS</command>は標準<acronym>SQL</acronym>に準拠しています。
 以下は非標準の拡張です。
 
    <itemizedlist spacing="compact">

--- a/doc/src/sgml/ref/create_type.sgml
+++ b/doc/src/sgml/ref/create_type.sgml
@@ -1450,7 +1450,7 @@ CREATE TABLE big_objs (
    the <acronym>SQL</acronym> standard also defines other forms that are not
    implemented in <productname>PostgreSQL</productname>.
 -->
-複合型を作成する、最初の<command>CREATE TYPE</command>コマンドの構文は標準<acronym>SQL</acronym>に従います。
+複合型を作成する、最初の<command>CREATE TYPE</command>コマンドの構文は標準<acronym>SQL</acronym>に準拠しています。
 他の構文は<productname>PostgreSQL</productname>の拡張です。
 標準<acronym>SQL</acronym>ではまた他の<command>CREATE TYPE</command>構文を定義していますが、<productname>PostgreSQL</productname>では実装されていません。
   </para>

--- a/doc/src/sgml/ref/create_user_mapping.sgml
+++ b/doc/src/sgml/ref/create_user_mapping.sgml
@@ -165,7 +165,7 @@ CREATE USER MAPPING FOR bob SERVER foo OPTIONS (user 'bob', password 'secret');
 <!--
    <command>CREATE USER MAPPING</command> conforms to ISO/IEC 9075-9 (SQL/MED).
 -->
-<command>CREATE USER MAPPING</command>はISO/IEC 9075-9 (SQL/MED)に従います。
+<command>CREATE USER MAPPING</command>はISO/IEC 9075-9 (SQL/MED)に準拠しています。
   </para>
  </refsect1>
 

--- a/doc/src/sgml/ref/drop_collation.sgml
+++ b/doc/src/sgml/ref/drop_collation.sgml
@@ -140,7 +140,7 @@ DROP COLLATION german;
    <acronym>SQL</acronym> standard, apart from the <literal>IF
    EXISTS</literal> option, which is a <productname>PostgreSQL</productname> extension.
 -->
-<productname>PostgreSQL</productname>の拡張である<literal>IF EXISTS</literal>オプションを除き、<command>DROP COLLATION</command>コマンドは標準<acronym>SQL</acronym>に従います。
+<command>DROP COLLATION</command>コマンドは標準<acronym>SQL</acronym>に準拠していますが、<productname>PostgreSQL</productname>の拡張である<literal>IF EXISTS</literal>オプションを除きます。
   </para>
  </refsect1>
 

--- a/doc/src/sgml/ref/drop_domain.sgml
+++ b/doc/src/sgml/ref/drop_domain.sgml
@@ -140,7 +140,7 @@ DROP DOMAIN box;
    <literal>IF EXISTS</literal> option, which is a <productname>PostgreSQL</productname>
    extension.
 -->
-このコマンドは、<productname>PostgreSQL</productname>の拡張である<literal>IF EXISTS</literal>オプションを除き、標準SQLに準拠しています。
+このコマンドは標準SQLに準拠していますが、<productname>PostgreSQL</productname>の拡張である<literal>IF EXISTS</literal>オプションを除きます。
   </para>
  </refsect1>
 

--- a/doc/src/sgml/ref/drop_foreign_data_wrapper.sgml
+++ b/doc/src/sgml/ref/drop_foreign_data_wrapper.sgml
@@ -140,7 +140,7 @@ DROP FOREIGN DATA WRAPPER dbi;
    9075-9 (SQL/MED).  The <literal>IF EXISTS</literal> clause is
    a <productname>PostgreSQL</productname> extension.
 -->
-<command>DROP FOREIGN DATA WRAPPER</command>はISO/IEC 9075-9 (SQL/MED)に従います。
+<command>DROP FOREIGN DATA WRAPPER</command>はISO/IEC 9075-9 (SQL/MED)に準拠しています。
 <literal>IF EXISTS</literal>句は<productname>PostgreSQL</productname>の拡張です。
   </para>
  </refsect1>

--- a/doc/src/sgml/ref/drop_foreign_table.sgml
+++ b/doc/src/sgml/ref/drop_foreign_table.sgml
@@ -141,7 +141,7 @@ DROP FOREIGN TABLE films, distributors;
    from the <literal>IF EXISTS</literal> option, which is a <productname>PostgreSQL</productname>
    extension.
 -->
-このコマンドは、ISO/IEC 9075-9 (SQL/MED)では１つのコマンドで１つの外部テーブルのみを削除できるという点、および、<productname>PostgreSQL</productname>の拡張である<literal>IF EXISTS</literal>オプションを除き、この標準に従います。
+このコマンドはISO/IEC 9075-9（SQL/MED）に準拠していますが、標準では1コマンドで1つの外部テーブルしか削除できないという点、および、<productname>PostgreSQL</productname>の拡張である<literal>IF EXISTS</literal>オプションを除きます。
   </para>
  </refsect1>
 

--- a/doc/src/sgml/ref/drop_function.sgml
+++ b/doc/src/sgml/ref/drop_function.sgml
@@ -234,13 +234,13 @@ DROP FUNCTION update_employee_salaries();
    This command conforms to the SQL standard, with
    these <productname>PostgreSQL</productname> extensions:
 -->
-このコマンドは標準SQLに従いしますが、以下は<productname>PostgreSQL</productname>の拡張です。
+このコマンドは標準SQLに準拠していますが、以下の<productname>PostgreSQL</productname>の拡張があります。
    <itemizedlist>
     <listitem>
 <!--
      <para>The standard only allows one function to be dropped per command.</para>
 -->
-     <para>標準SQLでは1つのコマンドで関数を1つ削除することしかできません。</para>
+     <para>標準では1コマンドで1つの関数しか削除できません。</para>
     </listitem>
     <listitem>
 <!--

--- a/doc/src/sgml/ref/drop_procedure.sgml
+++ b/doc/src/sgml/ref/drop_procedure.sgml
@@ -218,7 +218,7 @@ DROP PROCEDURE [ IF EXISTS ] <replaceable class="parameter">name</replaceable> [
    traditional <productname>PostgreSQL</productname> interpretation to be
    used.
 -->
-SQL標準との互換性のため、<replaceable class="parameter">argmode</replaceable>印を付けずに、すべての引数のデータ型（<literal>OUT</literal>引数のデータ型を含む）を書くこともできます。
+標準SQLとの互換性のため、<replaceable class="parameter">argmode</replaceable>印を付けずに、すべての引数のデータ型（<literal>OUT</literal>引数のデータ型を含む）を書くこともできます。
 これが行なわれると、プロシージャの<literal>OUT</literal>引数の型はコマンドに対して検証されるように<emphasis>なるでしょう</emphasis>。
 この規定は、引数リストに<replaceable class="parameter">argmode</replaceable>印が含まれていない場合、どの規則を意図しているのかが不明確であるという曖昧さを生じさせます。
 <command>DROP</command>コマンドは両方の方法で検索を試み、2つの異なるプロシージャが見つかった場合エラーを生じます。
@@ -291,13 +291,13 @@ CREATE PROCEDURE do_db_maintenance(IN target_schema text, IN options text) ...
    This command conforms to the SQL standard, with
    these <productname>PostgreSQL</productname> extensions:
 -->
-このコマンドはSQL標準に準拠しますが、以下の<productname>PostgreSQL</productname>の拡張があります。
+このコマンドは標準SQLに準拠していますが、以下の<productname>PostgreSQL</productname>の拡張があります。
    <itemizedlist>
     <listitem>
 <!--
      <para>The standard only allows one procedure to be dropped per command.</para>
 -->
-     <para>標準はコマンドごとに一つのプロシージャしか削除できません。</para>
+     <para>標準では1コマンドで1つのプロシージャしか削除できません。</para>
     </listitem>
     <listitem>
 <!--

--- a/doc/src/sgml/ref/drop_routine.sgml
+++ b/doc/src/sgml/ref/drop_routine.sgml
@@ -130,13 +130,13 @@ DROP ROUTINE foo(integer);
    This command conforms to the SQL standard, with
    these <productname>PostgreSQL</productname> extensions:
 -->
-このコマンドはSQL標準に準拠していますが、以下の<productname>PostgreSQL</productname>の拡張があります。
+このコマンドは標準SQLに準拠していますが、以下の<productname>PostgreSQL</productname>の拡張があります。
    <itemizedlist>
     <listitem>
 <!--
      <para>The standard only allows one routine to be dropped per command.</para>
 -->
-     <para>標準ではコマンド毎に一つのルーチンしか削除できません。</para>
+     <para>標準では1コマンドで1つのルーチンしか削除できません。</para>
     </listitem>
     <listitem>
 <!--

--- a/doc/src/sgml/ref/drop_schema.sgml
+++ b/doc/src/sgml/ref/drop_schema.sgml
@@ -166,7 +166,7 @@ DROP SCHEMA mystuff CASCADE;
    <literal>IF EXISTS</literal> option, which is a <productname>PostgreSQL</productname>
    extension.
 -->
-標準SQLでは一度のコマンド実行につき1つのスキーマしか削除できないという点を除き、および、<productname>PostgreSQL</productname>の拡張である<literal>IF EXISTS</literal>を除き、<command>DROP SCHEMA</command>は、標準SQLと完全な互換性を持ちます。
+<command>DROP SCHEMA</command>は、標準SQLと完全な互換性を持ちますが、標準では1コマンドで1つのスキーマしか削除できないという点、および、<productname>PostgreSQL</productname>の拡張である<literal>IF EXISTS</literal>を除きます。
   </para>
  </refsect1>
 

--- a/doc/src/sgml/ref/drop_sequence.sgml
+++ b/doc/src/sgml/ref/drop_sequence.sgml
@@ -141,7 +141,7 @@ DROP SEQUENCE serial;
    <literal>IF EXISTS</literal> option, which is a <productname>PostgreSQL</productname>
    extension.
 -->
-標準では1コマンドで1つのシーケンスだけを削除できるという点、および、<productname>PostgreSQL</productname>の拡張である <literal>IF EXISTS</literal>オプションを除き、<command>DROP SEQUENCE</command>は標準<acronym>SQL</acronym>に準拠します。
+<command>DROP SEQUENCE</command>は標準<acronym>SQL</acronym>に準拠していますが、標準では1コマンドで1つのシーケンスしか削除できないという点、および、<productname>PostgreSQL</productname>の拡張である <literal>IF EXISTS</literal>オプションを除きます。
   </para>
  </refsect1>
 

--- a/doc/src/sgml/ref/drop_server.sgml
+++ b/doc/src/sgml/ref/drop_server.sgml
@@ -140,7 +140,7 @@ DROP SERVER IF EXISTS foo;
    (SQL/MED).  The <literal>IF EXISTS</literal> clause is
    a <productname>PostgreSQL</productname> extension.
 -->
-<command>DROP SERVER</command>はISO/IEC 9075-9 (SQL/MED)に従います。
+<command>DROP SERVER</command>はISO/IEC 9075-9 (SQL/MED)に準拠しています。
 <literal>IF EXISTS</literal>句は<productname>PostgreSQL</productname>の拡張です。
   </para>
  </refsect1>

--- a/doc/src/sgml/ref/drop_table.sgml
+++ b/doc/src/sgml/ref/drop_table.sgml
@@ -161,7 +161,7 @@ DROP TABLE films, distributors;
    <literal>IF EXISTS</literal> option, which is a <productname>PostgreSQL</productname>
    extension.
 -->
-標準では1コマンドで1テーブルのみを削除できるという点、および、<productname>PostgreSQL</productname>の拡張である<literal>IF EXISTS</literal>オプションを除き、このコマンドは標準SQLに従います。
+このコマンドは標準SQLに準拠していますが、標準では1コマンドで1つのテーブルしか削除できないという点、および、<productname>PostgreSQL</productname>の拡張である<literal>IF EXISTS</literal>オプションを除きます。
   </para>
  </refsect1>
 

--- a/doc/src/sgml/ref/drop_user_mapping.sgml
+++ b/doc/src/sgml/ref/drop_user_mapping.sgml
@@ -137,7 +137,7 @@ DROP USER MAPPING IF EXISTS FOR bob SERVER foo;
    (SQL/MED).  The <literal>IF EXISTS</literal> clause is
    a <productname>PostgreSQL</productname> extension.
 -->
-<command>DROP USER MAPPING</command>はISO/IEC 9075-9 (SQL/MED)に従います。
+<command>DROP USER MAPPING</command>はISO/IEC 9075-9 (SQL/MED)に準拠しています。
 <literal>IF EXISTS</literal>句は<productname>PostgreSQL</productname>の拡張です。
   </para>
  </refsect1>

--- a/doc/src/sgml/ref/drop_view.sgml
+++ b/doc/src/sgml/ref/drop_view.sgml
@@ -140,7 +140,7 @@ DROP VIEW kinds;
    <literal>IF EXISTS</literal> option, which is a <productname>PostgreSQL</productname>
    extension.
 -->
-標準では1コマンドで1つのビューのみを削除できるという点を除き、および<productname>PostgreSQL</productname>の拡張である<literal>IF EXISTS</literal>オプションを除き、このコマンドは標準SQLに従っています。
+このコマンドは標準SQLに準拠していますが、標準では1コマンドで1つのビューしか削除できないという点、および、<productname>PostgreSQL</productname>の拡張である<literal>IF EXISTS</literal>オプションを除きます。
   </para>
  </refsect1>
 

--- a/doc/src/sgml/ref/import_foreign_schema.sgml
+++ b/doc/src/sgml/ref/import_foreign_schema.sgml
@@ -211,7 +211,7 @@ IMPORT FOREIGN SCHEMA foreign_films LIMIT TO (actors, directors)
    <acronym>SQL</acronym> standard, except that the <literal>OPTIONS</literal>
    clause is a <productname>PostgreSQL</productname> extension.
 -->
-<command>IMPORT FOREIGN SCHEMA</command>コマンドは、<literal>OPTIONS</literal>句が<productname>PostgreSQL</productname>の拡張であるという点を除き、標準<acronym>SQL</acronym>に準拠しています。
+<command>IMPORT FOREIGN SCHEMA</command>コマンドは、標準<acronym>SQL</acronym>に準拠していますが、<literal>OPTIONS</literal>句は<productname>PostgreSQL</productname>の拡張です。
   </para>
 
  </refsect1>

--- a/doc/src/sgml/ref/insert.sgml
+++ b/doc/src/sgml/ref/insert.sgml
@@ -1093,7 +1093,7 @@ INSERT INTO distributors (did, dname) VALUES (10, 'Conrad International')
    conforming statement than <literal>ON CONFLICT</literal>, see
    <xref linkend="sql-merge"/>.
 -->
-<command>INSERT</command>は標準SQLに準拠します。
+<command>INSERT</command>は標準SQLに準拠しています。
 ただし、<literal>RETURNING</literal>句、<command>INSERT</command>で<literal>WITH</literal>が可能であること、<literal>ON CONFLICT</literal>で代替の動作を指定できることは<productname>PostgreSQL</productname>の拡張です。
 また、標準SQLでは、列名リストが省略された時に、<literal>VALUES</literal>句または<replaceable>query</replaceable>で一部の列のみを指定することはできません。
 <literal>ON CONFLICT</literal>よりも標準SQLにより準拠した文がお望みであれば、<xref linkend="sql-merge"/>を参照してください。

--- a/doc/src/sgml/ref/merge.sgml
+++ b/doc/src/sgml/ref/merge.sgml
@@ -913,7 +913,7 @@ WHEN MATCHED THEN
 <!--
     This command conforms to the <acronym>SQL</acronym> standard.
 -->
-このコマンドは、標準<acronym>SQL</acronym>に準拠しています。
+このコマンドは標準<acronym>SQL</acronym>に準拠しています。
   </para>
    <para>
 <!--

--- a/doc/src/sgml/ref/rollback_to.sgml
+++ b/doc/src/sgml/ref/rollback_to.sgml
@@ -206,7 +206,7 @@ COMMIT;
 SQLで使用できるのは、<literal>WORK</literal>のみです。
 <literal>TRANSACTION</literal>は使用できず、<literal>ROLLBACK</literal>の後の意味のない言葉として扱われます。
 また、SQLでは<literal>AND [ NO ] CHAIN</literal>句(省略可能)がありますが、これは<productname>PostgreSQL</productname>では現在サポートされていません。
-その他については、このコマンドは標準SQLと互換性を持ちます。
+その他については、このコマンドは標準SQLに準拠しています。
   </para>
  </refsect1>
 

--- a/doc/src/sgml/ref/values.sgml
+++ b/doc/src/sgml/ref/values.sgml
@@ -349,7 +349,7 @@ WHERE ip_address IN (VALUES('192.168.0.1'::inet), ('192.168.0.10'), ('192.168.1.
    under <xref linkend="sql-select"/>.
 -->
   <para>
-<command>VALUES</command>はSQL標準に従います。
+<command>VALUES</command>は標準SQLに準拠しています。
 <literal>LIMIT</literal>および<literal>OFFSET</literal>は<productname>PostgreSQL</productname>の拡張です。
 <xref linkend="sql-select"/>も参照してください。
   </para>


### PR DESCRIPTION
SQL標準を標準SQLに統一。
conforms to ～を準拠するに統一。