### PR TITLE
Update planstats.sgml for v17

### DIFF
--- a/doc/src/sgml/planstats.sgml
+++ b/doc/src/sgml/planstats.sgml
@@ -54,12 +54,8 @@
    while producing statistics, the results will change slightly after
    any new <command>ANALYZE</command>.
 -->
-《マッチ度[55.755396]》以下の例は<productname>PostgreSQL</productname>リグレッションテストデータベース内のテーブルを使用します。
-表示される出力はバージョン8.3で取得しました。
-以前の（または以降の）バージョンとは動作が変わっているかもしれません。
-また、<command>ANALYZE</command>は統計情報を生成する時にランダムなサンプリングを行いますので、結果は<command>ANALYZE</command>を新しく行った後に多少変わることに注意してください。
-《機械翻訳》以下の例は<productname>PostgreSQL</productname>リグレッションテストデータベースのテーブルを使用しています。
-また、<command>ANALYZE</command>は統計を生成する際にランダムサンプリングを使用するため、新しい<command>ANALYZE</command>を実行した後は結果がわずかに変化することに注意してください。
+以下の例では<productname>PostgreSQL</productname>のリグレッションテストデータベース内のテーブルを使用しています。
+また、<command>ANALYZE</command>は統計情報を生成する時にランダムなサンプリングを行うため、<command>ANALYZE</command>を実行するたびに結果が若干変化することに注意してください。
   </para>
 
   <para>
@@ -560,10 +556,8 @@ tablename  | null_frac | n_distinct | most_common_vals
    count estimates for both relations (num_rows, not shown, but "tenk")
    together with the column null fractions (zero for both):
 -->
-《マッチ度[62.269939]》今回の場合、すべての値が一意であるため、<structfield>unique2</structfield>に関する<acronym>MCV</acronym>情報がありません。
-ですので、両リレーションの個別値数とNULL値の部分のみに依存したアルゴリズムを使用することができます。
-《機械翻訳》この場合、<structname>unique2</structname>に対する<acronym>MCV</acronym>情報は存在せず、すべての値は一意であるように見えます(n_distinct = -1)。
-そこで、両方の関係（num_rows、図示せず、ただし"tenk"）に対する行数の推定値と列のNULL部分（両方ともゼロ）を使用するアルゴリズムを使用します。
+この場合、<structname>unique2</structname> に関する <acronym>MCV</acronym> の情報はなく、すべての値が一意であるように見えます（n_distinct = -1）。
+そのため、両方のリレーション（この場合は "tenk"）の行数推定値（num_rows、ここでは表示されていません）と、カラムのNULL率（両方ともゼロ）に基づいたアルゴリズムが使用されます。
 
 <programlisting>
 selectivity = (1 - null_frac1) * (1 - null_frac2) / max(num_rows1, num_rows2)
@@ -580,10 +574,8 @@ selectivity = (1 - null_frac1) * (1 - null_frac2) / max(num_rows1, num_rows2)
    Cartesian product of the two inputs, multiplied by the
    selectivity:
 -->
-《マッチ度[76.946108]》これは、各リレーションにおいて、1からNULL部分を差し引き、個別値数の最大値で割った値です。
-この結合が生成するはずの行数は、2つの入力のデカルト積の濃度に、この選択度を掛けたものとして計算されます。
-《機械翻訳》これは、各リレーションに対してNULL分数を1から減算し、より大きなリレーションの行カウントで割った値です（この値は、一意でない場合にスケーリングされます）。
-結合が発行する可能性のある行数は、2つの入力の直積のカーディナリティに選択性を掛けたものとして計算されます。
+これは、各リレーションにおいて、1からNULL部分を差し引き、それを大きい方のリレーションの行数で割ります（この値は一意でない場合にはスケーリングされます）。
+この結合が生成するはずの行数は、2つの入力のデカルト積のカーディナリティに、この選択度を掛けたものとして計算されます。
 
 <programlisting>
 rows = (outer_cardinality * inner_cardinality) * selectivity

--- a/doc/src/sgml/planstats.sgml
+++ b/doc/src/sgml/planstats.sgml
@@ -557,7 +557,7 @@ tablename  | null_frac | n_distinct | most_common_vals
    together with the column null fractions (zero for both):
 -->
 この場合、<structname>unique2</structname>に関する<acronym>MCV</acronym>の情報はなく、すべての値が一意であるように見えます（n_distinct = -1）。
