### PR TITLE
amcheck.sgml の日本語訳の PG17 対応

### DIFF
--- a/doc/src/sgml/amcheck.sgml
+++ b/doc/src/sgml/amcheck.sgml
@@ -35,16 +35,11 @@
   linkend="guc-search-path"/> is temporarily changed to <literal>pg_catalog,
   pg_temp</literal>.
 -->
-《マッチ度[80.790960]》B-Tree検査関数は、特定のリレーションの構造表現における様々な<emphasis>不変量</emphasis>を検査します。
+B-Tree検査関数は、特定のリレーションの構造表現における様々な<emphasis>不変量</emphasis>を検査します。
 インデックスの走査や、その他の重要な操作を担うアクセスメソッド関数の正しさは、これらの不変量を常に保つことに依存しています。
 たとえば、ある関数は、とりわけすべてのB-Treeページの中の項目が<quote>論理的な</quote>順序になっていることを検査します。（たとえば<type>text</type>のB-Treeインデックスでは、インデックスタプルは語句の照合順になっていなければなりません。）
 その特定の不変量が何らかの理由で保たれなければ、該当するページで二分探索が不正なインデックス走査をもたらし、SQL問い合わせに誤った答えを返すことになるでしょう。
 構造が適正であると見なされれば、エラーは報告されません。
-《機械翻訳》Bツリー検査関数は、特定のリレーションの表現形式の構造における様々な<emphasis>不変量</emphasis>を検証する。
-インデックススキャンやその他の重要な操作の背後にあるアクセスメソッド関数の正確さは、これらの不変量が常に保持されていることに依存している。
-例について、特定の関数は、とりわけ、すべてのB-ツリーページが<quote>ロジカル</quote>オーダーにアイテムを有することを検証する（例えば、<type>テキスト</type>上のB-ツリーインデックスについては、インデックスタプルは、照合されたレキシカルオーダーにあるべきである）。
-この特定の不変式が何らかの形で成立しない場合、影響を受けたバイナリでのページ検索が誤ってガイドインデックススキャンを行い、その結果、間違いがSQLクエリに応答することが予想される。
-構造が有効であると思われる場合、エラーは上げられません。
 これらのチェック関数の実行中、<xref linkend="guc-search-path"/>は一時的に<literal>pg_catalog, pg_temp</literal>に変更されます。
  </para>
  <para>
@@ -174,15 +169,11 @@ ORDER BY c.relpages DESC LIMIT 10;
       trade-off between thoroughness of verification and limiting the
       impact on application performance and availability.
 -->
-《マッチ度[73.312565]》<function>bt_index_check</function>は、ターゲットとなるインデックスと、それが所属するヒープリレーションに対して<literal>AccessShareLock</literal>を獲得します。
+<function>bt_index_check</function>は、ターゲットとなるインデックスと、それが所属するヒープリレーションに対して<literal>AccessShareLock</literal>を獲得します。
 このロックモードは、単純な<literal>SELECT</literal>文がリレーションに対して獲得するのと同じものです。
-<function>bt_index_check</function>は、子／親関係に渡る不変量を検査しませんが、<parameter>heapallindexed</parameter>が<literal>true</literal>の場合には、インデックス中のインデックスタプルに対応するすべてのヒープタプルの存在が検証されます。
+<function>bt_index_check</function>は、子／親関係にわたる不変量を検査しませんが、<parameter>heapallindexed</parameter>が<literal>true</literal>の場合には、インデックス中のインデックスタプルに対応するすべてのヒープタプルの存在が検証されます。
+<parameter>checkunique</parameter>が<literal>true</literal>の場合、<function>bt_index_check</function>は一意インデックス内の重複エントリの中で可視のものが1つだけであることを検証します。
 実行中の運用環境で定期的、軽量なデータ破損検査が必要な場合、<function>bt_index_check</function>を使うのが、検査の完全性と、アプリケーションの性能と稼働への影響を限定することとの間の最良のトレードオフになることがしばしばあります。
