### PR TITLE
wal_writer_delay と wal_writer_flush_after の説明を修正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -5114,7 +5114,7 @@ WALバッファの内容はトランザクションのコミット毎にディ�
 -->
 WALライタがWALをフラッシュする頻度を時間で指定します。
 WALをフラッシュしたあと、非同期コミットしているトランザクションに起こされない限り、<varname>wal_writer_delay</varname>ミリ秒待機します。
-最後のフラッシュが過去<varname>wal_writer_delay</varname>以内に行われ、かつそれ以降<varname>wal_writer_flush_after</varname>相当のWALが生成されている場合は、WALはオペレーティングシステムに書き込まれますが、ディスクにはフラッシュされません。
+最後のフラッシュが過去<varname>wal_writer_delay</varname>以内に行われ、かつそれ以降<varname>wal_writer_flush_after</varname>相当のWALが生成されていない場合は、WALはオペレーティングシステムに書き込まれますが、ディスクにはフラッシュされません。
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
 デフォルト値は200ミリ秒（<literal>200ms</literal>）です。
 ある種のシステムでは、待機間隔の実質的な分解能は10ミリ秒です。
@@ -5150,7 +5150,7 @@ WALをフラッシュしたあと、非同期コミットしているトラン�
         <filename>postgresql.conf</filename> file or on the server command line.
 -->
 WALライタがWALをフラッシュする頻度を量で指定します。
-最後のフラッシュが過去<varname>wal_writer_delay</varname>以内に起こなわれ、かつそれ以降<varname>wal_writer_flush_after</varname>相当のWALが生成されている場合は、WALはオペレーティングシステムに書き込まれますが、ディスクにはフラッシュされません。
+最後のフラッシュが過去<varname>wal_writer_delay</varname>以内に行われ、かつそれ以降<varname>wal_writer_flush_after</varname>相当のWALが生成されていない場合は、WALはオペレーティングシステムに書き込まれますが、ディスクにはフラッシュされません。
 <varname>wal_writer_flush_after</varname>が<literal>0</literal>に設定されている場合は、WALデータが書かれるたびにWALが即時にフラッシュされます。
 この値が単位なしで指定された場合は、WALブロック単位であるとみなします。すなわち、<symbol>XLOG_BLCKSZ</symbol>バイト、一般的には8kBです。
 デフォルト値は<literal>1MB</literal>です。

--- a/doc/src/sgml/config1.sgml
+++ b/doc/src/sgml/config1.sgml
@@ -798,7 +798,7 @@ WALバッファの内容はトランザクションのコミット毎にディ�
 -->
 WALライタがWALをフラッシュする頻度を時間で指定します。
 WALをフラッシュしたあと、非同期コミットしているトランザクションに起こされない限り、<varname>wal_writer_delay</varname>ミリ秒待機します。
-最後のフラッシュが過去<varname>wal_writer_delay</varname>以内に行われ、かつそれ以降<varname>wal_writer_flush_after</varname>相当のWALが生成されている場合は、WALはオペレーティングシステムに書き込まれますが、ディスクにはフラッシュされません。
+最後のフラッシュが過去<varname>wal_writer_delay</varname>以内に行われ、かつそれ以降<varname>wal_writer_flush_after</varname>相当のWALが生成されていない場合は、WALはオペレーティングシステムに書き込まれますが、ディスクにはフラッシュされません。
 この値が単位なしで指定された場合は、ミリ秒単位であるとみなします。
 デフォルト値は200ミリ秒（<literal>200ms</literal>）です。
 ある種のシステムでは、待機間隔の実質的な分解能は10ミリ秒です。
@@ -834,7 +834,7 @@ WALをフラッシュしたあと、非同期コミットしているトラン�
         <filename>postgresql.conf</filename> file or on the server command line.
 -->
 WALライタがWALをフラッシュする頻度を量で指定します。
-最後のフラッシュが過去<varname>wal_writer_delay</varname>以内に起こなわれ、かつそれ以降<varname>wal_writer_flush_after</varname>相当のWALが生成されている場合は、WALはオペレーティングシステムに書き込まれますが、ディスクにはフラッシュされません。
+最後のフラッシュが過去<varname>wal_writer_delay</varname>以内に行われ、かつそれ以降<varname>wal_writer_flush_after</varname>相当のWALが生成されていない場合は、WALはオペレーティングシステムに書き込まれますが、ディスクにはフラッシュされません。
 <varname>wal_writer_flush_after</varname>が<literal>0</literal>に設定されている場合は、WALデータが書かれるたびにWALが即時にフラッシュされます。
 この値が単位なしで指定された場合は、WALブロック単位であるとみなします。すなわち、<symbol>XLOG_BLCKSZ</symbol>バイト、一般的には8kBです。
 デフォルト値は<literal>1MB</literal>です。


### PR DESCRIPTION
wal_writer_delay と wal_writer_flush_after の説明に一部誤りがある（または誤読の可能性がある）ように見受けられたので PR いたしました。

現状は「最後のフラッシュが wal_writer_delay 未満に行われ、かつ wal_writer_flush_after 相当の出力がある場合はフラッシュされない」という説明に読めますが、wal_writer_flush_after 相当の出力がある（つまり wal_writer_flush_after を越えるような出力がある）場合はフラッシュされると認識しております。

README にもそのような説明がございました。
https://github.com/postgres/postgres/blob/master/src/backend/access/transam/README#L804-L806
```
If more than wal_writer_delay has
passed, or more than wal_writer_flush_after blocks have been written, since
the last flush, WAL is also flushed up to the current location.
```