-そのため、両方のリレーション（この場合は "tenk"）の行数推定値（num_rows、ここでは表示されていません）と、列のNULL率（両方ともゼロ）に基づいたアルゴリズムが使用されます。
+そのため、両方のリレーションの行数推定値（（ここでは表示されていませんが"tenk"の）num_rows）と、列のNULL率（両方ともゼロ）に基づいたアルゴリズムが使用されます。
 
 <programlisting>
 selectivity = (1 - null_frac1) * (1 - null_frac2) / max(num_rows1, num_rows2)

--- a/doc/src/sgml/planstats.sgml
+++ b/doc/src/sgml/planstats.sgml
@@ -78,7 +78,7 @@ EXPLAIN SELECT * FROM tenk1;
    completeness. The number of pages and rows is looked up in
    <structname>pg_class</structname>:
 -->
-プランナがどのように<structname>tenk1</structname>の濃度を決定するかについては<xref linkend="planner-stats"/>で説明しました。
+プランナがどのように<structname>tenk1</structname>のカーディナリティを決定するかについては<xref linkend="planner-stats"/>で説明しました。
 しかし、ここでは完全を期するために説明を繰り返します。
 ページ数および行数は<structname>pg_class</structname>から検索されます。
 
@@ -181,7 +181,7 @@ selectivity = (1 + (1000 - bucket[2].min)/(bucket[2].max - bucket[2].min))/num_b
    <structname>tenk1</structname>:
 -->
 つまり、1つのバケット全体に、2番目のバケットとの線形比率を加えたものを、バケット数で割ったものとなります。
-ここで、行の推定値は、選択度と<structname>tenk1</structname>の濃度を掛け合わせたものとして計算されます。
+ここで、行の推定値は、選択度と<structname>tenk1</structname>のカーディナリティを掛け合わせたものとして計算されます。
 
 <programlisting>
 rows = rel_cardinality * selectivity
@@ -251,7 +251,7 @@ selectivity = mcf[3]
    As before, the estimated number of rows is just the product of this with the
    cardinality of <structname>tenk1</structname>:
 -->
-前と同様、推定される行数は単に前回同様、この値と<structname>tenk1</structname>の濃度との積です。
+前と同様、推定される行数は単に前回同様、この値と<structname>tenk1</structname>のカーディナリティとの積です。
 
 <programlisting>
 rows = 10000 * 0.003
@@ -673,7 +673,7 @@ ANALYZE t;
     cardinality of <structname>t</structname> using the number of pages and
     rows obtained from <structname>pg_class</structname>:
 -->
-<xref linkend="planner-stats"/>で説明されているように、<structname>pg_class</structname>から得られるページ数と行数を使って、<structname>t</structname>の濃度を決定できます。
+<xref linkend="planner-stats"/>で説明されているように、<structname>pg_class</structname>から得られるページ数と行数を使って、<structname>t</structname>のカーディナリティを決定できます。
 
 <programlisting>
 SELECT relpages, reltuples FROM pg_class WHERE relname = 't';
@@ -779,7 +779,7 @@ EXPLAIN (ANALYZE, TIMING OFF) SELECT * FROM t WHERE a = 1 AND b = 1;
     estimated number of rows returned by the HashAggregate node) is very
     accurate:
 -->
-<command>GROUP BY</command>句が生成するグループ数のような、複数列の集合の濃度の見積もりについても、同様の問題が起きます。
+<command>GROUP BY</command>句が生成するグループ数のような、複数列の集合のカーディナリティの見積もりについても、同様の問題が起きます。
 <command>GROUP BY</command>の対象が単一の列なら、N個別値の推定（HashAggregateノードが返す推定行数で示されます）はとても正確です。
 <programlisting>
 EXPLAIN (ANALYZE, TIMING OFF) SELECT COUNT(*) FROM t GROUP BY a;

--- a/doc/src/sgml/planstats.sgml
+++ b/doc/src/sgml/planstats.sgml
@@ -556,8 +556,8 @@ tablename  | null_frac | n_distinct | most_common_vals
    count estimates for both relations (num_rows, not shown, but "tenk")
    together with the column null fractions (zero for both):
 -->
