### PR TITLE
fix translation of 'source' and 'target'

### DIFF
--- a/doc/src/sgml/amcheck.sgml
+++ b/doc/src/sgml/amcheck.sgml
@@ -169,7 +169,7 @@ ORDER BY c.relpages DESC LIMIT 10;
       trade-off between thoroughness of verification and limiting the
       impact on application performance and availability.
 -->
-<function>bt_index_check</function>は、ターゲットとなるインデックスと、それが所属するヒープリレーションに対して<literal>AccessShareLock</literal>を獲得します。
+<function>bt_index_check</function>は、対象となるインデックスと、それが所属するヒープリレーションに対して<literal>AccessShareLock</literal>を獲得します。
 このロックモードは、単純な<literal>SELECT</literal>文がリレーションに対して獲得するのと同じものです。
 <function>bt_index_check</function>は、子／親関係にわたる不変量を検査しませんが、<parameter>heapallindexed</parameter>が<literal>true</literal>の場合には、インデックス中のインデックスタプルに対応するすべてのヒープタプルの存在が検証されます。
 <parameter>checkunique</parameter>が<literal>true</literal>の場合、<function>bt_index_check</function>は一意インデックス内の重複エントリの中で可視のものが1つだけであることを検証します。
@@ -213,7 +213,7 @@ ORDER BY c.relpages DESC LIMIT 10;
       convention of raising an error if it finds a logical
       inconsistency or other problem.
 -->
-<function>bt_index_parent_check</function>は、ターゲットとなるB-Treeインデックスが様々な不変量を保っていることを検査します。
+<function>bt_index_parent_check</function>は、対象となるB-Treeインデックスが様々な不変量を保っていることを検査します。
 オプションとして、<parameter>heapallindexed</parameter>引数が<literal>true</literal>の場合、インデックスに対応して存在すべきすべてのヒープタプルの存在を検証します。
 <parameter>checkunique</parameter>が<literal>true</literal>の場合、一意インデックスの重複エントリの中で可視のものが1つだけであることを検査します。
 省略可能な引数<parameter>rootdescend</parameter>が<literal>true</literal>であれば、各タプルに対するルートページから新しく探索することで、検証はリーフレベルのタプルを再び見つけます。
@@ -234,7 +234,7 @@ ORDER BY c.relpages DESC LIMIT 10;
       all other utility commands.  Note that the function holds locks
       only while running, not for the entire transaction.
 -->
-<function>bt_index_parent_check</function>は、ターゲットインデックスに<literal>ShareLock</literal>を獲得することを必要とします。
+<function>bt_index_parent_check</function>は、対象インデックスに<literal>ShareLock</literal>を獲得することを必要とします。
 （<literal>ShareLock</literal>はヒープリレーションにも獲得されます。）
 このロックは、<command>INSERT</command>、<command>UPDATE</command>、<command>DELETE</command>が並行してデータ更新することを防ぎます。
 また、このロックは<command>VACUUM</command>その他のユーティリティコマンドによって、背後にあるリレーションが同時に処理されることを防ぎます。
@@ -402,7 +402,7 @@ SET client_min_messages = DEBUG1;
          target table.
 -->
 指定すると、破損検査は前のブロックをすべてスキップして指定ブロックから開始されます。
-<parameter>startblock</parameter>をターゲットテーブルに含まれるブロックの範囲外で指定するとエラーになります。
+<parameter>startblock</parameter>を対象テーブルに含まれるブロックの範囲外で指定するとエラーになります。
         </para>
         <para>
 <!--
@@ -423,7 +423,7 @@ SET client_min_messages = DEBUG1;
          table.
 -->
 指定すると、残りのすべてのブロックをスキップして指定ブロックで破損検査が終了します。
-<parameter>endblock</parameter>をターゲットテーブルに含まれるブロックの範囲外で指定するとエラーになります。
+<parameter>endblock</parameter>を対象テーブルに含まれるブロックの範囲外で指定するとエラーになります。
         </para>
         <para>
 <!--
@@ -514,10 +514,10 @@ SET client_min_messages = DEBUG1;
   index that is equivalent to the existing, target index must only
   have entries that can be found in the existing structure.
 -->
-B-Tree検証関数の<parameter>heapallindexed</parameter>引数が<literal>true</literal>ならば、ターゲットのインデックスリレーションと関連付けられたテーブルに対して追加の検証フェーズが実施されます。
+B-Tree検証関数の<parameter>heapallindexed</parameter>引数が<literal>true</literal>ならば、対象のインデックスリレーションと関連付けられたテーブルに対して追加の検証フェーズが実施されます。
 これは<quote>ダミー</quote>の<command>CREATE INDEX</command>操作から構成され、インメモリ上の一時的なサマリ構造（これは必要に応じて基礎的な最初の検証フェーズで構築されます）に対する仮想的な新しいインデックスタプルがすべて存在することをチェックします。
