### PR TITLE
サブスクリプション関連の翻訳を修正

### DIFF
--- a/doc/src/sgml/ref/alter_subscription.sgml
+++ b/doc/src/sgml/ref/alter_subscription.sgml
@@ -196,7 +196,7 @@ ALTER SUBSCRIPTION <replaceable class="parameter">name</replaceable> RENAME TO <
           <literal>REFRESH PUBLICATION</literal> should then be executed separately.
           The default is <literal>true</literal>.
 -->
-falseにすると、このコマンドはテーブルを情報を更新しません。
+falseにすると、このコマンドはテーブル情報を更新しません。
 後で別に<literal>REFRESH PUBLICATION</literal>を実行することになります。
 デフォルトは<literal>true</literal>です。
          </para>
@@ -393,7 +393,7 @@ falseにすると、このコマンドはテーブルを情報を更新しませ
 受信データが何らかの制約に違反している場合、解決されるまで論理レプリケーションは停止します。
 <command>ALTER SUBSCRIPTION ... SKIP</command>コマンドを使用すると、論理レプリケーションワーカーはトランザクション内のすべてのデータ修正変更をスキップします。
 このオプションは、サブスクライバーで<link linkend="sql-createsubscription-params-with-two-phase"><literal>two_phase</literal></link>を有効にしてすでに準備されているトランザクションには影響しません。
-論理レプリケーションワーカーがトランザクションをスキップするかトランザクションを終了ことに成功した後、LSN(<structname>pg_subscription</structname>.<structfield>subskiplsn</structfield>に格納されています)がクリアされます。
+論理レプリケーションワーカーがトランザクションをスキップするかトランザクションを終了することに成功した後、LSN（<structname>pg_subscription</structname>.<structfield>subskiplsn</structfield>に格納されています）がクリアされます。
 論理レプリケーションの競合の詳細については<xref linkend="logical-replication-conflicts"/>を参照してください。
      </para>
 

--- a/doc/src/sgml/ref/pg_createsubscriber.sgml
+++ b/doc/src/sgml/ref/pg_createsubscriber.sgml
@@ -314,7 +314,7 @@ PostgreSQL documentation
 -->
 論理レプリケーションを設定するレプリケーションスロット名。
 複数の<option>--replication-slot</option>スイッチを書くことで、複数のレプリケーションスロットを指定できます。
-パブリケーションスロット名の数は、指定されたデータベースの数と一致する必要があります。
+レプリケーションスロット名の数は、指定されたデータベースの数と一致する必要があります。
 一致しない場合、エラーが報告されます。
 複数のレプリケーションスロット名スイッチの順序は、データベーススイッチの順序と一致する必要があります。
 このオプションを指定しない場合、サブスクリプション名がレプリケーションスロット名に割り当てられます。
@@ -353,7 +353,7 @@ PostgreSQL documentation
 <!--
        Print the <application>pg_createsubscriber</application> version and exit.
 -->
-<application>pg_createsubscriber</application>のバージョンを出力して終了します。
+<application>pg_createsubscriber</application>のバージョンを表示し、終了します。
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
- 「パブリケーションスロット」→「レプリケーションスロット」に修正
- 「テーブルを情報」→「テーブル情報」に修正
- トランザクション終了の表現を「終了こと」→「終了すること」に修正
- 括弧の表記を全角に統一（）
- バージョン表示の表現を「出力して終了」→「表示し、終了」に統一