### PR TITLE
貢献者の形式をリリースノートに合わせる

### DIFF
--- a/doc/src/sgml/jpug-doc.sgml
+++ b/doc/src/sgml/jpug-doc.sgml
@@ -1,6 +1,6 @@
 <!-- doc/src/sgml/jpug-doc.sgml -->
 
-<appendix  id="jpug-doc">
+<appendix id="jpug-doc">
 
 <title>貢献者</title>
 
@@ -9,878 +9,597 @@
 ありがとうございました。(PostgreSQL9.6以降の貢献者を記載)
 </para>
 
-<para>
-PostgreSQL16
+<simplesect id="jpug-doc-postgresql-16">
+<title>PostgreSQL 16</title>
 <!--2023/9/20以降の貢献-->
-</para>
-  <itemizedlist>
-   <listitem>
-    <para>
+<para>
 翻訳者
-    </para>
-    <para>
+</para>
+<simplelist>
 <!--
 翻訳(arch-dev.sgmlなど多数)
 -->
-小泉 悟
-    </para>
-    <para>
+<member>小泉 悟</member>
 <!--
 翻訳(adminpack.sgmlなど多数)/レビュー/対訳表管理(git管理)/翻訳改善提案/GIT管理(リポジトリの整備、Travis管理,英語日本語併記版マニュアルのコンパイル/公開)/コンフリクト解消
 /pdf,epub対応
 -->
-斉藤 登
-    </para>
-    <para>
+<member>斉藤 登</member>
 <!--
 翻訳(config.sgmlなど多数)/レビュー
 -->
-SRA OSS LLC 顧問 石井 達夫
-    </para>
-    <para>
+<member>SRA OSS LLC 顧問 石井 達夫</member>
 <!--
 翻訳(release-16.sgml)/レビュー
 -->
-SRA OSS LLC 北山 貴広
-    </para>
-    <para>
+<member>SRA OSS LLC 北山 貴広</member>
 <!--
 翻訳(datatype.sgml)/レビュー/理事
 -->
-株式会社アシスト 田中 健一朗
-    </para>
-    <para>
+<member>株式会社アシスト 田中 健一朗</member>
 <!--
 翻訳(protocol.sgml)
 -->
-富士通株式会社 黒田 隼人
-    </para>
-   </listitem>
-
-   <listitem>
-    <para>
+<member>富士通株式会社 黒田 隼人</member>
+</simplelist>
+<para>
 その他の貢献
-    </para>
-    <para>
+</para>
+<simplelist>
 <!--
 翻訳改善(ISSIES2802)
 -->
-SRA OSS LLC 高塚 遥
-    </para>
-    <para>
+<member>SRA OSS LLC 高塚 遥</member>
 <!--
 翻訳改善(ISSIES2961)
 -->
-三菱電機株式会社 藤井雄規
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-謝辞
-    </para>
-    <para>
-国立研究開発法人情報通信研究機構（NICT）が開発した「みんなの自動翻訳＠TexTra®」による機械翻訳を参考に翻訳活動を行なっています。
-    </para>
-   </listitem>
-  </itemizedlist>
-
+<member>三菱電機株式会社 藤井雄規</member>
+</simplelist>
 <para>
-PostgreSQL15
-<!--2022/10/6以降の貢献-->
+謝辞
 </para>
-  <itemizedlist>
-   <listitem>
-    <para>
+<simplelist>
+<member>国立研究開発法人情報通信研究機構（NICT）が開発した「みんなの自動翻訳＠TexTra®」による機械翻訳を参考に翻訳活動を行なっています。</member>
+</simplelist>
+</simplesect>
+
+<simplesect id="jpug-doc-postgresql-15">
+<title>PostgreSQL 15</title>
+<!--2022/10/6以降の貢献-->
+<para>
 翻訳者
-    </para>
-    <para>
+</para>
+<simplelist>
 <!--
 翻訳(arch-dev.sgmlなど多数)
 -->
