### PR TITLE
訳抜けの修正

### DIFF
--- a/doc/src/sgml/plpgsql.sgml
+++ b/doc/src/sgml/plpgsql.sgml
@@ -254,7 +254,7 @@
      could be written as a procedure in that case.)
 -->
 最後に、有用な戻り値を持たない場合、<application>PL/pgSQL</application>関数は、<type>void</type>を返すように宣言することができます。
-（あるいは、この場合はプロシージャとして書くこともできます）
+（あるいは、この場合はプロシージャとして書くこともできます。）
     </para>
 
     <para>
@@ -1395,7 +1395,7 @@ IF count(*) &gt; 0 FROM my_table THEN ...
 -->
 <literal>IF</literal>と<literal>THEN</literal>間の<replaceable>式</replaceable>は<literal>SELECT count(*) &gt; 0 FROM my_table</literal>であるかのように解析されるからです。
 <literal>SELECT</literal>は1つの列、2つ以上でない行を生成しなければなりません。
-(行を生成しないのであれば、結果はNULLとして受け付けられます。)
+（行を生成しないのであれば、結果はNULLとして受け付けられます。）
     </para>
   </sect1>
 
@@ -2032,7 +2032,7 @@ EXECUTE format('SELECT count(*) FROM %I '
      (This example relies on the SQL rule that string literals separated by a
      newline are implicitly concatenated.)
 -->
-(この例は、改行により分割された文字列リテラルが暗黙に連結されるというSQL規則に依存しています。)
+（この例は、改行により分割された文字列リテラルが暗黙に連結されるというSQL規則に依存しています。）
     </para>
 
     <para>
@@ -2151,7 +2151,7 @@ EXECUTE format('SELECT count(*) FROM %I '
 -->
 動的コマンドを使用する時、しばしば単一引用符をエスケープしなければなりません。
 関数本体における固定のテキストを引用符付けする推奨方法は、ドル引用符を使用する方法です。
-（ドル引用符を用いない旧式のコードを保有している場合は、<xref linkend="plpgsql-quote-tips"/>の概要を参照することが、理解しやすいコードへの変換作業の手助けになります）。
+（ドル引用符を用いない旧式のコードを保有している場合は、<xref linkend="plpgsql-quote-tips"/>の概要を参照することが、理解しやすいコードへの変換作業の手助けになります。）
     </para>
 
     <para>
@@ -2322,6 +2322,7 @@ EXECUTE format('UPDATE tbl SET %I = $1 WHERE key = $2', colname)
      text and quoting them via <literal>%L</literal>.  It is also more efficient.
 -->
 変数が、無条件にテキストに変換されて<literal>%L</literal>で引用符付けされることなく、固有のデータ形式で処理されるため、この形式はより優れています。
+また、より効率的です。
     </para>
    </example>
 
@@ -4990,7 +4991,7 @@ FETCH <optional> <replaceable>direction</replaceable> { FROM | IN } </optional> 
      with the <literal>SCROLL</literal> option.
 -->
 <replaceable>direction</replaceable>句の省略は、<literal>NEXT</literal>の指定と同じです。
-<replaceable>count</replaceable>を使う形式では、<replaceable>count</replaceable>はいかなる整数値の式も可能です。(SQL <command>FETCH</command>コマンドとは異なります。あちらは整数定数のみを受け付けます。)
+<replaceable>count</replaceable>を使う形式では、<replaceable>count</replaceable>はいかなる整数値の式も可能です（SQL <command>FETCH</command>コマンドとは異なります。あちらは整数定数のみを受け付けます）。
 <literal>SCROLL</literal>オプションを用いてカーソルを宣言または開かないと、<replaceable>direction</replaceable>の値による逆方向への移動の要求は失敗します。
     </para>
 
@@ -6649,7 +6650,7 @@ SELECT * FROM sales_summary_bytime;
 これは、呼び出された文が多くの行を変更する場合には行トリガの方法よりとても速くなる場合があります。
 <literal>REFERENCING</literal>句はそれぞれの場合で異ならなければなりませんので、それぞれの種類のイベントに対して別々のトリガ宣言をしなければならないことに注意してください。
 ですが、もし選ぶのなら、このために単一のトリガ関数が使えなくなることはありません。
-(実際には、3つに別れた関数を使い、実行時の<varname>TG_OP</varname>の確認を避ける方が良いでしょう。)
+（実際には、3つに別れた関数を使い、実行時の<varname>TG_OP</varname>の確認を避ける方が良いでしょう。）
     </para>
 
 <programlisting>
@@ -6862,7 +6863,7 @@ INSERT INTO foo (foo) VALUES (foo(foo));
     <xref linkend="plpgsql-statements-executing-dyn"/>.)
 -->
 これを理解する別の方法は、変数の置換はSQLコマンドへデータ値を挿入できるだけだということです。コマンドが参照するデータベースオブジェクトを動的には変更できません。
-(そのようにしたければ、<xref linkend="plpgsql-statements-executing-dyn"/>に書かれているように、コマンド文字列を動的に構成しなければなりません。)
+（そのようにしたければ、<xref linkend="plpgsql-statements-executing-dyn"/>に書かれているように、コマンド文字列を動的に構成しなければなりません。）
    </para>
 
    <para>
@@ -7125,7 +7126,7 @@ $$ LANGUAGE plpgsql;
 その後にその式やコマンドが行われる時には、そのプリペアドステートメントを再利用します。
 こうして、めったに分岐されない条件付きコードパスを持つ関数では、現在のセッションで実行されないそれらのコマンドの解析によるオーバーヘッドを背負いこむことはありません。
 欠点は特定の式や問い合わせのエラーが、関数の該当部分が実行されるまで検出されないことです。
-（典型的な構文エラーは、最初の解釈において検出されますが、それより深いエラーは、実行の時まで検出されません）。
+（典型的な構文エラーは、最初の解釈において検出されますが、それより深いエラーは、実行の時まで検出されません。）
    </para>
 
    <para>
@@ -7847,7 +7848,7 @@ SQLコマンド内に使用された名前が、コマンドで使われてい�
 -->
 <productname>PostgreSQL</productname>の関数本体は文字列リテラルとして書かなければなりません。
 したがって、関数本体内部でドル引用符を使用するか、単一引用符をエスケープする必要があります。
-（<xref linkend="plpgsql-quote-tips"/>を参照してください）。
+（<xref linkend="plpgsql-quote-tips"/>を参照してください。）
       </para>
      </listitem>
 

--- a/doc/src/sgml/pltcl.sgml
+++ b/doc/src/sgml/pltcl.sgml
@@ -290,7 +290,8 @@ CALL tcl_triple(5, 10);
       The result list can be made from an array representation of the
       desired tuple with the <literal>array get</literal> Tcl command.  For example:
 -->
-<literal>array get</literal> Tclコマンドを使って、希望するタプルの配列表現から結果リストを作成することができます。
+<literal>array get</literal> Tclコマンドを使って、希望するタプルの配列表現から結果リストを作成できます。
+以下に例を示します。
 
 <programlisting>
 CREATE FUNCTION raise_pay(employee, delta int) RETURNS employee AS $$

--- a/doc/src/sgml/queries.sgml
+++ b/doc/src/sgml/queries.sgml
@@ -1878,6 +1878,7 @@ SELECT product_id, p.name, (sum(s.units) * (p.price - p.cost)) AS profit
     A clause of the form
 -->
 グループ化セットの中で一般的な２種類については、略記法での指定方法が提供されています。
+以下の句は
 <programlisting>
 ROLLUP ( <replaceable>e1</replaceable>, <replaceable>e2</replaceable>, <replaceable>e3</replaceable>, ... )
 </programlisting>
@@ -1885,7 +1886,7 @@ ROLLUP ( <replaceable>e1</replaceable>, <replaceable>e2</replaceable>, <replacea
     represents the given list of expressions and all prefixes of the list including
     the empty list; thus it is equivalent to
 -->
-上の句は、式の指定されたリストと空のリストを含めたリストのすべてのプレフィックスを表します。
+式の指定されたリストと空のリストを含めたリストのすべてのプレフィックスを表します。
 したがって、以下と同等です。
 <programlisting>
 GROUPING SETS (
@@ -3822,6 +3823,7 @@ SELECT * FROM w AS w1 JOIN w AS w2 ON w1.f = w2.f;
 -->
 ほとんどのデータ変更文（<command>INSERT</command>、<command>UPDATE</command>、<command>DELETE</command>は使用できますが、<command>MERGE</command>は使用できません）は、<literal>WITH</literal>内で使用できます。
 これにより同じ問い合わせ内で複数の異なる操作を行うことができます。
+以下に例を示します。
 
 <programlisting>
 WITH moved_rows AS (

--- a/doc/src/sgml/ref/psql-ref.sgml
+++ b/doc/src/sgml/ref/psql-ref.sgml
@@ -79,7 +79,7 @@ PostgreSQL documentation
       <literal>all</literal>.
 -->
 読み込んだ全ての空でない入力行を標準出力に表示します。
-(これは対話式に読み込まれる行には適用されません。)
+（これは対話式に読み込まれる行には適用されません。）
 これは<varname>ECHO</varname>変数を<literal>all</literal>に設定するのと同じ意味を持ちます。
       </para>
       </listitem>
@@ -166,7 +166,7 @@ echo '\x \\ SELECT * FROM foo;' | psql
 <!--
        (<literal>\\</literal> is the separator meta-command.)
 -->
-のようにします（<literal>\\</literal>はメタコマンドの区切り文字です）。
+のようにします（<literal>\\</literal>はメタコマンドの区切り文字です。）
       </para>
       <para>
 <!--
@@ -506,8 +506,8 @@ EOF
       to <literal>on</literal>.
 -->
 <application>psql</application>がメッセージ出力なしで処理を行うように指示します。
-デフォルトでは、ウェルカム（welcome）メッセージや各種の情報が表示されますが、
-このオプションを使用した場合、これらのメッセージが表示されません。
+デフォルトでは、ウェルカム（welcome）メッセージや各種の情報が表示されます。
+このオプションを使用すると、これらのメッセージが表示されません。
 <option>-c</option>オプションと併用すると便利です。
 これは変数<varname>QUIET</varname>を<literal>on</literal>に設定するのと同じ効力を持ちます。
       </para>
@@ -616,8 +616,8 @@ EOF
       class="parameter">username</replaceable> instead of the default.
       (You must have permission to do so, of course.)
 -->
-デフォルトのユーザではなく<replaceable class="parameter">username</replaceable>ユーザとしてデータベースに接続します
-（当然、そうする権限を持っていなければなりません）。
+デフォルトのユーザではなく<replaceable class="parameter">username</replaceable>ユーザとしてデータベースに接続します。
+（当然、そうする権限を持っていなければなりません。）
       </para>
       </listitem>
     </varlistentry>
@@ -1243,7 +1243,7 @@ Cの形式のブロックコメントは、サーバに送信され、サーバ�
         kept for backwards compatibility. See <command>\pset</command> for a
         more general solution.
 -->
-現在のテーブルの出力形式が「揃えない」になっていれば「揃える」に、
+現在のテーブルの出力形式が「揃えない」になっていれば「揃える」に切り替えます。
 「揃える」になっていれば「揃えない」に設定します。
 このコマンドは後方互換性を保持するためにあります。
 より一般的な解決策は<command>\pset</command>を参照してください。
@@ -2009,8 +2009,8 @@ INSERT INTO tbl1 VALUES ($1, $2) \bind 'first value' 'second value' \g
 サーバ構成パラメータとその値の一覧を表示します。
 <replaceable class="parameter">pattern</replaceable>が指定されている場合は、そのパターンに名前がマッチするパラメータのみが一覧表示されます。
 <replaceable class="parameter">pattern</replaceable>が指定されていない場合は、デフォルト以外の値に設定されているパラメータのみが一覧表示されます。
-(すべてのパラメータを表示するには<literal>\dconfig *</literal>を使用してください。)
-コマンド名に<literal>+</literal>が追加されている場合は、各パラメータが、そのデータ型、パラメータを設定できるコンテキスト、および(デフォルト以外のアクセス権限が付与されている場合)アクセス権限とともに一覧表示されます。
+（すべてのパラメータを表示するには<literal>\dconfig *</literal>を使用してください。）
+コマンド名に<literal>+</literal>が追加されている場合は、各パラメータが、そのデータ型、パラメータを設定できるコンテキスト、および（デフォルト以外のアクセス権限が付与されている場合）アクセス権限とともに一覧表示されます。
         </para>
         </listitem>
       </varlistentry>
@@ -2306,8 +2306,8 @@ INSERT INTO tbl1 VALUES ($1, $2) \bind 'first value' 'second value' \g
 特定種類の関数のみを表示させるには、対応する文字<literal>a</literal>、<literal>n</literal>、<literal>p</literal>、<literal>t</literal>、<literal>w</literal>をコマンドに付けて下さい。
 <replaceable class="parameter">pattern</replaceable>が指定されている場合は、そのパターンに名前がマッチする関数のみが表示されます。
 追加の引数は、型名のパターンで、関数の第1、第2などの引数の型名にマッチします。
-(マッチする関数は指定したものよりも多くの引数を取るかもしれません。
-それを防ぐには、<replaceable class="parameter">arg_pattern</replaceable>の最後にダッシュ<literal>-</literal>を書いてください。)
+（マッチする関数は指定したものよりも多くの引数を取るかもしれません。
+それを防ぐには、<replaceable class="parameter">arg_pattern</replaceable>の最後にダッシュ<literal>-</literal>を書いてください。）
 デフォルトではユーザが作成したオブジェクトのみが表示されます。
 システムオブジェクトを含めるためには、パターンまたは<literal>S</literal>修飾子を付与してください。
 <literal>\df+</literal>構文が使われた場合、各関数の、揮発性、並列処理での安全性、所有者、セキュリティ分類、アクセス権限、言語、内部名（Cと内部関数に対してのみ）や説明を含む付加的情報も表示されます。
@@ -2411,7 +2411,7 @@ INSERT INTO tbl1 VALUES ($1, $2) \bind 'first value' 'second value' \g
         role.
 -->
 データベースロールを一覧表示します。
-(<quote>ユーザ</quote>と<quote>グループ</quote>という概念は<quote>ロール</quote>に統合されましたので、このコマンドは<literal>\du</literal>と同じものになりました。)
+（<quote>ユーザ</quote>と<quote>グループ</quote>という概念は<quote>ロール</quote>に統合されましたので、このコマンドは<literal>\du</literal>と同じものになりました。）
 デフォルトでは、ユーザによって作成されたロールのみが表示されます。
 システムロールを含めるには<literal>S</literal>修飾子を付与してください。
 <replaceable class="parameter">pattern</replaceable>が指定されている場合は、そのパターンに名前がマッチするロールのみが表示されます。
@@ -2513,7 +2513,7 @@ INSERT INTO tbl1 VALUES ($1, $2) \bind 'first value' 'second value' \g
 <replaceable class="parameter">pattern</replaceable>を指定すると、パターンに名前がマッチする演算子のみが表示されます。
 <replaceable class="parameter">arg_pattern</replaceable>を1つ指定すると、パターンに右辺の引数の型名がマッチする前置演算子のみが表示されます。
 <replaceable class="parameter">arg_pattern</replaceable>を2つ指定すると、パターンに引数の型名がマッチする二項演算子のみが表示されます。
-(あるいは、単項演算子の使われない引数に対して<literal>-</literal>と書いてください。)
+（あるいは、単項演算子の使われない引数に対して<literal>-</literal>と書いてください。）
 デフォルトではユーザが作成したオブジェクトのみが表示されます。
 システムオブジェクトを含めるためには、パターンまたは<literal>S</literal>修飾子を付与してください。
 コマンド名に<literal>+</literal>を付加すると、各演算子についての追加情報が表示されますが、現在はその元になっている関数の名前だけです。
@@ -2771,7 +2771,7 @@ INSERT INTO tbl1 VALUES ($1, $2) \bind 'first value' 'second value' \g
         role.
 -->
 データベースロールを一覧表示します。
-(<quote>ユーザ</quote>と<quote>グループ</quote>という概念は<quote>ロール</quote>に統合されましたので、このコマンドは<literal>\dg</literal>と同じものになりました。)
+（<quote>ユーザ</quote>と<quote>グループ</quote>という概念は<quote>ロール</quote>に統合されましたので、このコマンドは<literal>\dg</literal>と同じものになりました。）
 <replaceable class="parameter">pattern</replaceable>が指定されている場合は、そのパターンに名前がマッチするロールのみが表示されます。
 デフォルトでは、ユーザによって作成されたロールのみが表示されます。
 システムロールを含めるには<literal>S</literal>修飾子を付与してください。
@@ -5285,8 +5285,8 @@ SQLの名前と異なり、パターンの一部を二重引用符で括るこ�
 -->
 <replaceable class="parameter">pattern</replaceable>パラメータが完全に省略されている場合、<literal>\d</literal>コマンドは現在のスキーマ検索パス内で可視のオブジェクトを全て表示します。
 これは<literal>*</literal>というパターンを使用することと同じです。
-(オブジェクトを含むスキーマが検索パス上にあり、同じ種類かつ同じ名前のオブジェクトが検索パス上それより前に存在しない場合、そのオブジェクトは<firstterm>可視</firstterm>であるといいます。
-これは明示的なスキーマ修飾がない名前でオブジェクトを参照できるということと同じです。)
+（オブジェクトを含むスキーマが検索パス上にあり、同じ種類かつ同じ名前のオブジェクトが検索パス上それより前に存在しない場合、そのオブジェクトは<firstterm>可視</firstterm>であるといいます。
+これは明示的なスキーマ修飾がない名前でオブジェクトを参照できるということと同じです。）
 可視か否かに関わらずデータベース内の全てのオブジェクトを表示するには、<literal>*.*</literal>というパターンを使用します。
   </para>
 
@@ -5415,7 +5415,8 @@ SQLの名前と異なり、パターンの一部を二重引用符で括るこ�
     To set a variable, use the <application>psql</application> meta-command
     <command>\set</command>.  For example,
 -->
-変数を設定するには、<application>psql</application>の<command>\set</command>メタコマンドを以下のように使用します。
+変数を設定するには、<application>psql</application>の<command>\set</command>メタコマンドを使用します。
+以下に例を示します。
 <programlisting>
 testdb=&gt; <userinput>\set foo bar</userinput>
 </programlisting>
@@ -5629,7 +5630,7 @@ SQLキーワードを補完する時に大文字小文字のどちらを使用�
         <literal>none</literal> (the default), then no queries are displayed.
 -->
 <literal>all</literal>に設定された場合、空でない全ての入力行は、標準出力に書き出されます。
-(これは対話式に読み込まれる行には適用されません。)
+（これは対話式に読み込まれる行には適用されません。）
 この動作をプログラム起動時に設定するには、<option>-a</option>スイッチを使用してください。
 <literal>queries</literal>に設定された場合、<application>psql</application>は各問い合わせがサーバに送信されるときに表示します。
 この動作を選択するオプションは<option>-e</option>です。
@@ -5657,7 +5658,7 @@ SQLキーワードを補完する時に大文字小文字のどちらを使用�
 -->
 この変数が<literal>on</literal>に設定されている場合、バックスラッシュコマンドがデータベースに問い合わせを行う時、最初にその問い合わせが表示されます。
 この機能は、<productname>PostgreSQL</productname>内部動作について調べたり、自作プログラム内で同様の関数機能を用意したりするのに役立つでしょう。
-（この動作をプログラム起動時に選択するには<option>-E</option>スイッチを使用してください）。
+（この動作をプログラム起動時に選択するには<option>-E</option>スイッチを使用してください。）
 この変数を<literal>noexec</literal>という値に設定した場合、問い合わせは実際にサーバに送信、実行されずに、単に表示されるだけになります。
 デフォルト値は<literal>off</literal>です。
         </para>
@@ -6336,8 +6337,8 @@ testdb=&gt; <userinput>SELECT * FROM :"foo";</userinput>
     since it wouldn't correctly handle quotes embedded in the value).
 -->
 変数差し替えは、引用符付けされた<acronym>SQL</acronym>リテラルと識別子の中では行われません。
-したがって<literal>':foo'</literal>などの式は、変数の値から引用符付けしたリテラルを生成するようには動作しません。
-(値の中に埋め込まれた引用符を正しく取り扱えませんので、もし動作したとしたら安全ではありません。)
+したがって<literal>':foo'</literal>などの式は、変数の値から引用符付けしたリテラルを生成するようには動作しません
+（値の中に埋め込まれた引用符を正しく取り扱えませんので、もし動作したとしたら安全ではありません）。
     </para>
 
     <para>
@@ -6357,8 +6358,8 @@ testdb=&gt; <userinput>INSERT INTO my_table VALUES (:'content');</userinput>
     (Note that this still won't work if <filename>my_file.txt</filename> contains NUL bytes.
     <application>psql</application> does not support embedded NUL bytes in variable values.)
 -->
-(<filename>my_file.txt</filename>にNULバイトが含まれている場合、これはうまく動作しないことに注意してください。
-<application>psql</application>は変数値内に埋め込まれたNULバイトをサポートしません。)
+（<filename>my_file.txt</filename>にNULバイトが含まれている場合、これはうまく動作しないことに注意してください。
+<application>psql</application>は変数値内に埋め込まれたNULバイトをサポートしません。）
     </para>
 
     <para>
@@ -6494,8 +6495,8 @@ SQLリテラルまたは識別子として変数の値をエスケープさせ�
           of the command <command>SET SESSION
           AUTHORIZATION</command>.)
 -->
-データベースセッションユーザの名前です
-（この値の展開結果は、<command>SET SESSION AUTHORIZATION</command>コマンドの実行によってデータベースセッション中に変わることがあります）。
+データベースセッションユーザの名前です。
+（この値の展開結果は、<command>SET SESSION AUTHORIZATION</command>コマンドの実行によってデータベースセッション中に変わることがあります。）
          </para>
         </listitem>
       </varlistentry>
@@ -6528,8 +6529,8 @@ SQLリテラルまたは識別子として変数の値をエスケープさせ�
           session as the result of the command <command>SET SESSION
           AUTHORIZATION</command>.)
 -->
-セッションユーザがデータベーススーパーユーザである場合は<literal>#</literal>、それ以外の場合は<literal>&gt;</literal>となります
-（この値の展開結果は、<command>SET SESSION AUTHORIZATION</command>コマンドの実行によってデータベースセッション中に変わることがあります）。
+セッションユーザがデータベーススーパーユーザである場合は<literal>#</literal>、それ以外の場合は<literal>&gt;</literal>となります。
+（この値の展開結果は、<command>SET SESSION AUTHORIZATION</command>コマンドの実行によってデータベースセッション中に変わることがあります。）
          </para>
         </listitem>
       </varlistentry>
@@ -6767,7 +6768,7 @@ testdb=&gt; \set PROMPT1 '%[%033[1;33;40m%]%n@%/%R%[%033[0m%]%# '
 タブ補完を使用して、多くの(すべてではない)コンテキストで部分的に入力されたキーワードやSQLオブジェクト名を入力することもできます。
 たとえば、コマンドの開始時に<literal>ins</literal>と入力してTABキーを押すと<literal>insert into </literal>が入力されます。
 次に、テーブル名またはスキーマ名の数文字を入力して<literal>TAB</literal>キーを押すと、入力されていない名前が入力されたり、複数の補完候補がある場合に補完候補のメニューが表示されます。
-(使用しているライブラリによっては、メニューを表示するには<literal>TAB</literal>キーを複数回押す必要があります。)
+（使用しているライブラリによっては、メニューを表示するには<literal>TAB</literal>キーを複数回押す必要があります。）
     </para>
 
     <para>
@@ -7257,8 +7258,8 @@ Windowsのコンソールウィンドウは、システムの他の部分とは�
       German; replace it with your value.) If you are using Cygwin,
       you can put this command in <filename>/etc/profile</filename>.
 -->
-<userinput>cmd.exe /c chcp 1252</userinput>と入力して、コードページを設定します
-（1252はドイツ圏における適切なコードページです。システムに合わせて変更してください）。
+<userinput>cmd.exe /c chcp 1252</userinput>と入力して、コードページを設定します。
+（1252はドイツ圏における適切なコードページです。システムに合わせて変更してください。）
 Cygwinを使用しているのであれば、このコマンドを<filename>/etc/profile</filename>に追加してください。
      </para>
     </listitem>


### PR DESCRIPTION
文の数が足りない箇所の修正
「。）」のチェックのために括弧を全角に変更したものも含みます。