### PR TITLE
pgstatstatements.sgmlのPostgreSQL17.0対応

### DIFF
--- a/doc/src/sgml/pgstatstatements.sgml
+++ b/doc/src/sgml/pgstatstatements.sgml
@@ -211,8 +211,8 @@ SQL文のプラン生成に費やした総時間（ミリ秒単位）
        <structfield>minmax_only</structfield> parameter set to <literal>true</literal>
        and never been planned since.
 -->
-《機械翻訳》ステートメントの計画に費やされた最小時間（ミリ秒単位）。
-このフィールドは、<varname>pg_stat_statements.track_planning</varname>が無効な場合、またはカウンタが<function>pg_stat_statements_reset</function>関数を使用してリセットであり、<structfield>minmax_only</structfield>パラメータが<literal>true</literal>に設定されており、それ以降計画されていない場合にゼロになります。
+SQL文のプラン生成に費やした最小時間（ミリ秒単位）
+このフィールドは、<varname>pg_stat_statements.track_planning</varname>が無効な場合、または<structfield>minmax_only</structfield>パラメータに<literal>true</literal>を設定した<function>pg_stat_statements_reset</function>関数を使用してカウンタがリセットされ、それ以降プランが生成されていない場合にゼロになります
       </para></entry>
      </row>
 
@@ -229,8 +229,8 @@ SQL文のプラン生成に費やした総時間（ミリ秒単位）
        <structfield>minmax_only</structfield> parameter set to <literal>true</literal>
        and never been planned since.
 -->
-《機械翻訳》ステートメントの計画に費やされた最大時間（ミリ秒単位）。
-このフィールドは、<varname>pg_stat_statements.track_planning</varname>が無効な場合、またはカウンタが<function>pg_stat_statements_reset</function>関数を使用してリセットであり、<structfield>minmax_only</structfield>パラメータが<literal>true</literal>に設定されており、それ以降計画されていない場合にはゼロになります。
+SQL文のプラン生成に費やした最大時間（ミリ秒単位）
+このフィールドは、<varname>pg_stat_statements.track_planning</varname>が無効な場合、または<structfield>minmax_only</structfield>パラメータに<literal>true</literal>を設定した<function>pg_stat_statements_reset</function>関数を使用してカウンタがリセットされ、それ以降プランが生成されていない場合にゼロになります
       </para></entry>
      </row>
 
@@ -301,8 +301,8 @@ SQL文の実行に費やした総時間（ミリ秒単位）
        <function>pg_stat_statements_reset</function> function with the
        <structfield>minmax_only</structfield> parameter set to <literal>true</literal>
 -->
-《機械翻訳》文を実行するために費やされた最小時間。
-このフィールドは、<function>pg_stat_statements_reset</function>関数が<structfield>minmax_only</structfield>パラメータを<literal>true</literal>に設定して実行した後、この文が最初に実行されるまでゼロになります。
+SQL文の実行に費やした最小時間（ミリ秒単位）
+このフィールドは、<structfield>minmax_only</structfield>パラメータに<literal>true</literal>を設定した<function>pg_stat_statements_reset</function>関数を使用してリセットされた後、SQL文が最初に実行されるまでゼロになります
       </para></entry>
      </row>
 
@@ -318,8 +318,8 @@ SQL文の実行に費やした総時間（ミリ秒単位）
        <function>pg_stat_statements_reset</function> function with the
        <structfield>minmax_only</structfield> parameter set to <literal>true</literal>
 -->
-《機械翻訳》文を実行するために費やされた最大時間（ミリ秒）。
-このフィールドは、<function>pg_stat_statements_reset</function>関数が<structfield>minmax_only</structfield>パラメータを<literal>true</literal>に設定して実行した後、この文が最初に実行されるまではゼロです。
+SQL文の実行に費やした最大時間（ミリ秒単位）
+このフィールドは、<structfield>minmax_only</structfield>パラメータに<literal>true</literal>を設定した<function>pg_stat_statements_reset</function>関数を使用してリセットされた後、SQL文が最初に実行されるまでゼロになります
       </para></entry>
      </row>
 
@@ -488,9 +488,8 @@ SQL文によって書き込まれた一時ブロックの総数
        Total time the statement spent reading shared blocks, in milliseconds
        (if <xref linkend="guc-track-io-timing"/> is enabled, otherwise zero)
 -->
-《マッチ度[84.172662]》SQL文がデータファイルブロックの読み取りに費やした総時間（ミリ秒単位）
+SQL文が共有ブロックの読み取りに費やした総時間（ミリ秒単位）
 （<xref linkend="guc-track-io-timing"/>が有効な場合。無効であればゼロ）
