### PR TITLE
<entry>の分割（3）

### DIFF
--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -2858,7 +2858,10 @@ SELECT 'abc \153\154\155 \052\251\124'::bytea;
         <entry>12 bytes</entry>
 -->
         <entry>12 バイト</entry>
+<!--
         <entry>time of day (no date), with time zone</entry>
+-->
+        <entry>時刻（日付なし）、時間帯付き</entry>
         <!-- see MAX_TZDISP_HOUR in datatype/timestamp.h -->
 <!--
         <entry>00:00:00+1559</entry>

--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -60,11 +60,15 @@
       <row>
 <!--
        <entry>Name</entry>
-       <entry>Aliases</entry>
-       <entry>Description</entry>
 -->
        <entry>名称</entry>
+<!--
+       <entry>Aliases</entry>
+-->
        <entry>別名</entry>
+<!--
+       <entry>Description</entry>
+-->
        <entry>説明</entry>
       </row>
      </thead>
@@ -549,13 +553,19 @@
        <row>
 <!--
         <entry>Name</entry>
-        <entry>Storage Size</entry>
-        <entry>Description</entry>
-        <entry>Range</entry>
 -->
         <entry>型名</entry>
+<!--
+        <entry>Storage Size</entry>
+-->
         <entry>格納サイズ</entry>
+<!--
+        <entry>Description</entry>
+-->
         <entry>説明</entry>
+<!--
+        <entry>Range</entry>
+-->
         <entry>範囲</entry>
        </row>
       </thead>
@@ -565,33 +575,45 @@
         <entry><type>smallint</type></entry>
 <!--
         <entry>2 bytes</entry>
-        <entry>small-range integer</entry>
-        <entry>-32768 to +32767</entry>
 -->
         <entry>2バイト</entry>
+<!--
+        <entry>small-range integer</entry>
+-->
         <entry>狭範囲の整数</entry>
+<!--
+        <entry>-32768 to +32767</entry>
+-->
         <entry>-32768から+32767</entry>
        </row>
        <row>
         <entry><type>integer</type></entry>
 <!--
         <entry>4 bytes</entry>
-        <entry>typical choice for integer</entry>
-        <entry>-2147483648 to +2147483647</entry>
 -->
         <entry>4バイト</entry>
+<!--
+        <entry>typical choice for integer</entry>
+-->
         <entry>典型的に使用する整数</entry>
+<!--
+        <entry>-2147483648 to +2147483647</entry>
+-->
         <entry>-2147483648から+2147483647</entry>
        </row>
        <row>
         <entry><type>bigint</type></entry>
 <!--
         <entry>8 bytes</entry>
-        <entry>large-range integer</entry>
-        <entry>-9223372036854775808 to +9223372036854775807</entry>
 -->
         <entry>8バイト</entry>
+<!--
+        <entry>large-range integer</entry>
+-->
         <entry>広範囲整数</entry>
+<!--
+        <entry>-9223372036854775808 to +9223372036854775807</entry>
+-->
         <entry>-9223372036854775808から+9223372036854775807</entry>
        </row>
 
@@ -599,22 +621,30 @@
         <entry><type>decimal</type></entry>
 <!--
         <entry>variable</entry>
-        <entry>user-specified precision, exact</entry>
-        <entry>up to 131072 digits before the decimal point; up to 16383 digits after the decimal point</entry>
 -->
         <entry>可変長</entry>
+<!--
+        <entry>user-specified precision, exact</entry>
+-->
         <entry>ユーザ指定精度、正確</entry>
+<!--
+        <entry>up to 131072 digits before the decimal point; up to 16383 digits after the decimal point</entry>
+-->
         <entry>小数点より上は131072桁まで、小数点より下は16383桁まで</entry>
        </row>
        <row>
         <entry><type>numeric</type></entry>
 <!--
         <entry>variable</entry>
-        <entry>user-specified precision, exact</entry>
-        <entry>up to 131072 digits before the decimal point; up to 16383 digits after the decimal point</entry>
 -->
         <entry>可変長</entry>
+<!--
+        <entry>user-specified precision, exact</entry>
+-->
         <entry>ユーザ指定精度、正確</entry>
+<!--
+        <entry>up to 131072 digits before the decimal point; up to 16383 digits after the decimal point</entry>
+-->
         <entry>小数点より上は131072桁まで、小数点より下は16383桁まで</entry>
        </row>
 
@@ -622,22 +652,30 @@
         <entry><type>real</type></entry>
 <!--
         <entry>4 bytes</entry>
-        <entry>variable-precision, inexact</entry>
-        <entry>6 decimal digits precision</entry>
 -->
         <entry>4バイト</entry>
+<!--
+        <entry>variable-precision, inexact</entry>
+-->
         <entry>可変精度、不正確</entry>
+<!--
+        <entry>6 decimal digits precision</entry>
+-->
         <entry>6桁精度</entry>
        </row>
        <row>
         <entry><type>double precision</type></entry>
 <!--
         <entry>8 bytes</entry>
-        <entry>variable-precision, inexact</entry>
-        <entry>15 decimal digits precision</entry>
 -->
         <entry>8バイト</entry>
+<!--
+        <entry>variable-precision, inexact</entry>
+-->
         <entry>可変精度、不正確</entry>
+<!--
+        <entry>15 decimal digits precision</entry>
+-->
         <entry>15桁精度</entry>
        </row>
 
@@ -645,11 +683,15 @@
         <entry><type>smallserial</type></entry>
 <!--
         <entry>2 bytes</entry>
-        <entry>small autoincrementing integer</entry>
-        <entry>1 to 32767</entry>
 -->
         <entry>2バイト</entry>
+<!--
+        <entry>small autoincrementing integer</entry>
+-->
         <entry>狭範囲自動整数</entry>
+<!--
+        <entry>1 to 32767</entry>
+-->
         <entry>1から32767</entry>
        </row>
 
@@ -657,11 +699,15 @@
         <entry><type>serial</type></entry>
 <!--
         <entry>4 bytes</entry>
-        <entry>autoincrementing integer</entry>
-        <entry>1 to 2147483647</entry>
 -->
         <entry>4バイト</entry>
+<!--
+        <entry>autoincrementing integer</entry>
+-->
         <entry>自動増分整数</entry>
+<!--
+        <entry>1 to 2147483647</entry>
+-->
         <entry>1から2147483647</entry>
        </row>
 
@@ -669,11 +715,15 @@
         <entry><type>bigserial</type></entry>
 <!--
         <entry>8 bytes</entry>
-        <entry>large autoincrementing integer</entry>
-        <entry>1 to 9223372036854775807</entry>
 -->
         <entry>8バイト</entry>
+<!--
+        <entry>large autoincrementing integer</entry>
+-->
         <entry>広範囲自動増分整数</entry>
+<!--
+        <entry>1 to 9223372036854775807</entry>
+-->
         <entry>1から9223372036854775807</entry>
        </row>
       </tbody>
@@ -1605,13 +1655,19 @@ ALTER SEQUENCE <replaceable class="parameter">tablename</replaceable>_<replaceab
        <row>
 <!--
         <entry>Name</entry>
-        <entry>Storage Size</entry>
-        <entry>Description</entry>
-        <entry>Range</entry>
 -->
         <entry>型名</entry>
+<!--
+        <entry>Storage Size</entry>
+-->
         <entry>格納サイズ</entry>
+<!--
+        <entry>Description</entry>
+-->
         <entry>説明</entry>
+<!--
+        <entry>Range</entry>
+-->
         <entry>範囲</entry>
        </row>
       </thead>
@@ -1620,11 +1676,15 @@ ALTER SEQUENCE <replaceable class="parameter">tablename</replaceable>_<replaceab
         <entry><type>money</type></entry>
 <!--
         <entry>8 bytes</entry>
