### PR TITLE
postgres.sgmlのファイルをPG17向けに翻訳

### DIFF
--- a/doc/src/sgml/postgres.sgml
+++ b/doc/src/sgml/postgres.sgml
@@ -258,7 +258,7 @@ break is not needed in a wider output rendering.
 ここでは<productname>PostgreSQL</productname>に附属するクライアントプログラミングインタフェースについて説明します。
 各章は独立して読むことができます。
 クライアントプログラムには、数多くの外部プログラミングインタフェースがありますが、これらのインタフェースは独自の資料とともに個別に配布されています。
-（<xref linkend="external-projects"/>に人気があるインターフェースの一部を列挙しています）。
+（<xref linkend="external-projects"/>に人気があるインタフェースの一部を列挙しています）。
 読者は、データベースの操作や問い合わせを行うための<acronym>SQL</acronym>（<xref linkend="sql"/>を参照）、また、当然ながら、ご自身の選んだプログラミング言語に慣れ親しんでいることが必要です。
    </para>
   </partintro>

--- a/doc/src/sgml/postgres.sgml
+++ b/doc/src/sgml/postgres.sgml
@@ -64,17 +64,11 @@ break is not needed in a wider output rendering.
     important aspects of the <productname>PostgreSQL</productname> system.
     It makes no attempt to be a comprehensive treatment of the topics it covers.
 -->
-《マッチ度[68.528864]》<productname>PostgreSQL</productname>のチュートリアルにようこそ。
-本書は数章から構成され、ここで、<productname>PostgreSQL</productname>やリレーショナルデータベースの概念、SQL言語を初めて使用する方向けに、簡単に紹介します。
-ここでは、コンピュータの一般的な使い方についての知識だけを前提としています。
-Unixやプログラミングに関する経験は必要ありません。
-ここでは、主に<productname>PostgreSQL</productname>システムの重要なポイントについて実践的な経験を得ることを目的としています。
-扱っているトピックについての完全で詳細な処理を記述しているものではありません。
-《機械翻訳》<productname>PostgreSQL</productname>のチュートリアルへようこそ。
+<productname>PostgreSQL</productname>のチュートリアルへようこそ。
 このチュートリアルは、<productname>PostgreSQL</productname>、リレーショナルデータベースの概念、およびSQL言語の紹介を目的としています。
 コンピュータの使い方についての一般的な知識を前提としており、特定の Unix やプログラミングの経験は必要ありません。
-このチュートリアルは、<productname>PostgreSQL</productname>システムの重要な側面を実際に体験できるようにすることを目的としています。
-この本は、扱うトピックを包括的に扱おうとするものではない。
+このチュートリアルは、<productname>PostgreSQL</productname>システムの重要なポイントについて実践的な経験を得ることを目的としています。
+扱っているトピックについての完全で詳細な処理を記述しているものではありません。
    </para>
 
    <para>
@@ -86,10 +80,8 @@ Unixやプログラミングに関する経験は必要ありません。
     <productname>PostgreSQL</productname>.  Those who provision and
     manage their own PostgreSQL installation should also read <xref linkend="admin"/>.
 -->
-《マッチ度[69.367089]》このチュートリアルの内容を読んだ後、SQL言語のより体系的な知識を学習したいのであれば、<xref linkend="sql"/>を、<productname>PostgreSQL</productname>用のアプリケーションの開発に関する情報を学習したいのであれば、<xref linkend="client-interfaces"/>を続いて読んでください。
-また、サーバをセットアップおよび管理される方は、<xref linkend="admin"/>も参照してください。
-《機械翻訳》このチュートリアルを問題なく完了したら、<xref linkend="sql"/>セクションを読んでSQL言語をよりよく理解するか、<productname>PostgreSQL</productname>でのアプリケーション開発についての情報を読んでください。
-自分でPostgreSQLインストレーションを準備して管理する人は、<xref linkend="admin"/>も読んでください。
+このチュートリアルを問題なく完了した後、SQL言語に関する理解を深めたい場合は<xref linkend="sql"/>を、<productname>PostgreSQL</productname>用のアプリケーションの開発に関する情報を学習したいのであれば、<xref linkend="client-interfaces"/>を読んでください。
+また、PostgreSQLの導入を準備、提供、管理される方は、<xref linkend="admin"/>も参照してください。
    </para>
   </partintro>
 
@@ -116,14 +108,10 @@ Unixやプログラミングに関する経験は必要ありません。
     functions for use in <acronym>SQL</acronym> commands.  Lastly,
     we address several aspects of importance for tuning a database.
 -->
