### PR TITLE
update dfunc for 17.0

### DIFF
--- a/doc/src/sgml/dfunc.sgml
+++ b/doc/src/sgml/dfunc.sgml
@@ -106,9 +106,7 @@ cc -shared -o foo.so foo.o
       <systemitem class="osname">FreeBSD</systemitem>, older versions used
       the <filename>gcc</filename> compiler.
 -->
-《マッチ度[51.351351]》これは<systemitem class="osname">FreeBSD</systemitem>のバージョン3.0に適用されます。
-《機械翻訳》これは<systemitem class="osname">FreeBSD</systemitem>のバージョン13.0で適用されます。
-古いバージョンでは<filename>gcc</filename>コンパイラを使用していました。
+これは<systemitem class="osname">FreeBSD</systemitem>のバージョン13.0に適用されます。古いバージョンでは<filename>gcc</filename>コンパイラを使用していました。
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
dfunc.sgml の 17.0 対応です。

FreeBSD13.0（というか14も含めて最近のFreeBSD）での標準Cコンパイラはclangで、3.0当時はgccだったのは確実です。なので変更前も変更後も間違ったことは書いてません。が、その間があるよね。標準Cコンパイラは確かかなり以前に切り替わっているよね、と思いました。独り言です。
あと、FreeBSDでは今でも追加でgccを（パッケージから）インストールして使うことは可能です。これも独り言です。