### PR TITLE
fix overtranslation

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -28516,7 +28516,7 @@ NULLをスキップして、すべての入力値をJSON配列に収集します
         If <literal>ORDER BY</literal> is specified, the elements will
         appear in the array in that order rather than in the input order.
 -->
-<function>JSON_配列</function>と同じように動作しますが、集約関数として動作するため、1つの<replaceable>value_式</replaceable>パラメータのみを使用します。
+<function>json_array</function>と同じように動作しますが、集約関数として動作するため、1つの<replaceable>value_expression</replaceable>パラメータのみを使用します。
 <literal>ABSENT ON NULL</literal>が指定されている場合、NULL値は無視されます。
 <literal>ORDER BY</literal>が指定されている場合、要素は入力順ではなく、配列の順に表示されます。
        </para>

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -8207,7 +8207,7 @@ NULLをスキップして、すべての入力値をJSON配列に収集します
         If <literal>ORDER BY</literal> is specified, the elements will
         appear in the array in that order rather than in the input order.
 -->
-<function>JSON_配列</function>と同じように動作しますが、集約関数として動作するため、1つの<replaceable>value_式</replaceable>パラメータのみを使用します。
+<function>json_array</function>と同じように動作しますが、集約関数として動作するため、1つの<replaceable>value_expression</replaceable>パラメータのみを使用します。
 <literal>ABSENT ON NULL</literal>が指定されている場合、NULL値は無視されます。
 <literal>ORDER BY</literal>が指定されている場合、要素は入力順ではなく、配列の順に表示されます。
        </para>


### PR DESCRIPTION
functionタグとreplaceableタグの中まで訳してしまっているところを見つけました。