### PR TITLE
pg_resetwal.sgmlのPostgreSQL17.0対応

### DIFF
--- a/doc/src/sgml/ref/pg_resetwal.sgml
+++ b/doc/src/sgml/ref/pg_resetwal.sgml
@@ -73,8 +73,8 @@ PostgreSQL documentation
    otherwise sound database cluster, if none of the dangerous modes mentioned
    below are used.
 -->
-《機械翻訳》<option>--wal-segsize</option>（下記参照）のようなオプションは、<command>initdb</command>を再実行しなくても、データベースクラスタの特定のグローバル設定を変更するために使用することもできます。
-これは、下記で述べる危険なモードが使用されていない場合、健全なデータベースクラスタ上で安全に使用できます。
+<option>--wal-segsize</option>（後述）のようないくつかのオプションは、<command>initdb</command>を再実行せずに、データベースクラスタの特定のグローバル設定を変更するために使用することもできます。
+これは、後述する危険なモードが使用されていないか、正常なデータベースクラスタ上であれば安全に使用できます。
   </para>
 
   <para>
@@ -88,9 +88,9 @@ PostgreSQL documentation
    working on a data directory in an unclean shutdown state or with a
    corrupted control file.
 -->
-《機械翻訳》サーバが正常にシャットダウンされ、制御ファイルが無傷の状態で、<command>pg_resetwal</command>がデータディレクトリに対して使用された場合、使用されなくなったWALファイルがクリアされる以外に、データベースシステムの内容に影響を与えることはありません。
-その他の使用は危険を伴う可能性があり、細心の注意を払って行う必要があります。
-<command>pg_resetwal</command>は、不正なシャットダウン状態で、または制御ファイルが破損した状態でデータディレクトリを操作する前に、<option>-f</option>（強制）オプションを指定する必要があります。
+サーバが正常にシャットダウンされ、かつ制御ファイルが正常な状態で、<command>pg_resetwal</command>がデータディレクトリに対して使用された場合、使用されなくなったWALファイルが削除される以外に、データベースシステムの内容に影響を与えることはありません。
+その他の状態での使用は危険をともなう可能性があり、細心の注意をはらって使用しなければなりません。
+<command>pg_resetwal</command>は、正常にシャットダウンされていない状態のデータディレクトリや、破損した制御ファイルが存在する場合、実行時に<option>-f</option> (force,強制) オプションを指定する必要があります。
   </para>
 
   <para>
@@ -102,13 +102,10 @@ PostgreSQL documentation
    run <command>initdb</command>, and restore.  After restore, check for
    inconsistencies and repair as needed.
 -->
-《マッチ度[78.516624]》このコマンドを実行すると、サーバが開始できるようになるはずです。
+破損したWALファイルや、破損した制御ファイルが存在するデータディレクトリに対してこのコマンドを実行すると、サーバが開始できるようになるはずです。
 ただし、不完全にコミットされたトランザクションが原因でデータベースのデータに矛盾が起こる可能性があることに注意してください。
 コマンドの実行後は、ただちにデータをダンプし、<command>initdb</command>を実行し、リストアすべきです。
 リストア後、矛盾がないか検査し、必要に応じて修復を行ってください。
-《機械翻訳》破損したWALや制御ファイルを含むデータディレクトリでこのコマンドを実行した後、サーバを起動することは可能ですが、データベースには部分的にコミットされたトランザクションによる不整合なデータが含まれている可能性があることに注意してください。
-すぐにデータをダンプし、<command>initdb</command>を実行して復元する必要があります。
-復元後、不整合をチェックし、必要に応じて修復してください。
   </para>
 
   <para>
@@ -142,7 +139,7 @@ PostgreSQL documentation
    This utility can only be run by the user who installed the server, because
    it requires read/write access to the data directory.
 -->
-《機械翻訳》このユーティリティは、データディレクトリへの読み取り/書き込みアクセスが必要なため、サーバをインストールしたユーザのみが実行できます。
+このユーティリティは、データディレクトリへの読み取り/書き込みアクセスが必要なため、サーバをインストールしたユーザのみ実行できます。
   </para>
  </refsect1>
 
