### PR TITLE
datatype.sgml の17.0対応

### DIFF
--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -5103,14 +5103,22 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
        </row>
        <row>
         <entry><type>lseg</type></entry>
+<!--
         <entry>32 bytes</entry>
         <entry>Finite line segment</entry>
+-->
+        <entry>32バイト</entry>
+        <entry>有限の線分</entry>
         <entry>[(x1,y1),(x2,y2)]</entry>
        </row>
        <row>
         <entry><type>box</type></entry>
+<!--
         <entry>32 bytes</entry>
         <entry>Rectangular box</entry>
+-->
+        <entry>32バイト</entry>
+        <entry>矩形</entry>
         <entry>(x1,y1),(x2,y2)</entry>
        </row>
        <row>
@@ -5456,7 +5464,7 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
      semantic difference is that a polygon is considered to include the
      area within it, while a path is not.
 -->
-《マッチ度[90.638298]》多角形は座標点（多角形の頂点）のリストで表現されます。
+多角形は座標点（多角形の頂点）のリストで表現されます。
 多角形は閉経路ととても良く似ています。多角形は領域をその内側に含むと考えますが、閉経路ではそのように考えない点が本質的な意味の違いです。
     </para>
 

--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -1447,10 +1447,8 @@ IEEE 754では、<literal>NaN</literal>は（<literal>NaN</literal>を含む）�
       autoincrementing column.  Another way is to use the SQL-standard
       identity column feature, described at <xref linkend="ddl-identity-columns"/>.
 -->
-《マッチ度[83.743842]》このセクションではPostgreSQL固有の自動増分列の作成方法について記述します。
-SQL標準の識別列を作成する方法は、<xref linkend="sql-createtable"/>に記述されています。
-《機械翻訳》このセクションでは、自動増分カラムを作成するPostgreSQL固有の方法について説明します。
-もう1つの方法は、<xref linkend="ddl-identity-columns"/>で説明されているSQL標準のアイデンティティカラム機能を使用することです。
+このセクションではPostgreSQL固有の自動増分列の作成方法について記述します。
+標準SQLの識別列機能を使用する方法は、<xref linkend="ddl-identity-columns"/>に記述されています。
      </para>
     </note>
 


### PR DESCRIPTION
変更箇所はリンクの更新だけでしたが、同行の既存訳も少し修正しています。