### PR TITLE
see noteの訳抜けを修正

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -22789,7 +22789,10 @@ JSON数値あるいは文字列から変換した概算の浮動小数点数
        <entry role="func_table_entry"><para role="func_signature">
         <replaceable>string</replaceable> <literal>.</literal> <literal>datetime()</literal>
         <returnvalue><replaceable>datetime_type</replaceable></returnvalue>
+<!--
         (see note)
+-->
+（注記を参照）
        </para>
        <para>
 <!--
@@ -22807,7 +22810,10 @@ JSON数値あるいは文字列から変換した概算の浮動小数点数
        <entry role="func_table_entry"><para role="func_signature">
         <replaceable>string</replaceable> <literal>.</literal> <literal>datetime(<replaceable>template</replaceable>)</literal>
         <returnvalue><replaceable>datetime_type</replaceable></returnvalue>
+<!--
         (see note)
+-->
+（注記を参照）
        </para>
        <para>
 <!--
@@ -36530,7 +36536,7 @@ bgwriterやcheckpointerがログするのを待たずに、実行中のトラン
 -->
 上記の関数において、テーブルやインデックスを<type>regclass</type>引数として受け取って処理するものがありますが、この引数は単に<structname>pg_class</structname>システムカタログにあるテーブルやインデックスのOIDです。
 ただし、<type>regclass</type>データ型が自動で入力変換を行うため、ユーザが手動で該当するOIDを調べる必要はありません。
-詳細は<xref linkend="datatype-oid"/>を参照ください。
+詳細は<xref linkend="datatype-oid"/>を参照してください。
    </para>
 
    <para>
@@ -37819,7 +37825,7 @@ SELECT convert_from(pg_read_binary_file('file_in_utf8.txt'), 'UTF8');
    For more information about creating triggers, see
    <xref linkend="sql-createtrigger"/>.
 -->
-トリガ作成についてより詳細は<xref linkend="sql-createtrigger"/>を参照ください。
+トリガ作成についてのより詳細は<xref linkend="sql-createtrigger"/>を参照してください。
   </para>
 
    <table id="builtin-triggers-table">

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -2847,7 +2847,10 @@ JSON数値あるいは文字列から変換した概算の浮動小数点数
        <entry role="func_table_entry"><para role="func_signature">
         <replaceable>string</replaceable> <literal>.</literal> <literal>datetime()</literal>
         <returnvalue><replaceable>datetime_type</replaceable></returnvalue>
+<!--
         (see note)
+-->
+（注記を参照）
        </para>
        <para>
 <!--
@@ -2865,7 +2868,10 @@ JSON数値あるいは文字列から変換した概算の浮動小数点数
        <entry role="func_table_entry"><para role="func_signature">
         <replaceable>string</replaceable> <literal>.</literal> <literal>datetime(<replaceable>template</replaceable>)</literal>
         <returnvalue><replaceable>datetime_type</replaceable></returnvalue>
+<!--
         (see note)
+-->
+（注記を参照）
        </para>
        <para>
 <!--
@@ -7091,6 +7097,7 @@ SELECT b1 = ANY((SELECT b2 FROM t2 ...)) FROM t1 ...;
     entire table. A query like:
 -->
 他のSQLデータベース管理システムでの作業に親しんだユーザは、<function>count</function>集約関数がテーブル全体に適用される場合の性能に失望するかも知れません。
+次のような問い合わせ：
 <programlisting>
 SELECT count(*) FROM sometable;
 </programlisting>
@@ -7100,7 +7107,8 @@ SELECT count(*) FROM sometable;
     entire table or the entirety of an index that includes all rows in
     the table.
 -->
-のような問い合わせはテーブルサイズに比例した労力が必要です。<productname>PostgreSQL</productname>はテーブル全体か、そのテーブルの全ての行を含んだインデックス全体のスキャンを必要とします。
+はテーブルサイズに比例した労力が必要です。
+<productname>PostgreSQL</productname>はテーブル全体か、そのテーブルの全ての行を含んだインデックス全体のスキャンを必要とします。
    </para>
   </note>
 

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -8083,7 +8083,7 @@ bgwriterやcheckpointerがログするのを待たずに、実行中のトラン
 -->
 上記の関数において、テーブルやインデックスを<type>regclass</type>引数として受け取って処理するものがありますが、この引数は単に<structname>pg_class</structname>システムカタログにあるテーブルやインデックスのOIDです。
 ただし、<type>regclass</type>データ型が自動で入力変換を行うため、ユーザが手動で該当するOIDを調べる必要はありません。
-詳細は<xref linkend="datatype-oid"/>を参照ください。
+詳細は<xref linkend="datatype-oid"/>を参照してください。
    </para>
 
    <para>
@@ -9372,7 +9372,7 @@ SELECT convert_from(pg_read_binary_file('file_in_utf8.txt'), 'UTF8');
    For more information about creating triggers, see
    <xref linkend="sql-createtrigger"/>.
 -->
-トリガ作成についてより詳細は<xref linkend="sql-createtrigger"/>を参照ください。
+トリガ作成についてのより詳細は<xref linkend="sql-createtrigger"/>を参照してください。
   </para>
 
    <table id="builtin-triggers-table">


### PR DESCRIPTION
(see note)は<note>を指していて、これはDocBookで注記となるため、そうしました。
「参照ください」は、語尾の統一のために「参照してください」としました。