### PR TITLE
sgmlの翻訳改善（PR3194で改善し損ねたコメントの反映）

### DIFF
--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -2173,7 +2173,7 @@ TABLE ... CONSTRAINT ... EXCLUDE</command></link>を参照してください。
    command, whose reference page contains details beyond those given
    here.
 -->
-これらの操作は全て<xref linkend="sql-altertable"/>コマンドを使用して行うことができます、そのリファレンスページにはここで説明している内容以上の詳細が記載されています。
+これらの操作は全て<xref linkend="sql-altertable"/>コマンドを使用して行うことができ、そのリファレンスページにはここで説明している内容以上の詳細が記載されています。
   </para>
 
   <sect2 id="ddl-alter-adding-a-column">


### PR DESCRIPTION
https://github.com/pgsql-jp/jpug-doc/pull/3194
でディスカッションしないままマージしてしまいました。
「行うことができます、」のところは日本語としては「。」が良いですが、原文の「,」に合わせるとこうなりますが
日本語としておかしい気がするので
「これらの操作は全てコマンドを使用して行うことができ、そのリファレンスページにはここで説明している内容以上の詳細が記載されています。」
くらいにするのはどうでしょうか。
@noborus さん、見ていただけると助かります。