### PR TITLE
trigger.sgml: 日本語訳の表現統一と文章構造の改善

### DIFF
--- a/doc/src/sgml/trigger.sgml
+++ b/doc/src/sgml/trigger.sgml
@@ -182,7 +182,7 @@
 文レベルの<literal>BEFORE</literal>トリガは、もちろん文が何かを始める前に発行され、文レベルの<literal>AFTER</literal>トリガは文の本当に最後に発行されます。
 これらのタイプのトリガはテーブル、ビュー、あるいは外部テーブルに定義できます。
 行レベルの<literal>BEFORE</literal>トリガは、特定の行が操作される直前に発行され、行レベルの<literal>AFTER</literal>トリガは文の終わり（ただし、全ての文レベルの<literal>AFTER</literal>トリガの前）に発行されます。
-これらのタイプのトリガは、外部テーブルに定義できますが、ビューには定義できません。
+これらのタイプのトリガは、テーブルおよび外部テーブルにのみ定義でき、ビューには定義できません。
 <literal>INSTEAD OF</literal>トリガはビューにのみ定義され、行レベルのみが許されます。
 つまり、ビュー上のそれぞれの行で処理が必要と判断された場合には、即座に発動します。
    </para>
@@ -290,7 +290,7 @@
     actions are performed.
 -->
 <command>MERGE</command>には個別のトリガは定義されません。
-かわりに、文レベルまたは行レベルの<command>UPDATE</command>、<command>DELETE</command>および<command>INSERT</command>トリガが、<command>MERGE</command>問い合わせで指定されたアクション(文レベルトリガの場合)および実行されたアクション(行レベルトリガの場合)に応じて起動されます。
+代わりに、文レベルまたは行レベルの<command>UPDATE</command>、<command>DELETE</command>および<command>INSERT</command>トリガが、<command>MERGE</command>問い合わせで指定されたアクション（文レベルトリガの場合）および実行されたアクション（行レベルトリガの場合）に応じて起動されます。
    </para>
 
    <para>
@@ -334,7 +334,7 @@
        row-level operation that invoked the trigger (the insertion,
        modification, or deletion of a particular table row).
 -->
-<symbol>NULL</symbol>を返して、現在の行への操作を飛ばすことができます。
+<symbol>NULL</symbol>を返して、現在の行への操作をスキップできます。
 これは、エグゼキュータにトリガの元になった行レベルの操作（特定のテーブル行の挿入、更新、削除）を行わないよう指示します。
       </para>
      </listitem>
@@ -583,7 +583,7 @@ C言語インタフェースでは、この時点では列の内容は未定義�
     for <command>UPDATE</command> and <command>DELETE</command> triggers.
 -->
 トリガをサポートするプログラミング言語はそれぞれ独自の方法で、トリガ関数で利用できるトリガの入力データを作成します。
-この入力データにはトリガイベント種類（例えば<command>INSERT</command>や<command>UPDATE</command>など、<command>CREATE TRIGGER</command>で指定された全ての引数）が含まれます。
+この入力データには、トリガイベントの種類（例えば<command>INSERT</command>や<command>UPDATE</command>）、および<command>CREATE TRIGGER</command>で指定された引数が含まれます。
 行レベルトリガの入力データには、<command>INSERT</command>および<command>UPDATE</command>トリガの場合は<varname>NEW</varname>行が、<command>UPDATE</command>および<command>DELETE</command>トリガの場合は<varname>OLD</varname>行が含まれます。
    </para>
 
@@ -862,7 +862,7 @@ typedef struct TriggerData
 <!--
             Returns true if the trigger fired before the operation.
 -->
-トリガが操作の前に(before)発行された場合真を返します。
+トリガが操作の前に(before)発行された場合に真を返します。
            </para>
           </listitem>
          </varlistentry>
@@ -874,7 +874,7 @@ typedef struct TriggerData
 <!--
             Returns true if the trigger fired after the operation.
 -->
-トリガが操作の後に(after)発行された場合真を返します。
+トリガが操作の後に(after)発行された場合に真を返します。
            </para>
           </listitem>
          </varlistentry>
@@ -886,7 +886,7 @@ typedef struct TriggerData
 <!--
             Returns true if the trigger fired instead of the operation.
 -->
-トリガがINSTEAD OFで発行された場合真を返します。
+トリガがINSTEAD OFで発行された場合に真を返します。
            </para>
           </listitem>
          </varlistentry>
@@ -898,7 +898,7 @@ typedef struct TriggerData
 <!--
             Returns true if the trigger fired for a row-level event.
 -->
-トリガが行レベルのイベントで発行された場合真を返します。
+トリガが行レベルのイベントで発行された場合に真を返します。
            </para>
           </listitem>
          </varlistentry>
@@ -910,7 +910,7 @@ typedef struct TriggerData
 <!--
             Returns true if the trigger fired for a statement-level event.
 -->
-トリガが文レベルのイベントで発行された場合真を返します。
+トリガが文レベルのイベントで発行された場合に真を返します。
            </para>
           </listitem>
          </varlistentry>
