### PR TITLE
先行書き込みログの修正漏れ（title）

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -4331,7 +4331,7 @@ I/Oを結合する操作で最大のI/Oサイズを制御します。
 <!--
     <title>Write Ahead Log</title>
 -->
-    <title>ログ先行書き込み（WAL）</title>
+    <title>先行書き込みログ（WAL）</title>
 
    <para>
 <!--

--- a/doc/src/sgml/config1.sgml
+++ b/doc/src/sgml/config1.sgml
@@ -12,7 +12,7 @@
 <!--
     <title>Write Ahead Log</title>
 -->
-    <title>ログ先行書き込み（WAL）</title>
+    <title>先行書き込みログ（WAL）</title>
 
    <para>
 <!--

--- a/doc/src/sgml/wal.sgml
+++ b/doc/src/sgml/wal.sgml
@@ -4,7 +4,7 @@
 <!--
  <title>Reliability and the Write-Ahead Log</title>
 -->
- <title>信頼性とログ先行書き込み</title>
+ <title>信頼性と先行書き込みログ（WAL）</title>
 
  <para>
 <!--
@@ -425,7 +425,7 @@ CRCの値はそれぞれのWALレコードを書き込む時に設定され、�
 <!--
    <title>Write-Ahead Logging (<acronym>WAL</acronym>)</title>
 -->
-   <title>ログ先行書き込み(<acronym>WAL</acronym>)</title>
+   <title>先行書き込みログ(<acronym>WAL</acronym>)</title>
 
    <indexterm zone="wal">
     <primary>WAL</primary>


### PR DESCRIPTION
 #3238 の対応でtitleのフォワードポートが漏れていました。