### PR TITLE
update features for 17.0

### DIFF
--- a/doc/src/sgml/features.sgml
+++ b/doc/src/sgml/features.sgml
@@ -305,8 +305,7 @@ SQL:2006でISO/IEC 9075-14 (SQL/XML)のXML関連の仕様についての重要�
        clauses, functions which are defined to have these in the specification
        are implicitly returning content.
 -->
-《機械翻訳》<productname>PostgreSQL</productname>は<literal>RETURNING CONTENT</literal>や<literal>RETURNING SEQUENCE</literal>句をサポートしません。
-これらの句を持つように定義された関数は暗黙的にコンテンツを返します。
+<productname>PostgreSQL</productname>は<literal>RETURNING CONTENT</literal>や<literal>RETURNING SEQUENCE</literal>句をサポートしません。これらの句を持つように定義された関数は暗黙的に内容を返します。
       </para>
      </listitem>
     </itemizedlist>
@@ -555,7 +554,7 @@ XPath 1.0では、XQuery/XPathで定義されているところの<firstterm>値
          context item to any <productname>PostgreSQL</productname>
          XPath-based function must be in document form.
 -->
-XQuery/XPathデータモデルでは、<firstterm>ドキュメントノード</firstterm>はドキュメント形式（すなわちコメントと外側の処理指示だけを伴う厳密に一つだけのトップレベル要素）かコンテキスト形式（これらの制約が緩められたもの）のいずれかを持つことができます。
+XQuery/XPathデータモデルでは、<firstterm>ドキュメントノード</firstterm>はドキュメント形式（すなわちコメントと外側の処理指示だけを伴う厳密に一つだけのトップレベル要素）かコンテント形式（これらの制約が緩められたもの）のいずれかを持つことができます。
 これに対してXPath 1.0では<firstterm>ルートノード</firstterm>はドキュメント形式のみです。
 このことは、<productname>PostgreSQL</productname>のXPathに基づくどの関数に対してもコンテキスト要素として渡される<type>xml</type>値がドキュメント形式でなければならない理由の一つです。
         </para>


### PR DESCRIPTION
features.sgml の 17.0 対応です。

それ以外にもcontentをcontextと間違えて訳していた部分を修正しています。

実はどちらも同じものを指しているはずなので、揃えられるなら揃えた方がいいとは思ってます。
コンテントとカタカナにするのも一理あるとは思いますが、JISでは「（XML）内容」とやっているようですし、、、