-        <entry>currency amount</entry>
-        <entry>-92233720368547758.08 to +92233720368547758.07</entry>
 -->
         <entry>8バイト</entry>
+<!--
+        <entry>currency amount</entry>
+-->
         <entry>貨幣金額</entry>
+<!--
+        <entry>-92233720368547758.08 to +92233720368547758.07</entry>
+-->
         <entry>-92233720368547758.08 から +92233720368547758.07</entry>
        </row>
       </tbody>
@@ -1753,9 +1813,11 @@ SELECT '52093.89'::money::numeric::float8;
        <row>
 <!--
         <entry>Name</entry>
-        <entry>Description</entry>
 -->
         <entry>型名</entry>
+<!--
+        <entry>Description</entry>
+-->
         <entry>説明</entry>
        </row>
       </thead>
@@ -2068,11 +2130,15 @@ SELECT b, char_length(b) FROM test2;
        <row>
 <!--
         <entry>Name</entry>
-        <entry>Storage Size</entry>
-        <entry>Description</entry>
 -->
         <entry>型名</entry>
+<!--
+        <entry>Storage Size</entry>
+-->
         <entry>格納サイズ</entry>
+<!--
+        <entry>Description</entry>
+-->
         <entry>説明</entry>
        </row>
       </thead>
@@ -2081,18 +2147,22 @@ SELECT b, char_length(b) FROM test2;
         <entry><type>"char"</type></entry>
 <!--
         <entry>1 byte</entry>
-        <entry>single-byte internal type</entry>
 -->
         <entry>1バイト</entry>
+<!--
+        <entry>single-byte internal type</entry>
+-->
         <entry>単一バイト内部データ型</entry>
        </row>
        <row>
         <entry><type>name</type></entry>
 <!--
         <entry>64 bytes</entry>
-        <entry>internal type for object names</entry>
 -->
         <entry>64バイト</entry>
+<!--
+        <entry>internal type for object names</entry>
+-->
         <entry>オブジェクト名用の内部データ型</entry>
        </row>
       </tbody>
@@ -2140,11 +2210,15 @@ SELECT b, char_length(b) FROM test2;
       <row>
 <!--
        <entry>Name</entry>
-       <entry>Storage Size</entry>
-       <entry>Description</entry>
 -->
        <entry>型名</entry>
+<!--
+       <entry>Storage Size</entry>
+-->
        <entry>格納サイズ</entry>
+<!--
+       <entry>Description</entry>
+-->
        <entry>説明</entry>
       </row>
      </thead>
@@ -2153,9 +2227,11 @@ SELECT b, char_length(b) FROM test2;
        <entry><type>bytea</type></entry>
 <!--
        <entry>1 or 4 bytes plus the actual binary string</entry>
-       <entry>variable-length binary string</entry>
 -->
        <entry>1または4バイトと実際のバイナリ列の長さ</entry>
+<!--
+       <entry>variable-length binary string</entry>
+-->
        <entry>可変長のバイナリ列</entry>
       </row>
      </tbody>
@@ -2334,15 +2410,23 @@ SELECT '\xDEADBEEF'::bytea;
       <row>
 <!--
        <entry>Decimal Octet Value</entry>
-       <entry>Description</entry>
-       <entry>Escaped Input Representation</entry>
-       <entry>Example</entry>
-       <entry>Hex Representation</entry>
 -->
        <entry>10進オクテット値</entry>
+<!--
+       <entry>Description</entry>
+-->
        <entry>説明</entry>
+<!--
+       <entry>Escaped Input Representation</entry>
+-->
        <entry>エスケープされた入力表現</entry>
+<!--
+       <entry>Example</entry>
+-->
        <entry>例</entry>
+<!--
+       <entry>Hex Representation</entry>
+-->
        <entry>出力表現</entry>
       </row>
      </thead>
@@ -2352,13 +2436,19 @@ SELECT '\xDEADBEEF'::bytea;
        <entry>0</entry>
 <!--
        <entry>zero octet</entry>
-       <entry><literal>'\000'</literal></entry>
-       <entry><literal>'\000'::bytea</literal></entry>
-       <entry><literal>\x00</literal></entry>
 -->
        <entry>ゼロオクテット</entry>
+<!--
        <entry><literal>'\000'</literal></entry>
+-->
+       <entry><literal>'\000'</literal></entry>
+<!--
+       <entry><literal>'\000'::bytea</literal></entry>
+-->
        <entry><literal>'\000'::bytea;</literal></entry>
+<!--
+       <entry><literal>\x00</literal></entry>
+-->
        <entry><literal>\x00</literal></entry>
       </row>
 
