### PR TITLE
段落の文の共通化（EXECUTE権限）

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -37175,7 +37175,7 @@ LOG:  Grand total: 1651920 bytes in 201 blocks; 622360 free (88 chunks); 1029560
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトではスーパーユーザのみ実施可能ですが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -37260,7 +37260,7 @@ LOG:  Grand total: 1651920 bytes in 201 blocks; 622360 free (88 chunks); 1029560
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトではスーパーユーザのみ実施可能ですが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -37350,7 +37350,7 @@ falseの場合、この関数はバックアップの完了後、WALがアーカ
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトではスーパーユーザのみ実施可能ですが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -37383,7 +37383,7 @@ falseの場合、この関数はバックアップの完了後、WALがアーカ
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトではスーパーユーザのみ実施可能ですが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -37800,7 +37800,7 @@ postgres=# SELECT '0/0'::pg_lsn + pd.segment_number * ps.setting::int + :offset 
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトではスーパーユーザのみ実施可能ですが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -37836,7 +37836,7 @@ postgres=# SELECT '0/0'::pg_lsn + pd.segment_number * ps.setting::int + :offset 
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -37859,7 +37859,7 @@ postgres=# SELECT '0/0'::pg_lsn + pd.segment_number * ps.setting::int + :offset 
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
      </tbody>
@@ -39624,7 +39624,7 @@ SELECT pg_size_pretty(sum(pg_relation_size(relid))) AS total_size
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -39882,7 +39882,7 @@ WALアーカイブステータスディレクトリ(<filename>pg_wal/archive_sta
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -39910,7 +39910,7 @@ WALアーカイブステータスディレクトリ(<filename>pg_wal/archive_sta
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para>
        <para>
 <!--
@@ -39953,7 +39953,7 @@ SELECT convert_from(pg_read_binary_file('file_in_utf8.txt'), 'UTF8');
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -6735,7 +6735,7 @@ LOG:  Grand total: 1651920 bytes in 201 blocks; 622360 free (88 chunks); 1029560
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトではスーパーユーザのみ実施可能ですが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -6820,7 +6820,7 @@ LOG:  Grand total: 1651920 bytes in 201 blocks; 622360 free (88 chunks); 1029560
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトではスーパーユーザのみ実施可能ですが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -6910,7 +6910,7 @@ falseの場合、この関数はバックアップの完了後、WALがアーカ
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトではスーパーユーザのみ実施可能ですが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -6943,7 +6943,7 @@ falseの場合、この関数はバックアップの完了後、WALがアーカ
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトではスーパーユーザのみ実施可能ですが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -7360,7 +7360,7 @@ postgres=# SELECT '0/0'::pg_lsn + pd.segment_number * ps.setting::int + :offset 
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトではスーパーユーザのみ実施可能ですが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -7396,7 +7396,7 @@ postgres=# SELECT '0/0'::pg_lsn + pd.segment_number * ps.setting::int + :offset 
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -7419,7 +7419,7 @@ postgres=# SELECT '0/0'::pg_lsn + pd.segment_number * ps.setting::int + :offset 
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
      </tbody>
@@ -9184,7 +9184,7 @@ SELECT pg_size_pretty(sum(pg_relation_size(relid))) AS total_size
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -9442,7 +9442,7 @@ WALアーカイブステータスディレクトリ(<filename>pg_wal/archive_sta
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -9470,7 +9470,7 @@ WALアーカイブステータスディレクトリ(<filename>pg_wal/archive_sta
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para>
        <para>
 <!--
@@ -9513,7 +9513,7 @@ SELECT convert_from(pg_read_binary_file('file_in_utf8.txt'), 'UTF8');
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザに関数を実行するEXECUTE権限を与えることができます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 

--- a/doc/src/sgml/monitoring.sgml
+++ b/doc/src/sgml/monitoring.sgml
@@ -6578,7 +6578,7 @@ SLRUでの切り詰めの数です。
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXECUTE権限を付与できます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -6677,7 +6677,7 @@ SLRUでの切り詰めの数です。
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXECUTE権限を付与できます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -6701,7 +6701,7 @@ SLRUでの切り詰めの数です。
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXECUTE権限を付与できます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -6725,7 +6725,7 @@ SLRUでの切り詰めの数です。
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXECUTE権限を付与できます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -6766,7 +6766,7 @@ SLRUでの切り詰めの数です。
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXECUTE権限を付与できます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -6792,7 +6792,7 @@ SLRUでの切り詰めの数です。
          This function is restricted to superusers by default, but other users
          can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXECUTE権限を付与できます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
 
@@ -6819,7 +6819,7 @@ SLRUでの切り詰めの数です。
         This function is restricted to superusers by default, but other users
         can be granted EXECUTE to run the function.
 -->
-この関数はデフォルトでスーパーユーザに限定されていますが、関数を実行できるように他のユーザにEXECUTE権限を付与できます。
+デフォルトではこの関数の実行はスーパーユーザに限定されますが、他のユーザにも関数を実行するEXECUTE権限を与えることができます。
        </para></entry>
       </row>
      </tbody>


### PR DESCRIPTION
以下の文を共通化しました。

This function is restricted to superusers by default, but other users can be granted EXECUTE to run the function.
デフォルトではこの関数の実行はスーパーユーザに限定されますが、
他のユーザにも関数を実行するEXECUTE権限を与えることができます。

This function is restricted to superusers and roles with privileges of the <literal>pg_monitor</literal> role by default, but other users can be granted EXECUTE to run the function.
デフォルトではこの関数の実行はスーパーユーザと
<literal>pg_monitor</literal>ロールの権限を持つロールに限定されますが、 他のユーザに関数を実行するEXECUTE権限を与えることができます。

This function is restricted to superusers and members of the <literal>pg_monitor</literal> role by default, but other users can be granted EXECUTE to run the function.
デフォルトではこの関数の実行はスーパーユーザと
<literal>pg_monitor</literal>ロールのメンバに限定されますが、
他のユーザに関数を実行するEXECUTE権限を与えることができます。

#2910 の対応です。