### PR TITLE
pg_monitorロールのメンバの統一

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -39780,7 +39780,7 @@ SELECT pg_size_pretty(sum(pg_relation_size(relid))) AS total_size
         the <literal>pg_monitor</literal> role by default, but other users can
         be granted EXECUTE to run the function.
 -->
-デフォルトではこの関数の実行はスーパーユーザと<literal>pg_monitor</literal>ロールに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザと<literal>pg_monitor</literal>ロールのメンバに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -9340,7 +9340,7 @@ SELECT pg_size_pretty(sum(pg_relation_size(relid))) AS total_size
         the <literal>pg_monitor</literal> role by default, but other users can
         be granted EXECUTE to run the function.
 -->
-デフォルトではこの関数の実行はスーパーユーザと<literal>pg_monitor</literal>ロールに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザと<literal>pg_monitor</literal>ロールのメンバに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 


### PR DESCRIPTION
「pg_monitorロールの権限を持つロール」と「pg_monitorロールのメンバ」
が使い分けされていますが、ここだけ訳文が違いました。