-《機械翻訳》<function>bt_index_check</function>は、ターゲットインデックスとそれが属するヒープリレーションの<literal>AccessShareLock</literal>を取得します。
-このロックモードは、シンプル<literal>セレクト</literal>の声明によってリレーションで取得されたのと同じロックモードです。
-<function>bt_index_check</function>は、子と親の関係にまたがる不変条件を検証しませんが、<parameter>heapallindexed</parameter>が<literal>ヒープ</literal>の場合、インデックス内のインデックスタプルとしてすべての真タプルの存在を検証します。
-<parameter>checkunique</parameter>が<literal>真</literal><function>bt_index_check</function>の場合、一意インデックス内の重複エントリの中で可視のものが1つだけであることをチェックする。
-実際の運用環境で、破損に対するルーチンの軽量なテストが必要な場合、<function>bt_index_check</function>を使用すると、検証の徹底と、アプリケーションパフォーマンスのインパクトとアベイラビリティの制限との間のベストの取引-オフが提供されることがよくある。
      </para>
     </listitem>
    </varlistentry>
@@ -222,20 +213,14 @@ ORDER BY c.relpages DESC LIMIT 10;
       convention of raising an error if it finds a logical
       inconsistency or other problem.
 -->
-《マッチ度[77.753465]》<function>bt_index_parent_check</function>は、ターゲットとなるB-Treeインデックスが様々な不変量を保っていることを検査します。
+<function>bt_index_parent_check</function>は、ターゲットとなるB-Treeインデックスが様々な不変量を保っていることを検査します。
 オプションとして、<parameter>heapallindexed</parameter>引数が<literal>true</literal>の場合、インデックスに対応して存在すべきすべてのヒープタプルの存在を検証します。
+<parameter>checkunique</parameter>が<literal>true</literal>の場合、一意インデックスの重複エントリの中で可視のものが1つだけであることを検査します。
 省略可能な引数<parameter>rootdescend</parameter>が<literal>true</literal>であれば、各タプルに対するルートページから新しく探索することで、検証はリーフレベルのタプルを再び見つけます。
 <function>bt_index_parent_check</function>により実施される検査は、<function>bt_index_check</function>により実施される検査のスーパーセットになっています。
 <function>bt_index_parent_check</function>は、<function>bt_index_check</function>の更なる完璧版であると考えることができます。
 つまり、<function>bt_index_check</function>と違って<function>bt_index_parent_check</function>は、インデックス構造中のダウンリンクに漏れがないことを含め、親／子関係に渡る不変量も検査します。
 <function>bt_index_parent_check</function>は、論理的な非一貫性やその他の問題を発見した場合、一般的な習慣に従ってエラーを報告します。
-《機械翻訳》<function>bt_index_parent_check</function>は、そのターゲットであるB-ツリーインデックスがさまざまな不変条件を尊重することをテストする。
-オプションで、<parameter>heapallindexed</parameter>引数が<literal>真</literal>の場合、関数は、インデックス内で検出されるすべてのヒープタプルの存在を検証します。
-<parameter>checkunique</parameter>が<literal>真</literal><function>bt_index_parent_check</function>の場合、一意インデックスの重複エントリの中で可視のものが1つだけであることをチェックします。
-オプショナル<parameter>rootdescend</parameter>引数が<literal>真</literal>である場合、検証は、各リーフレベルに対してルートページから新しい検索を実行することによって、タプル上のタプルを再検索する。
-<function>bt_index_parent_check</function>で実行可能なチェックは、<function>bt_index_check</function>で実行可能なチェックのスーパーセットです。
-<function>bt_index_parent_check</function>は、<function>bt_index_check</function>のより完全な変形と考えることができます:<function>bt_index_check</function>とは異なり、<function>bt_index_parent_check</function>は、インデックス構造に欠落したダウンリンクがないことをチェックするなど、親/子の関係にまたがる不変条件もチェックします。
-<function>bt_index_parent_check</function>は、ロジカルの不一致やその他の問題を検出した場合にエラーを上げるという一般的な規則に従います。
      </para>
      <para>
 <!--


### PR DESCRIPTION
差分の以外に「子／親関係に渡る不変量」を「子／親関係にわたる不変量」とした。
（漢字で書くなら「亘る」）