### PR TITLE
table/tablesの見直し

### DIFF
--- a/doc/src/sgml/file-fdw.sgml
+++ b/doc/src/sgml/file-fdw.sgml
@@ -180,7 +180,7 @@
   <command>COPY</command> options typically written without a value, you can pass
   the value TRUE, since all such options are Booleans.
 -->
-<command>COPY</command>では<literal>HEADER</literal>といったオプションを対応する値なしで指定できるのに対して、外部データラッパーの構文では全ての場合において値を指定する必要がある点に注意してください。
+<command>COPY</command>では<literal>HEADER</literal>といったオプションを対応する値なしで指定できるのに対して、外部テーブルのオプション構文では全ての場合において値を指定する必要がある点に注意してください。
 通常の値なしで指定される<command>COPY</command>オプションを有効にするには、それらはすべてブールオプションであるため、代わりにTRUEを渡すことができます。
  </para>
 

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -25120,7 +25120,7 @@ where <replaceable class="parameter">json_table_column</replaceable> is:
       In the examples that follow, the following table containing JSON data
       will be used:
 -->
-以下の例では、次の表にJSONデータを含めます。
+以下の例では、次のテーブルにJSONデータを含めます。
 
 <programlisting>
 CREATE TABLE my_films ( js jsonb );
@@ -39466,7 +39466,7 @@ SELECT pg_size_pretty(sum(pg_relation_size(relid))) AS total_size
         Removes the BRIN index tuple that summarizes the page range covering
         the given table block, if there is one.
 -->
-指定のブロックを含むページ範囲が要約されていれば、それを含むページ範囲を要約するBRINインデックスタプルを削除します。
+指定のテーブルブロックを含むページ範囲を要約するBRINインデックスタプルが存在する場合、それを削除します。
        </para></entry>
       </row>
 

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -4808,7 +4808,7 @@ where <replaceable class="parameter">json_table_column</replaceable> is:
       In the examples that follow, the following table containing JSON data
       will be used:
 -->
-以下の例では、次の表にJSONデータを含めます。
+以下の例では、次のテーブルにJSONデータを含めます。
 
 <programlisting>
 CREATE TABLE my_films ( js jsonb );

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -9026,7 +9026,7 @@ SELECT pg_size_pretty(sum(pg_relation_size(relid))) AS total_size
         Removes the BRIN index tuple that summarizes the page range covering
         the given table block, if there is one.
 -->
-指定のブロックを含むページ範囲が要約されていれば、それを含むページ範囲を要約するBRINインデックスタプルを削除します。
+指定のテーブルブロックを含むページ範囲を要約するBRINインデックスタプルが存在する場合、それを削除します。
        </para></entry>
       </row>
 

--- a/doc/src/sgml/ref/alter_table.sgml
+++ b/doc/src/sgml/ref/alter_table.sgml
@@ -2224,7 +2224,7 @@ ALTER TABLE distributors ADD COLUMN address varchar(30);
    That will cause all existing rows in the table to be filled with null
    values for the new column.
 -->
-これは表の既存の行すべてで、新しい列をNULL値で埋めることになります。
+これはテーブルの既存の行すべてで、新しい列をNULL値で埋めることになります。
   </para>
 
   <para>

--- a/doc/src/sgml/ref/values.sgml
+++ b/doc/src/sgml/ref/values.sgml
@@ -100,7 +100,7 @@ VALUES ( <replaceable class="parameter">expression</replaceable> [, ...] ) [, ..
       default value should be inserted.  <literal>DEFAULT</literal> cannot
       be used when <command>VALUES</command> appears in other contexts.
 -->
-定数あるいは式です。これを計算した結果が、表（行セット）の中の指定した場所に挿入されます。
+定数あるいは式です。これを計算した結果が、テーブル（行セット）の中の指定した場所に挿入されます。
 <command>VALUES</command>リストを<command>INSERT</command>の最上位レベルで使用する場合は、<replaceable class="parameter">expression</replaceable>を<literal>DEFAULT</literal>で置き換えることができます。
 これは、その列のデフォルト値を挿入することを表します。
 他の場所で<command>VALUES</command>を使用する場合には、<literal>DEFAULT</literal>は使用できません。
@@ -216,7 +216,7 @@ VALUES (1, 'one'), (2, 'two'), (3, 'three');
    This will return a table of two columns and three rows.  It's effectively
    equivalent to:
 -->
-これは、列が二つで行が三つの表を返します。事実上、これは次と同じことです。
+これは、列が二つで行が三つのテーブルを返します。事実上、これは次と同じことです。
 
 <programlisting>
 SELECT 1 AS column1, 'one' AS column2

--- a/doc/src/sgml/release-17.sgml
+++ b/doc/src/sgml/release-17.sgml
@@ -2791,7 +2791,7 @@ dshashテーブルが1ギガバイトを超えて拡張できるようになり�
       process several million tables.
 -->
 これにより、<quote>invalid DSA memory alloc request size</quote>などのエラーが回避されます。
-これは、例えば数百万の表を処理するトランザクションで発生する可能性がありました。
+これは、例えば数百万のテーブルを処理するトランザクションで発生する可能性がありました。
      </para>
     </listitem>
 


### PR DESCRIPTION
データベースのテーブルを指しているところはテーブルと表記するように見直しました。