### PR TITLE
「update pgbench for 17.0 #3265」の続き

### DIFF
--- a/doc/src/sgml/ref/pgbench.sgml
+++ b/doc/src/sgml/ref/pgbench.sgml
@@ -340,7 +340,7 @@ pgbench <optional> <replaceable>options</replaceable> </optional> <replaceable>d
 -->
 <literal>g</literal>(クライアント側データ生成)は、データは<command>pgbench</command>クライアントで生成されてからサーバに送られます。
 これは<command>COPY</command>でクライアント/サーバの帯域を大きく使います。
-<command>pgbench</command>は、バージョン14またはそれ以降の<productname>PostgreSQL</productname>では<option>FREEZE</option>オプションを使用して、パーティションが有効になっている場合には、<literal>pgbench_accounts</literal>テーブルを除き、その後の<command>VACUUM</command>を高速化します。
+<command>pgbench</command>は、バージョン14またはそれ以降の<productname>PostgreSQL</productname>ではパーティションが有効になっている<literal>pgbench_accounts</literal>テーブルを除き、<option>FREEZE</option>オプションを使用してその後の<command>VACUUM</command>を高速化します。
 <literal>g</literal>を使うと、すべてのテーブルのためにデータを生成する間、100,000行毎にメッセージを1つログ出力するようになります。
            </para>
            <para>


### PR DESCRIPTION
改めて精査しましたが、
・pgbenchはパーティションオプションをつけることでpgbench_account表をパーテイション化できる
https://pgsql-jp.github.io/current/html/pgbench.html

・COPY FREEZEはパーティション表では利用できない
https://pgsql-jp.github.io/current/html/sql-copy.html

・COPY FREEZEするとその後のVACUUMが早くなる
→これはVACUUMの中で実行する処理を事前に行うので自明かなと思います。

ですので、PRした内容で良いと思いますが気になる点があればお知らせください。