-《機械翻訳》共有ブロックの読み込みにかかった合計時間 （ミリ秒単位） （<xref linkend="guc-track-io-timing"/>が有効な場合、それ以外の場合はゼロ）。
       </para></entry>
      </row>
 
@@ -503,9 +502,8 @@ SQL文によって書き込まれた一時ブロックの総数
        Total time the statement spent writing shared blocks, in milliseconds
        (if <xref linkend="guc-track-io-timing"/> is enabled, otherwise zero)
 -->
-《マッチ度[84.172662]》SQL文がデータファイルブロックの書き出しに費やした総時間（ミリ秒単位）
+SQL文が共有ブロックの書き出しに費やした総時間（ミリ秒単位）
 （<xref linkend="guc-track-io-timing"/>が有効な場合。無効であればゼロ）
-《機械翻訳》共有ブロックの書き込みにかかった合計時間 （ミリ秒単位） （<xref linkend="guc-track-io-timing"/>が有効な場合、それ以外の場合はゼロ）。
       </para></entry>
      </row>
 
@@ -518,9 +516,8 @@ SQL文によって書き込まれた一時ブロックの総数
        Total time the statement spent reading local blocks, in milliseconds
        (if <xref linkend="guc-track-io-timing"/> is enabled, otherwise zero)
 -->
-《マッチ度[84.782609]》SQL文がデータファイルブロックの読み取りに費やした総時間（ミリ秒単位）
+SQL文がローカルブロックの読み取りに費やした総時間（ミリ秒単位）
 （<xref linkend="guc-track-io-timing"/>が有効な場合。無効であればゼロ）
-《機械翻訳》ステートメントがローカルブロックを読み取るのに費やした合計時間 （ミリ秒単位） （<xref linkend="guc-track-io-timing"/> が有効な場合、それ以外の場合はゼロ）。
       </para></entry>
      </row>
 
@@ -533,9 +530,8 @@ SQL文によって書き込まれた一時ブロックの総数
        Total time the statement spent writing local blocks, in milliseconds
        (if <xref linkend="guc-track-io-timing"/> is enabled, otherwise zero)
 -->
-《マッチ度[84.782609]》SQL文がデータファイルブロックの書き出しに費やした総時間（ミリ秒単位）
+SQL文がローカルブロックの書き出しに費やした総時間（ミリ秒単位）
 （<xref linkend="guc-track-io-timing"/>が有効な場合。無効であればゼロ）
-《機械翻訳》ローカルブロックの書き込みにかかった合計時間 （ミリ秒単位） （<xref linkend="guc-track-io-timing"/>が有効な場合、それ以外の場合はゼロ）。
       </para></entry>
      </row>
 
@@ -709,8 +705,7 @@ SQL文のコードを出力するのに費やした総時間（ミリ秒単位�
 <!--
        Total number of tuple deform functions JIT-compiled by the statement
 -->
-《マッチ度[70.588235]》SQL文がJITコンパイルされた関数の総数
-《機械翻訳》文によってJITコンパイルされたタプル変形関数の合計数
+SQL文がJITコンパイルされたタプルデフォーム関数の総数
       </para></entry>
      </row>
 
@@ -723,8 +718,7 @@ SQL文のコードを出力するのに費やした総時間（ミリ秒単位�
        Total time spent by the statement on JIT-compiling tuple deform
        functions, in milliseconds
 -->
-《マッチ度[67.777778]》SQL文が関数のインライン化に費やした総時間（ミリ秒単位）
-《機械翻訳》タプルのJITコンパイルに要した時間（ミリ秒単位）。
+SQL文がJITコンパイルによる関数のタプルデフォームに費やした総時間（ミリ秒単位）
       </para></entry>
      </row>
 
@@ -736,7 +730,7 @@ SQL文のコードを出力するのに費やした総時間（ミリ秒単位�
 <!--
        Time at which statistics gathering started for this statement
 -->
-《機械翻訳》この文に対して統計情報の収集が開始された時刻。
+SQL文の統計情報収集が開始された時刻
       </para></entry>
      </row>
 
@@ -752,7 +746,7 @@ SQL文のコードを出力するのに費やした総時間（ミリ秒単位�
        <structfield>min_exec_time</structfield> and
        <structfield>max_exec_time</structfield>)
 -->
