### PR TITLE
fix typos in AT TIME ZONE

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -14092,8 +14092,8 @@ SELECT date_bin('15 minutes', TIMESTAMP '2020-02-11 15:44:17', TIMESTAMP '2001-0
          zone.  Since no date is supplied, this uses the currently active UTC
          offset for the named destination zone.
 -->
-与えられた時刻<emphasis>with</emphasis> time zoneを新しい時間帯に変換します。
-判断するためのデータがないので、現在の有効なUTCオフセットを目的の時間帯のために使用します。
+与えられた<emphasis>時間帯付き</emphasis>時刻を新しい時間帯に変換します。
+日付が指定されないので、現在の有効なUTCオフセットを目的の時間帯のために使用します。
         </para>
         <para>
          <literal>time with time zone '05:34:17-05' at time zone 'UTC'</literal>

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -14073,7 +14073,7 @@ SELECT date_bin('15 minutes', TIMESTAMP '2020-02-11 15:44:17', TIMESTAMP '2001-0
          time stamp <emphasis>without</emphasis> time zone, as the time would
          appear in that zone.
 -->
-与えられた<emphasis>時間帯付き</emphasis>時刻を、時刻がその時間帯にあるものとして<emphasis>時間帯なし</emphasis>タイムスタンプに変換します。
+与えられた<emphasis>時間帯付き</emphasis>タイムスタンプを、時刻がその時間帯にあるものとして<emphasis>時間帯なし</emphasis>タイムスタンプに変換します。
         </para>
         <para>
          <literal>timestamp with time zone '2001-02-16 20:38:40-05' at time zone 'America/Denver'</literal>

--- a/doc/src/sgml/func2.sgml
+++ b/doc/src/sgml/func2.sgml
@@ -4040,8 +4040,8 @@ SELECT date_bin('15 minutes', TIMESTAMP '2020-02-11 15:44:17', TIMESTAMP '2001-0
          zone.  Since no date is supplied, this uses the currently active UTC
          offset for the named destination zone.
 -->
-与えられた時刻<emphasis>with</emphasis> time zoneを新しい時間帯に変換します。
-判断するためのデータがないので、現在の有効なUTCオフセットを目的の時間帯のために使用します。
+与えられた<emphasis>時間帯付き</emphasis>時刻を新しい時間帯に変換します。
+日付が指定されないので、現在の有効なUTCオフセットを目的の時間帯のために使用します。
         </para>
         <para>
          <literal>time with time zone '05:34:17-05' at time zone 'UTC'</literal>


### PR DESCRIPTION
バージョン16で奇妙な訳を見つけました。

時刻with time zone
 型ではないので、"with time zone"も訳すべきかと。（英語では強調はwithだけですが、直前では時間帯まで含めて強調していますので、そちらに合わせました。）

判断するためのデータがないので
 原文はdataではなくdateなので、「日付が指定されないので」だと思います。（日付が指定されないので、夏時間かそうでないか判断するためのデータがない、ということなのかもしれませんが、意訳しすぎかと。）
