### PR TITLE
ref/pg_dump.sgmlの翻訳改善（PR3185で改善し損ねたコメントの反映）

### DIFF
--- a/doc/src/sgml/ref/pg_dump.sgml
+++ b/doc/src/sgml/ref/pg_dump.sgml
@@ -1881,7 +1881,7 @@ pg_dumpを始めた時に読み書きを行う実行中のトランザクショ�
         to match any objects is not considered an error.
 -->
 このオプションは<option>--exclude-extension</option>、<option>-N</option>/<option>--exclude-schema</option>、<option>-T</option>/<option>--exclude-table</option>、<option>-T</option>/<option>--exclude-table-data</option>には影響を与えません。
-オブジェクトに一致しない除外パターンはエラーとはみなされません。
+除外パターンがオブジェクトとマッチしなくてもエラーとみなされません。
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
https://github.com/pgsql-jp/jpug-doc/pull/3185
で誤ってコメントしたままマージしてしまいました。
@tatsuo-ishii さん
見ていただけますと助かります。