### PR TITLE
phraseの統一

### DIFF
--- a/doc/src/sgml/pgcrypto.sgml
+++ b/doc/src/sgml/pgcrypto.sgml
@@ -680,7 +680,7 @@ Intel Mobile Core i3のマシンを使用しました。
    (<ulink url="https://datatracker.ietf.org/doc/html/rfc4880">RFC 4880</ulink>)
    standard.  Supported are both symmetric-key and public-key encryption.
 -->
-ここで示す関数はOpenPGP（(<ulink url="https://datatracker.ietf.org/doc/html/rfc4880">RFC 4880</ulink>）標準の暗号処理部分を実装します。
+ここで示す関数はOpenPGP（<ulink url="https://datatracker.ietf.org/doc/html/rfc4880">RFC 4880</ulink>）標準の暗号処理部分を実装します。
 対称鍵および公開鍵暗号化がサポートされます。
   </para>
 
@@ -1625,7 +1625,7 @@ decrypt_iv(data bytea, key bytea, iv bytea, type text) returns bytea
 <!--
    where <replaceable>algorithm</replaceable> is one of:
 -->
-ここで<replaceable>algorithm</replaceable>は以下の1つです。
+ここで<replaceable>algorithm</replaceable>は以下のいずれかです。
 
   <itemizedlist>
    <listitem><para><literal>bf</literal> &mdash; Blowfish</para></listitem>
@@ -1634,7 +1634,7 @@ decrypt_iv(data bytea, key bytea, iv bytea, type text) returns bytea
 <!--
    and <replaceable>mode</replaceable> is one of:
 -->
-また<replaceable>mode</replaceable>は以下の1つです。
+また<replaceable>mode</replaceable>は以下のいずれかです。
   <itemizedlist>
    <listitem>
     <para>
@@ -1657,7 +1657,7 @@ decrypt_iv(data bytea, key bytea, iv bytea, type text) returns bytea
 <!--
    and <replaceable>padding</replaceable> is one of:
 -->
-<replaceable>padding</replaceable>は以下の1つです。
+<replaceable>padding</replaceable>は以下のいずれかです。
   <itemizedlist>
    <listitem>
     <para>

--- a/doc/src/sgml/ref/alter_function.sgml
+++ b/doc/src/sgml/ref/alter_function.sgml
@@ -41,7 +41,7 @@ ALTER FUNCTION <replaceable>name</replaceable> [ ( [ [ <replaceable class="param
 <!--
 <phrase>where <replaceable class="parameter">action</replaceable> is one of:</phrase>
 -->
-<phrase>ここで、<replaceable class="parameter">action</replaceable>は以下のいずれかです。</phrase>
+<phrase>ここで<replaceable class="parameter">action</replaceable>は以下のいずれかです。</phrase>
 
     CALLED ON NULL INPUT | RETURNS NULL ON NULL INPUT | STRICT
     IMMUTABLE | STABLE | VOLATILE

--- a/doc/src/sgml/ref/alter_table.sgml
+++ b/doc/src/sgml/ref/alter_table.sgml
@@ -47,7 +47,7 @@ ALTER TABLE [ IF EXISTS ] <replaceable class="parameter">name</replaceable>
 <!--
 <phrase>where <replaceable class="parameter">action</replaceable> is one of:</phrase>
 -->
-<phrase>ここで、<replaceable class="parameter">action</replaceable>は以下のいずれかです。</phrase>
+<phrase>ここで<replaceable class="parameter">action</replaceable>は以下のいずれかです。</phrase>
 
     ADD [ COLUMN ] [ IF NOT EXISTS ] <replaceable class="parameter">column_name</replaceable> <replaceable class="parameter">data_type</replaceable> [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">column_constraint</replaceable> [ ... ] ]
     DROP [ COLUMN ] [ IF EXISTS ] <replaceable class="parameter">column_name</replaceable> [ RESTRICT | CASCADE ]
@@ -99,7 +99,7 @@ ALTER TABLE [ IF EXISTS ] <replaceable class="parameter">name</replaceable>
 <!--
 <phrase>and <replaceable class="parameter">partition_bound_spec</replaceable> is:</phrase>
 -->
-<phrase>また、<replaceable class="parameter">partition_bound_spec</replaceable>は以下のいずれかです。</phrase>
+<phrase>また、<replaceable class="parameter">partition_bound_spec</replaceable>は以下の通りです。</phrase>
 
 IN ( <replaceable class="parameter">partition_bound_expr</replaceable> [, ...] ) |
 FROM ( { <replaceable class="parameter">partition_bound_expr</replaceable> | MINVALUE | MAXVALUE } [, ...] )

--- a/doc/src/sgml/ref/alter_type.sgml
+++ b/doc/src/sgml/ref/alter_type.sgml
@@ -41,9 +41,7 @@ ALTER TYPE <replaceable class="parameter">name</replaceable> SET ( <replaceable 
 <!--
 <phrase>where <replaceable class="parameter">action</replaceable> is one of:</phrase>
 -->
-<phrase>
-ここで<replaceable class="parameter">action</replaceable>は以下のいずれかです。
-</phrase>
+<phrase>ここで<replaceable class="parameter">action</replaceable>は以下のいずれかです。</phrase>
 
     ADD ATTRIBUTE <replaceable class="parameter">attribute_name</replaceable> <replaceable class="parameter">data_type</replaceable> [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ CASCADE | RESTRICT ]
     DROP ATTRIBUTE [ IF EXISTS ] <replaceable class="parameter">attribute_name</replaceable> [ CASCADE | RESTRICT ]

--- a/doc/src/sgml/ref/alter_user.sgml
+++ b/doc/src/sgml/ref/alter_user.sgml
@@ -32,7 +32,7 @@ ALTER USER <replaceable class="parameter">role_specification</replaceable> [ WIT
 <!--
 <phrase>where <replaceable class="parameter">option</replaceable> can be:</phrase>
 -->
-<phrase><replaceable class="parameter">option</replaceable>は次の通りです。</phrase>
+<phrase>ここで<replaceable class="parameter">option</replaceable>は以下の通りです。</phrase>
 
       SUPERUSER | NOSUPERUSER
     | CREATEDB | NOCREATEDB

--- a/doc/src/sgml/ref/analyze.sgml
+++ b/doc/src/sgml/ref/analyze.sgml
@@ -33,7 +33,7 @@ ANALYZE [ VERBOSE ] [ <replaceable class="parameter">table_and_columns</replacea
 <!--
 <phrase>where <replaceable class="parameter">option</replaceable> can be one of:</phrase>
 -->
-<phrase><replaceable class="parameter">option</replaceable>には以下のいずれかが入ります。</phrase>
+<phrase>ここで<replaceable class="parameter">option</replaceable>は以下の一つです。</phrase>
 
     VERBOSE [ <replaceable class="parameter">boolean</replaceable> ]
     SKIP_LOCKED [ <replaceable class="parameter">boolean</replaceable> ]
@@ -42,7 +42,7 @@ ANALYZE [ VERBOSE ] [ <replaceable class="parameter">table_and_columns</replacea
 <!--
 <phrase>and <replaceable class="parameter">table_and_columns</replaceable> is:</phrase>
 -->
-<phrase>また、<replaceable class="parameter">table_and_columns</replaceable>は以下の通りです。</phrase>
+<phrase>また<replaceable class="parameter">table_and_columns</replaceable>は以下の通りです。</phrase>
 
     <replaceable class="parameter">table_name</replaceable> [ ( <replaceable class="parameter">column_name</replaceable> [, ...] ) ]
 </synopsis>

--- a/doc/src/sgml/ref/copy.sgml
+++ b/doc/src/sgml/ref/copy.sgml
@@ -39,7 +39,7 @@ COPY { <replaceable class="parameter">table_name</replaceable> [ ( <replaceable 
 <!--
 <phrase>where <replaceable class="parameter">option</replaceable> can be one of:</phrase>
 -->
-<phrase>ここで<replaceable class="parameter">option</replaceable>は以下のいずれかです。</phrase>
+<phrase>ここで<replaceable class="parameter">option</replaceable>は以下の一つです。</phrase>
 
     FORMAT <replaceable class="parameter">format_name</replaceable>
     FREEZE [ <replaceable class="parameter">boolean</replaceable> ]

--- a/doc/src/sgml/ref/create_domain.sgml
+++ b/doc/src/sgml/ref/create_domain.sgml
@@ -35,7 +35,7 @@ CREATE DOMAIN <replaceable class="parameter">name</replaceable> [ AS ] <replacea
 <!--
 <phrase>where <replaceable class="parameter">constraint</replaceable> is:</phrase>
 -->
-<phrase>ここで<replaceable class="parameter">constraint</replaceable>は、以下の通りです。</phrase>
+<phrase>ここで<replaceable class="parameter">constraint</replaceable>は以下の通りです。</phrase>
 
 [ CONSTRAINT <replaceable class="parameter">constraint_name</replaceable> ]
 { NOT NULL | NULL | CHECK (<replaceable class="parameter">expression</replaceable>) }

--- a/doc/src/sgml/ref/create_group.sgml
+++ b/doc/src/sgml/ref/create_group.sgml
@@ -32,7 +32,7 @@ CREATE GROUP <replaceable class="parameter">name</replaceable> [ [ WITH ] <repla
 <!--
 <phrase>where <replaceable class="parameter">option</replaceable> can be:</phrase>
 -->
-<phrase><replaceable class="parameter">option</replaceable>は次のようになります。</phrase>
+<phrase>ここで<replaceable class="parameter">option</replaceable>は以下の通りです。</phrase>
 
       SUPERUSER | NOSUPERUSER
     | CREATEDB | NOCREATEDB

--- a/doc/src/sgml/ref/create_rule.sgml
+++ b/doc/src/sgml/ref/create_rule.sgml
@@ -36,7 +36,7 @@ CREATE [ OR REPLACE ] RULE <replaceable class="parameter">name</replaceable> AS 
 <!--
 <phrase>where <replaceable class="parameter">event</replaceable> can be one of:</phrase>
 -->
-<phrase>ここで<replaceable class="parameter">event</replaceable>は以下のうちの1つです。</phrase>
+<phrase>ここで<replaceable class="parameter">event</replaceable>は以下の一つです。</phrase>
 
     SELECT | INSERT | UPDATE | DELETE
 </synopsis>

--- a/doc/src/sgml/ref/create_table.sgml
+++ b/doc/src/sgml/ref/create_table.sgml
@@ -67,7 +67,7 @@ CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXI
 <!--
 <phrase>where <replaceable class="parameter">column_constraint</replaceable> is:</phrase>
 -->
-<phrase>ここで<replaceable class="parameter">column_constraint</replaceable>には、次の構文が入ります。</phrase>
+<phrase>ここで<replaceable class="parameter">column_constraint</replaceable>は以下の通りです。</phrase>
 
 [ CONSTRAINT <replaceable class="parameter">constraint_name</replaceable> ]
 { NOT NULL |
@@ -85,7 +85,7 @@ CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXI
 <!--
 <phrase>and <replaceable class="parameter">table_constraint</replaceable> is:</phrase>
 -->
-<phrase>また、<replaceable class="parameter">table_constraint</replaceable>には、次の構文が入ります。</phrase>
+<phrase>また、<replaceable class="parameter">table_constraint</replaceable>は以下の通りです。</phrase>
 
 [ CONSTRAINT <replaceable class="parameter">constraint_name</replaceable> ]
 { CHECK ( <replaceable class="parameter">expression</replaceable> ) [ NO INHERIT ] |
@@ -100,14 +100,14 @@ class="parameter">referential_action</replaceable> ] [ ON UPDATE <replaceable cl
 <!--
 <phrase>and <replaceable class="parameter">like_option</replaceable> is:</phrase>
 -->
-<phrase>また<replaceable class="parameter">like_option</replaceable>は、以下の通りです。</phrase>
+<phrase>また<replaceable class="parameter">like_option</replaceable>は以下の通りです。</phrase>
 
 { INCLUDING | EXCLUDING } { COMMENTS | COMPRESSION | CONSTRAINTS | DEFAULTS | GENERATED | IDENTITY | INDEXES | STATISTICS | STORAGE | ALL }
 
 <!--
 <phrase>and <replaceable class="parameter">partition_bound_spec</replaceable> is:</phrase>
 -->
-<phrase>また<replaceable class="parameter">partition_bound_spec</replaceable>は、以下の通りです。</phrase>
+<phrase>また<replaceable class="parameter">partition_bound_spec</replaceable>は以下の通りです。</phrase>
 
 IN ( <replaceable class="parameter">partition_bound_expr</replaceable> [, ...] ) |
 FROM ( { <replaceable class="parameter">partition_bound_expr</replaceable> | MINVALUE | MAXVALUE } [, ...] )

--- a/doc/src/sgml/ref/create_trigger.sgml
+++ b/doc/src/sgml/ref/create_trigger.sgml
@@ -48,9 +48,7 @@ CREATE [ OR REPLACE ] [ CONSTRAINT ] TRIGGER <replaceable class="parameter">name
 <!--
 <phrase>where <replaceable class="parameter">event</replaceable> can be one of:</phrase>
 -->
-<phrase>
-ここで<replaceable class="parameter">event</replaceable>は以下のいずれかを取ることができます。
-</phrase>
+<phrase>ここで<replaceable class="parameter">event</replaceable>は以下の一つです。</phrase>
 
     INSERT
     UPDATE [ OF <replaceable class="parameter">column_name</replaceable> [, ... ] ]

--- a/doc/src/sgml/ref/explain.sgml
+++ b/doc/src/sgml/ref/explain.sgml
@@ -51,7 +51,7 @@ EXPLAIN [ ANALYZE ] [ VERBOSE ] <replaceable class="parameter">statement</replac
 <!--
 <phrase>where <replaceable class="parameter">option</replaceable> can be one of:</phrase>
 -->
-<phrase>ここで<replaceable class="parameter">option</replaceable>は以下のいずれかを取ることができます。</phrase>
+<phrase>ここで<replaceable class="parameter">option</replaceable>は以下の一つです。</phrase>
 
     ANALYZE [ <replaceable class="parameter">boolean</replaceable> ]
     VERBOSE [ <replaceable class="parameter">boolean</replaceable> ]

--- a/doc/src/sgml/ref/fetch.sgml
+++ b/doc/src/sgml/ref/fetch.sgml
@@ -42,7 +42,7 @@ FETCH [ <replaceable class="parameter">direction</replaceable> ] [ FROM | IN ] <
 <!--
 <phrase>where <replaceable class="parameter">direction</replaceable> can be one of:</phrase>
 -->
-<phrase>ここで<replaceable class="parameter">direction</replaceable>には、次のいずれかを指定できます。</phrase>
+<phrase>ここで<replaceable class="parameter">direction</replaceable>は以下の一つです。</phrase>
 
     NEXT
     PRIOR

--- a/doc/src/sgml/ref/insert.sgml
+++ b/doc/src/sgml/ref/insert.sgml
@@ -37,7 +37,7 @@ INSERT INTO <replaceable class="parameter">table_name</replaceable> [ AS <replac
 <!--
 <phrase>where <replaceable class="parameter">conflict_target</replaceable> can be one of:</phrase>
 -->
-<phrase>ここで<replaceable class="parameter">conflict_target</replaceable>は以下のいずれかです。</phrase>
+<phrase>ここで<replaceable class="parameter">conflict_target</replaceable>は以下の一つです。</phrase>
 
     ( { <replaceable class="parameter">index_column_name</replaceable> | ( <replaceable class="parameter">index_expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ...] ) [ WHERE <replaceable class="parameter">index_predicate</replaceable> ]
     ON CONSTRAINT <replaceable class="parameter">constraint_name</replaceable>

--- a/doc/src/sgml/ref/lock.sgml
+++ b/doc/src/sgml/ref/lock.sgml
@@ -32,7 +32,7 @@ LOCK [ TABLE ] [ ONLY ] <replaceable class="parameter">name</replaceable> [ * ] 
 <!--
 <phrase>where <replaceable class="parameter">lockmode</replaceable> is one of:</phrase>
 -->
-<phrase>ここで<replaceable class="parameter">lockmode</replaceable>には以下のいずれかが入ります。</phrase>
+<phrase>ここで<replaceable class="parameter">lockmode</replaceable>は以下のいずれかです。</phrase>
 
     ACCESS SHARE | ROW SHARE | ROW EXCLUSIVE | SHARE UPDATE EXCLUSIVE
     | SHARE | SHARE ROW EXCLUSIVE | EXCLUSIVE | ACCESS EXCLUSIVE

--- a/doc/src/sgml/ref/move.sgml
+++ b/doc/src/sgml/ref/move.sgml
@@ -42,7 +42,7 @@ MOVE [ <replaceable class="parameter">direction</replaceable> ] [ FROM | IN ] <r
 <!--
 <phrase>where <replaceable class="parameter">direction</replaceable> can be one of:</phrase>
 -->
-<phrase>ここで<replaceable class="parameter">direction</replaceable>には以下のいずれかを指定できます。</phrase>
+<phrase>ここで<replaceable class="parameter">direction</replaceable>は以下の一つです。</phrase>
 
     NEXT
     PRIOR

--- a/doc/src/sgml/ref/select.sgml
+++ b/doc/src/sgml/ref/select.sgml
@@ -63,7 +63,7 @@ SELECT [ ALL | DISTINCT [ ON ( <replaceable class="parameter">expression</replac
 <!--
 <phrase>where <replaceable class="parameter">from_item</replaceable> can be one of:</phrase>
 -->
-<phrase>ここで<replaceable class="parameter">from_item</replaceable>は以下のいずれかです。</phrase>
+<phrase>ここで<replaceable class="parameter">from_item</replaceable>は以下の一つです。</phrase>
 
     [ ONLY ] <replaceable class="parameter">table_name</replaceable> [ * ] [ [ AS ] <replaceable class="parameter">alias</replaceable> [ ( <replaceable class="parameter">column_alias</replaceable> [, ...] ) ] ]
                 [ TABLESAMPLE <replaceable class="parameter">sampling_method</replaceable> ( <replaceable class="parameter">argument</replaceable> [, ...] ) [ REPEATABLE ( <replaceable class="parameter">seed</replaceable> ) ] ]
@@ -82,7 +82,7 @@ SELECT [ ALL | DISTINCT [ ON ( <replaceable class="parameter">expression</replac
 <!--
 <phrase>and <replaceable class="parameter">grouping_element</replaceable> can be one of:</phrase>
 -->
-<phrase>また<replaceable class="parameter">grouping_element</replaceable>は以下のいずれかです。</phrase>
+<phrase>また<replaceable class="parameter">grouping_element</replaceable>は以下の一つです。</phrase>
 
     ( )
     <replaceable class="parameter">expression</replaceable>

--- a/doc/src/sgml/ref/start_transaction.sgml
+++ b/doc/src/sgml/ref/start_transaction.sgml
@@ -32,7 +32,7 @@ START TRANSACTION [ <replaceable class="parameter">transaction_mode</replaceable
 <!--
 <phrase>where <replaceable class="parameter">transaction_mode</replaceable> is one of:</phrase>
 -->
-<phrase><replaceable class="parameter">transaction_mode</replaceable>には以下のいずれかが入ります。</phrase>
+<phrase>ここで<replaceable class="parameter">transaction_mode</replaceable>は以下のいずれかです。</phrase>
 
     ISOLATION LEVEL { SERIALIZABLE | REPEATABLE READ | READ COMMITTED | READ UNCOMMITTED }
     READ WRITE | READ ONLY

--- a/doc/src/sgml/ref/vacuum.sgml
+++ b/doc/src/sgml/ref/vacuum.sgml
@@ -35,7 +35,7 @@ VACUUM [ FULL ] [ FREEZE ] [ VERBOSE ] [ ANALYZE ] [ <replaceable class="paramet
 <!--
 <phrase>where <replaceable class="parameter">option</replaceable> can be one of:</phrase>
 -->
-<phrase>ここで<replaceable class="parameter">option</replaceable>は以下の一つであり、</phrase>
+<phrase>ここで<replaceable class="parameter">option</replaceable>は以下の一つです。</phrase>
 
     FULL [ <replaceable class="parameter">boolean</replaceable> ]
     FREEZE [ <replaceable class="parameter">boolean</replaceable> ]
@@ -55,7 +55,7 @@ VACUUM [ FULL ] [ FREEZE ] [ VERBOSE ] [ ANALYZE ] [ <replaceable class="paramet
 <!--
 <phrase>and <replaceable class="parameter">table_and_columns</replaceable> is:</phrase>
 -->
-<phrase><replaceable class="parameter">table_and_columns</replaceable>は以下の通りです。</phrase>
+<phrase>また<replaceable class="parameter">table_and_columns</replaceable>は以下の通りです。</phrase>
 
     <replaceable class="parameter">table_name</replaceable> [ ( <replaceable class="parameter">column_name</replaceable> [, ...] ) ]
 </synopsis>


### PR DESCRIPTION
<phrase>[where] or [and]<replaceable class="parameter">[option] or [...]</replaceable>[is] or [can be] or [is one of] or [can be one of]:</phrase> の統一をするように修正しました。

where 〜ここで
and 〜また

〜 is: 〜は以下の通りです。
〜 can be: 〜は以下の通りです
〜 is one of: 〜は以下のいずれかです。
〜 can be one of: 〜は以下の一つです。