-《機械翻訳》この文に対して最小/最大統計情報収集が開始された時刻（フィールド<structfield>min_plan_time</structfield>、<structfield>max_plan_time</structfield>、<structfield>min_exec_time</structfield>、<structfield>max_exec_time</structfield>）。
+SQL文の最小/最大の統計情報収集が開始された時刻（<structfield>min_plan_time</structfield>、<structfield>max_plan_time</structfield>、<structfield>min_exec_time</structfield>、<structfield>max_exec_time</structfield> フィールド）
       </para></entry>
      </row>
     </tbody>
@@ -1090,17 +1084,17 @@ SQL文のコードを出力するのに費やした総時間（ミリ秒単位�
       By default, this function can only be executed by superusers.
       Access may be granted to others using <command>GRANT</command>.
 -->
-《機械翻訳》<function>pg_stat_statements_reset</function>は、指定された<structfield>userid</structfield>、<structfield>dbid</structfield>、<structfield>queryid</structfield>に対応する<filename>pg_stat_statements</filename>までに収集された統計処理を破棄します。
-いずれかのパラメータが指定されていない場合、各パラメータにはデフォルト値<literal>0</literal>（無効）が使用され、他のパラメータを持つマッチの統計処理はリセットになります。
-パラメータが指定されていない場合、または指定したパラメータがすべて<literal>0</literal>（無効）の場合は、すべての統計処理が破棄されます。
-<filename>pg_stat_statements</filename>統計処理のすべてのビューが破棄された場合、<structname>pg_stat_statements_info</structname>リセットの統計処理も破棄されます。
-ビュー<structfield>minmax_only</structfield>が<literal>true</literal>の場合、最小および最大の計画および実行時間の値のみがリセットになります（<structfield>min_plan_time</structfield>、<structfield>max_plan_time</structfield>、<structfield>min_exec_time</structfield>、および<structfield>max_exec_time</structfield>フィールド）。
-<structfield>minmax_のみ</structfield>パラメータのデフォルト値は<literal>false</literal>です。
-最後に実行された分/最大リセットの時刻は、<structname>pg_stat_statements</structname>フィールドの<structfield>minmax_stats_since</structfield> ビューに表示されます。
-この関数は、リセットの時刻を返します。
-対応するリセットが実際に実行された場合、この時間は<structname>pg_stat_statements_info</structname>フィールドの<structfield>minmax_stats_since</structfield>ビュー、または<structname>pg_stat_statements</structname>フィールドの<structfield>minmax_stats_since</structfield>ビューに保存されます。
-デフォルトでは、この関数はスーパーユーザのみが実行できます。
-アクセスは、<command>GRANT</command>を使用して他者に付与することができる。
+<function>pg_stat_statements_reset</function>は指定された<structfield>userid</structfield>、<structfield>dbid</structfield>、<structfield>queryid</structfield>に対応する<filename>pg_stat_statements</filename>によってこれまでに収集したすべての統計情報を削除します。
+いずれかのパラメータを指定しないのであれば、デフォルト値<literal>0</literal>（無効）を使ってください。他のパラメータに一致する統計情報がリセットされます。
+どのパラメータも指定しない、または、すべての指定されたパラメータが<literal>0</literal>（無効）ならば、すべての統計情報を削除します。
+<filename>pg_stat_statements</filename>ビューのすべての統計情報が破棄された場合、<structname>pg_stat_statements_info</structname>ビューの統計情報もリセットされます。
+<structfield>minmax_only</structfield>が<literal>true</literal>の場合、最小および最大のプラン生成・実行時間の値のみリセットされます。（<structfield>min_plan_time</structfield>、<structfield>max_plan_time</structfield>、<structfield>min_exec_time</structfield>、<structfield>max_exec_time</structfield> フィールド）。
+<structfield>minmax_only</structfield>パラメータのデフォルト値は<literal>false</literal>です。
+最後に実行された最小/最大のリセット時刻は、<structname>pg_stat_statements</structname>ビューの<structfield>minmax_stats_since</structfield>フィールドに表示されます。
+この関数は、リセット時刻を返します。
+対応するリセットが実際に実行された場合、この時刻は<structname>pg_stat_statements_info</structname>ビューの<structfield>minmax_stats_since</structfield>フィールド、または<structname>pg_stat_statements</structname>ビューの<structfield>minmax_stats_since</structfield>フィールドに保存されます。
+デフォルトでは、この関数はスーパーユーザのみ実行できます。
+<command>GRANT</command>を使ってアクセス権を他のユーザに付与できます。
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
tuple deforming(タプルデフォーミング)は他にも出てきますが、tuple deform はこのドキュメントでのみ使われています。そのまま「タプルデフォーム」としました。