-サマリ構造はターゲットのインデックスで見つかったすべてのタプルに対して<quote>指紋採取(fingerprint)</quote>を行います。
-<parameter>heapallindexed</parameter>検証の背後にある高レベルの原理は、新しいインデックスが既存のインデックスと等しいこと、ターゲットインデックスが既存の構造中に見つかったエントリのみを含むことです。
+サマリ構造は対象のインデックスで見つかったすべてのタプルに対して<quote>指紋採取(fingerprint)</quote>を行います。
+<parameter>heapallindexed</parameter>検証の背後にある高レベルの原理は、新しいインデックスが既存のインデックスと等しいこと、対象のインデックスが既存の構造中に見つかったエントリのみを含むことです。
  </para>
  <para>
 <!--

--- a/doc/src/sgml/dml.sgml
+++ b/doc/src/sgml/dml.sgml
@@ -539,8 +539,8 @@ DELETE FROM products
    can lead to a lot of duplicated columns, so it is often more useful to
    qualify it so as to return just the source or target row.  For example:
 -->
-<command>MERGE</command>では、<literal>RETURNING</literal>で利用できるデータは、ソース行の内容と挿入、更新、または削除された対象行の内容です。
-ソースと対象が多くの同じ列を持つことは非常に一般的であるため、<literal>RETURNING *</literal>を指定すると、多くの重複した列が発生する可能性があります。そのため、ソース行または対象行だけを返すように修飾するのがより有用なことがしばしばあります。
+<command>MERGE</command>では、<literal>RETURNING</literal>で利用できるデータは、元となる行の内容と挿入、更新、または削除された対象行の内容です。
+元となるものと対象が多くの同じ列を持つことは非常に一般的であるため、<literal>RETURNING *</literal>を指定すると、多くの重複した列が発生する可能性があります。そのため、元となる行または対象行だけを返すように修飾するのがより有用なことがしばしばあります。
 例を示します。
 <programlisting>
 MERGE INTO products p USING new_products n ON p.product_no = n.product_no

--- a/doc/src/sgml/fdwhandler.sgml
+++ b/doc/src/sgml/fdwhandler.sgml
@@ -672,7 +672,7 @@ AddForeignUpdateTargets(PlannerInfo *root,
 -->
 <command>UPDATE</command>と<command>DELETE</command>の操作は、テーブルスキャン関数によって事前にフェッチされた行に対して実行されます。
 FDWは、更新や削除の対象行を厳密に識別できるように行IDや主キー列の値といった追加情報を必要とするかもしれません。
-それをサポートするために、この関数は<command>UPDATE</command>や<command>DELETE</command>の間に外部テーブルから取得される列のリストに追加の隠された(または<quote>ジャンクの</quote>)ターゲット列を追加することができます。
+それをサポートするために、この関数は<command>UPDATE</command>や<command>DELETE</command>の間に外部テーブルから取得される列のリストに追加の隠された(または<quote>ジャンクの</quote>)対象列を追加できます。
     </para>
 
     <para>
@@ -703,7 +703,8 @@ FDWは、更新や削除の対象行を厳密に識別できるように行IDや
      junk column besides these, it might be wise to choose a name prefixed
      with your extension name, to avoid conflicts against other FDWs.
 -->
-それを行うには、必要な追加の値を表す<structname>Var</structname>を作成し、それをジャンク列の名前とともに<function>add_row_identity_var</function>に渡します。（複数の列が必要な場合は、これを二回以上実行できます。）
+それを行うには、必要な追加の値を表す<structname>Var</structname>を作成し、それをジャンク列の名前とともに<function>add_row_identity_var</function>に渡します。
+（複数の列が必要な場合は、これを二回以上実行できます。）
 必要とするそれぞれの<structname>Var</structname>に個別のジャンク列名を選択する必要があります。ただし、<structname>Var</structname>が<structfield>varno</structfield>フィールドを除いて同一である場合は、列名を共有することができるのでそうすべきです。
 コアシステムは、テーブルの<structfield>tableoid</structfield>列をジャンク列名<literal>tableoid</literal>に、<literal>ctid</literal>または<literal>ctid<replaceable>N</replaceable></literal>を<structfield>ctid</structfield>に使用し、<structfield>vartype</structfield> = <type>RECORD</type>と記された行全体の<structname>Var</structname>を<literal>wholerow</literal>に、<structfield>vartype</structfield>を記された行全体の<structname>Var</structname>を<literal>wholerow<replaceable>N</replaceable></literal>使用しており、テーブルで宣言された行型が同じです。
 できる限りこれらの名前を再利用してください（プランナは同一のジャンク列に対する重複したリクエストを結合します）。
@@ -718,7 +719,7 @@ FDWは、更新や削除の対象行を厳密に識別できるように行IDや
      operations, though <command>UPDATE</command> may still be feasible if the FDW
      relies on an unchanging primary key to identify rows.)
 -->
