### PR TITLE
update backup.sgml, pg_dump.sgml, pg_dumpall.sgml for 17.5

### DIFF
--- a/doc/src/sgml/backup.sgml
+++ b/doc/src/sgml/backup.sgml
@@ -175,7 +175,7 @@ pg_dump <replaceable class="parameter">dbname</replaceable> &gt; <replaceable cl
     settings. The general command form to restore a text dump is
 -->
 <application>pg_dump</application>で作成されたテキストファイルは、デフォルト設定の<application>psql</application>プログラムで読み込まれることを意図しています。
-以下に、ダンプをリストアする一般的なコマンドを示します。
+以下に、テキストダンプをリストアする一般的なコマンドを示します。
 <synopsis>
 psql -X <replaceable class="parameter">dbname</replaceable> &lt; <replaceable class="parameter">dumpfile</replaceable>
 </synopsis>
@@ -197,7 +197,7 @@ psql -X <replaceable class="parameter">dbname</replaceable> &lt; <replaceable cl
 ここで<replaceable class="parameter">dumpfile</replaceable>は<application>pg_dump</application>コマンドにより出力されたファイルです。
 <replaceable class="parameter">dbname</replaceable>データベースはこのコマンドでは作成されません。
 （例えば<literal>createdb -T template0 <replaceable class="parameter">dbname</replaceable></literal> のようにして）<application>psql</application>を実行する前に自分で<literal>template0</literal>から作成してください。
-<application>psql</application>をデフォルト設定で実行することを保証するためには、<option>-X</option>(<option>&#45;-no-psqlrc</option>)オプションを使用します。
+<application>psql</application>をデフォルト設定で実行することを保証するためには、<option>-X</option>(<option>--no-psqlrc</option>)オプションを使用します。
 <application>psql</application>は<application>pg_dump</application>と似たような、接続データベースサーバと使用するユーザ名を指定するオプションに対応しています。
 詳細については、<xref linkend="app-psql"/>のリファレンスページを参照してください。
    </para>
@@ -207,7 +207,7 @@ psql -X <replaceable class="parameter">dbname</replaceable> &lt; <replaceable cl
     Non-text file dumps should be restored using the <xref
     linkend="app-pgrestore"/> utility.
 -->
-テキスト形式ではないダンプファイルは<xref linkend="app-pgrestore"/> ユーティリティを使いリストアします。
+テキスト形式ではないダンプファイルは<xref linkend="app-pgrestore"/>ユーティリティを使いリストアします。
    </para>
 
    <para>

--- a/doc/src/sgml/ref/pg_dump.sgml
+++ b/doc/src/sgml/ref/pg_dump.sgml
@@ -2332,7 +2332,7 @@ CREATE DATABASE foo WITH TEMPLATE template0;
    restore process and prevent potential conflicts with
    non-default <application>psql</application> configurations.
 -->
-一般的に、データベースを平文の<application>pg_dump</application>スクリプトからリストアする場合、クリーンなリストアプロセスを保証し、デフォルト以外の<application>psql</application>設定との潜在的な競合を防ぐために、<option>-X</option>(<option>&#45;-no-psqlrc</option>)オプションの使用を推奨します。
+一般的に、データベースを平文の<application>pg_dump</application>スクリプトからリストアする場合、クリーンなリストアプロセスを保証し、デフォルト以外の<application>psql</application>設定との潜在的な競合を防ぐために、<option>-X</option>(<option>--no-psqlrc</option>)オプションの使用を推奨します。
   </para>
  </refsect1>
 

--- a/doc/src/sgml/ref/pg_dumpall.sgml
+++ b/doc/src/sgml/ref/pg_dumpall.sgml
@@ -1142,7 +1142,7 @@ exclude database <replaceable class="parameter">PATTERN</replaceable>
    include <application>psql</application> meta-commands, it may be
    incompatible with clients other than <application>psql</application>.
 -->
-一般的に、データベースを<application>pg_dumpall</application>スクリプトからリストアする場合、クリーンなリストアプロセスを保証し、デフォルト以外の<application>psql</application>設定との潜在的な競合を防ぐために、<option>-X</option>(<option>&#45;-no-psqlrc</option>)オプションの使用を推奨します。
+一般的に、データベースを<application>pg_dumpall</application>スクリプトからリストアする場合、クリーンなリストアプロセスを保証し、デフォルト以外の<application>psql</application>設定との潜在的な競合を防ぐために、<option>-X</option>(<option>--no-psqlrc</option>)オプションの使用を推奨します。
 さらに、<application>pg_dumpall</application>スクリプトは<application>psql</application>メタコマンドを含む場合があるため、<application>psql</application>以外のクライアントとは互換性がない可能性があります。
   </para>
  </refsect1>


### PR DESCRIPTION
https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=76601c0c885aca203966d8f6f6d6683726a0823b;hp=50cd651254354397ca2f2b795dd6aac300826076

変更点は上記コミットのもので、psqlを用いて平文pg_dumpスクリプトやpg_dumpallスクリプトをリストアする場合に、-X(--no-psqlrc)を使用してデフォルト設定で動作させることを推奨する文言が追加されています。