### PR TITLE
Update pg_rewind.sgml for v17

### DIFF
--- a/doc/src/sgml/ref/pg_rewind.sgml
+++ b/doc/src/sgml/ref/pg_rewind.sgml
@@ -403,7 +403,7 @@ WALファイルが<filename>pg_wal</filename>ディレクトリにもはや存�
         files in the data directory.  The search for files will follow symbolic
         links for the WAL directory and each configured tablespace.
 -->
-《機械翻訳》デフォルトの<literal>fsync</literal>に設定すると、<command>pg_rewind</command>はデータディレクトリ内の全てのファイルを再帰的に開いて同期します。
+デフォルトの<literal>fsync</literal>に設定すると、<command>pg_rewind</command>はデータディレクトリ内のすべてのファイルを再帰的に開いて同期します。
 ファイルの検索はWALディレクトリと設定された各テーブル空間のシンボリックリンクをたどります。
        </para>
        <para>
@@ -414,14 +414,14 @@ WALファイルが<filename>pg_wal</filename>ディレクトリにもはや存�
         <xref linkend="guc-recovery-init-sync-method"/> for information about
         the caveats to be aware of when using <literal>syncfs</literal>.
 -->
-《機械翻訳》Linuxでは、<literal>syncfs</literal>を代わりに使用して、オペレーティングシステム、WALファイル、各テーブル空間を含むファイルシステム全体を同期させるようにオペレーティングシステムに要求できます。
+Linuxでは、<literal>syncfs</literal>を代わりに使用して、データディレクトリ、WALファイル、各テーブル空間を含むファイルシステム全体を同期させるようにオペレーティングシステムに要求することもできます。
 <literal>syncfs</literal>を使用する際に注意すべき点については、<xref linkend="guc-recovery-init-sync-method"/>を参照してください。
        </para>
        <para>
 <!--
         This option has no effect when <option>&#45;-no-sync</option> is used.
 -->
-《機械翻訳》このオプションは<option>--no-sync</option>が使われている場合は効果がありません。
+このオプションは<option>--no-sync</option>が使われている場合は効果がありません。
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
pg_rewind.sgmlのPostgreSQL17対応です。
差分となっていた翻訳対象が、下記の翻訳済みの「--sync-method=method」と同様の内容でしたので合わせています。
https://pgsql-jp.github.io/current/html/app-pgchecksums.html