### PR TITLE
indexam.sgmlのPostgreSQL17.0対応

### DIFF
--- a/doc/src/sgml/indexam.sgml
+++ b/doc/src/sgml/indexam.sgml
@@ -308,14 +308,14 @@ typedef struct IndexAmRoutine
    <literal>IS NULL</literal> and <literal>IS NOT NULL</literal> clauses as search
    conditions.
 -->
-《マッチ度[94.352562]》<structname>IndexAmRoutine</structname>のフラグフィールドの中には、意味がわかりにくいものがあります。
+<structname>IndexAmRoutine</structname>のフラグフィールドの中には、意味がわかりにくいものがあります。
 <structfield>amcanunique</structfield>の必要条件は<xref linkend="index-unique-checks"/>で説明されています。
 <structfield>amcanmulticol</structfield>フラグはアクセスメソッドが複数キー列に対するインデックスをサポートすることを表し、<structfield>amoptionalkey</structfield>は、インデックス可能な制限句が最初のインデックス列に指定されていないスキャンを許可することを表します。
 <structfield>amcanmulticol</structfield>が偽の場合、<structfield>amoptionalkey</structfield>は基本的に、アクセスメソッドが制限句なしで完全なインデックススキャンをサポートするかどうかを表します。
 複数列に対するインデックスをサポートするアクセスメソッドは、最初の列以降のすべてまたは一部の列に関する制限がなくてもスキャンをサポート<emphasis>しなければなりません</emphasis>。
 しかし、最初のインデックス列にいくつかの制限を要求することは認められています。
 これは、<structfield>amoptionalkey</structfield>を偽に設定することで通知されます。
-インデックスアクセスメソッドが<structfield>amoptionalkey</structfield>を偽にする１つの理由は、NULLをインデックス付けしない場合です。
+インデックス<acronym>AM</acronym>が<structfield>amoptionalkey</structfield>を偽にする１つの理由は、NULLをインデックス付けしない場合です。
 ほとんどのインデックス可能な演算子は厳密で、NULL値の入力に対して真を返すことができませんので、NULLに対してインデックス項目を格納しないことは一見魅力的です。
 これはインデックススキャンによって何も返しません。
 しかし、最初のインデックス列に対する制限がないインデックススキャンでは、この引数は失敗します。