@@ -2370,9 +2460,11 @@ SELECT '\xDEADBEEF'::bytea;
        <entry>単一引用符</entry>
 <!--
        <entry><literal>''''</literal> or <literal>'\047'</literal></entry>
-       <entry><literal>''''::bytea</literal></entry>
 -->
        <entry><literal>''''</literal>もしくは<literal>'\047'</literal></entry>
+<!--
+       <entry><literal>''''::bytea</literal></entry>
+-->
        <entry><literal>''''::bytea;</literal></entry>
        <entry><literal>\x27</literal></entry>
       </row>
@@ -2385,9 +2477,11 @@ SELECT '\xDEADBEEF'::bytea;
        <entry>バックスラッシュ</entry>
 <!--
        <entry><literal>'\\'</literal> or <literal>'\134'</literal></entry>
-       <entry><literal>'\\'::bytea</literal></entry>
 -->
        <entry><literal>'\\'</literal>もしくは<literal>'\\134'</literal></entry>
+<!--
+       <entry><literal>'\\'::bytea</literal></entry>
+-->
        <entry><literal>'\\'::bytea;</literal></entry>
        <entry><literal>\x5c</literal></entry>
       </row>
@@ -2395,15 +2489,19 @@ SELECT '\xDEADBEEF'::bytea;
       <row>
 <!--
        <entry>0 to 31 and 127 to 255</entry>
-       <entry><quote>non-printable</quote> octets</entry>
 -->
        <entry>0から31まで、および127から255まで</entry>
+<!--
+       <entry><quote>non-printable</quote> octets</entry>
+-->
        <entry><quote>表示できない</quote>オクテット</entry>
 <!--
        <entry><literal>'\<replaceable>xxx'</replaceable></literal> (octal value)</entry>
-       <entry><literal>'\001'::bytea</literal></entry>
 -->
        <entry><literal>'\<replaceable>xxx'</replaceable></literal> (8進数)</entry>
+<!--
+       <entry><literal>'\001'::bytea</literal></entry>
+-->
        <entry><literal>'\001'::bytea;</literal></entry>
        <entry><literal>\x01</literal></entry>
       </row>
@@ -2499,15 +2597,23 @@ SELECT 'abc \153\154\155 \052\251\124'::bytea;
       <row>
 <!--
        <entry>Decimal Octet Value</entry>
-       <entry>Description</entry>
-       <entry>Escaped Output Representation</entry>
-       <entry>Example</entry>
-       <entry>Output Result</entry>
 -->
        <entry>10進オクテット値</entry>
+<!--
+       <entry>Description</entry>
+-->
        <entry>説明</entry>
+<!--
+       <entry>Escaped Output Representation</entry>
+-->
        <entry>エスケープされた出力表現</entry>
+<!--
+       <entry>Example</entry>
+-->
        <entry>例</entry>
+<!--
+       <entry>Output Result</entry>
+-->
        <entry>出力結果</entry>
       </row>
      </thead>
@@ -2528,15 +2634,19 @@ SELECT 'abc \153\154\155 \052\251\124'::bytea;
       <row>
 <!--
        <entry>0 to 31 and 127 to 255</entry>
-       <entry><quote>non-printable</quote> octets</entry>
 -->
        <entry>0から31および127から255</entry>
+<!--
+       <entry><quote>non-printable</quote> octets</entry>
+-->
        <entry><quote>表示できない</quote>オクテット</entry>
 <!--
        <entry><literal>\<replaceable>xxx</replaceable></literal> (octal value)</entry>
-       <entry><literal>'\001'::bytea</literal></entry>
 -->
        <entry><literal>\<replaceable>xxx</replaceable></literal>（8進数）</entry>
+<!--
+       <entry><literal>'\001'::bytea</literal></entry>
+-->
        <entry><literal>'\001'::bytea;</literal></entry>
        <entry><literal>\001</literal></entry>
       </row>
@@ -2544,15 +2654,23 @@ SELECT 'abc \153\154\155 \052\251\124'::bytea;
       <row>
 <!--
        <entry>32 to 126</entry>
-       <entry><quote>printable</quote> octets</entry>
-       <entry>client character set representation</entry>
-       <entry><literal>'\176'::bytea</literal></entry>
-       <entry><literal>~</literal></entry>
 -->
        <entry>32から126</entry>
+<!--
+       <entry><quote>printable</quote> octets</entry>
+-->
        <entry><quote>表示できる</quote>オクテット</entry>
+<!--
+       <entry>client character set representation</entry>
+-->
        <entry>クライアント文字セットにおける表現</entry>
+<!--
+       <entry><literal>'\176'::bytea</literal></entry>
+-->
        <entry><literal>'\176'::bytea;</literal></entry>
+<!--
+       <entry><literal>~</literal></entry>
+-->
        <entry><literal>~</literal></entry>
       </row>
 
@@ -2641,17 +2759,27 @@ SELECT 'abc \153\154\155 \052\251\124'::bytea;
        <row>
 <!--
         <entry>Name</entry>
-        <entry>Storage Size</entry>
-        <entry>Description</entry>
-        <entry>Low Value</entry>
-        <entry>High Value</entry>
-        <entry>Resolution</entry>
 -->
         <entry>型名</entry>
+<!--
+        <entry>Storage Size</entry>
+-->
         <entry>格納サイズ</entry>
+<!--
+        <entry>Description</entry>
+-->
         <entry>説明</entry>
+<!--
+        <entry>Low Value</entry>
+-->
         <entry>最遠の過去</entry>
+<!--
+        <entry>High Value</entry>
+-->
         <entry>最遠の未来</entry>
+<!--
+        <entry>Resolution</entry>
+-->
         <entry>精度</entry>
        </row>
       </thead>
@@ -2660,9 +2788,11 @@ SELECT 'abc \153\154\155 \052\251\124'::bytea;
         <entry><type>timestamp [ (<replaceable>p</replaceable>) ] [ without time zone ]</type></entry>
 <!--
         <entry>8 bytes</entry>
-        <entry>both date and time (no time zone)</entry>
 -->
         <entry>8 バイト</entry>
+<!--
+        <entry>both date and time (no time zone)</entry>
+-->
         <entry>日付と時刻両方（時間帯なし）</entry>
         <entry>4713 BC</entry>
         <entry>294276 AD</entry>
@@ -2675,9 +2805,11 @@ SELECT 'abc \153\154\155 \052\251\124'::bytea;
         <entry><type>timestamp [ (<replaceable>p</replaceable>) ] with time zone</type></entry>
 <!--
         <entry>8 bytes</entry>
-        <entry>both date and time, with time zone</entry>
 -->
         <entry>8バイト</entry>
+<!--
+        <entry>both date and time, with time zone</entry>
+-->
         <entry>日付と時刻両方、時間帯付き</entry>
         <entry>4713 BC</entry>
         <entry>294276 AD</entry>
@@ -2690,9 +2822,11 @@ SELECT 'abc \153\154\155 \052\251\124'::bytea;
         <entry><type>date</type></entry>
 <!--
         <entry>4 bytes</entry>
-        <entry>date (no time of day)</entry>
 -->
         <entry>4バイト</entry>
+<!--
+        <entry>date (no time of day)</entry>
+-->
         <entry>日付（時刻なし）</entry>
         <entry>4713 BC</entry>
         <entry>5874897 AD</entry>
@@ -2705,9 +2839,11 @@ SELECT 'abc \153\154\155 \052\251\124'::bytea;
         <entry><type>time [ (<replaceable>p</replaceable>) ] [ without time zone ]</type></entry>
 <!--
         <entry>8 bytes</entry>
-        <entry>time of day (no date)</entry>
 -->
         <entry>8バイト</entry>
+<!--
+        <entry>time of day (no date)</entry>
+-->
         <entry>時刻（日付なし）</entry>
         <entry>00:00:00</entry>
         <entry>24:00:00</entry>
@@ -2720,31 +2856,44 @@ SELECT 'abc \153\154\155 \052\251\124'::bytea;
         <entry><type>time [ (<replaceable>p</replaceable>) ] with time zone</type></entry>
 <!--
         <entry>12 bytes</entry>
-        <entry>time of day (no date), with time zone</entry>
-        <!&#45;- see MAX_TZDISP_HOUR in datatype/timestamp.h &#45;->
-        <entry>00:00:00+1559</entry>
-        <entry>24:00:00-1559</entry>
-        <entry>1 microsecond</entry>
 -->
         <entry>12 バイト</entry>
-        <entry>時刻（日付なし）、時間帯付き</entry>
+        <entry>time of day (no date), with time zone</entry>
+        <!-- see MAX_TZDISP_HOUR in datatype/timestamp.h -->
+<!--
         <entry>00:00:00+1559</entry>
+-->
+        <entry>00:00:00+1559</entry>
+<!--
         <entry>24:00:00-1559</entry>
+-->
+        <entry>24:00:00-1559</entry>
+<!--
+        <entry>1 microsecond</entry>
+-->
         <entry>1 マイクロ秒</entry>
        </row>
        <row>
         <entry><type>interval [ <replaceable>fields</replaceable> ] [ (<replaceable>p</replaceable>) ]</type></entry>
 <!--
         <entry>16 bytes</entry>
-        <entry>time interval</entry>
-        <entry>-178000000 years</entry>
-        <entry>178000000 years</entry>
-        <entry>1 microsecond</entry>
 -->
         <entry>16バイト</entry>
+<!--
+        <entry>time interval</entry>
+-->
         <entry>時間間隔</entry>
+<!--
+        <entry>-178000000 years</entry>
+-->
         <entry>-178000000年</entry>
+<!--
+        <entry>178000000 years</entry>
+-->
         <entry>178000000年</entry>
+<!--
+        <entry>1 microsecond</entry>
+-->
         <entry>1マイクロ秒</entry>
        </row>
       </tbody>
@@ -2922,9 +3071,11 @@ MINUTE TO SECOND
         <row>
 <!--
          <entry>Example</entry>
-         <entry>Description</entry>
 -->
          <entry>例</entry>
+<!--
+         <entry>Description</entry>
+-->
          <entry>説明</entry>
         </row>
        </thead>
@@ -3117,9 +3268,11 @@ MINUTE TO SECOND
          <row>
 <!--
           <entry>Example</entry>
-          <entry>Description</entry>
 -->
           <entry>例</entry>
+<!--
+          <entry>Description</entry>
+-->
           <entry>説明</entry>
          </row>
         </thead>
@@ -3224,9 +3377,11 @@ MINUTE TO SECOND
          <row>
 <!--
           <entry>Example</entry>
-          <entry>Description</entry>
 -->
           <entry>例</entry>
+<!--
+          <entry>Description</entry>
+-->
           <entry>説明</entry>
          </row>
         </thead>
@@ -3515,11 +3670,15 @@ TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54+02'
          <row>
 <!--
           <entry>Input String</entry>
-          <entry>Valid Types</entry>
-          <entry>Description</entry>
 -->
           <entry>入力文字列</entry>
+<!--
+          <entry>Valid Types</entry>
+-->
           <entry>有効な型</entry>
+<!--
+          <entry>Description</entry>
+-->
           <entry>説明</entry>
          </row>
         </thead>
@@ -3701,11 +3860,15 @@ TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54+02'
         <row>
 <!--
          <entry>Style Specification</entry>
-         <entry>Description</entry>
-         <entry>Example</entry>
 -->
          <entry>様式指定</entry>
+<!--
+         <entry>Description</entry>
+-->
          <entry>説明</entry>
+<!--
+         <entry>Example</entry>
+-->
          <entry>例</entry>
         </row>
        </thead>
@@ -3790,11 +3953,15 @@ ISO 8601の仕様では日付と時刻を区切るために大文字の<literal>
         <row>
 <!--
          <entry><varname>datestyle</varname> Setting</entry>
-         <entry>Input Ordering</entry>
-         <entry>Example Output</entry>
 -->
          <entry><varname>datestyle</varname>の設定</entry>
+<!--
+         <entry>Input Ordering</entry>
+-->
          <entry>入力の順序</entry>
+<!--
+         <entry>Example Output</entry>
+-->
          <entry>出力例</entry>
         </row>
        </thead>
@@ -4242,9 +4409,11 @@ P <replaceable>quantity</replaceable> <replaceable>unit</replaceable> <optional>
         <row>
 <!--
          <entry>Abbreviation</entry>
-         <entry>Meaning</entry>
 -->
          <entry>省略形</entry>
+<!--
+         <entry>Meaning</entry>
+-->
          <entry>意味</entry>
         </row>
        </thead>
@@ -4436,9 +4605,11 @@ SELECT '2 years 15 months 100 weeks 99 hours 123456789 milliseconds'::interval;
         <row>
 <!--
          <entry>Example</entry>
-         <entry>Description</entry>
 -->
          <entry>例</entry>
+<!--
+         <entry>Description</entry>
+-->
          <entry>説明</entry>
         </row>
        </thead>
@@ -4592,13 +4763,19 @@ microseconds フィールドは、時間、分、秒、および小数の秒に�
          <row>
 <!--
           <entry>Style Specification</entry>
-          <entry>Year-Month Interval</entry>
-          <entry>Day-Time Interval</entry>
-          <entry>Mixed Interval</entry>
 -->
           <entry>形式指定</entry>
+<!--
+          <entry>Year-Month Interval</entry>
+-->
           <entry>年-月時間間隔</entry>
+<!--
+          <entry>Day-Time Interval</entry>
+-->
           <entry>日-時刻時間間隔</entry>
+<!--
+          <entry>Mixed Interval</entry>
+-->
           <entry>混在した時間間隔</entry>
          </row>
         </thead>
@@ -4690,11 +4867,15 @@ microseconds フィールドは、時間、分、秒、および小数の秒に�
       <row>
 <!--
        <entry>Name</entry>
-       <entry>Storage Size</entry>
-       <entry>Description</entry>
 -->
        <entry>名前</entry>
+<!--
+       <entry>Storage Size</entry>
+-->
        <entry>格納サイズ</entry>
+<!--
+       <entry>Description</entry>
+-->
        <entry>説明</entry>
       </row>
      </thead>
@@ -4703,9 +4884,11 @@ microseconds フィールドは、時間、分、秒、および小数の秒に�
        <entry><type>boolean</type></entry>
 <!--
        <entry>1 byte</entry>
-       <entry>state of true or false</entry>
 -->
        <entry>1バイト</entry>
+<!--
+       <entry>state of true or false</entry>
+-->
        <entry>真または偽の状態</entry>
       </row>
      </tbody>
@@ -5071,13 +5254,19 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
        <row>
 <!--
         <entry>Name</entry>
-        <entry>Storage Size</entry>
-        <entry>Description</entry>
-        <entry>Representation</entry>
 -->
         <entry>型名</entry>
+<!--
+        <entry>Storage Size</entry>
+-->
         <entry>格納サイズ</entry>
+<!--
+        <entry>Description</entry>
+-->
         <entry>説明</entry>
+<!--
+        <entry>Representation</entry>
+-->
         <entry>表現</entry>
        </row>
       </thead>
@@ -5086,9 +5275,11 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry><type>point</type></entry>
 <!--
         <entry>16 bytes</entry>
-        <entry>Point on a plane</entry>
 -->
         <entry>16バイト</entry>
+<!--
+        <entry>Point on a plane</entry>
+-->
         <entry>平面における座標点</entry>
         <entry>(x,y)</entry>
        </row>
@@ -5096,9 +5287,11 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry><type>line</type></entry>
 <!--
         <entry>24 bytes</entry>
-        <entry>Infinite line</entry>
 -->
         <entry>24バイト</entry>
+<!--
+        <entry>Infinite line</entry>
+-->
         <entry>無限の直線</entry>
         <entry>{A,B,C}</entry>
        </row>
@@ -5106,9 +5299,11 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry><type>lseg</type></entry>
 <!--
         <entry>32 bytes</entry>
-        <entry>Finite line segment</entry>
 -->
         <entry>32バイト</entry>
+<!--
+        <entry>Finite line segment</entry>
+-->
         <entry>有限の線分</entry>
         <entry>((x1,y1),(x2,y2))</entry>
        </row>
@@ -5116,9 +5311,11 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry><type>box</type></entry>
 <!--
         <entry>32 bytes</entry>
-        <entry>Rectangular box</entry>
 -->
         <entry>32バイト</entry>
+<!--
+        <entry>Rectangular box</entry>
+-->
         <entry>矩形</entry>
         <entry>((x1,y1),(x2,y2))</entry>
        </row>
@@ -5126,9 +5323,11 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry><type>path</type></entry>
 <!--
         <entry>16+16n bytes</entry>
-        <entry>Closed path (similar to polygon)</entry>
 -->
         <entry>16+16nバイト</entry>
+<!--
+        <entry>Closed path (similar to polygon)</entry>
+-->
         <entry>閉経路（多角形に類似）</entry>
         <entry>((x1,y1),...)</entry>
        </row>
@@ -5136,9 +5335,11 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry><type>path</type></entry>
 <!--
         <entry>16+16n bytes</entry>
-        <entry>Open path</entry>
 -->
         <entry>16+16nバイト</entry>
+<!--
+        <entry>Open path</entry>
+-->
         <entry>開経路</entry>
         <entry>[(x1,y1),...]</entry>
        </row>
@@ -5146,9 +5347,11 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry><type>polygon</type></entry>
 <!--
         <entry>40+16n bytes</entry>
-        <entry>Polygon (similar to closed path)</entry>
 -->
         <entry>40+16nバイト</entry>
+<!--
+        <entry>Polygon (similar to closed path)</entry>
+-->
         <entry>多角形（閉経路に類似）</entry>
         <entry>((x1,y1),...)</entry>
        </row>
@@ -5156,11 +5359,15 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry><type>circle</type></entry>
 <!--
         <entry>24 bytes</entry>
-        <entry>Circle</entry>
-        <entry>&lt;(x,y),r&gt; (center point and radius)</entry>
 -->
         <entry>24バイト</entry>
+<!--
+        <entry>Circle</entry>
+-->
         <entry>円</entry>
+<!--
+        <entry>&lt;(x,y),r&gt; (center point and radius)</entry>
+-->
         <entry>&lt;(x,y),r&gt;（中心と半径）</entry>
        </row>
       </tbody>
@@ -5598,11 +5805,15 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
        <row>
 <!--
         <entry>Name</entry>
-        <entry>Storage Size</entry>
-        <entry>Description</entry>
 -->
         <entry>名前</entry>
+<!--
+        <entry>Storage Size</entry>
+-->
         <entry>格納サイズ</entry>
+<!--
+        <entry>Description</entry>
+-->
         <entry>説明</entry>
        </row>
       </thead>
@@ -5612,9 +5823,11 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry><type>cidr</type></entry>
 <!--
         <entry>7 or 19 bytes</entry>
-        <entry>IPv4 and IPv6 networks</entry>
 -->
         <entry>7もしくは19バイト</entry>
+<!--
+        <entry>IPv4 and IPv6 networks</entry>
+-->
         <entry>IPv4、およびIPv6ネットワーク</entry>
        </row>
 
@@ -5622,9 +5835,11 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry><type>inet</type></entry>
 <!--
         <entry>7 or 19 bytes</entry>
-        <entry>IPv4 and IPv6 hosts and networks</entry>
 -->
         <entry>7もしくは19バイト</entry>
+<!--
+        <entry>IPv4 and IPv6 hosts and networks</entry>
+-->
         <entry>IPv4もしくはIPv6ホスト、およびネットワーク</entry>
        </row>
 
@@ -5632,9 +5847,11 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry><type>macaddr</type></entry>
 <!--
         <entry>6 bytes</entry>
-        <entry>MAC addresses</entry>
 -->
         <entry>6バイト</entry>
+<!--
+        <entry>MAC addresses</entry>
+-->
         <entry>MACアドレス</entry>
        </row>
 
@@ -5642,9 +5859,11 @@ SELECT person.name, holidays.num_weeks FROM person, holidays
         <entry><type>macaddr8</type></entry>
 <!--
         <entry>8 bytes</entry>
-        <entry>MAC addresses (EUI-64 format)</entry>
 -->
         <entry>8 バイト</entry>
+<!--
+        <entry>MAC addresses (EUI-64 format)</entry>
+-->
         <entry>MAC アドレス (EUI-64 形式)</entry>
        </row>
 
@@ -5766,9 +5985,11 @@ IPv6ではアドレス長は128ビットですので、128ビットが一意な�
         <row>
 <!--
          <entry><type>cidr</type> Input</entry>
-         <entry><type>cidr</type> Output</entry>
 -->
          <entry><type>cidr</type>入力</entry>
+<!--
+         <entry><type>cidr</type> Output</entry>
+-->
          <entry><type>cidr</type>出力</entry>
          <entry><literal><function>abbrev(<type>cidr</type>)</function></literal></entry>
         </row>
@@ -7197,13 +7418,19 @@ SELECT * FROM pg_attribute
        <row>
 <!--
         <entry>Name</entry>
-        <entry>References</entry>
-        <entry>Description</entry>
-        <entry>Value Example</entry>
 -->
         <entry>型名</entry>
+<!--
+        <entry>References</entry>
+-->
         <entry>参照</entry>
+<!--
+        <entry>Description</entry>
+-->
         <entry>説明</entry>
+<!--
+        <entry>Value Example</entry>
+-->
         <entry>値の例</entry>
        </row>
       </thead>
@@ -7214,9 +7441,11 @@ SELECT * FROM pg_attribute
         <entry><type>oid</type></entry>
 <!--
         <entry>any</entry>
-        <entry>numeric object identifier</entry>
 -->
         <entry>すべて</entry>
+<!--
+        <entry>numeric object identifier</entry>
+-->
         <entry>数値オブジェクト識別子</entry>
         <entry><literal>564182</literal></entry>
        </row>
@@ -7748,9 +7977,11 @@ LSNは例えば、<literal>16/B374D848</literal>のように２つのスラッ�
        <row>
 <!--
         <entry>Name</entry>
-        <entry>Description</entry>
 -->
         <entry>型名</entry>
+<!--
+        <entry>Description</entry>
+-->
         <entry>説明</entry>
        </row>
       </thead>

--- a/doc/src/sgml/datetime.sgml
+++ b/doc/src/sgml/datetime.sgml
@@ -392,9 +392,11 @@ BCが指定されず年フィールドの長さが2桁の場合、年は4桁に�
        <row>
 <!--
         <entry>Month</entry>
-        <entry>Abbreviations</entry>
 -->
         <entry>月</entry>
+<!--
+        <entry>Abbreviations</entry>
+-->
         <entry>簡略形</entry>
        </row>
       </thead>
@@ -472,9 +474,11 @@ BCが指定されず年フィールドの長さが2桁の場合、年は4桁に�
         <row>
 <!--
          <entry>Day</entry>
-         <entry>Abbreviations</entry>
 -->
          <entry>曜日</entry>
+<!--
+         <entry>Abbreviations</entry>
+-->
          <entry>簡略形</entry>
         </row>
        </thead>
@@ -538,9 +542,11 @@ BCが指定されず年フィールドの長さが2桁の場合、年は4桁に�
        <row>
 <!--
         <entry>Identifier</entry>
-        <entry>Description</entry>
 -->
         <entry>識別子</entry>
+<!--
+        <entry>Description</entry>
+-->
         <entry>説明</entry>
        </row>
       </thead>

--- a/doc/src/sgml/ddl.sgml
+++ b/doc/src/sgml/ddl.sgml
@@ -3135,11 +3135,15 @@ PostgreSQLはあるタイプのオブジェクトが作成された時に、そ�
      <row>
 <!--
       <entry>Privilege</entry>
-      <entry>Abbreviation</entry>
-      <entry>Applicable Object Types</entry>
 -->
       <entry>権限</entry>
+<!--
+      <entry>Abbreviation</entry>
+-->
       <entry>短縮形</entry>
+<!--
+      <entry>Applicable Object Types</entry>
+-->
       <entry>適用可能なオブジェクトタイプ</entry>
      </row>
     </thead>
@@ -3278,13 +3282,19 @@ PostgreSQLはあるタイプのオブジェクトが作成された時に、そ�
      <row>
 <!--
       <entry>Object Type</entry>
-      <entry>All Privileges</entry>
-      <entry>Default <literal>PUBLIC</literal> Privileges</entry>
-      <entry><application>psql</application> Command</entry>
 -->
       <entry>オブジェクトタイプ</entry>
+<!--
+      <entry>All Privileges</entry>
+-->
       <entry>すべての権限</entry>
+<!--
+      <entry>Default <literal>PUBLIC</literal> Privileges</entry>
+-->
       <entry>デフォルト<literal>PUBLIC</literal>権限</entry>
+<!--
+      <entry><application>psql</application> Command</entry>
+-->
       <entry><application>psql</application>コマンド</entry>
      </row>
     </thead>

--- a/doc/src/sgml/high-availability.sgml
+++ b/doc/src/sgml/high-availability.sgml
@@ -464,23 +464,39 @@ Bucardoはこの種のレプリケーションの一例です。
     <row>
 <!--
      <entry>Feature</entry>
-     <entry>Shared Disk</entry>
-     <entry>File System Repl.</entry>
-     <entry>Write-Ahead Log Shipping</entry>
-     <entry>Logical Repl.</entry>
-     <entry>Trigger-&zwsp;Based Repl.</entry>
-     <entry>SQL Repl. Middle-ware</entry>
-     <entry>Async. MM Repl.</entry>
-     <entry>Sync. MM Repl.</entry>
 -->
      <entry>特徴</entry>
+<!--
+     <entry>Shared Disk</entry>
+-->
      <entry>共有ディスク</entry>
+<!--
+     <entry>File System Repl.</entry>
+-->
      <entry>ファイルシステムのレプリケーション</entry>
+<!--
+     <entry>Write-Ahead Log Shipping</entry>
+-->
      <entry>先行書き込みログシッピング</entry>
+<!--
+     <entry>Logical Repl.</entry>
+-->
      <entry>論理レプリケーション</entry>
+<!--
+     <entry>Trigger-&zwsp;Based Repl.</entry>
+-->
      <entry>トリガに基づいたレプリケーション</entry>
+<!--
+     <entry>SQL Repl. Middle-ware</entry>
+-->
      <entry>SQLに基づいたレプリケーションのミドルウェア</entry>
+<!--
+     <entry>Async. MM Repl.</entry>
+-->
      <entry>非同期マルチマスタレプリケーション</entry>
+<!--
+     <entry>Sync. MM Repl.</entry>
+-->
      <entry>同期マルチマスタレプリケーション</entry>
     </row>
    </thead>
@@ -490,230 +506,390 @@ Bucardoはこの種のレプリケーションの一例です。
     <row>
 <!--
      <entry>Popular examples</entry>
-     <entry align="center">NAS</entry>
-     <entry align="center">DRBD</entry>
-     <entry align="center">built-in streaming repl.</entry>
-     <entry align="center">built-in logical repl., pglogical</entry>
-     <entry align="center">Londiste, Slony</entry>
-     <entry align="center">pgpool-II</entry>
-     <entry align="center">Bucardo</entry>
-     <entry align="center"></entry>
 -->
      <entry>一般的な例</entry>
+<!--
      <entry align="center">NAS</entry>
+-->
+     <entry align="center">NAS</entry>
+<!--
      <entry align="center">DRBD</entry>
+-->
+     <entry align="center">DRBD</entry>
+<!--
+     <entry align="center">built-in streaming repl.</entry>
+-->
      <entry align="center">組み込みストリーミングレプリケーション</entry>
+<!--
+     <entry align="center">built-in logical repl., pglogical</entry>
+-->
      <entry align="center">組み込み論理レプリケーション、pglogical</entry>
+<!--
+     <entry align="center">Londiste, Slony</entry>
+-->
      <entry align="center">Londiste、Slony</entry>
+<!--
      <entry align="center">pgpool-II</entry>
+-->
+     <entry align="center">pgpool-II</entry>
+<!--
      <entry align="center">Bucardo</entry>
+-->
+     <entry align="center">Bucardo</entry>
+<!--
+     <entry align="center"></entry>
+-->
      <entry align="center"></entry>
     </row>
 
     <row>
 <!--
      <entry>Comm. method</entry>
-     <entry align="center">shared disk</entry>
-     <entry align="center">disk blocks</entry>
-     <entry align="center">WAL</entry>
-     <entry align="center">logical decoding</entry>
-     <entry align="center">table rows</entry>
-     <entry align="center">SQL</entry>
-     <entry align="center">table rows</entry>
-     <entry align="center">table rows and row locks</entry>
 -->
      <entry>通信方法</entry>
+<!--
+     <entry align="center">shared disk</entry>
+-->
      <entry align="center">共有ディスク</entry>
+<!--
+     <entry align="center">disk blocks</entry>
+-->
      <entry align="center">ディスクブロック</entry>
+<!--
      <entry align="center">WAL</entry>
+-->
+     <entry align="center">WAL</entry>
+<!--
+     <entry align="center">logical decoding</entry>
+-->
      <entry align="center">ロジカルデコーディング</entry>
+<!--
+     <entry align="center">table rows</entry>
+-->
      <entry align="center">テーブル行</entry>
+<!--
      <entry align="center">SQL</entry>
+-->
+     <entry align="center">SQL</entry>
+<!--
+     <entry align="center">table rows</entry>
+-->
      <entry align="center">テーブル行</entry>
+<!--
+     <entry align="center">table rows and row locks</entry>
+-->
      <entry align="center">テーブル行および行ロック</entry>
     </row>
 
     <row>
 <!--
      <entry>No special hardware required</entry>
-     <entry align="center"></entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
 -->
      <entry>特別なハードウェアが不要</entry>
+<!--
      <entry align="center"></entry>
+-->
+     <entry align="center"></entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
     </row>
 
     <row>
 <!--
      <entry>Allows multiple primary servers</entry>
-     <entry align="center"></entry>
-     <entry align="center"></entry>
-     <entry align="center"></entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center"></entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
 -->
      <entry>複数のプライマリサーバが可能</entry>
+<!--
      <entry align="center"></entry>
+-->
      <entry align="center"></entry>
+<!--
      <entry align="center"></entry>
+-->
+     <entry align="center"></entry>
+<!--
+     <entry align="center"></entry>
+-->
+     <entry align="center"></entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
      <entry align="center"></entry>
+-->
+     <entry align="center"></entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
     </row>
 
     <row>
 <!--
      <entry>No overhead on primary</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center"></entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center"></entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center"></entry>
-     <entry align="center"></entry>
 -->
      <entry>プライマリサーバにオーバーヘッドがない</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
      <entry align="center"></entry>
-     <entry align="center">○</entry>
-     <entry align="center">○</entry>
+-->
      <entry align="center"></entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
+     <entry align="center">○</entry>
+<!--
      <entry align="center"></entry>
+-->
+     <entry align="center"></entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
+     <entry align="center">○</entry>
+<!--
+     <entry align="center"></entry>
+-->
+     <entry align="center"></entry>
+<!--
+     <entry align="center"></entry>
+-->
      <entry align="center"></entry>
     </row>
 
     <row>
 <!--
      <entry>No waiting for multiple servers</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center"></entry>
-     <entry align="center">with sync off</entry>
-     <entry align="center">with sync off</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center"></entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center"></entry>
 -->
      <entry>複数のサーバを待たない</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
      <entry align="center"></entry>
-     <entry align="center">同期が無効の場合</entry>
-     <entry align="center">同期が無効の場合</entry>
-     <entry align="center">○</entry>
+-->
      <entry align="center"></entry>
+<!--
+     <entry align="center">with sync off</entry>
+-->
+     <entry align="center">同期が無効の場合</entry>
+<!--
+     <entry align="center">with sync off</entry>
+-->
+     <entry align="center">同期が無効の場合</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center"></entry>
+-->
+     <entry align="center"></entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
+     <entry align="center">○</entry>
+<!--
+     <entry align="center"></entry>
+-->
      <entry align="center"></entry>
     </row>
 
     <row>
 <!--
      <entry>Primary failure will never lose data</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">with sync on</entry>
-     <entry align="center">with sync on</entry>
-     <entry align="center"></entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center"></entry>
-     <entry align="center">&bull;</entry>
 -->
      <entry>プライマリの故障によるデータ損失がない</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">with sync on</entry>
+-->
      <entry align="center">同期が有効の場合</entry>
+<!--
+     <entry align="center">with sync on</entry>
+-->
      <entry align="center">同期が有効の場合</entry>
+<!--
      <entry align="center"></entry>
+-->
+     <entry align="center"></entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
      <entry align="center"></entry>
+-->
+     <entry align="center"></entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
     </row>
 
     <row>
 <!--
      <entry>Replicas accept read-only queries</entry>
-     <entry align="center"></entry>
-     <entry align="center"></entry>
-     <entry align="center">with hot standby</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
 -->
      <entry>レプリカは読み取り専用問い合わせを受理可能</entry>
+<!--
      <entry align="center"></entry>
+-->
      <entry align="center"></entry>
+<!--
+     <entry align="center"></entry>
+-->
+     <entry align="center"></entry>
+<!--
+     <entry align="center">with hot standby</entry>
+-->
      <entry align="center">ホットスタンバイ使用時</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
     </row>
 
     <row>
 <!--
      <entry>Per-table granularity</entry>
-     <entry align="center"></entry>
-     <entry align="center"></entry>
-     <entry align="center"></entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center"></entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
 -->
      <entry>テーブルごとの粒度</entry>
+<!--
      <entry align="center"></entry>
+-->
      <entry align="center"></entry>
+<!--
      <entry align="center"></entry>
+-->
+     <entry align="center"></entry>
+<!--
+     <entry align="center"></entry>
+-->
+     <entry align="center"></entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
      <entry align="center"></entry>
+-->
+     <entry align="center"></entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
     </row>
 
     <row>
 <!--
      <entry>No conflict resolution necessary</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center"></entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center">&bull;</entry>
-     <entry align="center"></entry>
-     <entry align="center">&bull;</entry>
 -->
      <entry>コンフリクトの回避が不要</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
+<!--
      <entry align="center"></entry>
-     <entry align="center">○</entry>
-     <entry align="center">○</entry>
+-->
      <entry align="center"></entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
+     <entry align="center">○</entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
+     <entry align="center">○</entry>
+<!--
+     <entry align="center"></entry>
+-->
+     <entry align="center"></entry>
+<!--
+     <entry align="center">&bull;</entry>
+-->
      <entry align="center">○</entry>
     </row>
 

--- a/doc/src/sgml/libpq.sgml
+++ b/doc/src/sgml/libpq.sgml
@@ -12682,11 +12682,15 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><literal>sslmode</literal></entry>
 <!--
       <entry>Eavesdropping protection</entry>
-      <entry><acronym>MITM</acronym> protection</entry>
-      <entry>Statement</entry>
 -->
       <entry>盗聴防止</entry>
+<!--
+      <entry><acronym>MITM</acronym> protection</entry>
+-->
       <entry><acronym>MITM</acronym>防止</entry>
+<!--
+      <entry>Statement</entry>
+-->
       <entry>声明</entry>
      </row>
     </thead>
@@ -12696,13 +12700,17 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><literal>disable</literal></entry>
 <!--
       <entry>No</entry>
+-->
+      <entry>いいえ</entry>
+<!--
       <entry>No</entry>
+-->
+      <entry>いいえ</entry>
+<!--
       <entry>I don't care about security, and I don't want to pay the overhead
        of encryption.
       </entry>
 -->
-      <entry>いいえ</entry>
-      <entry>いいえ</entry>
       <entry>セキュリティはどうでもよく、暗号化のオーバーヘッドを払いたくない
       </entry>
      </row>
@@ -12711,13 +12719,17 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><literal>allow</literal></entry>
 <!--
       <entry>Maybe</entry>
+-->
+      <entry>たぶん</entry>
+<!--
       <entry>No</entry>
+-->
+      <entry>いいえ</entry>
+<!--
       <entry>I don't care about security, but I will pay the overhead of
        encryption if the server insists on it.
       </entry>
 -->
-      <entry>たぶん</entry>
-      <entry>いいえ</entry>
       <entry>セキュリティはどうでもよいが、サーバがそれを強く要求するのであれば暗号化のオーバーヘッドを払ってもよい
       </entry>
      </row>
@@ -12726,13 +12738,17 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><literal>prefer</literal></entry>
 <!--
       <entry>Maybe</entry>
+-->
+      <entry>たぶん</entry>
+<!--
       <entry>No</entry>
+-->
+      <entry>いいえ</entry>
+<!--
       <entry>I don't care about encryption, but I wish to pay the overhead of
        encryption if the server supports it.
       </entry>
 -->
-      <entry>たぶん</entry>
-      <entry>いいえ</entry>
       <entry>セキュリティはどうでもよいが、サーバがそれをサポートするのであれば暗号化のオーバーヘッドを払ってもよい
       </entry>
      </row>
@@ -12741,13 +12757,17 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><literal>require</literal></entry>
 <!--
       <entry>Yes</entry>
+-->
+      <entry>はい</entry>
+<!--
       <entry>No</entry>
+-->
+      <entry>いいえ</entry>
+<!--
       <entry>I want my data to be encrypted, and I accept the overhead. I trust
        that the network will make sure I always connect to the server I want.
       </entry>
 -->
-      <entry>はい</entry>
-      <entry>いいえ</entry>
       <entry>データを暗号化して欲しい。そしてオーバーヘッドも受け入れる。意図したサーバに常に接続することをネットワークが確実にしてくれると信用する
       </entry>
      </row>
@@ -12756,13 +12776,17 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><literal>verify-ca</literal></entry>
 <!--
       <entry>Yes</entry>
+-->
+      <entry>はい</entry>
+<!--
       <entry>Depends on CA policy</entry>
+-->
+      <entry>CAの方針に依存</entry>
+<!--
       <entry>I want my data encrypted, and I accept the overhead. I want to be
        sure that I connect to a server that I trust.
       </entry>
 -->
-      <entry>はい</entry>
-      <entry>CAの方針に依存</entry>
       <entry>データを暗号化して欲しい。そしてオーバーヘッドも受け入れる。信頼するサーバに確実に接続したい
       </entry>
      </row>
@@ -12771,14 +12795,18 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><literal>verify-full</literal></entry>
 <!--
        <entry>Yes</entry>
+-->
+       <entry>はい</entry>
+<!--
        <entry>Yes</entry>
+-->
+       <entry>はい</entry>
+<!--
        <entry>I want my data encrypted, and I accept the overhead. I want to be
         sure that I connect to a server I trust, and that it's the one I
         specify.
        </entry>
 -->
-       <entry>はい</entry>
-       <entry>はい</entry>
        <entry>データを暗号化して欲しい。そしてオーバーヘッドも受け入れる。信頼するサーバに接続すること、そのサーバが指定したものであることを確実にしたい
        </entry>
       </row>
@@ -12841,11 +12869,15 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
      <row>
 <!--
       <entry>File</entry>
-      <entry>Contents</entry>
-      <entry>Effect</entry>
 -->
       <entry>ファイル</entry>
+<!--
+      <entry>Contents</entry>
+-->
       <entry>内容</entry>
+<!--
+      <entry>Effect</entry>
+-->
       <entry>効果</entry>
      </row>
     </thead>
@@ -12856,9 +12888,11 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><filename>~/.postgresql/postgresql.crt</filename></entry>
 <!--
       <entry>client certificate</entry>
-      <entry>sent to server</entry>
 -->
       <entry>クライアント証明書</entry>
+<!--
+      <entry>sent to server</entry>
+-->
       <entry>サーバにより要求されます</entry>
      </row>
 
@@ -12888,9 +12922,11 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><filename>~/.postgresql/root.crl</filename></entry>
 <!--
       <entry>certificates revoked by certificate authorities</entry>
-      <entry>server certificate must not be on this list</entry>
 -->
       <entry>認証局により失効された証明書</entry>
+<!--
+      <entry>server certificate must not be on this list</entry>
+-->
       <entry>サーバ証明書はこのリストにあってはいけません</entry>
      </row>
 

--- a/doc/src/sgml/libpq0.sgml
+++ b/doc/src/sgml/libpq0.sgml
@@ -3856,7 +3856,8 @@ int PQconnectionNeedsPassword(const PGconn *conn);
        Returns true (1) if the connection authentication method
        used a password. Returns false (0) if not.
 -->
-接続認証方式でパスワードを使用する場合は真（1）、さもなくば偽（0）を返します。
+接続認証方式でパスワードを使用する場合は真（1）を返します。
+さもなくば偽（0）を返します。
 
 <synopsis>
 int PQconnectionUsedPassword(const PGconn *conn);

--- a/doc/src/sgml/libpq2.sgml
+++ b/doc/src/sgml/libpq2.sgml
@@ -2956,8 +2956,8 @@ main(void)
      * Sends a PGEVT_REGISTER to myEventProc.
      */
 --><![CDATA[
-    /* イベントを受け取るべきすべての接続で１回呼ばれる
-     * myEventProcにPGEVT_REGISTERを送る
+    /* イベントを受け取るべきすべての接続で１回呼ばれる。
+     * myEventProcにPGEVT_REGISTERを送る。
      */
     if (!PQregisterEventProc(conn, myEventProc, "mydata_proc", NULL))
     {

--- a/doc/src/sgml/libpq3.sgml
+++ b/doc/src/sgml/libpq3.sgml
@@ -770,11 +770,15 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><literal>sslmode</literal></entry>
 <!--
       <entry>Eavesdropping protection</entry>
-      <entry><acronym>MITM</acronym> protection</entry>
-      <entry>Statement</entry>
 -->
       <entry>盗聴防止</entry>
+<!--
+      <entry><acronym>MITM</acronym> protection</entry>
+-->
       <entry><acronym>MITM</acronym>防止</entry>
+<!--
+      <entry>Statement</entry>
+-->
       <entry>声明</entry>
      </row>
     </thead>
@@ -784,13 +788,17 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><literal>disable</literal></entry>
 <!--
       <entry>No</entry>
+-->
+      <entry>いいえ</entry>
+<!--
       <entry>No</entry>
+-->
+      <entry>いいえ</entry>
+<!--
       <entry>I don't care about security, and I don't want to pay the overhead
        of encryption.
       </entry>
 -->
-      <entry>いいえ</entry>
-      <entry>いいえ</entry>
       <entry>セキュリティはどうでもよく、暗号化のオーバーヘッドを払いたくない
       </entry>
      </row>
@@ -799,13 +807,17 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><literal>allow</literal></entry>
 <!--
       <entry>Maybe</entry>
+-->
+      <entry>たぶん</entry>
+<!--
       <entry>No</entry>
+-->
+      <entry>いいえ</entry>
+<!--
       <entry>I don't care about security, but I will pay the overhead of
        encryption if the server insists on it.
       </entry>
 -->
-      <entry>たぶん</entry>
-      <entry>いいえ</entry>
       <entry>セキュリティはどうでもよいが、サーバがそれを強く要求するのであれば暗号化のオーバーヘッドを払ってもよい
       </entry>
      </row>
@@ -814,13 +826,17 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><literal>prefer</literal></entry>
 <!--
       <entry>Maybe</entry>
+-->
+      <entry>たぶん</entry>
+<!--
       <entry>No</entry>
+-->
+      <entry>いいえ</entry>
+<!--
       <entry>I don't care about encryption, but I wish to pay the overhead of
        encryption if the server supports it.
       </entry>
 -->
-      <entry>たぶん</entry>
-      <entry>いいえ</entry>
       <entry>セキュリティはどうでもよいが、サーバがそれをサポートするのであれば暗号化のオーバーヘッドを払ってもよい
       </entry>
      </row>
@@ -829,13 +845,17 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><literal>require</literal></entry>
 <!--
       <entry>Yes</entry>
+-->
+      <entry>はい</entry>
+<!--
       <entry>No</entry>
+-->
+      <entry>いいえ</entry>
+<!--
       <entry>I want my data to be encrypted, and I accept the overhead. I trust
        that the network will make sure I always connect to the server I want.
       </entry>
 -->
-      <entry>はい</entry>
-      <entry>いいえ</entry>
       <entry>データを暗号化して欲しい。そしてオーバーヘッドも受け入れる。意図したサーバに常に接続することをネットワークが確実にしてくれると信用する
       </entry>
      </row>
@@ -844,13 +864,17 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><literal>verify-ca</literal></entry>
 <!--
       <entry>Yes</entry>
+-->
+      <entry>はい</entry>
+<!--
       <entry>Depends on CA policy</entry>
+-->
+      <entry>CAの方針に依存</entry>
+<!--
       <entry>I want my data encrypted, and I accept the overhead. I want to be
        sure that I connect to a server that I trust.
       </entry>
 -->
-      <entry>はい</entry>
-      <entry>CAの方針に依存</entry>
       <entry>データを暗号化して欲しい。そしてオーバーヘッドも受け入れる。信頼するサーバに確実に接続したい
       </entry>
      </row>
@@ -859,14 +883,18 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><literal>verify-full</literal></entry>
 <!--
        <entry>Yes</entry>
+-->
+       <entry>はい</entry>
+<!--
        <entry>Yes</entry>
+-->
+       <entry>はい</entry>
+<!--
        <entry>I want my data encrypted, and I accept the overhead. I want to be
         sure that I connect to a server I trust, and that it's the one I
         specify.
        </entry>
 -->
-       <entry>はい</entry>
-       <entry>はい</entry>
        <entry>データを暗号化して欲しい。そしてオーバーヘッドも受け入れる。信頼するサーバに接続すること、そのサーバが指定したものであることを確実にしたい
        </entry>
       </row>
@@ -929,11 +957,15 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
      <row>
 <!--
       <entry>File</entry>
-      <entry>Contents</entry>
-      <entry>Effect</entry>
 -->
       <entry>ファイル</entry>
+<!--
+      <entry>Contents</entry>
+-->
       <entry>内容</entry>
+<!--
+      <entry>Effect</entry>
+-->
       <entry>効果</entry>
      </row>
     </thead>
@@ -944,9 +976,11 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><filename>~/.postgresql/postgresql.crt</filename></entry>
 <!--
       <entry>client certificate</entry>
-      <entry>sent to server</entry>
 -->
       <entry>クライアント証明書</entry>
+<!--
+      <entry>sent to server</entry>
+-->
       <entry>サーバにより要求されます</entry>
      </row>
 
@@ -976,9 +1010,11 @@ libpqにおいて、<literal>sslmode</literal>パラメータを<literal>verify-
       <entry><filename>~/.postgresql/root.crl</filename></entry>
 <!--
       <entry>certificates revoked by certificate authorities</entry>
-      <entry>server certificate must not be on this list</entry>
 -->
       <entry>認証局により失効された証明書</entry>
+<!--
+      <entry>server certificate must not be on this list</entry>
+-->
       <entry>サーバ証明書はこのリストにあってはいけません</entry>
      </row>
 
@@ -1195,7 +1231,8 @@ int PQisthreadsafe();
    <xref linkend="libpq-PQoidValue"/>.
 -->
 非推奨の関数、<xref linkend="libpq-PQrequestCancel"/>や<xref linkend="libpq-PQoidStatus"/>はスレッドセーフではありませんので、マルチスレッドプログラムでは使用してはなりません。
-<xref linkend="libpq-PQrequestCancel"/>は<xref linkend="libpq-PQcancel"/>に、<xref linkend="libpq-PQoidStatus"/>は<xref linkend="libpq-PQoidValue"/>に置き換えることができます。
+<xref linkend="libpq-PQrequestCancel"/>は<xref linkend="libpq-PQcancel"/>に置き換えできます。
+<xref linkend="libpq-PQoidStatus"/>は<xref linkend="libpq-PQoidValue"/>に置き換えできます。
   </para>
 
   <para>


### PR DESCRIPTION
複数の`<entry>`をまとめて日本語訳を付けていたのを分割しました。
 #3244 の対応です。

split-libpq.shの掛け漏れを実行してます。