### PR TITLE
<productname>PostgreSQL</productname>のコア配布物に統一

### DIFF
--- a/doc/src/sgml/contrib.sgml
+++ b/doc/src/sgml/contrib.sgml
@@ -314,7 +314,7 @@ pages.
 -->
 一部のアプリケーションは、<productname>PostgreSQL</productname>サーバ自体で実行されます。
 現在、そのようなアプリケーションは<literal>contrib</literal>ディレクトリに含まれていません。
-コア<productname>PostgreSQL</productname>ディストリビューションの一部であるサーバアプリケーションについては、<xref linkend="reference-server"/>も参照してください。
+<productname>PostgreSQL</productname>のコア配布物の一部であるサーバアプリケーションについては、<xref linkend="reference-server"/>も参照してください。
   </para>
 
  </sect1>

--- a/doc/src/sgml/external-projects.sgml
+++ b/doc/src/sgml/external-projects.sgml
@@ -148,7 +148,7 @@
    information, refer to its website
    and documentation.
 -->
-さらに、<productname>PostgreSQL</productname>のコア配布以外で開発、保守される手続き言語も多く存在します。
+さらに、<productname>PostgreSQL</productname>のコア配布物以外で開発、保守される手続き言語も多く存在します。
 <ulink url="https://wiki.postgresql.org/wiki/PL_Matrix">手続き言語</ulink>の一覧がPostgreSQL wikiで維持されています。
 これらのプロジェクトの中には、<productname>PostgreSQL</productname>と同じライセンスで提供されないものがあることに注意してください。
 ライセンス情報など各手続き言語の詳細については、そのWebサイトや文書を参照してください。

--- a/doc/src/sgml/spgist.sgml
+++ b/doc/src/sgml/spgist.sgml
@@ -95,7 +95,7 @@
   includes the <acronym>SP-GiST</acronym> operator classes shown in
   <xref linkend="spgist-builtin-opclasses-table"/>.
 -->
-<productname>PostgreSQL</productname>のコアディストリビューションには<xref linkend="spgist-builtin-opclasses-table"/>に示される<acronym>SP-GiST</acronym>の演算子クラスが含まれます。
+<productname>PostgreSQL</productname>のコア配布物には<xref linkend="spgist-builtin-opclasses-table"/>に示される<acronym>SP-GiST</acronym>の演算子クラスが含まれます。
  </para>
 
   <table id="spgist-builtin-opclasses-table">

--- a/doc/src/sgml/storage.sgml
+++ b/doc/src/sgml/storage.sgml
@@ -1774,7 +1774,7 @@ NULLビットマップは<firstterm>HEAP_HASNULL</firstterm>ビットが<structf
      linkend="brin">BRIN</link>.
 -->
 更新は、集約インデックスを除き、テーブルのインデックスによって参照される列を変更しません。
-コアの<productname>PostgreSQL</productname>配布で唯一の集約インデックスメソッドは<link linkend="brin">BRIN</link>です。
+<productname>PostgreSQL</productname>のコア配布物で唯一の集約インデックスメソッドは<link linkend="brin">BRIN</link>です。
      </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
「core <productname>PostgreSQL</productname> distribution」を 「<productname>PostgreSQL</productname>のコア配布物」に統一します。