-《マッチ度[72.811060]》ここでは、<productname>PostgreSQL</productname>で<acronym>SQL</acronym>言語を使用する方法を説明します。
-まず最初に<acronym>SQL</acronym>構文全般について述べ、データを保持する構造の作成方法、データベースに登録する方法、そして、データベースへの問い合わせを行う方法について説明していきます。
-本パートの中盤では、<acronym>SQL</acronym>コマンドで使用可能なデータ型と関数を紹介します。
-そして残りの部分では、最適な性能を実現するためにデータベースを調整する際に重要となるいくつかの点について説明します。
-《機械翻訳》この部分では、<productname>PostgreSQL</productname>での<acronym>SQL</acronym>言語の使用について説明します。
-まず、<acronym>SQL</acronym>の一般的な構文について説明し、次にテーブルの作成方法、データベースへのデータの入力方法、およびデータベースの問い合わせ方法について説明します。
-中間部では、<acronym>SQL</acronym>コマンドで使用できるデータ型と関数について説明します。
-最後に、データベースのチューニングに重要ないくつかの側面について説明します。
+ここでは、<productname>PostgreSQL</productname>での<acronym>SQL</acronym>言語を使用する方法を説明します。
+まず最初に<acronym>SQL</acronym>の一般的な構文について述べ、テーブルの作成方法、データベースに登録する方法、そして、データベースの問い合わせを行う方法について説明していきます。
+本パートの中盤では、<acronym>SQL</acronym>コマンドで使用できるデータ型と関数について説明します。
+最後に、データベースをチューニングする際に重要となるいくつかの点について説明します。
    </para>
 
    <para>
@@ -137,13 +125,10 @@ Unixやプログラミングに関する経験は必要ありません。
     description of a particular command are encouraged to review
     the <xref linkend="reference"/>.
 -->
-《マッチ度[80.082136]》ここでの内容は、初心者のユーザでも先のページを何度も参照することなく、最初から最後まで全てのトピックを理解できるような構成になっています。
-各章ごとに内容が独立していますので、上級ユーザは必要な章だけを選んで読むことができます。
-ここではトピックに関する説明が中心となっていますので、特定のコマンドの完全な記述が必要なユーザは<xref linkend="reference"/>を参照してください。
-《機械翻訳》情報は、初心者ユーザが最初から最後までそれに従って、あまり多くの参照を繰り返すことなく、トピックを完全に理解できるように配置されています。
+ここでの内容は、初心者のユーザでも先のページを何度も参照することなく、最初から最後まで全てのトピックを理解できるような構成になっています。
 これらの章は自己完結型であることを意図しており、上級ユーザは必要に応じて個別に章を読むことができます。
-情報はトピック単位で記述されています。
-特定のコマンドの完全な説明を探している読者は、<xref linkend="reference"/>を参照してください。
+ここでの情報はトピック単位で記述されています。
+特定のコマンドの完全な説明を探している読者は、<xref linkend="reference"/>を確認することをお勧めします。
    </para>
 
    <para>
@@ -157,12 +142,9 @@ Unixやプログラミングに関する経験は必要ありません。
     <application>psql</application>, but other programs that have
     similar functionality can be used as well.
 -->
-《マッチ度[89.782609]》対象読者は、<productname>PostgreSQL</productname>データベースへの接続および<acronym>SQL</acronym>コマンド発行の方法を知っているユーザです。
-まだこれらについて慣れていないユーザは、本書の前に<xref linkend="tutorial"/>をお読みになることをお勧めします。
-<acronym>SQL</acronym>コマンドは通常<productname>PostgreSQL</productname>の対話式端末<application>psql</application>を使用して入力しますが、同様の機能を備えた他のプログラムも使用することができます。
-《機械翻訳》読者は<productname>PostgreSQL</productname>データベースに接続し、<acronym>SQL</acronym>コマンドを発行する方法を知っている必要があります。
-これらの問題に不慣れな読者は、まず<xref linkend="tutorial"/>を読むことをお勧めします。
-<acronym>SQL</acronym>コマンドは通常、<productname>PostgreSQL</productname>の対話型端末である<application>psql</application>を使用して入力しますが、同様の機能を持つ他のプログラムも使用できます。
+読者は<productname>PostgreSQL</productname>データベースへの接続および<acronym>SQL</acronym>コマンド発行の方法を知っている必要があります。
+まだこれらについて慣れていない方は、先に<xref linkend="tutorial"/>を読むことをお勧めします。
+<acronym>SQL</acronym>コマンドは通常、<productname>PostgreSQL</productname>の対話型端末<application>psql</application>を使用して入力しますが、同様の機能を備えた他のプログラムも使用することができます。
    </para>
   </partintro>
 