-小泉 悟
-    </para>
-    <para>
+<member>小泉 悟</member>
 <!--
 翻訳(dminpack.sgmlなど多数)/レビュー/対訳表管理(git管理)/翻訳改善提案/GIT管理(リポジトリの整備、Travis管理,英語日本語併記版マニュアルのコンパイル/公開)/コンフリクト解消
 /pdf,epub対応
 -->
-斉藤 登
-    </para>
-    <para>
+<member>斉藤 登</member>
 <!--
 翻訳(config.sgmlなど多数)/レビュー
 -->
-SRA OSS LLC 顧問 石井 達夫
-    </para>
-    <para>
+<member>SRA OSS LLC 顧問 石井 達夫</member>
 <!--
 翻訳(release-15.sgmlなど多数)/レビュー
 -->
-SRA OSS LLC 北山 貴広
-    </para>
-    <para>
+<member>SRA OSS LLC 北山 貴広</member>
 <!--
 翻訳(datatype.sgml)/レビュー/理事
 -->
-株式会社アシスト 田中 健一朗
-    </para>
-   </listitem>
-
-   <listitem>
-    <para>
+<member>株式会社アシスト 田中 健一朗</member>
+</simplelist>
+<para>
 その他の貢献
-    </para>
-    <para>
+</para>
+<simplelist>
 <!--
 翻訳改善(ISSIES2158)
 -->
-伊東 貢一
-    </para>
-    <para>
+<member>伊東 貢一</member>
 <!--
 翻訳改善(PR2493)
 -->
-大平 直宏
-    </para>
-    <para>
+<member>大平 直宏</member>
 <!--
 翻訳改善(ISSUES2724)
 -->
-久保 健洋
-    </para>
-    <para>
+<member>久保 健洋</member>
 <!--
 翻訳改善(PR2537)
 -->
-Amazon Web Services 澤田 雅彦
-    </para>
-    <para>
+<member>Amazon Web Services 澤田 雅彦</member>
 <!--
 翻訳改善(ISSIES2580)
 -->
-NTTコムウェア株式会社 川本 将也
-    </para>
-    <para>
+<member>NTTコムウェア株式会社 川本 将也</member>
 <!--
 翻訳改善(PR2499)
 -->
-株式会社ナガツグ 神谷 広員
-    </para>
-    <para>
+<member>株式会社ナガツグ 神谷 広員</member>
 <!--
 翻訳改善(ISSIES2689)
 -->
-SRA OSS LLC 高塚 遥
-    </para>
-    <para>
+<member>SRA OSS LLC 高塚 遥</member>
 <!--
 翻訳改善(ISSIES2501)
 -->
-富士通株式会社 黒田 隼人
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-謝辞
-    </para>
-    <para>
-国立研究開発法人情報通信研究機構（NICT）が開発した「みんなの自動翻訳＠TexTra®」による機械翻訳を参考に翻訳活動を行なっています。
-    </para>
-   </listitem>
-  </itemizedlist>
-
+<member>富士通株式会社 黒田 隼人</member>
+</simplelist>
 <para>
-PostgreSQL14
-<!--2021/9/1以降の貢献-->
+謝辞
 </para>
+<simplelist>
+<member>国立研究開発法人情報通信研究機構（NICT）が開発した「みんなの自動翻訳＠TexTra®」による機械翻訳を参考に翻訳活動を行なっています。</member>
+</simplelist>
+</simplesect>
 
-  <itemizedlist>
-   <listitem>
-    <para>
+<simplesect id="jpug-doc-postgresql-14">
+<title>PostgreSQL 14</title>
+<!--2021/9/1以降の貢献-->
+<para>
 翻訳者
-    </para>
-    <para>
+</para>
+<simplelist>
 <!--
 翻訳(parallel.sgmlなど多数)
 -->
-阿部 陣一
-    </para>
-    <para>
+<member>阿部 陣一</member>
 <!--
 翻訳(adminpack.sgmlなど多数)
 -->
