### PR TITLE
SQL-standard,SQL-conformingの訳の統一

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -15996,7 +15996,7 @@ GINインデックススキャンにより返されるセットのソフトな�
         <literal>safe_encoding</literal> is the default setting.
 -->
 文字列リテラルの中で引用符が<literal>\'</literal>で表現されるかどうかを管理します。
-引用符の表現としてSQL準拠の方式では二重化（<literal>''</literal>）ですが、<productname>PostgreSQL</productname>は歴史的に<literal>\'</literal>も受け付けます。
+引用符の表現として標準SQLの方式では二重化（<literal>''</literal>）ですが、<productname>PostgreSQL</productname>は歴史的に<literal>\'</literal>も受け付けます。
 とは言っても、いくつかのクライアント文字集合符号化方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
 クライアント側のコードが事実上エスケープを正しく扱わない場合、SQLインジェクション攻撃が可能になります。この危険性の回避は、サーバが逆スラッシュでエスケープされた引用符を含む問い合わせを拒絶するようにします。
 許可される<varname>backslash_quote</varname>の値は、<literal>on</literal> （常に <literal>\'</literal> を許可）,<literal>off</literal> （常に拒否）、および<literal>safe_encoding</literal> （クライアント符号化方式がASCIIの<literal>\</literal>を許可しないときのみ、マルチバイト文字内で許可）。

--- a/doc/src/sgml/config3.sgml
+++ b/doc/src/sgml/config3.sgml
@@ -2202,7 +2202,7 @@ GINインデックススキャンにより返されるセットのソフトな�
         <literal>safe_encoding</literal> is the default setting.
 -->
 文字列リテラルの中で引用符が<literal>\'</literal>で表現されるかどうかを管理します。
-引用符の表現としてSQL準拠の方式では二重化（<literal>''</literal>）ですが、<productname>PostgreSQL</productname>は歴史的に<literal>\'</literal>も受け付けます。
+引用符の表現として標準SQLの方式では二重化（<literal>''</literal>）ですが、<productname>PostgreSQL</productname>は歴史的に<literal>\'</literal>も受け付けます。
 とは言っても、いくつかのクライアント文字集合符号化方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
 クライアント側のコードが事実上エスケープを正しく扱わない場合、SQLインジェクション攻撃が可能になります。この危険性の回避は、サーバが逆スラッシュでエスケープされた引用符を含む問い合わせを拒絶するようにします。
 許可される<varname>backslash_quote</varname>の値は、<literal>on</literal> （常に <literal>\'</literal> を許可）,<literal>off</literal> （常に拒否）、および<literal>safe_encoding</literal> （クライアント符号化方式がASCIIの<literal>\</literal>を許可しないときのみ、マルチバイト文字内で許可）。

--- a/doc/src/sgml/ref/savepoint.sgml
+++ b/doc/src/sgml/ref/savepoint.sgml
@@ -229,7 +229,7 @@ COMMIT;
 SQLでは、同じ名前のセーブポイントが設定された時は、自動的に古い方のセーブポイントを破棄することになっています。
 <productname>PostgreSQL</productname>では、古いセーブポイントも保持されますが、ロールバックや解放時には新しい方のセーブポイントが使用されます。
 （<command>RELEASE SAVEPOINT</command>を用いて新しいセーブポイントが解放されると、再び<command>ROLLBACK TO SAVEPOINT</command>や<command>RELEASE SAVEPOINT</command>から古いセーブポイントが使用できるようになります。）
-この点以外は、<command>SAVEPOINT</command>は完全にSQLに従っています。
+この点以外は、<command>SAVEPOINT</command>は完全にSQLに準拠しています。
   </para>
  </refsect1>
 


### PR DESCRIPTION
SQL-standardを標準SQL、SQL-conformingをSQL準拠に統一。
 #3135 の漏れの修正です。