@@ -404,19 +404,14 @@ ambuild (Relation heapRelation,
    Access methods supporting only non-parallel index builds should leave
    this flag set to <literal>false</literal>.
 -->
-《マッチ度[57.243816]》新しいインデックスを構築します。
+新しいインデックスを構築します。
 空のインデックスリレーションが物理的に作成されます。
 これは、アクセスメソッドが必要とする何らかの固定データと、テーブル内に既に存在するすべてのタプルに対応する項目が書き込まれなければなりません。
 通常、<function>ambuild</function>関数は<function>table_index_build_scan()</function>を呼び出し、既存のタプルをテーブルからスキャンし、インデックスに挿入しなければならないキーを計算します。
 この関数は、新しいインデックスに関する統計情報を含むpallocされた構造体を返さなければなりません。
-《機械翻訳》新しいインデックスのビルド。
-インデックスリレーションは物理的に作成されていますが、空です。
-アクセスメソッドが必要とする固定されたデータ、プラスにすでに存在するすべてのタプルのテーブルエントリを入力する必要があります。
-通常、<function>ambuild</function>関数は、既存のタプルのテーブルを呼び出し<function>table_index_build_scan()</function>し、インデックスに挿入する必要があるキーを計算します。
-スキャン関数は、新しいインデックスに関する統計処理を含むpallocされた構造体を結果する必要があります。
-<structfield>amcanbuildparallel</structfield>フラグは、アクセス方法がパラレルインデックス構築をサポートするかどうかを示します。
-<literal>true</literal>に設定すると、システムはビルドに並行ワーカーを割り当てようとします。
-アクセスメソッド以外のインデックスビルドのみをサポートするパラレルは、このフラグセットを<literal>false</literal>に残す必要があります。
+<structfield>amcanbuildparallel</structfield>フラグは、アクセスメソッドがパラレルインデックス作成をサポートするかどうかを示します。
+<literal>true</literal>に設定すると、システムは作成のためにパラレルワーカーを割り当てようとします。
+パラレルインデックス作成をサポートしないアクセスメソッドでは、このフラグは<literal>false</literal>のままにするべきです。
   </para>
 
   <para>
@@ -529,9 +524,8 @@ aminsert (Relation indexRelation,
    index insertions, <function>aminsertcleanup</function> may be provided,
    which will be called before the memory is released.
 -->
-《マッチ度[57.986871]》SQL文の中で、インデックスAMがインデックスへの連続的な挿入をまたがってデータをキャッシュすることが望ましい場合は、<literal>indexInfo-&gt;ii_Context</literal>にメモリを確保し、そのデータへのポインタを<literal>indexInfo-&gt;ii_AmCache</literal>（初期値はNULLです）に格納することができます。
-《機械翻訳》インデックスAMがインデックスステートメント内の連続するSQL挿入にわたってデータをキャッシュしたい場合は、<literal>indexInfo-&gt;ii_Context</literal>にスペースを割り当て、<literal>indexInfo-&gt;ii_AmCache</literal>にデータへのポインタを保存できます（最初はnullになります）。
-インデックス挿入の後にメモリ以外のリソースを解放する必要がある場合は、メモリが解放される前と呼ばれる<function>aminsertcleanup</function>が提供されることがあります。
+SQL文の中で、インデックスAMがインデックスへの連続的な挿入をまたがってデータをキャッシュすることが望ましい場合は、<literal>indexInfo-&gt;ii_Context</literal>にメモリを確保し、そのデータへのポインタを<literal>indexInfo-&gt;ii_AmCache</literal>（初期値はNULLです）に格納することができます。
+インデックスへの挿入の後に、メモリ以外のリソースを解放する必要がある場合は、メモリが解放される前に呼び出される<function>aminsertcleanup</function>が提供されます。
   </para>
 
   <para>
@@ -546,8 +540,8 @@ aminsertcleanup (Relation indexRelation,
    requires additional cleanup steps (e.g., releasing pinned buffers), and
    simply releasing the memory is not sufficient.
 -->
-《機械翻訳》<literal>indexInfo-&gt;ii_AmCache</literal>への連続した挿入で維持されていた状態をクリーンアップします。
-これは、データに追加のクリーンアップステップが必要で（固定されたバッファを解放するなど）、メモリを解放するだけでは不十分な場合に便利です。
+<literal>indexInfo-&gt;ii_AmCache</literal>への連続する挿入で維持されていた状態をクリーンアップします。
+これは、データに追加のクリーンアップステップ（たとえばピンの付いたバッファを解放するなど）が必要で、メモリを解放するだけでは不十分な場合に便利です。
   </para>
 
   <para>
@@ -1186,9 +1180,8 @@ amestimateparallelscan (int nkeys,
    used in the scan; the same values will be passed to <function>amrescan</function>.
    Note that the actual values of the scan keys aren't provided yet.
 -->
-《機械翻訳》<literal>nkeys</literal>および<literal>norderbys</literal>パラメータは、スキャンで使用される等価性演算子と順序付け演算子の個数を表します。
-これらの値は<function>amrescan</function>にも渡されます。
-スキャンキーの実際の値はまだ提供されていません。
+<literal>nkeys</literal>および<literal>norderbys</literal>パラメータは、スキャンで使用される等価性演算子と順序付け演算子の個数を表し、これらの値は<function>amrescan</function>にも渡されます。
+スキャンキーの実際の値はまだ提供されていないことに注意してください。
   </para>
 
   <para>


### PR DESCRIPTION
もともとは「インデックスアクセスメソッド」と翻訳されていた箇所に、原文でacronymタグが追加されていたため、「インデックス<acronym>AM</acronym>」としました。
acronymタグ自体が最近のHTMLでは廃止されているという情報もみかけましたが現時点では原文に合わせています。