### PR TITLE
indexam.sgmlのanyについて、とその他の修正

### DIFF
--- a/doc/src/sgml/indexam.sgml
+++ b/doc/src/sgml/indexam.sgml
@@ -320,11 +320,11 @@ typedef struct IndexAmRoutine
 これはインデックススキャンによって何も返しません。
 しかし、最初のインデックス列に対する制限がないインデックススキャンでは、この引数は失敗します。
 プランナがこうしたスキャンキーをまったく持たないインデックスを使用することを決定する可能性がありますので、実際これは、<structfield>amoptionalkey</structfield>が真のインデックスはNULLインデックスを持たなければならないことを意味します。
-関連する制限として、プランナはこれらの列を制限しない問い合わせでインデックスを使用できることを前提とするため、複数のインデックス列をサポートするインデックスアクセスメソッドは1番目の後の列でNULL値のインデックスをサポート<emphasis></emphasis>しなければならないということがあります。
+関連する制限として、プランナはこれらの列を制限しない問い合わせでインデックスを使用できることを前提とするため、複数のインデックス列をサポートするインデックスアクセスメソッドは1番目の後の列でNULL値のインデックスをサポート<emphasis>しなければならない</emphasis>ということがあります。
 例えば、(a,b)に対するインデックスに、<literal>WHERE a = 4</literal>という条件で問い合わせを行うことを考えてみます。
 システムは、このインデックスを<literal>a = 4</literal>を持つ行をスキャンすることに使用できるものと仮定します。
 これはもし、<literal>b</literal>がNULLの場合の行をインデックスが省略する場合は間違っています。
-しかし、最初のインデックス列がNULLの場合に行を省略することは問題ありません
+しかし、最初のインデックス列がNULLの場合に行を省略することは問題ありません。
 また、NULLをインデックス付けするインデックスアクセスメソッドは<structfield>amsearchnulls</structfield>を設定する可能性があります。
 これは検索条件として<literal>IS NULL</literal>および<literal>IS NOT NULL</literal>句をサポートすることを示します。
   </para>
@@ -980,7 +980,7 @@ amgettuple (IndexScanDesc scan,
 真の場合、そのタプルのTIDが<literal>scan</literal>に格納されます。
 <quote>成功</quote>とは、単にインデックスにスキャンキーに一致する項目があったことを意味しているだけです。
 タプルが必ずヒープ内に存在することや、呼び出し元のスナップショットの試験を通過したことを意味してはいません。
-成功の暁には、<function>amgettuple</function>は<literal>scan-&gt;xs_recheck</literal>を真か偽かに設定しなければなりません。
+成功した場合、<function>amgettuple</function>は<literal>scan-&gt;xs_recheck</literal>を真または偽に設定しなければなりません。
 偽の意味は、インデックス項目が確実にスキャンキーに一致することです。
 真の意味は、これが確かなことではなく、スキャンキーで表示された条件がヒープタプルを取り出された後で再検査されなければならないことです。
 この対策は<quote>非可逆</quote>インデックス演算子をサポートします。
@@ -1009,7 +1009,7 @@ amgettuple (IndexScanDesc scan,
    <function>amgettuple</function>, <function>amrescan</function>, or <function>amendscan</function>
    call for the scan.
 -->
-そのインデックスが<link linkend="indexes-index-only-scans">インデックスオンリースキャン</link>をサポートしている場合(つまり<function>amcanreturn</function>がすべての列に対して真を返す場合)、そのアクセスメソッドはスキャンが成功したならば<literal>scan-&gt;xs_want_itup</literal>も確認し、それが真の場合、そのインデックスエントリに対応する元のインデックスされたデータを返さなければなりません。
+そのインデックスが<link linkend="indexes-index-only-scans">インデックスオンリースキャン</link>をサポートしている場合（つまり<function>amcanreturn</function>がいずれかの列に対して真を返す場合）、そのアクセスメソッドはスキャンが成功したならば<literal>scan-&gt;xs_want_itup</literal>も確認し、それが真の場合、そのインデックスエントリに対応する元のインデックスされたデータを返さなければなりません。
 <function>amcanreturn</function>が列に対して偽を返す場合、その列はNULLとして返されます。
 返却されるデータは、<literal>scan-&gt;xs_itupdesc</literal>タプルディスクリプタとともに<literal>scan-&gt;xs_itup</literal>に格納された<structname>IndexTuple</structname>ポインタの形式か、あるいは、<literal>scan-&gt;xs_hitupdesc</literal>タプルディスクリプタとともに<literal>scan-&gt;xs_hitup</literal>に格納された<structname>HeapTuple</structname>ポインタの形式です。
 （後者の形式は、再構成されたデータが<structname>IndexTuple</structname>に収まらない場合に使用するべきです。）


### PR DESCRIPTION
emphasisで囲む文が空になっていたのを修正。
句読点の抜けを修正。
「成功の暁には」を「成功した場合」に修正。
anyが「すべての」になっていたのを「いずれかの」に修正。