-小泉 悟
-    </para>
-    <para>
+<member>小泉 悟</member>
 <!--
 翻訳(alter_type.sgml,ref/alter_trigger.sgml)
 -->
-五島 英明
-    </para>
-    <para>
+<member>五島 英明</member>
 <!--
 翻訳(btree-gin.sgmlなど多数)/レビュー/対訳表管理(git管理)/翻訳改善提案/GIT管理(リポジトリの整備、Travis管理,英語日本語併記版マニュアルのコンパイル/公開)/コンフリクト解消/pdf,epub対応
 -->
-斉藤 登
-    </para>
-    <para>
+<member>斉藤 登</member>
 <!--
 翻訳(trigger.sml)
 -->
-塚田 雄志郎
-    </para>
-    <para>
+<member>塚田 雄志郎</member>
 <!--
 翻訳(config.sgmlなど多数)/レビュー
 -->
-SRA OSS LLC 顧問 石井 達夫
-    </para>
-    <para>
+<member>SRA OSS LLC 顧問 石井 達夫</member>
 <!--
 翻訳(contrib.sgmlなど多数)/レビュー
 -->
-SRA OSS LLC 北山 貴広 
-    </para>
-    <para>
+<member>SRA OSS LLC 北山 貴広</member>
 <!--
 翻訳(release-14.sgmlなど多数)/レビュー
 -->
-SRA OSS LLC 高塚 遙 
-    </para>
-    <para>
+<member>SRA OSS LLC 高塚 遙</member>
 <!--
 翻訳(charset.sgmlなど)
 -->
-NTTコムウェア 星合 拓馬
-    </para>
-    <para>
+<member>NTTコムウェア 星合 拓馬</member>
 <!--
 翻訳(drop_statistics.sgml)
 -->
-株式会社アシスト 喜田 絋介
-    </para>
-    <para>
+<member>株式会社アシスト 喜田 絋介</member>
 <!--
 翻訳(datatype.sgml)/レビュー/理事
 -->
-株式会社アシスト 田中 健一朗
-    </para>
-   </listitem>
-
-   <listitem>
-    <para>
+<member>株式会社アシスト 田中 健一朗</member>
+</simplelist>
+<para>
 その他の貢献
