### PR TITLE
「pgupgrade.sgmlの17.0対応です #3310」の続き

### DIFF
--- a/doc/src/sgml/ref/pgupgrade.sgml
+++ b/doc/src/sgml/ref/pgupgrade.sgml
@@ -601,7 +601,7 @@ make prefix=/usr/local/pgsql.new install
 <application>pg_upgrade</application>は論理スロットの移行を試みます。
 これは、新しいパブリッシャー上で同じ論理スロットを手動で定義する必要性を回避するのに役立ちます。
 論理スロットの移行は、古いクラスタがバージョン17.0以降の場合にのみサポートされます。
-バージョン17.0より前のクラスタ上の論理スロットは、無視されます。
+バージョン17.0より前のクラスタ上の論理スロットは、警告なく無視されます。
     </para>
 
     <para>
@@ -674,7 +674,7 @@ make prefix=/usr/local/pgsql.new install
        is not <literal>true</literal>.
 -->
 古いクラスタの全てのスロットが使用可能でなければなりません。
-つまり<link linkend="view-pg-replication-slots">pg_replication_slots</link>.<structfield>conflicting</structfield>が<literal>true</literal>でないこと。
+つまり<link linkend="view-pg-replication-slots">pg_replication_slots</link>.<structfield>conflicting</structfield>が<literal>true</literal>であってはいけません。
       </para>
      </listitem>
      <listitem>
@@ -686,7 +686,7 @@ make prefix=/usr/local/pgsql.new install
        is <literal>false</literal>.
 -->
 新しいクラスタは、永続的な論理スロットを持ってはなりません。
-つまり、<link linkend="view-pg-replication-slots">pg_replication_slots</link>.<structfield>temporary</structfield>が<literal>false</literal>でないこと。
+つまり、<link linkend="view-pg-replication-slots">pg_replication_slots</link>.<structfield>temporary</structfield>が<literal>false</literal>であってはいけません。
       </para>
      </listitem>
     </itemizedlist>


### PR DESCRIPTION
１箇所、指摘の対応漏れがあったので修正しました。
silentlyは「警告なく」としています。
また、２箇所文末が他と違うところがあったので合わせて修正しています。