@@ -165,8 +162,8 @@ PostgreSQL documentation
       line.  <command>pg_resetwal</command> does not use the environment
       variable <envar>PGDATA</envar>.
 -->
-《機械翻訳》データベースディレクトリの場所を指定します。
-安全上の理由から、コマンドラインでデータディレクトリを指定する必要があります。
+データベースディレクトリの場所を指定します。
+安全上の理由から、コマンドラインでデータディレクトリを指定しなければなりません。
 <command>pg_resetwal</command>は環境変数<envar>PGDATA</envar>を使用しません。
      </para>
     </listitem>
@@ -184,8 +181,8 @@ PostgreSQL documentation
       <command>pg_resetwal</command> cannot determine valid data for
       <filename>pg_control</filename>.
 -->
-《機械翻訳》上記のように、危険な状況でも強制的に<command>pg_resetwal</command>を実行します。
-具体的には、サーバがクリーンにシャットダウンされていない場合や、<command>pg_resetwal</command>が<filename>pg_control</filename>の有効なデータを判断できない場合に、このオプションは必要です。
+前述のように、危険な状況でも強制的に<command>pg_resetwal</command>を実行します。
+具体的には、サーバが正常にシャットダウンされていない場合や、<command>pg_resetwal</command>が<filename>pg_control</filename>の有効なデータを確認できない場合に、このオプションは必要です。
      </para>
     </listitem>
    </varlistentry>
@@ -237,13 +234,10 @@ PostgreSQL documentation
    values can be specified by using the prefix <literal>0x</literal>.  Note
    that these instructions only apply with the standard block size of 8 kB.
 -->
-《マッチ度[76.600985]》以下のオプションは<command>pg_resetwal</command>が<filename>pg_control</filename>を読んでも適切な値を決定できない場合にのみ必要になります。
+以下のオプションは<command>pg_resetwal</command>が<filename>pg_control</filename>を読んでも適切な値を決定できない場合にのみ必要になります。
 安全な値は以下で説明するようにして決定できます。
 数値を引数として取る値については、<literal>0x</literal>の接頭辞をつけることで16進数の値を指定できます。
-《機械翻訳》以下のオプションは、<command>pg_resetwal</command>が<filename>pg_control</filename>を読み込んで適切な値を決定できない場合にのみ必要です。
-安全な値は以下のように決定できます。
-数値引数を取る値については、16進数を<literal>0x</literal>という接頭辞で指定することができます。
-これらの命令は標準的な8kBブロックサイズでのみ適用されることに注意してください。
+これらの手順は標準的な8kBブロックサイズでのみ適用されることに注意してください。
   </para>
 
   <variablelist>
@@ -466,8 +460,7 @@ PostgreSQL documentation
       existing database cluster, avoiding the need to
       re-<command>initdb</command>.
 -->
-《機械翻訳》このオプションは、既存のデータベースクラスタのWALセグメントサイズを変更するためにも使用できます。
-これにより、<command>initdb</command>を再度実行する必要がなくなります。
+このオプションは、既存のデータベースクラスタのWALセグメントサイズを変更するためにも使用でき、<command>initdb</command>を再実行する必要がなくなります。
      </para>
 
      <note>


### PR DESCRIPTION
翻訳時に気になった・迷ったところのメモ

「See Below」は「後述」としました。「下記参照」といった書き方も見られましたが補足的に使う場合は「後述」が多そうだったため。

「otherwise sound database cluster」は、「正常であり他に問題がない」という意味合いであるという認識で「正常なデータベースクラスタ」としました。

「dangerous modes」は、後述するforceオプションやXIDを手動設定するオプションを利用するケースを指している認識です。意味合いとしては「危険なオプション」となるのかなと思いましたが、そのまま「危険なモード」としました。

「read/write」は「読み取り/書き込み」としました。