-    </para>
-    <para>
+</para>
+<simplelist>
 <!--
 翻訳改善(log_line_prefixの説明の修正 #2397)
 -->
-tkuramoto33
-    </para>
-    <para>
+<member>tkuramoto33</member>
 <!--
 翻訳改善(ISSIES2228)
 -->
-Masatoshi Fukunaga
-    </para>
-    <para>
+<member>Masatoshi Fukunaga</member>
 <!--
 翻訳改善(ISSIES2163)
 -->
-ぬこ@横浜
-    </para>
-    <para>
+<member>ぬこ@横浜</member>
 <!--
 翻訳改善(ISSIES2158)
 -->
-伊東 貢一
-    </para>
-    <para>
+<member>伊東 貢一</member>
 <!--
 翻訳改善(ISSIES2163)
 -->
-篠田 典良
-    </para>
-    <para>
+<member>篠田 典良</member>
 <!--
 翻訳改善(ISSIES2192)
 -->
-SRA OSS LLC 矢吹 洋一 
-    </para>
-    <para>
+<member>SRA OSS LLC 矢吹 洋一 </member>
 <!--
 翻訳改善(ISSIES2154)
 -->
-NTT OSSセンタ 池田 真洋
-    </para>
-    <para>
+<member>NTT OSSセンタ 池田 真洋</member>
 <!--
 翻訳改善(ISSIES2096)
 -->
-NTT OSSセンタ 平光 友博
-    </para>
-    <para>
+<member>NTT OSSセンタ 平光 友博</member>
 <!--
 翻訳改善(Author"の翻訳の表記揺れを修正 #2367)
 -->
-NTTコムウェア 山田 達朗 
-    </para>
-    <para>
+<member>NTTコムウェア 山田 達朗</member>
 <!--
 翻訳改善(Fix a typo in protocol-replication #2353)
 -->
-株式会社クリアコード 堀本 泰弘
-    </para>
-    <para>
+<member>株式会社クリアコード 堀本 泰弘</member>
 <!--
 翻訳改善(ISSIES1967)
 -->
-富士通株式会社 黒田 隼人
-    </para>
-   </listitem>
-  </itemizedlist>
+<member>富士通株式会社 黒田 隼人</member>
+</simplelist>
+</simplesect>
 
-<para>
-PostgreSQL13
+<simplesect id="jpug-doc-postgresql-13">
+<title>PostgreSQL 13</title>
 <!--2020/11/13以降の貢献-->
-</para>
-
-  <itemizedlist>
-   <listitem>
-    <para>
+<para>
 翻訳者
-    </para>
-    <para>
+</para>
+<simplelist>
 <!--
 翻訳(adminpack.sgmlなど多数)/コンフリクト解消
 -->
-小泉 悟
-    </para>
-    <para>
+<member>小泉 悟</member>
 <!--
 翻訳(btree-gin.sgmlなど)/対訳表管理(git管理、翻訳改善提案)/GIT管理(リポジトリの整備、Travis管理,英語日本語併記版マニュアルのコンパイル/公開)/コンフリクト解消/pdf,epub対応
 -->
-斉藤 登
-    </para>
-    <para>
+<member>斉藤 登</member>
 <!--
 翻訳(auto_explain.sgml)
 -->
-田中 響
-    </para>
-    <para>
+<member>田中 響</member>
 <!--
 翻訳(config.sgmlなど)/レビュー
 -->
-SRA OSS, Inc. 日本支社 石井 達夫
-    </para>
-    <para>
+<member>SRA OSS, Inc. 日本支社 石井 達夫</member>
 <!--
 翻訳(contrib.sgmlなど)/レビュー
 -->
-SRA OSS, Inc. 日本支社 北山 貴広 
-    </para>
-    <para>
+<member>SRA OSS, Inc. 日本支社 北山 貴広</member>
 <!--
 翻訳(release-13.sgmlなど)/レビュー
 -->
-SRA OSS, Inc. 日本支社 高塚 遙 
-    </para>
-    <para>
+<member>SRA OSS, Inc. 日本支社 高塚 遙</member>
 <!--
 翻訳(charset.sgmlなど)
 -->
-NTTコムウェア 星合 拓馬
-    </para>
-    <para>
+<member>NTTコムウェア 星合 拓馬</member>
 <!--
 翻訳(datatype.sgml)/レビュー/GIT管理(最新化)/座長（アナウンスなど）
 -->
-株式会社アシスト 田中 健一朗
-    </para>
-    <para>
+<member>株式会社アシスト 田中 健一朗</member>
 <!--
 翻訳(create_trigger.sgml)
 -->
-株式会社スカイアーチHRソリューションズ 橋本 淳一
-    </para>
-   </listitem>
+<member>株式会社スカイアーチHRソリューションズ 橋本 淳一</member>
+</simplelist>
 
-   <listitem>
-    <para>
+<para>
 その他の貢献
-    </para>
-    <para>
+</para>
+<simplelist>
 <!--
 翻訳改善(ISSIES1967)
 -->
-富士通株式会社 黒田 隼人
-    </para>
-   </listitem>
-  </itemizedlist>
+<member>富士通株式会社 黒田 隼人</member>
+</simplelist>
+</simplesect>
+
+<simplesect id="jpug-doc-postgresql-12">
+<title>PostgreSQL 12</title>
+<!--2019/10/8以降の貢献-->
 
 <para>
-PostgreSQL12
-<!--2019/10/8以降の貢献-->
-</para>
-
-  <itemizedlist>
-   <listitem>
-    <para>
 翻訳者
-    </para>
-    <para>
+</para>
+<simplelist>
 <!--
 翻訳(amcheck.sgmlなど多数)/コンフリクト解消
 -->
-小泉 悟
-    </para>
-    <para>
+<member>小泉 悟</member>
 <!--
 翻訳(contrib.sgmlなど)/対訳表管理(git管理、翻訳改善提案)/GIT管理(リポジトリの整備、Travis管理,英語日本語併記版マニュアルのコンパイル/公開)/コンフリクト解消/pdf,epub対応
 -->
-斉藤 登
-    </para>
-    <para>
+<member>斉藤 登</member>
 <!--
 翻訳(clusterdb.sgm)
 -->
-藤井 隆夫
-    </para>
-    <para>
+<member>藤井 隆夫</member>
 <!--
 翻訳(charset.sgml)
 -->
-星合 拓馬
-    </para>
-    <para>
+<member>星合 拓馬</member>
 <!--
 翻訳(config.sgmlなど)/レビュー
 -->
-SRA OSS, Inc. 日本支社 石井 達夫
-    </para>
-    <para>
+<member>SRA OSS, Inc. 日本支社 石井 達夫</member>
 <!--
 翻訳(release-12.sgmlなど)/レビュー
 -->
-SRA OSS, Inc. 日本支社 高塚 遙 
-    </para>
-    <para>
+<member>SRA OSS, Inc. 日本支社 高塚 遙</member>
 <!--
 翻訳(datatype.sgmlなど)/レビュー/GIT管理(最新化)/座長（アナウンスなど）
 -->
-株式会社アシスト 田中 健一朗
-    </para>
-   </listitem>
+<member>株式会社アシスト 田中 健一朗</member>
+</simplelist>
 
-   <listitem>
-    <para>
+<para>
 その他の貢献
-    </para>
-    <para>
+</para>
+<simplelist>
 <!--
 翻訳改善
 -->
-大平 直宏
-    </para>
-    <para>
+<member>大平 直宏</member>
 <!--
 誤訳報告
 -->
-篠田 典良
-    </para>
-    <para>
+<member>篠田 典良</member>
 <!--
 誤訳報告(client_min_messagesの値にFATAL、PANICが含まれている #1713 など)
 -->
-SRA OSS, Inc. 日本支社 佐藤 友章
-    </para>
-    <para>
+<member>SRA OSS, Inc. 日本支社 佐藤 友章</member>
 <!--
 翻訳(config.sgmlなど)/レビュー
 -->
-SRA OSS, Inc. 日本支社 矢吹 洋一 
-    </para>
-    <para>
+<member>SRA OSS, Inc. 日本支社 矢吹 洋一</member>
 <!--
 翻訳改善(PR1723)
 -->
-NTT OSSセンタ 大塚 憲司 
-    </para>
-    <para>
+<member>NTT OSSセンタ 大塚 憲司</member>
 <!--
 翻訳改善
 -->
-NTT OSSセンタ 坂田 哲夫
-    </para>
-    <para>
+<member>NTT OSSセンタ 坂田 哲夫</member>
 <!--
 翻訳改善(PR1731)
 -->
-NTTコムウェア 山田達朗
-    </para>
-    <para>
+<member>NTTコムウェア 山田達朗</member>
 <!--
 翻訳改善
 -->
-株式会社NTTデータ 藤井 雅雄
-    </para>
-    <para>
+<member>株式会社NTTデータ 藤井 雅雄</member>
 <!--
 翻訳改善(PR1732)
 -->
-株式会社ソニックガーデン 西川 一樹
-    </para>
-    <para>
+<member>株式会社ソニックガーデン 西川 一樹</member>
 <!--
 翻訳改善(PR1712)
 -->
-富士通株式会社 黒田 隼人
-    </para>
-   </listitem>
-  </itemizedlist>
+<member>富士通株式会社 黒田 隼人</member>
+</simplelist>
+</simplesect>
+
+<simplesect id="jpug-doc-postgresql-11">
+<title>PostgreSQL 11</title>
+<!--2018/10以降の貢献-->
 
 <para>
-PostgreSQL11
-<!--2018/10以降の貢献-->
-</para>
-
-  <itemizedlist>
-   <listitem>
-    <para>
 翻訳者
-    </para>
-    <para>
+</para>
+<simplelist>
 <!--
 翻訳(gin.sgmlなど多数)/コンフリクト解消
 -->
-小泉 悟
-    </para>
-    <para>
+<member>小泉 悟</member>
 <!--
 翻訳(xaggr.sgmlなど)/対訳表管理(git管理、翻訳改善提案)/WEBサイト改善（CSS最適化）/GIT管理(リポジトリの整備、Travis管理,英語日本語併記版マニュアルのコンパイル/公開)/コンフリクト解消/pdf,epub対応
 -->
-斉藤 登
-    </para>
-    <para>
+<member>斉藤 登</member>
 <!--
 翻訳(bgworker.sgml)
 -->
-星合 拓馬
-    </para>
-    <para>
+<member>星合 拓馬</member>
 <!--
 翻訳(config.sgmlなど)/レビュー
 -->
-SRA OSS, Inc. 日本支社 石井 達夫
-    </para>
-    <para>
+<member>SRA OSS, Inc. 日本支社 石井 達夫</member>
 <!--
 翻訳(alter_domain.sgmlなど)/レビュー
 -->
-SRA OSS, Inc. 日本支社 千田 貴大 
-    </para>
-    <para>
+<member>SRA OSS, Inc. 日本支社 千田 貴大</member>
 <!--
 翻訳(release-11.sgmlなど)/レビュー
 -->
-SRA OSS, Inc. 日本支社 高塚 遙 
-    </para>
-    <para>
+<member>SRA OSS, Inc. 日本支社 高塚 遙</member>
 <!--
 翻訳(logical-replication.sgml)
 -->
-NTT OSSセンタ 細谷柚子 
-    </para>
-    <para>
+<member>NTT OSSセンタ 細谷柚子</member>
 <!--
 翻訳(datatype.sgmlなど)/レビュー/GIT管理(ブランチ作成、最新化)/コンフリクト解消/座長（アナウンスなど）
 -->
-株式会社アシスト 田中 健一朗
-    </para>
-   </listitem>
-
-   <listitem>
-    <para>
-その他の貢献
-    </para>
-    <para>
-<!--
-誤訳報告
--->
-azarakko
-    </para>
-    <para>
-<!--
-誤訳報告
--->
-上原 一樹
-    </para>
-    <para>
-<!--
-誤訳報告
--->
-篠田 典良
-    </para>
-    <para>
-<!--
-誤訳報告
--->
-堀田　倫英
-    </para>
-    <para>
-<!--
-翻訳改善
--->
-株式会社NTTデータ 藤井 雅雄
-    </para>
-    <para>
-<!--
-翻訳改善
--->
-中央大学 遠藤 杏奈
-    </para>
-    <para>
-<!--
-誤訳報告
--->
-日本電信電話株式会社 澤田 雅彦
-    </para>
-   </listitem>
-   </itemizedlist>
+<member>株式会社アシスト 田中 健一朗</member>
+</simplelist>
 
 <para>
-PostgreSQL10
-<!--2017/10/12以降の貢献-->
+その他の貢献
 </para>
+<simplelist>
+<!--
+誤訳報告
+-->
+<member>azarakko</member>
+<!--
+誤訳報告
+-->
+<member>上原 一樹</member>
+<!--
+誤訳報告
+-->
+<member>篠田 典良</member>
+<!--
+誤訳報告
+-->
+<member>堀田　倫英</member>
+<!--
+翻訳改善
+-->
+<member>株式会社NTTデータ 藤井 雅雄</member>
+<!--
+翻訳改善
+-->
+<member>中央大学 遠藤 杏奈</member>
+<!--
+誤訳報告
+-->
+<member>日本電信電話株式会社 澤田 雅彦</member>
+</simplelist>
+</simplesect>
 
-  <itemizedlist>
-   <listitem>
-    <para>
+<simplesect id="jpug-doc-postgresql-10">
+<title>PostgreSQL 10</title>
+<!--2017/10/12以降の貢献-->
+
+<para>
 翻訳者
-    </para>
-    <para>
+</para>
+<simplelist>
 <!--
 翻訳(gin.sgmlなど多数)/コンフリクト解消
 -->
-小泉 悟
-    </para>
-    <para>
+<member>小泉 悟</member>
 <!--
 翻訳(xaggr.sgmlなど)/対訳表管理(git管理、翻訳改善提案)/WEBサイト改善（CSS最適化）/GIT管理(リポジトリの整備、Travis管理,英語日本語併記版マニュアルのコンパイル/公開)/コンフリクト解消/pdf,epub対応
 -->
-斉藤 登
-    </para>
-    <para>
+<member>斉藤 登</member>
 <!--
 翻訳（user-manag.sgml）など
 -->
-寺内 大輝
-    </para>
-    <para>
+<member>寺内 大輝</member>
 <!--
 翻訳(parallel.sgmlなど)/レビュー（postgres-fdw.sgmlなど）
 -->
-SRA OSS, Inc. 日本支社 石井 達夫
-    </para>
-    <para>
+<member>SRA OSS, Inc. 日本支社 石井 達夫</member>
 <!--
 翻訳(release-9.6.sgmlなど)/レビュー
 -->
-SRA OSS, Inc. 日本支社 高塚 遙 
-    </para>
-    <para>
+<member>SRA OSS, Inc. 日本支社 高塚 遙</member>
 <!--
 翻訳(datatype.sgmlなど)/レビュー/GIT管理(ブランチ作成、最新化)/コンフリクト解消/座長（アナウンスなど）
 -->
-株式会社アシスト       田中 健一朗
-    </para>
-    <para>
+<member>株式会社アシスト       田中 健一朗</member>
 <!--
 翻訳（indices.sgmlなど）/レビュー(release-10.sgmlなど)/翻訳改善
 -->
-株式会社シーエーシー　 松田 神一
-    </para>
-   </listitem>
-
-   <listitem>
-    <para>
-その他の貢献
-    </para>
-    <para>
-<!--
-誤訳報告
--->
-SRA OSS, Inc. 日本支社 佐藤 友章
-    </para>
-    <para>
-<!--
-誤訳報告
--->
-SRA OSS, Inc. 日本支社 彭 博
-    </para>
-   </listitem>
-   </itemizedlist>
+<member>株式会社シーエーシー　 松田 神一</member>
+</simplelist>
 
 <para>
-PostgreSQL9.6
+その他の貢献
 </para>
-  <itemizedlist>
-   <listitem>
-    <para>
+<simplelist>
+<!--
+誤訳報告
+-->
+<member>SRA OSS, Inc. 日本支社 佐藤 友章</member>
+<!--
+誤訳報告
+-->
+<member>SRA OSS, Inc. 日本支社 彭 博</member>
+</simplelist>
+</simplesect>
+
+<simplesect id="jpug-doc-postgresql-96">
+<title>PostgreSQL 9.6</title>
+
+<para>
 翻訳者
-    </para>
-    <para>
+</para>
+<simplelist>
 <!--
 翻訳(catalogs.sgmlなど)
 -->
-垣谷 学
-    </para>
-    <para>
+<member>垣谷 学</member>
 <!--
 翻訳(gin.sgmlなど多数)/コンフリクト解消
 -->
-小泉 悟
-    </para>
-    <para>
+<member>小泉 悟</member>
 <!--
 翻訳(xaggr.sgmlなど)/対訳表管理(git管理、翻訳改善提案)/WEBサイト改善（CSS最適化）/GIT管理(リポジトリの整備、Travis管理,併記版マニュアルのコンパイル/公開)/コンフリクト解消/pdf,epub対応
 -->
-斉藤 登
-    </para>
-    <para>
+<member>斉藤 登</member>
 <!--
 翻訳(parallel.sgmlなど)/レビュー（postgres-fdw.sgmlなど）/GIT管理(ブランチの最新化)
 -->
-SRA OSS, Inc. 日本支社 石井 達夫
-    </para>
-    <para>
+<member>SRA OSS, Inc. 日本支社 石井 達夫</member>
 <!--
 翻訳(mvcc.sgml)
 -->
-SRA OSS, Inc. 日本支社 千田 貴大
-    </para>
-    <para>
+<member>SRA OSS, Inc. 日本支社 千田 貴大</member>
 <!--
 翻訳(release-9.6.sgmlなど)/レビュー
 -->
-SRA OSS, Inc. 日本支社 高塚 遙 
-    </para>
-    <para>
+<member>SRA OSS, Inc. 日本支社 高塚 遙</member>
 <!--
 翻訳(datatype.sgmlなど)/レビュー/GIT管理(ブランチ作成、最新化)/コンフリクト解消/座長（アナウンスなど）
 -->
-株式会社アシスト       田中 健一朗
-    </para>
-    <para>
+<member>株式会社アシスト       田中 健一朗</member>
 <!--
 翻訳（indices.sgmlなど）/レビュー(release-9.6.sgmlなど)/翻訳改善
 -->
-株式会社シーエーシー　 松田 神一
-    </para>
-   </listitem>
-
-   <listitem>
-    <para>
+<member>株式会社シーエーシー　 松田 神一</member>
+</simplelist>
+<para>
 その他の貢献
-    </para>
-    <para>
+</para>
+<simplelist>
 <!--
 誤訳報告
 -->
-大塚 憲司
-    </para>
-    <para>
+<member>大塚 憲司</member>
 <!--
 WEBサイト改善（CSS最適化）
 -->
-小山 哲志
-    </para>
-    <para>
+<member>小山 哲志</member>
 <!--
 誤訳報告
 -->
-篠田 典良
-    </para>
-    <para>
+<member>篠田 典良</member>
 <!--
 誤訳報告
 -->
-寺内 大輝
-    </para>
-    <para>
+<member>寺内 大輝</member>
 <!--
 誤訳報告
 -->
-ぬこ＠横浜
-    </para>
-    <para>
+<member>ぬこ＠横浜</member>
 <!--
 誤訳報告
 -->
-松枝 智也
-    </para>
-    <para>
+<member>松枝 智也</member>
 <!--
 誤訳報告
 -->
-SRA OSS, Inc. 日本支社 佐藤 友章
-    </para>
-    <para>
+<member>SRA OSS, Inc. 日本支社 佐藤 友章</member>
 <!--
 誤訳報告
 -->
-NTT OSSセンタ 澤田 雅彦
-    </para>
-    <para>
+<member>NTT OSSセンタ 澤田 雅彦</member>
 <!--
 誤訳報告
 -->
-NECソリューションイノベータ(株) 近藤 太樹
-    </para>
-    <para>
+<member>NECソリューションイノベータ(株) 近藤 太樹</member>
 <!--
 誤訳報告
 -->
-NECソリューションイノベータ(株) Dang Minh Huong
-    </para>
-    <para>
+<member>NECソリューションイノベータ(株) Dang Minh Huong</member>
 <!--
 誤訳報告
 -->
-株式会社NTTデータ 藤井 雅雄
-    </para>
-   </listitem>
-
-<!--
-<para>
-PostgreSQL11
-</para>
-
-  <itemizedlist>
-   <listitem>
-    <para>
-翻訳者
-    </para>
-    <para>
-XXXXXXXX
-    </para>
-    <para>
-XXXXXXXX
-    </para>
-   </listitem>
-
-   <listitem>
-    <para>
-その他の貢献
-    </para>
-    <para>
-XXXXXX
-    </para>
-   </listitem>
-   </itemizedlist>
--->
-  </itemizedlist>
-
+<member>株式会社NTTデータ 藤井 雅雄</member>
+</simplelist>
+</simplesect>
 
 </appendix>


### PR DESCRIPTION
貢献者のページがPDFだとページ送りがうまくいっていなかったので、
リリースノートと同じsimplelistにしました。