-この場合、<structname>unique2</structname> に関する <acronym>MCV</acronym> の情報はなく、すべての値が一意であるように見えます（n_distinct = -1）。
-そのため、両方のリレーション（この場合は "tenk"）の行数推定値（num_rows、ここでは表示されていません）と、カラムのNULL率（両方ともゼロ）に基づいたアルゴリズムが使用されます。
+この場合、<structname>unique2</structname>に関する<acronym>MCV</acronym>の情報はなく、すべての値が一意であるように見えます（n_distinct = -1）。
+そのため、両方のリレーション（この場合は "tenk"）の行数推定値（num_rows、ここでは表示されていません）と、列のNULL率（両方ともゼロ）に基づいたアルゴリズムが使用されます。
 
 <programlisting>
 selectivity = (1 - null_frac1) * (1 - null_frac2) / max(num_rows1, num_rows2)

--- a/doc/src/sgml/planstats.sgml
+++ b/doc/src/sgml/planstats.sgml
@@ -54,8 +54,8 @@
    while producing statistics, the results will change slightly after
    any new <command>ANALYZE</command>.
 -->
-以下の例では<productname>PostgreSQL</productname>のリグレッションテストデータベース内のテーブルを使用しています。
-また、<command>ANALYZE</command>は統計情報を生成する時にランダムなサンプリングを行うため、<command>ANALYZE</command>を実行するたびに結果が若干変化することに注意してください。
+以下の例は<productname>PostgreSQL</productname>リグレッションテストデータベースのテーブルを使用しています。
+また、<command>ANALYZE</command>は統計を生成する際にランダムサンプリングを使用するため、新しい<command>ANALYZE</command>を実行した後は結果がわずかに変化することに注意してください。
   </para>
 
   <para>


### PR DESCRIPTION
以下のファイルの 17.0 対応です。

- planstats.sgml

<details><summary>Details</summary>
<p>

英語版のv16とv17の差分です。

```diff
~/ghq/github.com/kkato/jpug-doc/doc/src/sgml % git diff REL_16_4 REL_17_0 planstats.sgml
diff --git a/doc/src/sgml/planstats.sgml b/doc/src/sgml/planstats.sgml
index d2b84b301f5..c7ec749d0a6 100644
--- a/doc/src/sgml/planstats.sgml
+++ b/doc/src/sgml/planstats.sgml
@@ -30,8 +30,6 @@
   <para>
    The examples shown below use tables in the <productname>PostgreSQL</productname>
    regression test database.
-   The outputs shown are taken from version 8.3.
-   The behavior of earlier (or later) versions might vary.
    Note also that since <command>ANALYZE</command> uses random sampling
    while producing statistics, the results will change slightly after
    any new <command>ANALYZE</command>.
@@ -391,18 +389,20 @@ tablename  | null_frac | n_distinct | most_common_vals
 </programlisting>
 
    In this case there is no <acronym>MCV</acronym> information for
-   <structfield>unique2</structfield> because all the values appear to be
-   unique, so we use an algorithm that relies only on the number of
-   distinct values for both relations together with their null fractions:
+   <structname>unique2</structname> and all the values appear to be
+   unique (n_distinct = -1), so we use an algorithm that relies on the row
+   count estimates for both relations (num_rows, not shown, but "tenk")
+   together with the column null fractions (zero for both):
 
 <programlisting>
-selectivity = (1 - null_frac1) * (1 - null_frac2) * min(1/num_distinct1, 1/num_distinct2)
+selectivity = (1 - null_frac1) * (1 - null_frac2) / max(num_rows1, num_rows2)
             = (1 - 0) * (1 - 0) / max(10000, 10000)
             = 0.0001
 </programlisting>
 
    This is, subtract the null fraction from one for each of the relations,
-   and divide by the maximum of the numbers of distinct values.
+   and divide by the row count of the larger relation (this value does get
+   scaled in the non-unique case).
    The number of rows
    that the join is likely to emit is calculated as the cardinality of the
    Cartesian product of the two inputs, multiplied by the
```

</p>
</details> 
