### PR TITLE
fix translation of "context"

### DIFF
--- a/doc/src/sgml/ref/psql-ref.sgml
+++ b/doc/src/sgml/ref/psql-ref.sgml
@@ -6784,7 +6784,7 @@ testdb=&gt; \set PROMPT1 '%[%033[1;33;40m%]%n@%/%R%[%033[0m%]%# '
     <filename>.inputrc</filename> in your home directory:
 -->
 SQLオブジェクト名のタブ補完は、マッチする可能性のあるものを見つけるためサーバへの問い合わせの送信が必要です。
-コンテクストによっては、これが他の操作と干渉することもあります。
+コンテキストによっては、これが他の操作と干渉することもあります。
 たとえば、<command>BEGIN</command>の後、タブ補完の問い合わせがその間に発行されれば、<command>SET TRANSACTION ISOLATION LEVEL</command>を発行するには遅いでしょう。
 タブ補完を何らかの事情により使用したくなければ、ホームディレクトリ内の<filename>.inputrc</filename>というファイルに以下のように書き込むことで無効にできます。
 <programlisting>


### PR DESCRIPTION
contextの訳を揃えました。
ここだけ「コンテクスト」になってました。（このファイルの中だけでも他は「コンテキスト」です。）