@@ -198,12 +180,9 @@ Unixやプログラミングに関する経験は必要ありません。
     personal use, but especially in production, should be familiar
     with these topics.
 -->
-《マッチ度[73.983740]》ここでは、<productname>PostgreSQL</productname>データベース管理者にとって関心のある事項を扱います。
-これには、ソフトウェアのインストール、サーバの設定や構成、ユーザやデータベースの管理、および保守作業が含まれます。
-<productname>PostgreSQL</productname>サーバを個人的に使用している場合もそうですが、特に業務で使用している場合は、ここで扱う事項に精通している必要があります。
-《機械翻訳》この部分は<productname>PostgreSQL</productname>管理者にとって興味深い話題を扱っています。
-これにはインストール、サーバの設定、ユーザとデータベースの管理、保守作業などが含まれます。
-<productname>PostgreSQL</productname>サーバを個人的に使用する場合でも、特に本番環境で使用する場合は、これらのトピックに精通している必要があります。
+ここでは、<productname>PostgreSQL</productname>管理者にとって関心のある事項を扱います。
+これには、インストール、サーバの設定、ユーザとデータベースの管理、および保守作業が含まれます。
+<productname>PostgreSQL</productname>サーバを個人的に使用している場合もそうですが、特に業務で使用している場合は、これらのトピックに精通している必要があります。
    </para>
 
    <para>
@@ -215,14 +194,10 @@ Unixやプログラミングに関する経験は必要ありません。
     description of a command are encouraged to review the
     <xref linkend="reference"/>.
 -->
-《マッチ度[67.867868]》ここに記載された情報は、大体において新規ユーザが読み進めるべき順番に並べられています。
-ただ、章ごとに内容が独立していますので、必要に応じて個々の章を読むこともできます。
-ここでの情報は、項目単位で限定して説明されています。
-特定のコマンドについて完全な説明を知りたい場合は、<xref linkend="reference"/>を参照してください。
-《機械翻訳》情報は、新しいユーザが読むべき順序で記述しようとしています。
-各章は独立しており、必要に応じて個別に読むことができます。
-情報は、トピック単位で物語形式で提示されます。
-コマンドの完全な説明を探している読者は、<xref linkend="reference"/>を参照することをお勧めします。
+ここでの情報は、新規ユーザが読み進めるべき順番に並べられています。
+各章は独立しており、必要に応じて個々の章を読むこともできます。
+ここでの情報は項目単位で記述されています。
+コマンドについて完全な説明を知りたい場合は、<xref linkend="reference"/>を確認することをお勧めします。
    </para>
 
    <para>
@@ -236,13 +211,9 @@ Unixやプログラミングに関する経験は必要ありません。
     encouraged review the <xref linkend="tutorial"/> and <xref
     linkend="sql"/> parts for additional information.
 -->
-《マッチ度[86.610879]》最初の数章は、これからサーバを構築する新規ユーザにも読めるように、前提知識がなくても理解できるようになっています。
+最初の数章は、これからサーバを構築する新規ユーザにも読めるように、前提知識がなくても理解できるようになっています。
 残りの部分では調整や管理について記されていますが、その資料は読者が<productname>PostgreSQL</productname>データベースシステムの一般的な使用について理解していることを前提としています。
-詳細な情報については<xref linkend="tutorial"/>や<xref linkend="sql"/>を参照することをお勧めします。
-《機械翻訳》最初の数章は、前提知識なしに理解できるように書かれているので、自分のサーバをセットアップする必要のある新しいユーザは、探索を始めることができます。
-この部分の残りはチューニングと管理についてです。
-その資料は、読者が<productname>PostgreSQL</productname>データベースシステムの一般的な使用法に精通していることを前提としています。
-追加情報については、<xref linkend="tutorial"/>と<xref linkend="sql"/>の部分を参照することをお勧めします。
+詳細な情報については<xref linkend="tutorial"/>と<xref linkend="sql"/>を確認することをお勧めします。
    </para>
   </partintro>
 
@@ -284,16 +255,11 @@ Unixやプログラミングに関する経験は必要ありません。
     and query the database (see <xref linkend="sql"/>) and of course
     with the programming language of their choice.
 -->