@@ -922,7 +922,7 @@ typedef struct TriggerData
 <!--
             Returns true if the trigger was fired by an <command>INSERT</command> command.
 -->
-トリガが<command>INSERT</command>コマンドで発行された場合真を返します。
+トリガが<command>INSERT</command>コマンドで発行された場合に真を返します。
            </para>
           </listitem>
          </varlistentry>
@@ -934,7 +934,7 @@ typedef struct TriggerData
 <!--
             Returns true if the trigger was fired by an <command>UPDATE</command> command.
 -->
-トリガが<command>UPDATE</command>コマンドで発行された場合真を返します。
+トリガが<command>UPDATE</command>コマンドで発行された場合に真を返します。
            </para>
           </listitem>
          </varlistentry>
@@ -946,7 +946,7 @@ typedef struct TriggerData
 <!--
             Returns true if the trigger was fired by a <command>DELETE</command> command.
 -->
-トリガが<command>DELETE</command>コマンドで発行された場合真を返します。
+トリガが<command>DELETE</command>コマンドで発行された場合に真を返します。
            </para>
           </listitem>
          </varlistentry>
@@ -958,7 +958,7 @@ typedef struct TriggerData
 <!--
             Returns true if the trigger was fired by a <command>TRUNCATE</command> command.
 -->
-トリガが<command>TRUNCATE</command>コマンドで発行された場合真を返します。
+トリガが<command>TRUNCATE</command>コマンドで発行された場合に真を返します。
            </para>
           </listitem>
          </varlistentry>
@@ -984,7 +984,7 @@ typedef struct TriggerData
 -->
 トリガの発行元のリレーションを記述する構造体へのポインタです。
 この構造体についての詳細は、<filename>utils/rel.h</filename>を参照してください。
-最も興味深いのは、<literal>tg_relation-&gt;rd_att</literal>（リレーションタプルの記述子）と<literal>tg_relation-&gt;rd_rel->relname</literal>です（リレーション名、これは<type>char*</type>ではなく<type>NameData</type>です。
+最も興味深いのは、<literal>tg_relation-&gt;rd_att</literal>（リレーションタプルの記述子）と<literal>tg_relation-&gt;rd_rel-&gt;relname</literal>です（リレーション名、これは<type>char*</type>ではなく<type>NameData</type>です。
 名前のコピーが必要な場合は、<type>char*</type>を得るために<literal>SPI_getrelname(tg_relation)</literal>を使用してください）。
        </para>
       </listitem>
@@ -1006,7 +1006,7 @@ typedef struct TriggerData
 -->
 トリガが発行された行へのポインタです。
 これは挿入される、削除される、あるいは更新される行です。
-もし<command>INSERT</command>/<command>DELETE</command>でこのトリガが発行された時、この行を別のもので置き換えたくない（<command>INSERT</command>の場合）場合や、その操作を飛ばしたくない場合は、これをこの関数から返してください。
+もし<command>INSERT</command>/<command>DELETE</command>でこのトリガが発行された時、この行を別のもので置き換えたくない（<command>INSERT</command>の場合）場合や、その操作をスキップしたくない場合は、これをこの関数から返してください。
 外部テーブルのトリガに対しては、システム列の値はここでは指定されません。
        </para>
       </listitem>
@@ -1028,7 +1028,7 @@ typedef struct TriggerData
 -->
 トリガが<command>UPDATE</command>で発行された場合は、行の新しいバージョンへのポインタです。
 <command>INSERT</command>もしくは<command>DELETE</command>の場合は、<symbol>NULL</symbol>です。
-<command>UPDATE</command>イベントの時、この行を別のもので置き換えたくない場合や操作を飛ばしたくない場合は、これをこの関数から返してください。
+<command>UPDATE</command>イベントの時、この行を別のもので置き換えたくない場合や操作をスキップしたくない場合は、これをこの関数から返してください。
 外部テーブルのトリガに対しては、システム列の値はここでは指定されません。
        </para>
       </listitem>
@@ -1323,7 +1323,7 @@ trigf(PG_FUNCTION_ARGS)
 ]]><!--
     /* count(*) returns int8, so be careful to convert */
 --><![CDATA[
-    /* count(*)はint8を返す。変換に注意してください*/
+    /* count(*)はint8を返すため、変換に注意してください */
     i = DatumGetInt64(SPI_getbinval(SPI_tuptable->vals[0],
                                     SPI_tuptable->tupdesc,
                                     1,
@@ -1378,7 +1378,7 @@ INSERT 0 0
 <!--
 &#45;- Insertion skipped and AFTER trigger is not fired
 -->
--- 挿入操作は飛ばされ、また、AFTERトリガも発行されません。
+-- 挿入操作はスキップされ、また、AFTERトリガも発行されません。
 
 =&gt; SELECT * FROM ttest;
  x


### PR DESCRIPTION
- 「飛ばす」→「スキップ」への用語統一
- 「かわりに」→「代わりに」への表記修正
- 括弧記号の全角統一と矢印記号の修正
- 説明文の構造改善と専門用語の統一
- コメント文の句読点修正