### PR TITLE
（<literal>00:00</literal>）の厳密性を追加

### DIFF
--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -3721,7 +3721,7 @@ TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54+02'
 <!--
           <entry>midnight (<literal>00:00</literal>) today</entry>
 -->
-          <entry>今日の午前０時</entry>
+          <entry>今日の午前０時（<literal>00:00</literal>）</entry>
          </row>
          <row>
           <entry><literal>tomorrow</literal></entry>
@@ -3729,7 +3729,7 @@ TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54+02'
 <!--
           <entry>midnight (<literal>00:00</literal>) tomorrow</entry>
 -->
-          <entry>明日の午前０時</entry>
+          <entry>明日の午前０時（<literal>00:00</literal>）</entry>
          </row>
          <row>
           <entry><literal>yesterday</literal></entry>
@@ -3737,7 +3737,7 @@ TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54+02'
 <!--
           <entry>midnight (<literal>00:00</literal>) yesterday</entry>
 -->
-          <entry>昨日の午前０時</entry>
+          <entry>昨日の午前０時（<literal>00:00</literal>）</entry>
          </row>
          <row>
           <entry><literal>allballs</literal></entry>


### PR DESCRIPTION
前からliteralタグが足りなくてチェックに引っかかっていたので修正