-もし<function>AddForeignUpdateTargets</function>ポインタが<literal>NULL</literal>に設定されている場合は、追加のターゲット式は追加されません。
+もし<function>AddForeignUpdateTargets</function>ポインタが<literal>NULL</literal>に設定されている場合は、追加の対象式は追加されません。
 (FDWが行を識別するのに不変の主キーに依存するのであれば<command>UPDATE</command>は依然として実現可能かもしれませんが、<command>DELETE</command>操作を実装することは不可能になるでしょう。)
     </para>
 
@@ -758,7 +759,7 @@ PlanForeignModify(PlannerInfo *root,
 <literal>plan</literal>は<structfield>fdwPrivLists</structfield>フィールドを除いて完成している<structname>ModifyTable</structname>プランノードです。
 <literal>resultRelation</literal>は対象の外部テーブルをレンジテーブルの添字で識別します。
 <literal>subplan_index</literal>は<structname>ModifyTable</structname>プランノードの対象がどれであるかを0始まりで識別します。
-これは、<literal>plan</literal>ノードのターゲットリレーションごとのサブ構造にインデックスを付けたい場合に使用してください。
+これは、<literal>plan</literal>ノードの対象リレーションごとのサブ構造にインデックスを付けたい場合に使用してください。
     </para>
 
     <para>
@@ -1242,7 +1243,7 @@ BeginForeignInsert(ModifyTableState *mtstate,
 -->
 <literal>mtstate</literal>は、実行中の<structname>ModifyTable</structname>プランノードの全体的な状態です。
 プランのグローバルデータと実行状態がこの構造体を通じて得られます。
-<literal>rinfo</literal>は<structname>ResultRelInfo</structname>構造体で、ターゲットの外部テーブルを記述します。
+<literal>rinfo</literal>は<structname>ResultRelInfo</structname>構造体で、対象の外部テーブルを記述します。
 （この操作中に必要なFDWのプライベート状態を保存するために<structname>ResultRelInfo</structname>の<structfield>ri_FdwState</structfield>フィールドが利用可能です。）
     </para>
 

--- a/doc/src/sgml/logical-replication.sgml
+++ b/doc/src/sgml/logical-replication.sgml
@@ -2189,8 +2189,8 @@ test_sub=# SELECT * FROM t1 ORDER BY id;
    <productname>PostgreSQL</productname>.
 -->
 論理レプリケーション操作は、サブスクリプションを所有するロールの権限を使用して実行されます。
-ターゲットテーブルで権限が失敗すると、レプリケーション競合が発生します。
-サブスクリプション所有者が適用されるターゲットテーブルで有効<link linkend="ddl-rowsecurity">行レベルセキュリティ</link>になりますが、レプリケーションされている<command>INSERT</command>、<command>UPDATE</command>、<command>DELETE</command>または<command>TRUNCATE</command>をポリシーが通常拒否するかどうかには関係ありません。
+対象テーブルで権限が失敗すると、レプリケーション競合が発生します。
+これは、サブスクリプション所有者が従う、対象テーブルで有効な<link linkend="ddl-rowsecurity">行レベルセキュリティ</link>と同じですが、レプリケーションされている<command>INSERT</command>、<command>UPDATE</command>、<command>DELETE</command>または<command>TRUNCATE</command>をポリシーが通常拒否するかどうかには関係ありません。
 行レベルセキュリティに対するこの制限は、<productname>PostgreSQL</productname>の将来のバージョンで解除される可能性があります。
   </para>
 

--- a/doc/src/sgml/logical-replication.sgml
+++ b/doc/src/sgml/logical-replication.sgml
@@ -2189,7 +2189,7 @@ test_sub=# SELECT * FROM t1 ORDER BY id;
    <productname>PostgreSQL</productname>.
 -->
 論理レプリケーション操作は、サブスクリプションを所有するロールの権限を使用して実行されます。
-対象テーブルで権限が失敗すると、レプリケーション競合が発生します。
+対象テーブルで権限違反が起こると、レプリケーション競合が発生します。
 これは、サブスクリプション所有者が従う、対象テーブルで有効な<link linkend="ddl-rowsecurity">行レベルセキュリティ</link>と同じですが、レプリケーションされている<command>INSERT</command>、<command>UPDATE</command>、<command>DELETE</command>または<command>TRUNCATE</command>をポリシーが通常拒否するかどうかには関係ありません。
 行レベルセキュリティに対するこの制限は、<productname>PostgreSQL</productname>の将来のバージョンで解除される可能性があります。
   </para>

--- a/doc/src/sgml/ref/alter_table.sgml
+++ b/doc/src/sgml/ref/alter_table.sgml
@@ -592,7 +592,7 @@ WITH ( MODULUS <replaceable class="parameter">numeric_literal</replaceable>, REM
 この構文を使用すると、列の圧縮方式を設定し、将来挿入される値がどのように圧縮されるかを決定できます（格納モードで圧縮が許可されている場合）。
 これによってテーブルが書き換えられることはないため、既存のデータは他の圧縮方式で圧縮されたままの可能性があります。
 テーブルを<application>pg_restore</application>でリストアした場合、すべての値は設定された圧縮方式で書き直されます。
-しかし、データが別のリレーションから挿入された場合(例えば<command>INSERT ... SELECT</command>によって)、ソーステーブルからの値は必ずしも非TOAST化されるとは限らないため、以前に圧縮されたデータは、ターゲット列の圧縮方式で再圧縮されるのではなく、既存の圧縮方式を保持する場合があります。
+しかし、データが別のリレーションから挿入された場合(例えば<command>INSERT ... SELECT</command>によって)、元となるテーブルからの値は必ずしも非TOAST化されるとは限らないため、以前に圧縮されたデータは、対象列の圧縮方式で再圧縮されるのではなく、既存の圧縮方式を保持する場合があります。
 サポートされている圧縮方式は、<literal>pglz</literal>と<literal>lz4</literal>です。
 （<literal>lz4</literal>は、<productname>PostgreSQL</productname>のビルド時に<option>--with-lz4</option>が使用された場合にのみ使用できます。）
 さらに、<replaceable class="parameter">compression_method</replaceable>を<literal>default</literal>にすることができ、これにより、データ挿入時に<xref linkend="guc-default-toast-compression"/>設定を参照して、使用する方法を決定するデフォルトの動作が選択されます。

--- a/doc/src/sgml/ref/merge.sgml
+++ b/doc/src/sgml/ref/merge.sgml
@@ -125,8 +125,8 @@ DELETE
    NOTHING</literal> can be handy to skip non-interesting source rows before
    more fine-grained handling.
 -->
-<literal>DO NOTHING</literal>が指定されている場合、ソース行はスキップされます。
-アクションは指定された順序で評価されるため、<literal>DO NOTHING</literal>は、より詳細な処理の前に、関心のないソース行をスキップする場合に便利です。
+<literal>DO NOTHING</literal>が指定されている場合、元となる行はスキップされます。
+アクションは指定された順序で評価されるため、<literal>DO NOTHING</literal>は、より詳細な処理の前に、関心のない元となる行をスキップする場合に便利です。
   </para>
 
   <para>
@@ -143,7 +143,7 @@ DELETE
    of <command>SELECT</command>.
 -->
 オプションの<literal>RETURNING</literal>句は、挿入、更新、削除された各行に基づいて値を計算し、返すように<command>MERGE</command>を設定します。
-ソーステーブルまたは対象テーブルの列、あるいは<link linkend="merge-action"><function>merge_action()</function></link>関数を使用する式が計算可能です。
+元となるテーブルまたは対象テーブルの列、あるいは<link linkend="merge-action"><function>merge_action()</function></link>関数を使用する式が計算可能です。
 <command>INSERT</command>または<command>UPDATE</command>アクションが実行されると、対象テーブルの列の新しい値が使用されます。
 <command>DELETE</command>が実行されると、対象テーブルの列の古い値が使用されます。
 <literal>RETURNING</literal>リストの構文は、<command>SELECT</command>の出力リストと同じです。
@@ -285,7 +285,7 @@ DELETE
       <literal>*</literal> can be specified after the table name to explicitly
       indicate that descendant tables are included.
 -->
-ソーステーブル、ビュー、または遷移テーブルの名前(スキーマ修飾名も可)。
+元となるテーブル、ビュー、または遷移テーブルの名前(スキーマ修飾名も可)。
 テーブル名の前に<literal>ONLY</literal>を指定すると、指定したテーブルのみからの一致する行が含まれます。
 <literal>ONLY</literal>を指定しないと、指定したテーブルを継承するすべてのテーブルからも一致する行が含まれます。
 オプションで、テーブル名の後に<literal>*</literal>を指定して、子孫のテーブルが含まれることを明示的に示すことができます。
@@ -460,9 +460,9 @@ DELETE
       the source relation, since by definition there is no matching target row.
       Only the system attributes from the target table are accessible.
 -->
-<literal>WHEN MATCHED</literal>句の条件は、ソースリレーションとターゲットリレーションの両方の列を参照できます。
-<literal>WHEN NOT MATCHED BY SOURCE</literal>句の条件は、ターゲットリレーションの列のみを参照できます。これは、定義上、一致するソース行がないためです。
-<literal>WHEN NOT MATCHED [BY TARGET]</literal>句の条件は、ソースリレーションの列のみを参照できます。これは、定義上、一致する対象行がないためです。
+<literal>WHEN MATCHED</literal>句の条件は、元となるリレーションと対象リレーションの両方の列を参照できます。
+<literal>WHEN NOT MATCHED BY SOURCE</literal>句の条件は、対象リレーションの列のみを参照できます。これは、定義上、一致する元となる行がないためです。
+<literal>WHEN NOT MATCHED [BY TARGET]</literal>句の条件は、元となるリレーションの列のみを参照できます。これは、定義上、一致する対象行がないためです。
 対象テーブルのシステム属性のみにアクセスできます。
      </para>
     </listitem>
@@ -518,7 +518,7 @@ DELETE
       the source relation, since by definition there is no matching target row.
 -->
 <literal>VALUES</literal>句は1つしか指定できません。
-<literal>VALUES</literal>句はソースリレーションの列のみを参照できます。
+<literal>VALUES</literal>句は元となるリレーションの列のみを参照できます。
 これは、定義上、一致する対象行がないためです。
      </para>
     </listitem>
@@ -701,7 +701,7 @@ DELETE
       function to return additional information about the action executed.
 -->
 各行が変更（挿入、更新、削除）された後に<command>MERGE</command>コマンドによって計算され、返される式です。
-式には、ソーステーブルまたは対象テーブルの任意の列、あるいは実行されたアクションに関する追加情報を返す<link linkend="merge-action"><function>merge_action()</function></link>関数を使用できます。
+式には、元となるテーブルまたは対象テーブルの任意の列、あるいは実行されたアクションに関する追加情報を返す<link linkend="merge-action"><function>merge_action()</function></link>関数を使用できます。
      </para>
      <para>
 <!--
@@ -712,9 +712,9 @@ DELETE
       qualifying the <literal>*</literal> with the name or alias of the source
       or target table.
 -->
-<literal>*</literal>を指定すると、ソーステーブルのすべての列が返され、その後に対象テーブルのすべての列が返されます。
-多くの場合、ソーステーブルと対象テーブルは同じ列を多く持つため、この方法では重複が多くなります。
-この問題を回避するには、ソーステーブルまたは対象テーブルの名前または別名で<literal>*</literal>を修飾します。
+<literal>*</literal>を指定すると、元となるテーブルのすべての列が返され、その後に対象テーブルのすべての列が返されます。
+多くの場合、元となるテーブルと対象テーブルは同じ列を多く持つため、この方法では重複が多くなります。
+この問題を回避するには、元となるテーブルまたは対象テーブルの名前または別名で<literal>*</literal>を修飾します。
      </para>
     </listitem>
    </varlistentry>
@@ -801,7 +801,7 @@ MERGE <replaceable class="parameter">total_count</replaceable>
        The resulting query will be optimized normally and will produce
        a set of candidate change rows. For each candidate change row,
 -->
-ソーステーブルから対象テーブルへの結合を実行します。
+元となるテーブルから対象テーブルへの結合を実行します。
 結果の問合せは通常どおり最適化され、一連の変更候補行が生成されます。
 各変更候補行について、
        <orderedlist>
@@ -864,7 +864,7 @@ MERGE <replaceable class="parameter">total_count</replaceable>
           triggers for the action's event type, they are used to perform the
           action instead.
 -->
-ターゲットリレーションがアクションのイベントタイプに対して<literal>INSTEAD OF ROW</literal>トリガを持つビューである場合、それらは代わりにアクションを実行するために使われます。
+対象リレーションがアクションのイベントタイプに対して<literal>INSTEAD OF ROW</literal>トリガを持つビューである場合、それらは代わりにアクションを実行するために使われます。
          </para>
         </listitem>
        </orderedlist></para>


### PR DESCRIPTION
#3297 の対応です。

基本的に
source -> 元となる
target -> 対象
としています。

ただし、"~ source"でひとまとまりっぽいものはそのままです。（"data source"だけだったかな）