### PR TITLE
plpgsqlの翻訳改善

### DIFF
--- a/doc/src/sgml/plpgsql.sgml
+++ b/doc/src/sgml/plpgsql.sgml
@@ -5516,7 +5516,7 @@ CALL transaction_test2();
 -->
 通常、カーソルはトランザクションのコミット時に自動的に閉じられます。
 しかしながら、このようにループの一部として作られたカーソルは、最初の<command>COMMIT</command>または<command>ROLLBACK</command>から自動的に保持可能カーソルに変換されます。
-このことは、今や、最初の<command>COMMIT</command>や<command>ROLLBACK</command>の時点でカーソルが行ごとではなく完全に評価されることを意味します。
+このことは、最初の<command>COMMIT</command>や<command>ROLLBACK</command>の時点でカーソルが行ごとではなく全体が評価されることを意味します。
 従来通りカーソルはループ後に自動で削除されるので、このことはユーザにほとんど認識されません。
 しかし、カーソルの問い合わせによって取得されたテーブルまたは行のロックは、最初の<command>COMMIT</command>または<command>ROLLBACK</command>の後にはもはや保持されないことに留意しなければなりません。
    </para>

--- a/doc/src/sgml/plpgsql.sgml
+++ b/doc/src/sgml/plpgsql.sgml
@@ -5516,7 +5516,7 @@ CALL transaction_test2();
 -->
 通常、カーソルはトランザクションのコミット時に自動的に閉じられます。
 しかしながら、このようにループの一部として作られたカーソルは、最初の<command>COMMIT</command>または<command>ROLLBACK</command>から自動的に保持可能カーソルに変換されます。
-このことは、最初の<command>COMMIT</command>や<command>ROLLBACK</command>の時点でカーソルが行ごとではなく全体が評価されることを意味します。
+このことは、カーソルが行ごとではなく、最初に<command>COMMIT</command>や<command>ROLLBACK</command>された時点で全体として評価されることを意味します。
 従来通りカーソルはループ後に自動で削除されるので、このことはユーザにほとんど認識されません。
 しかし、カーソルの問い合わせによって取得されたテーブルまたは行のロックは、最初の<command>COMMIT</command>または<command>ROLLBACK</command>の後にはもはや保持されないことに留意しなければなりません。
    </para>


### PR DESCRIPTION
https://github.com/pgsql-jp/jpug-doc/pull/3284/files
の査読中に気になるところを見つけtので別PRをあげました。

①「今や」は不要かと思います。
② fully evaluatedは「完全に評価されます」となっていましたが、カーソルの行ごとではなく、カーゾル「全体が評価されます」ということかと思いますのでそのように修正してみました。