-《マッチ度[85.288967]》ここでは<productname>PostgreSQL</productname>に附属するクライアントプログラミングインタフェースについて説明します。
+ここでは<productname>PostgreSQL</productname>に附属するクライアントプログラミングインタフェースについて説明します。
 各章は独立して読むことができます。
-クライアントプログラムには、この他にも様々なプログラミングインタフェースがありますが、これらのインタフェースは独自の資料とともに個別に配布されていますのでご注意ください
-（<xref linkend="external-projects"/>に人気があるインタフェースの一部を列挙しています）。
-読者は、データベースの操作や問い合わせを行うための<acronym>SQL</acronym>コマンド（<xref linkend="sql"/>を参照）、また、当然ながら、インタフェースが使用するプログラミング言語にも慣れ親しんでいることが必要です。
-《機械翻訳》この章では、<productname>PostgreSQL</productname>に付属するクライアントプログラミングインタフェースについて説明します。
-これらの各章は、独立して読むことができる。
-クライアントプログラム用の外部プログラミングインタフェースは、別々に配布されます。
-それらは独自のドキュメントを持っています（<xref linkend="external-projects"/>に、より一般的なもののいくつかをリストしています）。
-この部分の読者は、データベースを操作して問い合わせるための<acronym>SQL</acronym>の使用（<xref linkend="sql"/>参照）と、もちろん、自分の選んだプログラミング言語の使用に慣れている必要があります。
+クライアントプログラムには、数多くの外部プログラミングインタフェースがありますが、これらのインタフェースは独自の資料とともに個別に配布されています。
+（<xref linkend="external-projects"/>に人気があるインターフェースの一部を列挙しています）。
+読者は、データベースの操作や問い合わせを行うための<acronym>SQL</acronym>（<xref linkend="sql"/>を参照）、また、当然ながら、ご自身の選んだプログラミング言語に慣れ親しんでいることが必要です。
    </para>
   </partintro>
 
@@ -325,15 +291,11 @@ Unixやプログラミングに関する経験は必要ありません。
     linkend="extend"/> (covering functions) before diving into the
     material about server-side programming.
 -->
-《マッチ度[88.161994]》ここでは、ユーザ定義の関数、データ型、演算子、トリガなどを使用してサーバの機能を拡張する方法について説明します。
-これらはおそらく、<productname>PostgreSQL</productname>に関するユーザ向けの文書を理解した後にのみたどり着く先進的な話題です。
+ここでは、ユーザ定義関数、データ型、トリガなどを使用してサーバの機能を拡張する方法について説明します。
+これらは<productname>PostgreSQL</productname>に関するユーザ向けの文書を理解した後にのみたどり着く先進的な話題です。
 また、最後の数章で<productname>PostgreSQL</productname>に附属するサーバサイドのプログラミング言語についても説明します。
 同時にサーバサイドのプログラミング言語に関する一般的な問題についても説明します。
 サーバサイドのプログラミング言語の章に進む前に、少なくとも、<xref linkend="extend"/>（関数も説明しています）の最初の数節を読破することは重要です。
-《機械翻訳》この部分では、ユーザ定義関数、データ型、トリガなどを使用してサーバの機能を拡張する方法について説明します。
-これらは高度なトピックであり、<productname>PostgreSQL</productname>に関する他のユーザドキュメントをすべて理解した後にのみアプローチする必要があります。
-このパートの後の章では、<productname>PostgreSQL</productname>配布物で利用可能なサーバ側プログラミング言語と、サーバ側プログラミングに関する一般的な問題について説明します。
-サーバ側プログラミングに関する資料を読む前に、<xref linkend="extend"/>の前半部分 （関数を扱う部分） を読んでおくことが必須です。
    </para>
   </partintro>
 


### PR DESCRIPTION
ドキュメントをシンプルにすることが目的で、多くの細かな表現の修正がありました。
https://github.com/pgsql-jp/jpug-doc/commit/322f55bdbd018bf18a0c5605c7bc592c625dc263

1点、悩んでいるのが、以下の文章で、set up が provision になっています。
(16)
Those who set up and manage their own server should also read <xref linkend="admin"/>.
また、サーバをセットアップおよび管理される方は、<xref linkend="admin"/>も参照してください。
(17)
Those who provision and manage their own PostgreSQL installation should also read <xref linkend="admin"/>.
また、PostgreSQLの導入を準備、提供、管理される方は、<xref linkend="admin"/>も参照してください。

上記のようにしましたが、provision をどう表現するのが一番正しいのかは難しいです。