### PR TITLE
character set、character repertoireの訳語変更

### DIFF
--- a/doc/src/sgml/bki.sgml
+++ b/doc/src/sgml/bki.sgml
@@ -716,7 +716,7 @@ Cコード中でOIDの実際の数値を書くのは非常に良くないと考�
       not currently represented as catalog OIDs, but have a set of values
       known to <filename>genbki.pl</filename>.
 -->
-文字セット符号化方式を参照する整数の列に<literal>BKI_LOOKUP(encoding)</literal>を加えることも許容されます。これは今のところカタログのOIDとして現れませんが、値の集合を<filename>genbki.pl</filename>に知らせます。
+文字集合符号化方式を参照する整数の列に<literal>BKI_LOOKUP(encoding)</literal>を加えることも許容されます。これは今のところカタログのOIDとして現れませんが、値の集合を<filename>genbki.pl</filename>に知らせます。
      </para>
     </listitem>
 

--- a/doc/src/sgml/charset.sgml
+++ b/doc/src/sgml/charset.sgml
@@ -115,7 +115,7 @@ initdb --locale=sv_SE
 Unixシステム用のこの例の設定はロケールをスウェーデン（<literal>SE</literal>）で使用されているスウェーデン語（<literal>sv</literal>）に合わせています。
 他にも<literal>en_US</literal>（米国英語）や<literal>fr_CA</literal>（カナダのフランス語）などの設定もできます。
 ロケールに複数の文字集合が使用可能であれば、<replaceable>language_territory.codeset</replaceable>のように記述することができます。
-例えば、<literal>fr_BE.UTF-8</literal>はベルギー（BE）で使用されているフランス語（fr）で<acronym>UTF-8</acronym>の文字集合を表します。
+例えば、<literal>fr_BE.UTF-8</literal>はベルギー（BE）で使用されているフランス語（fr）で、<acronym>UTF-8</acronym>文字集合符号化方式を表します。
    </para>
 
    <para>
@@ -1267,7 +1267,7 @@ ICUロケールは、PostgreSQLがビルドされた際にICUサポートが設�
 （名称から推測されるように、照合順序の主な目的はソート順序を制御する<symbol>LC_COLLATE</symbol>を設定することです。
 しかし実際には<symbol>LC_CTYPE</symbol>の設定を<symbol>LC_COLLATE</symbol>と異なるようにする必要はほとんどありません。
 そのため、式ごとに<symbol>LC_CTYPE</symbol>を設定するような別の機構を作成するより、これらの設定を収集する方が、より便利です。）
-また、<literal>libc</literal>の照合順序は文字集合エンコーディングと結びついています（<xref linkend="multibyte"/>を参照してください）。
+また、<literal>libc</literal>の照合順序は文字集合符号化方式と結びついています（<xref linkend="multibyte"/>を参照してください）。
 同一の照合順序名称が異なるエンコーディングに対して存在しています。
    </para>
 

--- a/doc/src/sgml/charset.sgml
+++ b/doc/src/sgml/charset.sgml
@@ -39,7 +39,7 @@
       between client and server.
       This is covered in <xref linkend="multibyte"/>.
 -->
-全ての種類の言語によるテキストの格納のサポート、およびクライアントサーバ間の文字セット翻訳の提供を行うため、多くの文字セットを提供します。
+全ての種類の言語によるテキストの格納のサポート、およびクライアントサーバ間の文字集合翻訳の提供を行うため、多くの文字集合を提供します。
 これは<xref linkend="multibyte"/>内で解説されています。
      </para>
     </listitem>
@@ -114,8 +114,8 @@ initdb --locale=sv_SE
 -->
 Unixシステム用のこの例の設定はロケールをスウェーデン（<literal>SE</literal>）で使用されているスウェーデン語（<literal>sv</literal>）に合わせています。
 他にも<literal>en_US</literal>（米国英語）や<literal>fr_CA</literal>（カナダのフランス語）などの設定もできます。
-ロケールに複数の文字セットが使用可能であれば、<replaceable>language_territory.codeset</replaceable>のように記述することができます。
-例えば、<literal>fr_BE.UTF-8</literal>はベルギー（BE）で使用されているフランス語（fr）で<acronym>UTF-8</acronym>の文字セットを表します。
+ロケールに複数の文字集合が使用可能であれば、<replaceable>language_territory.codeset</replaceable>のように記述することができます。
+例えば、<literal>fr_BE.UTF-8</literal>はベルギー（BE）で使用されているフランス語（fr）で<acronym>UTF-8</acronym>の文字集合を表します。
    </para>
 
    <para>
@@ -1267,7 +1267,7 @@ ICUロケールは、PostgreSQLがビルドされた際にICUサポートが設�
 （名称から推測されるように、照合順序の主な目的はソート順序を制御する<symbol>LC_COLLATE</symbol>を設定することです。
 しかし実際には<symbol>LC_CTYPE</symbol>の設定を<symbol>LC_COLLATE</symbol>と異なるようにする必要はほとんどありません。
 そのため、式ごとに<symbol>LC_CTYPE</symbol>を設定するような別の機構を作成するより、これらの設定を収集する方が、より便利です。）
-また、<literal>libc</literal>の照合順序は文字セットエンコーディングと結びついています（<xref linkend="multibyte"/>を参照してください）。
+また、<literal>libc</literal>の照合順序は文字集合エンコーディングと結びついています（<xref linkend="multibyte"/>を参照してください）。
 同一の照合順序名称が異なるエンコーディングに対して存在しています。
    </para>
 
@@ -2556,10 +2556,10 @@ ORDER BY c COLLATE ebcdic;
 <!--
   <title>Character Set Support</title>
 -->
-  <title>文字セットサポート</title>
+  <title>文字集合サポート</title>
 
   <indexterm zone="multibyte"><primary>character set</primary></indexterm>
-  <indexterm zone="multibyte"><primary>文字セット</primary></indexterm>
+  <indexterm zone="multibyte"><primary>文字集合</primary></indexterm>
 
   <para>
 <!--
@@ -2577,9 +2577,9 @@ ORDER BY c COLLATE ebcdic;
    create a database, so you can have multiple
    databases each with a different character set.
 -->
-<productname>PostgreSQL</productname>の文字セット（エンコーディングとも呼ばれます）サポートにより、ISO 8859シリーズなどのシングルバイト文字や<acronym>EUC</acronym>（拡張Unixコード）、UTF-8、Mule内部コードなどのマルチバイト文字を含む、各種文字セットでテキストを保存できます。
-全ての文字セットはクライアントにより透過的に使用できますが、いくつかは、サーバ内での（つまりサーバサイドエンコーディングとして）使用はサポートされていません。デフォルトの文字セットは、<command>initdb</command>を使用した<productname>PostgreSQL</productname>データベースクラスタの初期化時に決定されます。
-これは、データベースを作成する時に上書きできるので、異なる文字セットを使用した複数のデータベースを持つことができます。
+<productname>PostgreSQL</productname>の文字集合（エンコーディングとも呼ばれます）サポートにより、ISO 8859シリーズなどのシングルバイト文字や<acronym>EUC</acronym>（拡張Unixコード）、UTF-8、Mule内部コードなどのマルチバイト文字を含む、各種文字集合でテキストを保存できます。
+全ての文字集合はクライアントにより透過的に使用できますが、いくつかは、サーバ内での（つまりサーバサイドエンコーディングとして）使用はサポートされていません。デフォルトの文字集合は、<command>initdb</command>を使用した<productname>PostgreSQL</productname>データベースクラスタの初期化時に決定されます。
+これは、データベースを作成する時に上書きできるので、異なる文字集合を使用した複数のデータベースを持つことができます。
   </para>
 
   <para>
@@ -2595,9 +2595,9 @@ ORDER BY c COLLATE ebcdic;
    If you have ICU support configured, ICU-provided locales can be used
    with most but not all server-side encodings.
 -->
-しかし重要な制限として、それぞれのデータベースの文字セットがサーバの<envar>LC_CTYPE</envar>（文字分類）および<envar>LC_COLLATE</envar>（文字列並べ替え順序）ロケール設定と互換性がなくてはいけないことがあげられます。
-<literal>C</literal>もしくは<literal>POSIX</literal>ロケール設定の場合、どのような文字セットも許可されています。
-しかし、libcが提供する他のロケール設定の場合、正しく動作する文字セットはひとつだけとなります。
+しかし重要な制限として、それぞれのデータベースの文字集合がサーバの<envar>LC_CTYPE</envar>（文字分類）および<envar>LC_COLLATE</envar>（文字列並べ替え順序）ロケール設定と互換性がなくてはいけないことがあげられます。
+<literal>C</literal>もしくは<literal>POSIX</literal>ロケール設定の場合、どのような文字集合も許可されています。
+しかし、libcが提供する他のロケール設定の場合、正しく動作する文字集合はひとつだけとなります。
 （しかしWindowsではUTF-8符号化方式をどのロケールでも使用できます。）
 ICUサポートが組み込まれている場合は、サーバサイドのすべてではないにしても、ほとんどのエンコーディングで、ICUが提供する照合順序が利用できます。
   </para>
@@ -2606,21 +2606,21 @@ ICUサポートが組み込まれている場合は、サーバサイドのす�
 <!--
     <title>Supported Character Sets</title>
 -->
-    <title>サポートされる文字セット</title>
+    <title>サポートされる文字集合</title>
 
     <para>
 <!--
      <xref linkend="charset-table"/> shows the character sets available
      for use in <productname>PostgreSQL</productname>.
 -->
-<productname>PostgreSQL</productname>で使用できる文字セットを<xref linkend="charset-table"/>に示します。
+<productname>PostgreSQL</productname>で使用できる文字集合を<xref linkend="charset-table"/>に示します。
     </para>
 
      <table id="charset-table">
 <!--
       <title><productname>PostgreSQL</productname> Character Sets</title>
 -->
-      <title><productname>PostgreSQL</productname>文字セット</title>
+      <title><productname>PostgreSQL</productname>文字集合</title>
       <tgroup cols="7">
        <colspec colname="col1" colwidth="3*"/>
        <colspec colname="col2" colwidth="2*"/>
@@ -3538,7 +3538,7 @@ ICUサポートが組み込まれている場合は、サーバサイドのす�
       JDBC driver does not support <literal>MULE_INTERNAL</literal>, <literal>LATIN6</literal>,
       <literal>LATIN8</literal>, and <literal>LATIN10</literal>.
 -->
-全てのクライアントの<acronym>API</acronym>が上の一覧表に示した文字セットをサポートしているわけではありません。
+全てのクライアントの<acronym>API</acronym>が上の一覧表に示した文字集合をサポートしているわけではありません。
 例えば<productname>PostgreSQL</productname> JDBCドライバは<literal>MULE_INTERNAL</literal>、<literal>LATIN6</literal>、<literal>LATIN8</literal>、そして<literal>LATIN10</literal>をサポートしません。
      </para>
 
@@ -3557,7 +3557,7 @@ ICUサポートが組み込まれている場合は、サーバサイドのす�
       <productname>PostgreSQL</productname> will be unable to help you by
       converting or validating non-ASCII characters.
 -->
-<literal>SQL_ASCII</literal>の設定は、他の設定とかなり異なります。サーバの文字セットが<literal>SQL_ASCII</literal>のとき、サーバは0から127のバイト値をASCIIに変換します。一方、128から255までは変換されません。
+<literal>SQL_ASCII</literal>の設定は、他の設定とかなり異なります。サーバの文字集合が<literal>SQL_ASCII</literal>のとき、サーバは0から127のバイト値をASCIIに変換します。一方、128から255までは変換されません。
 設定が<literal>SQL_ASCII</literal>の場合は、符号化は実行されません。よって、この設定は特定の符号化を使用している場合には、その符号化を無視するようになってしまいます。
 多くの場合、ASCIIではない環境で作業する場合は<literal>SQL_ASCII</literal>の設定を使用するのは、賢いことではありません。なぜなら<productname>PostgreSQL</productname>はASCIIではない文字を変換したり検査したりすることは出来ないからです。
      </para>
@@ -3567,14 +3567,14 @@ ICUサポートが組み込まれている場合は、サーバサイドのす�
 <!--
     <title>Setting the Character Set</title>
 -->
-    <title>文字セットの設定</title>
+    <title>文字集合の設定</title>
 
     <para>
 <!--
      <command>initdb</command> defines the default character set (encoding)
      for a <productname>PostgreSQL</productname> cluster. For example,
 -->
-<command>initdb</command>で<productname>PostgreSQL</productname>クラスタのデフォルト文字セット（エンコーディング）を定義します。
+<command>initdb</command>で<productname>PostgreSQL</productname>クラスタのデフォルト文字集合（エンコーディング）を定義します。
 以下に例を示します。
 
 <screen>
@@ -3590,7 +3590,7 @@ initdb -E EUC_JP
      given, <command>initdb</command> attempts to determine the appropriate
      encoding to use based on the specified or default locale.
 -->
-これはデフォルトの文字セットを<literal>EUC_JP</literal>（日本語拡張Unixコード）に設定します。
+これはデフォルトの文字集合を<literal>EUC_JP</literal>（日本語拡張Unixコード）に設定します。
 より長いオプションの文字列がお好みなら<option>-E</option>の代わりに<option>--encoding</option>と書くこともできます。
 <option>-E</option>オプションも<option>--encoding</option>オプションも与えられない場合、<command>initdb</command>は、指定もしくはデフォルトのロケールに基づいて適当な符号化方式を決定しようとします。
     </para>
@@ -3611,7 +3611,7 @@ createdb -E EUC_KR -T template0 --lc-collate=ko_KR.euckr --lc-ctype=ko_KR.euckr 
      uses the character set <literal>EUC_KR</literal>, and locale <literal>ko_KR</literal>.
      Another way to accomplish this is to use this SQL command:
 -->
-これは<literal>EUC_KR</literal>文字セットと<literal>ko_KR</literal>ロケールを使用する<literal>korean</literal>という名前のデータベースを作成します。
+これは<literal>EUC_KR</literal>文字集合と<literal>ko_KR</literal>ロケールを使用する<literal>korean</literal>という名前のデータベースを作成します。
 SQLコマンドで同じことを行うには次のようにします。
 
 <programlisting>
@@ -3667,7 +3667,7 @@ $ <userinput>psql -l</userinput>
       this area is likely to lead to strange behavior of locale-dependent
       operations such as sorting.
 -->
-最近のオペレーティングシステムでは、<productname>PostgreSQL</productname>は、<envar>LC_CTYPE</envar>の設定によりどの文字セットが指定されているか決定できます。
+最近のオペレーティングシステムでは、<productname>PostgreSQL</productname>は、<envar>LC_CTYPE</envar>の設定によりどの文字集合が指定されているか決定できます。
 そして、一致するデータベース符号化方式のみを強制的に使用します。
 古いオペレーティングシステムでは、自分で選択したロケールが想定している符号化方式を確実に使用することは各自の責任になります。
 ここでの間違いは、ソート処理などのロケールに依存する操作が、奇妙な動作するといったことにつながります。
@@ -3694,7 +3694,7 @@ $ <userinput>psql -l</userinput>
 <!--
     <title>Automatic Character Set Conversion Between Server and Client</title>
 -->
-    <title>サーバ・クライアント間の自動文字セット変換</title>
+    <title>サーバ・クライアント間の自動文字集合変換</title>
 
     <para>
 <!--
@@ -3703,7 +3703,7 @@ $ <userinput>psql -l</userinput>
      character sets (<xref linkend="multibyte-conversions-supported"/>
      shows which ones).
 -->
-<productname>PostgreSQL</productname>は、多数の文字セットの組み合わせ（<xref linkend="multibyte-conversions-supported"/> のいずれか）に対してサーバとクライアントの間で自動的に文字セットを変換する機能を提供しています。
+<productname>PostgreSQL</productname>は、多数の文字集合の組み合わせ（<xref linkend="multibyte-conversions-supported"/> のいずれか）に対してサーバとクライアントの間で自動的に文字集合を変換する機能を提供しています。
     </para>
 
     <para>
@@ -3713,7 +3713,7 @@ $ <userinput>psql -l</userinput>
      (encoding) you would like to use in the client. There are several
      ways to accomplish this:
 -->
-自動文字セット変換を有効にするためには、クライアントでどのような文字セット（符号化方式）を使用させたいかを<productname>PostgreSQL</productname>に伝えなければなりません。
+自動文字集合変換を有効にするためには、クライアントでどのような文字集合（符号化方式）を使用させたいかを<productname>PostgreSQL</productname>に伝えなければなりません。
 これを行うにはいくつかの方法があります。
 
      <itemizedlist>
@@ -3847,8 +3847,8 @@ RESET client_encoding;
      Just as for the server, use of <literal>SQL_ASCII</literal> is unwise
      unless you are working with all-ASCII data.
 -->
-クライアント側の文字セットが<literal>SQL_ASCII</literal>に定義されている場合は、符号化変換はサーバ側の文字セットに関係無く無効化されます。
-（ただし、サーバの文字セットが<literal>SQL_ASCII</literal>でない場合、サーバは受信データがそのエンコーディングに対して有効であることをチェックします。したがって、クライアントの文字セットがサーバの文字セットと同じであるかのような結果になります。）
+クライアント側の文字集合が<literal>SQL_ASCII</literal>に定義されている場合は、符号化変換はサーバ側の文字集合に関係無く無効化されます。
+（ただし、サーバの文字集合が<literal>SQL_ASCII</literal>でない場合、サーバは受信データがそのエンコーディングに対して有効であることをチェックします。したがって、クライアントの文字集合がサーバの文字集合と同じであるかのような結果になります。）
 サーバ側と同じように、<literal>SQL_ASCII</literal>を使用することは、すべてASCIIのデータを扱っている場合を除き、賢い方法ではありません。
     </para>
    </sect2>
@@ -3857,7 +3857,7 @@ RESET client_encoding;
 <!--
     <title>Available Character Set Conversions</title>
 -->
-    <title>利用可能な文字セットの変換</title>
+    <title>利用可能な文字集合の変換</title>
 
     <para>
 <!--
@@ -3873,16 +3873,16 @@ RESET client_encoding;
      client/server conversions, a conversion must be marked
      as <quote>default</quote> for its character set pair.)
 -->
-<productname>PostgreSQL</productname>は、<link linkend="catalog-pg-conversion"><structname>pg_conversion</structname></link>システムカタログ内にリストされた変換関数によって2つの文字セット間を変換できます。
+<productname>PostgreSQL</productname>は、<link linkend="catalog-pg-conversion"><structname>pg_conversion</structname></link>システムカタログ内にリストされた変換関数によって2つの文字集合間を変換できます。
 <productname>PostgreSQL</productname>では<xref linkend="multibyte-translation-table"/>で要約され<xref linkend="builtin-conversions-table"/>に詳細が示されているように、いくつかの変換があらかじめ組み込まれています。
-<xref linkend="sql-createconversion"/>SQLコマンドを用いることで新しい変換を作成できます。（クライアントもしくはサーバの自動変換を使用するためには、変換がその文字セットの組み合わせのための<quote>デフォルト</quote>として設定されている必要があります。）
+<xref linkend="sql-createconversion"/>SQLコマンドを用いることで新しい変換を作成できます。（クライアントもしくはサーバの自動変換を使用するためには、変換がその文字集合の組み合わせのための<quote>デフォルト</quote>として設定されている必要があります。）
     </para>
 
     <table id="multibyte-translation-table">
 <!--
      <title>Built-in Client/Server Character Set Conversions</title>
 -->
-     <title>組み込みクライアントもしくはサーバ文字セット変換</title>
+     <title>組み込みクライアントもしくはサーバ文字集合変換</title>
      <tgroup cols="2">
       <colspec colname="col1" colwidth="1*"/>
       <colspec colname="col2" colwidth="3*"/>
@@ -3891,11 +3891,11 @@ RESET client_encoding;
 <!--
         <entry>Server Character Set</entry>
 -->
-        <entry>サーバ文字セット</entry>
+        <entry>サーバ文字集合</entry>
 <!--
         <entry>Available Client Character Sets</entry>
 -->
-        <entry>利用可能なクライアント文字セット</entry>
+        <entry>利用可能なクライアント文字集合</entry>
        </row>
       </thead>
       <tbody>
@@ -4221,7 +4221,7 @@ RESET client_encoding;
 <!--
      <title>All Built-in Character Set Conversions</title>
 -->
-     <title>すべての組み込み文字セット変換</title>
+     <title>すべての組み込み文字集合変換</title>
      <tgroup cols="3">
       <colspec colname="col1" colwidth="2*"/>
       <colspec colname="col2" colwidth="1*"/>

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -15033,7 +15033,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
        <primary><varname>client_encoding</varname>設定パラメータ</primary>
       </indexterm>
       <indexterm><primary>character set</primary></indexterm>
-      <indexterm><primary>文字セット</primary></indexterm>
+      <indexterm><primary>文字集合</primary></indexterm>
       </term>
       <listitem>
        <para>
@@ -15043,8 +15043,8 @@ SET XML OPTION { DOCUMENT | CONTENT };
         The character sets supported by the <productname>PostgreSQL</productname>
         server are described in <xref linkend="multibyte-charset-supported"/>.
 -->
-クライアント側符号化方式（文字セット）を設定します。デフォルトはデータベース符号化方式を使用します。
-<productname>PostgreSQL</productname>サーバでサポートされている文字セットは<xref linkend="multibyte-charset-supported"/>に記載されています。
+クライアント側符号化方式（文字集合）を設定します。デフォルトはデータベース符号化方式を使用します。
+<productname>PostgreSQL</productname>サーバでサポートされている文字集合は<xref linkend="multibyte-charset-supported"/>に記載されています。
        </para>
       </listitem>
      </varlistentry>
@@ -15997,7 +15997,7 @@ GINインデックススキャンにより返されるセットのソフトな�
 -->
 文字列リテラルの中で引用符が<literal>\'</literal>で表現されるかどうかを管理します。
 引用符の表現として標準SQLの方式では二重化（<literal>''</literal>）ですが、<productname>PostgreSQL</productname>は歴史的に<literal>\'</literal>も受け付けます。
-とは言っても、いくつかのクライアント文字セットエンコーディング方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
+とは言っても、いくつかのクライアント文字集合エンコーディング方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
 クライアント側のコードが事実上エスケープを正しく扱わない場合、SQLインジェクション攻撃が可能になります。この危険性の回避は、サーバが逆スラッシュでエスケープされた引用符を含む問い合わせを拒絶するようにします。
 許可される<varname>backslash_quote</varname>の値は、<literal>on</literal> （常に <literal>\'</literal> を許可）,<literal>off</literal> （常に拒否）、および<literal>safe_encoding</literal> （クライアント符号化方式がASCIIの<literal>\</literal>を許可しないときのみ、マルチバイト文字内で許可）。
 <literal>safe_encoding</literal> がデフォルトの設定。
@@ -16823,7 +16823,7 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
        <primary><varname>server_encoding</varname>設定パラメータ</primary>
       </indexterm>
       <indexterm><primary>character set</primary></indexterm>
-      <indexterm><primary>文字セット</primary></indexterm>
+      <indexterm><primary>文字集合</primary></indexterm>
       </term>
       <listitem>
        <para>
@@ -16833,7 +16833,7 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
         clients need only be concerned with the value of <xref
         linkend="guc-client-encoding"/>.
 -->
-データベース符号化方式（文字セット）を報告します。
+データベース符号化方式（文字集合）を報告します。
 データベースが作成された時に決定されます。通常クライアントは<xref linkend="guc-client-encoding"/>の値にのみ注意する必要があります。
        </para>
       </listitem>

--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -15997,7 +15997,7 @@ GINインデックススキャンにより返されるセットのソフトな�
 -->
 文字列リテラルの中で引用符が<literal>\'</literal>で表現されるかどうかを管理します。
 引用符の表現として標準SQLの方式では二重化（<literal>''</literal>）ですが、<productname>PostgreSQL</productname>は歴史的に<literal>\'</literal>も受け付けます。
-とは言っても、いくつかのクライアント文字集合エンコーディング方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
+とは言っても、いくつかのクライアント文字集合符号化方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
 クライアント側のコードが事実上エスケープを正しく扱わない場合、SQLインジェクション攻撃が可能になります。この危険性の回避は、サーバが逆スラッシュでエスケープされた引用符を含む問い合わせを拒絶するようにします。
 許可される<varname>backslash_quote</varname>の値は、<literal>on</literal> （常に <literal>\'</literal> を許可）,<literal>off</literal> （常に拒否）、および<literal>safe_encoding</literal> （クライアント符号化方式がASCIIの<literal>\</literal>を許可しないときのみ、マルチバイト文字内で許可）。
 <literal>safe_encoding</literal> がデフォルトの設定。

--- a/doc/src/sgml/config3.sgml
+++ b/doc/src/sgml/config3.sgml
@@ -1239,7 +1239,7 @@ SET XML OPTION { DOCUMENT | CONTENT };
        <primary><varname>client_encoding</varname>設定パラメータ</primary>
       </indexterm>
       <indexterm><primary>character set</primary></indexterm>
-      <indexterm><primary>文字セット</primary></indexterm>
+      <indexterm><primary>文字集合</primary></indexterm>
       </term>
       <listitem>
        <para>
@@ -1249,8 +1249,8 @@ SET XML OPTION { DOCUMENT | CONTENT };
         The character sets supported by the <productname>PostgreSQL</productname>
         server are described in <xref linkend="multibyte-charset-supported"/>.
 -->
-クライアント側符号化方式（文字セット）を設定します。デフォルトはデータベース符号化方式を使用します。
-<productname>PostgreSQL</productname>サーバでサポートされている文字セットは<xref linkend="multibyte-charset-supported"/>に記載されています。
+クライアント側符号化方式（文字集合）を設定します。デフォルトはデータベース符号化方式を使用します。
+<productname>PostgreSQL</productname>サーバでサポートされている文字集合は<xref linkend="multibyte-charset-supported"/>に記載されています。
        </para>
       </listitem>
      </varlistentry>
@@ -2203,7 +2203,7 @@ GINインデックススキャンにより返されるセットのソフトな�
 -->
 文字列リテラルの中で引用符が<literal>\'</literal>で表現されるかどうかを管理します。
 引用符の表現として標準SQLの方式では二重化（<literal>''</literal>）ですが、<productname>PostgreSQL</productname>は歴史的に<literal>\'</literal>も受け付けます。
-とは言っても、いくつかのクライアント文字セットエンコーディング方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
+とは言っても、いくつかのクライアント文字集合エンコーディング方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
 クライアント側のコードが事実上エスケープを正しく扱わない場合、SQLインジェクション攻撃が可能になります。この危険性の回避は、サーバが逆スラッシュでエスケープされた引用符を含む問い合わせを拒絶するようにします。
 許可される<varname>backslash_quote</varname>の値は、<literal>on</literal> （常に <literal>\'</literal> を許可）,<literal>off</literal> （常に拒否）、および<literal>safe_encoding</literal> （クライアント符号化方式がASCIIの<literal>\</literal>を許可しないときのみ、マルチバイト文字内で許可）。
 <literal>safe_encoding</literal> がデフォルトの設定。
@@ -3029,7 +3029,7 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
        <primary><varname>server_encoding</varname>設定パラメータ</primary>
       </indexterm>
       <indexterm><primary>character set</primary></indexterm>
-      <indexterm><primary>文字セット</primary></indexterm>
+      <indexterm><primary>文字集合</primary></indexterm>
       </term>
       <listitem>
        <para>
@@ -3039,7 +3039,7 @@ Linuxでは代わりに、オペレーティングシステムに対して、デ
         clients need only be concerned with the value of <xref
         linkend="guc-client-encoding"/>.
 -->
-データベース符号化方式（文字セット）を報告します。
+データベース符号化方式（文字集合）を報告します。
 データベースが作成された時に決定されます。通常クライアントは<xref linkend="guc-client-encoding"/>の値にのみ注意する必要があります。
        </para>
       </listitem>

--- a/doc/src/sgml/config3.sgml
+++ b/doc/src/sgml/config3.sgml
@@ -2203,7 +2203,7 @@ GINインデックススキャンにより返されるセットのソフトな�
 -->
 文字列リテラルの中で引用符が<literal>\'</literal>で表現されるかどうかを管理します。
 引用符の表現として標準SQLの方式では二重化（<literal>''</literal>）ですが、<productname>PostgreSQL</productname>は歴史的に<literal>\'</literal>も受け付けます。
-とは言っても、いくつかのクライアント文字集合エンコーディング方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
+とは言っても、いくつかのクライアント文字集合符号化方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
 クライアント側のコードが事実上エスケープを正しく扱わない場合、SQLインジェクション攻撃が可能になります。この危険性の回避は、サーバが逆スラッシュでエスケープされた引用符を含む問い合わせを拒絶するようにします。
 許可される<varname>backslash_quote</varname>の値は、<literal>on</literal> （常に <literal>\'</literal> を許可）,<literal>off</literal> （常に拒否）、および<literal>safe_encoding</literal> （クライアント符号化方式がASCIIの<literal>\</literal>を許可しないときのみ、マルチバイト文字内で許可）。
 <literal>safe_encoding</literal> がデフォルトの設定。

--- a/doc/src/sgml/datatype.sgml
+++ b/doc/src/sgml/datatype.sgml
@@ -1979,8 +1979,8 @@ SELECT '52093.89'::money::numeric::float8;
     the character with code zero (sometimes called NUL) cannot be stored.
     For more information refer to <xref linkend="multibyte"/>.
 -->
-これらのデータ型のいずれかに格納できる文字はデータベースを作成するときに選択されるデータベース文字セットによって決定されます。
-特定の文字セットに関わらず、コード0（時にはNULと呼ばれます）を格納することはできません。
+これらのデータ型のいずれかに格納できる文字はデータベースを作成するときに選択されるデータベース文字集合によって決定されます。
+特定の文字集合に関わらず、コード0（時にはNULと呼ばれます）を格納することはできません。
 より詳細な情報は<xref linkend="multibyte"/>を参照ください。
    </para>
 
@@ -2258,7 +2258,7 @@ SELECT b, char_length(b) FROM test2;
 バイナリ列は２つの点で文字列と区別されます。
 1点目は、バイナリ列はゼロの値のオクテットと他の<quote>表示できない</quote>オクテット（通常10進数表記で32から126の範囲外のオクテット）を保存できるということです。
 文字列ではゼロというオクテットは使用できません。
-また、データベースで選択している文字セット符号化方式で無効なオクテット値やオクテット値の並びも使用できません。
+また、データベースで選択している文字集合符号化方式で無効なオクテット値やオクテット値の並びも使用できません。
 2点目は、バイナリ列を演算すると実際のバイトが処理されるのに対して、文字列の処理はロケール設定に従うということです。
 まとめると、バイナリ列はプログラマが<quote>バイト列そのもの</quote>と考えるものを格納するのに適し、文字列はテキストを格納するのに適しています。
    </para>
@@ -2563,7 +2563,7 @@ SELECT '\xDEADBEEF'::bytea;
 -->
 <type>Bytea</type>オクテットはデフォルトでは<literal>hex</literal>書式で出力されます。
 <xref linkend="guc-bytea-output"/>を<literal>escape</literal>に変えると、<quote>表示できない</quote>オクテットは先頭にバックスラッシュがついた3桁のオクテットの値に変換されます。
-ほとんどの<quote>表示可能な</quote>オクテットはクライアント文字セットの標準的な表示で出力されます。例:
+ほとんどの<quote>表示可能な</quote>オクテットはクライアント文字集合の標準的な表示で出力されます。例:
 
 <programlisting>
 SET bytea_output = 'escape';
@@ -2663,7 +2663,7 @@ SELECT 'abc \153\154\155 \052\251\124'::bytea;
 <!--
        <entry>client character set representation</entry>
 -->
-       <entry>クライアント文字セットにおける表現</entry>
+       <entry>クライアント文字集合における表現</entry>
 <!--
        <entry><literal>'\176'::bytea</literal></entry>
 -->

--- a/doc/src/sgml/extend.sgml
+++ b/doc/src/sgml/extend.sgml
@@ -1085,7 +1085,7 @@ RETURNS anycompatible AS ...
         be specified if the script files contain any non-ASCII characters.
         Otherwise the files will be assumed to be in the database encoding.
 -->
-スクリプトファイルで使用される文字セット符号化方式です。
+スクリプトファイルで使用される文字集合符号化方式です。
 スクリプトファイルに何らかの非ASCII文字が含まれる場合に指定しなければなりません。
 指定がなければ、ファイルはデータベース符号化方式であると仮定されます。
        </para>

--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -5993,7 +5993,7 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
    in the database's default encoding, while arguments or results of
    type <type>bytea</type> are in an encoding named by another argument.
 -->
-異なる文字セット（文字符号化方式）間で文字列を変換する関数と、テキスト形式の任意のバイナリデータを表現する関数を<xref linkend="functions-binarystring-conversions"/>で示します。
+異なる文字集合（文字符号化方式）間で文字列を変換する関数と、テキスト形式の任意のバイナリデータを表現する関数を<xref linkend="functions-binarystring-conversions"/>で示します。
 引数あるいは結果の<type>text</type>型はデータベースのデフォルト文字符号化方式で表現され、<type>bytea</type>型の引数あるいは結果は別の引数で指定する文字符号化方式名で表現されます。
   </para>
 

--- a/doc/src/sgml/information_schema.sgml
+++ b/doc/src/sgml/information_schema.sgml
@@ -942,8 +942,8 @@
    support multiple character sets within one database, this view only
    shows one, which is the database encoding.
 -->
-この<literal>character_sets</literal>ビューは、現在のデータベースで利用可能な文字セットを示します。
-PostgreSQLはひとつのデータベース内で複数の文字セットをサポートしないので、このビューは常にデータベースエンコーディングの一行だけを表示します。
+この<literal>character_sets</literal>ビューは、現在のデータベースで利用可能な文字集合を示します。
+PostgreSQLはひとつのデータベース内で複数の文字集合をサポートしないので、このビューは常にデータベースエンコーディングの一行だけを表示します。
   </para>
 
   <para>
@@ -956,7 +956,7 @@ PostgreSQLはひとつのデータベース内で複数の文字セットをサ�
 <!--
      <term>character repertoire</term>
 -->
-     <term>文字集合</term>
+     <term>文字レパートリ</term>
      <listitem>
       <para>
 <!--
@@ -965,7 +965,7 @@ PostgreSQLはひとつのデータベース内で複数の文字セットをサ�
        <literal>LATIN1</literal>.  Not exposed as an SQL object, but
        visible in this view.
 -->
-例えば<literal>UNICODE</literal>や<literal>UCS</literal>、<literal>LATIN1</literal>といった抽象的な文字集合です。SQLオブジェクトとしては出てきませんが、このビューで参照できます。
+例えば<literal>UNICODE</literal>や<literal>UCS</literal>、<literal>LATIN1</literal>といった抽象的な文字レパートリです。SQLオブジェクトとしては出てきませんが、このビューで参照できます。
       </para>
      </listitem>
     </varlistentry>
@@ -987,8 +987,8 @@ PostgreSQLはひとつのデータベース内で複数の文字セットをサ�
        all supported by PostgreSQL).  Encoding forms are not exposed
        as an SQL object, but are visible in this view.
 -->
-文字集合の符号化方式です。
-ほとんどの古い文字集合はひとつの符号化形式を使うため、それらについては分離した名称はありません(たとえば、<literal>LATIN2</literal>は<literal>LATIN2</literal>集合に適用可能な符号化形式です)。
+文字レパートリの符号化方式です。
+ほとんどの古い文字レパートリはひとつの符号化形式を使うため、それらについては分離した名称はありません(たとえば、<literal>LATIN2</literal>は<literal>LATIN2</literal>集合に適用可能な符号化形式です)。
 しかし例えばUnicodeには<literal>UTF8</literal>、<literal>UTF16</literal>などの符号化形式があります（PostgreSQLでは一部だけサポートしています）。
 符号化形式はSQLオブジェクトとして表にでませんが、このビューで参照できます。
       </para>
@@ -999,7 +999,7 @@ PostgreSQLはひとつのデータベース内で複数の文字セットをサ�
 <!--
      <term>character set</term>
 -->
-     <term>文字セット</term>
+     <term>文字集合</term>
      <listitem>
       <para>
 <!--
@@ -1011,8 +1011,8 @@ PostgreSQLはひとつのデータベース内で複数の文字セットをサ�
        the character repertoire <literal>UCS</literal>, encoding
        form <literal>UTF8</literal>, and some default collation.
 -->
-文字集合、文字符号化方式とデフォルトの照合を識別する順序名前つきのSQLオブジェクトです。定義済みの文字セットは、一般的に符号化形式と同じ名前を持ちますが、ユーザは他の名前を定義できます。
-例えば、文字セット<literal>UTF8</literal>は一般的に文字集合<literal>UCS</literal>、符号化形式<literal>UTF8</literal>と何らかのデフォルト照合を示します。
+文字レパートリ、文字符号化方式とデフォルトの照合を識別する順序名前つきのSQLオブジェクトです。定義済みの文字集合は、一般的に符号化形式と同じ名前を持ちますが、ユーザは他の名前を定義できます。
+例えば、文字集合<literal>UTF8</literal>は一般的に文字レパートリ<literal>UCS</literal>、符号化形式<literal>UTF8</literal>と何らかのデフォルト照合を示します。
       </para>
      </listitem>
     </varlistentry>
@@ -1023,7 +1023,7 @@ PostgreSQLはひとつのデータベース内で複数の文字セットをサ�
    a character set or a character encoding form.  They will have the
    same name, and there can only be one in one database.
 -->
-PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文字符号化形式のいずれかと考えられます。これらは同じ名前を持ち一つのデータベースでは一つだけ存在できます。
+PostgreSQLにおける<quote>encoding</quote>は、文字集合または文字符号化形式のいずれかと考えられます。これらは同じ名前を持ち一つのデータベースでは一つだけ存在できます。
   </para>
 
   <table>
@@ -1058,7 +1058,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
 <!--
        Character sets are currently not implemented as schema objects, so this column is null.
 -->
-文字セットはスキーマオブジェクトとして実装されていないので、この列はNULLです。
+文字集合はスキーマオブジェクトとして実装されていないので、この列はNULLです。
       </para></entry>
      </row>
 
@@ -1070,7 +1070,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
 <!--
        Character sets are currently not implemented as schema objects, so this column is null.
 -->
-文字セットはスキーマオブジェクトとして実装されていないので、この列はNULLです。
+文字集合はスキーマオブジェクトとして実装されていないので、この列はNULLです。
       </para></entry>
      </row>
 
@@ -1082,7 +1082,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
 <!--
        Name of the character set, currently implemented as showing the name of the database encoding
 -->
-文字セットの名前で、現在はデータベースエンコーディングを表示するように実装されています。
+文字集合の名前で、現在はデータベースエンコーディングを表示するように実装されています。
       </para></entry>
      </row>
 
@@ -1094,7 +1094,7 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
 <!--
        Character repertoire, showing <literal>UCS</literal> if the encoding is <literal>UTF8</literal>, else just the encoding name
 -->
-文字集合で、エンコーディングが<literal>UTF8</literal>の場合は<literal>UCS</literal>を、それ以外の場合は単にエンコーディング名を表示します。
+文字レパートリで、エンコーディングが<literal>UTF8</literal>の場合は<literal>UCS</literal>を、それ以外の場合は単にエンコーディング名を表示します。
       </para></entry>
      </row>
 
@@ -1471,8 +1471,8 @@ PostgreSQLにおける<quote>encoding</quote>は、文字セットまたは文�
    in <xref linkend="infoschema-character-sets"/>), so this view does
    not provide much useful information.
 -->
-<literal>collation_character_set_applicability</literal>ビューは、利用可能な照合がどの文字セットに適用可能かを示します。
-PostgreSQLでは、データベースごとに一つの文字セットしか存在しない(<xref linkend="infoschema-character-sets"/>の説明を参照してください)ので、このビューは有益な情報を提供しません。
+<literal>collation_character_set_applicability</literal>ビューは、利用可能な照合がどの文字集合に適用可能かを示します。
+PostgreSQLでは、データベースごとに一つの文字集合しか存在しない(<xref linkend="infoschema-character-sets"/>の説明を参照してください)ので、このビューは有益な情報を提供しません。
   </para>
 
   <table>
@@ -1543,7 +1543,7 @@ PostgreSQLでは、データベースごとに一つの文字セットしか存�
 <!--
        Character sets are currently not implemented as schema objects, so this column is null
 -->
-文字セットはスキーマオブジェクトとして実装されていないので、この列はNULLです。
+文字集合はスキーマオブジェクトとして実装されていないので、この列はNULLです。
       </para></entry>
      </row>
 
@@ -1555,7 +1555,7 @@ PostgreSQLでは、データベースごとに一つの文字セットしか存�
 <!--
        Character sets are currently not implemented as schema objects, so this column is null
 -->
-文字セットはスキーマオブジェクトとして実装されていないので、この列はNULLです。
+文字集合はスキーマオブジェクトとして実装されていないので、この列はNULLです。
       </para></entry>
      </row>
 
@@ -1567,7 +1567,7 @@ PostgreSQLでは、データベースごとに一つの文字セットしか存�
 <!--
        Name of the character set
 -->
-文字セットの名前です。
+文字集合の名前です。
       </para></entry>
      </row>
     </tbody>

--- a/doc/src/sgml/ref/create_conversion.sgml
+++ b/doc/src/sgml/ref/create_conversion.sgml
@@ -43,7 +43,7 @@ CREATE [ DEFAULT ] CONVERSION <replaceable>name</replaceable>
    <command>CREATE CONVERSION</command> defines a new conversion between
    two character set encodings.
 -->
-<command>CREATE CONVERSION</command>を使用すると、2つの文字セット符号化方式間の新しい変換を定義できます。
+<command>CREATE CONVERSION</command>を使用すると、2つの文字集合符号化方式間の新しい変換を定義できます。
   </para>
 
   <para>

--- a/doc/src/sgml/ref/create_database.sgml
+++ b/doc/src/sgml/ref/create_database.sgml
@@ -157,10 +157,10 @@ CREATE DATABASE <replaceable class="parameter">name</replaceable>
         <xref linkend="multibyte-charset-supported"/>. See below for
         additional restrictions.
 -->
-新しいデータベースで使われる文字セット符号化方式です。
+新しいデータベースで使われる文字集合符号化方式です。
 文字列定数（例えば<literal>'SQL_ASCII'</literal>）、整数の符号化方式番号、<literal>DEFAULT</literal>のいずれかを指定します。
 <literal>DEFAULT</literal>とすると、デフォルトの符号化方式（すなわちテンプレートデータベースの符号化方式）を使います。
-<productname>PostgreSQL</productname>サーバでサポートされる文字セットについては<xref linkend="multibyte-charset-supported"/>で説明します。
+<productname>PostgreSQL</productname>サーバでサポートされる文字集合については<xref linkend="multibyte-charset-supported"/>で説明します。
 この他の制限については後述します。
        </para>
       </listitem>
@@ -594,7 +594,7 @@ false（デフォルト）の場合、スーパーユーザまたはデータベ
    character-string functions if data that is not encoding-compatible
    with the locale is stored in the database.
 -->
-新しいデータベース用に指定される文字セット符号化方式は選択されたロケール設定（<literal>LC_COLLATE</literal>および<literal>LC_CTYPE</literal>）と互換性がなければなりません。
+新しいデータベース用に指定される文字集合符号化方式は選択されたロケール設定（<literal>LC_COLLATE</literal>および<literal>LC_CTYPE</literal>）と互換性がなければなりません。
 ロケールが<literal>C</literal>（や同等の<literal>POSIX</literal>）であれば、すべての符号化方式が許されますが、他のロケール設定では適切に動作する符号化方式は1つしかありません。
 （しかしWindowsではUTF-8符号化方式をすべてのロケールで使用できます。）
 <command>CREATE DATABASE</command>では、ロケール設定に関係なくスーパーユーザが<literal>SQL_ASCII</literal>符号化方式を指定することを許していますが、こうした選択は廃止予定であり、データベース内にロケールと互換性がない符号化方式でデータが格納された場合、文字列関数の誤動作を多く引き起こします。
@@ -696,7 +696,7 @@ CREATE DATABASE music
    To create a database <literal>music2</literal> with a different locale and a
    different character set encoding:
 -->
-別のロケールおよび別の文字セット符号化方式でデータベース<literal>music2</literal>を作成します。
+別のロケールおよび別の文字集合符号化方式でデータベース<literal>music2</literal>を作成します。
 <programlisting>
 CREATE DATABASE music2
     LOCALE 'sv_SE.iso885915'

--- a/doc/src/sgml/ref/createdb.sgml
+++ b/doc/src/sgml/ref/createdb.sgml
@@ -158,7 +158,7 @@ PostgreSQL documentation
         <xref linkend="multibyte-charset-supported"/>.
 -->
 このデータベース内で使用する文字符号化方式を指定します。
-<productname>PostgreSQL</productname>サーバでサポートされる文字セットについては<xref linkend="multibyte-charset-supported"/>で説明します。
+<productname>PostgreSQL</productname>サーバでサポートされる文字集合については<xref linkend="multibyte-charset-supported"/>で説明します。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/ref/grant.sgml
+++ b/doc/src/sgml/ref/grant.sgml
@@ -718,7 +718,7 @@ PostgreSQLではグラントオプションはロールに対して与えるこ�
     on other kinds of objects: character sets, collations,
     translations.
 -->
-標準SQLでは、文字セット、照合順序、翻訳といったその他の種類のオブジェクトに対して、<literal>USAGE</literal>権限を付与することができます。
+標準SQLでは、文字集合、照合順序、翻訳といったその他の種類のオブジェクトに対して、<literal>USAGE</literal>権限を付与することができます。
    </para>
 
    <para>

--- a/doc/src/sgml/ref/initdb.sgml
+++ b/doc/src/sgml/ref/initdb.sgml
@@ -128,7 +128,7 @@ PostgreSQL documentation
    settings for the template databases, which will serve as the default for
    all other databases.
 -->
-<command>initdb</command>は、データベースクラスタのデフォルトのロケールと文字セット符号化方式を初期化します。
+<command>initdb</command>は、データベースクラスタのデフォルトのロケールと文字集合符号化方式を初期化します。
 これらは、データベースの作成時にデータベースごとに個別に設定することもできます。
 <command>initdb</command>はテンプレートデータベースのこれらの設定を決定します。この設定が他のすべてのデータベースのデフォルトとして提供されます。
   </para>
@@ -311,7 +311,7 @@ PostgreSQL documentation
 -->
 テンプレートデータベースの符号化方式を選択します。
 これが今後作成されるすべてのデータベースについてのデフォルト符号化方式となりますが、作成時に上書きすることもできます。
-<productname>PostgreSQL</productname>サーバでサポートされる文字セットについては、<xref linkend="multibyte-charset-supported"/>を参照してください。
+<productname>PostgreSQL</productname>サーバでサポートされる文字集合については、<xref linkend="multibyte-charset-supported"/>を参照してください。
        </para>
        <para>
 <!--

--- a/doc/src/sgml/ref/pg_dump.sgml
+++ b/doc/src/sgml/ref/pg_dump.sgml
@@ -375,7 +375,7 @@ PostgreSQL documentation
         variable to the desired dump encoding.)  The supported encodings are
         described in <xref linkend="multibyte-charset-supported"/>.
 -->
-指定した文字セット符号化方式でダンプを作成します。
+指定した文字集合符号化方式でダンプを作成します。
 デフォルトではダンプはデータベースの符号化方式で作成されます。
 （環境変数<envar>PGCLIENTENCODING</envar>を好みのダンプ時の符号化方式に設定することで、同じ結果を得ることができます。）
 サポートする符号化方式は<xref linkend="multibyte-charset-supported"/>に記載されています。

--- a/doc/src/sgml/ref/pg_dumpall.sgml
+++ b/doc/src/sgml/ref/pg_dumpall.sgml
@@ -156,9 +156,9 @@ SQLスクリプトは標準出力に書き込まれます。
         same result is to set the <envar>PGCLIENTENCODING</envar> environment
         variable to the desired dump encoding.)
 -->
-指定された文字集合エンコーディングでダンプを作ります。
-デフォルトでは、ダンプはデータベースエンコーディングで作られます。
-（同じ結果を得る他の方法は<envar>PGCLIENTENCODING</envar>環境変数を望みのダンプエンコーディングに設定することです。）
+指定された文字集合符号化方式でダンプを作ります。
+デフォルトではダンプはデータベースの符号化方式で作成されます。
+（環境変数<envar>PGCLIENTENCODING</envar>を好みのダンプ時の符号化方式に設定することで、同じ結果を得ることができます。）
        </para>
       </listitem>
      </varlistentry>
@@ -1087,7 +1087,7 @@ exclude database <replaceable class="parameter">PATTERN</replaceable>
    database-level properties, as well as any pre-existing contents.
 -->
 <option>--clean</option>オプションは、ダンプスクリプトを新しいクラスタにリストアする意図のときであっても、有用なことがあります。
-<option>--clean</option>の使用は、スクリプトに組み込みの<literal>postgres</literal>および<literal>template1</literal>データベースを削除して再作成する権限を与え、これらのデータベースが元のクラスタに持っていたものと同じ属性（例えばロケールやエンコーディング）を保つことを保証します。
+<option>--clean</option>の使用は、スクリプトに組み込みの<literal>postgres</literal>および<literal>template1</literal>データベースを削除して再作成する権限を与え、これらのデータベースが元のクラスタに持っていたものと同じ属性（例えばロケールや符号化方式）を保つことを保証します。
 このオプションが無いと、これらのデータベースは既存のデータベースレベルの属性を維持します。
   </para>
 

--- a/doc/src/sgml/ref/pg_dumpall.sgml
+++ b/doc/src/sgml/ref/pg_dumpall.sgml
@@ -156,7 +156,7 @@ SQLスクリプトは標準出力に書き込まれます。
         same result is to set the <envar>PGCLIENTENCODING</envar> environment
         variable to the desired dump encoding.)
 -->
-指定された文字セットエンコーディングでダンプを作ります。
+指定された文字集合エンコーディングでダンプを作ります。
 デフォルトでは、ダンプはデータベースエンコーディングで作られます。
 （同じ結果を得る他の方法は<envar>PGCLIENTENCODING</envar>環境変数を望みのダンプエンコーディングに設定することです。）
        </para>

--- a/doc/src/sgml/ref/psql-ref.sgml
+++ b/doc/src/sgml/ref/psql-ref.sgml
@@ -1980,7 +1980,7 @@ INSERT INTO tbl1 VALUES ($1, $2) \bind 'first value' 'second value' \g
         If <literal>+</literal> is appended to the command name, each object
         is listed with its associated description.
 -->
-文字セット符号化方式間の変換の一覧を表示します。
+文字集合符号化方式間の変換の一覧を表示します。
 <replaceable class="parameter">pattern</replaceable>が指定された場合、そのパターンに名前がマッチする変換のみが表示されます。
 デフォルトではユーザが作成したオブジェクトのみが表示されます。
 システムオブジェクトを含めるためには、パターンまたは<literal>S</literal>修飾子を付与してください。
@@ -3055,7 +3055,7 @@ Tue Oct 26 21:40:57 CEST 1999
         Sets the client character set encoding.  Without an argument, this command
         shows the current encoding.
 -->
-クライアント側の文字セット符号化方式を設定します。
+クライアント側の文字集合符号化方式を設定します。
 引数を指定しない場合、このコマンドは現在の符号化方式を表示します。
         </para>
         </listitem>
@@ -3696,7 +3696,7 @@ SELECT
         (Size information is only available for databases that the current
         user can connect to.)
 -->
-サーバ内のデータベースについて、その名前、所有者、文字セット符号化方式、アクセス権限を一覧表示します。
+サーバ内のデータベースについて、その名前、所有者、文字集合符号化方式、アクセス権限を一覧表示します。
 <replaceable class="parameter">pattern</replaceable>を指定すると、パターンにマッチする名前を持つデータベースのみを表示します。
 コマンド名に<literal>+</literal>を付けると、データベースのサイズ、デフォルトのテーブル空間、説明も表示します。
 （サイズ情報は現在のユーザが接続可能なデータベースでのみ表示されます。）
@@ -5676,7 +5676,7 @@ SQLキーワードを補完する時に大文字小文字のどちらを使用�
         program start-up), and when you change the encoding
         with <literal>\encoding</literal>, but it can be changed or unset.
 -->
-現在のクライアント側の文字セット符号化方式です。
+現在のクライアント側の文字集合符号化方式です。
 これは（プログラムの起動時を含め）データベースに接続する度に、また符号化方式を<literal>\encoding</literal>で変更した時に設定されますが、変更したり、未設定にすることができます。
         </para>
         </listitem>

--- a/doc/src/sgml/ref/show.sgml
+++ b/doc/src/sgml/ref/show.sgml
@@ -100,7 +100,7 @@ SHOW ALL
           this parameter can be shown but not set, because the
           encoding is determined at database creation time.
 -->
-          サーバ側の文字セット符号化方式を表示します。
+          サーバ側の文字集合符号化方式を表示します。
           現時点では、符号化方式はデータベース作成時に決定されるため、このパラメータは表示のみ可能で、変更することができません。
          </para>
         </listitem>

--- a/doc/src/sgml/runtime.sgml
+++ b/doc/src/sgml/runtime.sgml
@@ -360,7 +360,7 @@ postgres$ <userinput>initdb -D /usr/local/pgsql/data</userinput>
    for the database cluster.  Normally this should be chosen to match the
    locale setting.  For details see <xref linkend="multibyte"/>.
 -->
-また<command>initdb</command>は、データベースクラスタのデフォルトの文字セット符号化方式も設定します。
+また<command>initdb</command>は、データベースクラスタのデフォルトの文字集合符号化方式も設定します。
 通常これは、ロケールの設定と合うものが選ばれなければなりません。
 詳細は<xref linkend="multibyte"/>を参照してください。
   </para>
@@ -374,7 +374,7 @@ postgres$ <userinput>initdb -D /usr/local/pgsql/data</userinput>
    either through snapshot restore, binary streaming replication, a
    different operating system, or an operating system upgrade.
 -->
-非<literal>C</literal>および非<literal>POSIX</literal>のロケールでは、文字セットのソート順はオペレーティングシステムの照合ライブラリに依存しています。
+非<literal>C</literal>および非<literal>POSIX</literal>のロケールでは、文字集合のソート順はオペレーティングシステムの照合ライブラリに依存しています。
 これは、インデックスに格納されているキーの順序を制御します。
 このためにクラスタは、スナップショットのリストア、バイナリストリーミングレプリケーション、異なるオペレーティングシステム、またはオペレーティングシステムのアップグレードのいずれでも互換性のない照合ライブラリバージョンに切り替えることは出来ません。
   </para>

--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -696,7 +696,7 @@ SELECT 'foo'      'bar';
      in <xref linkend="sql-syntax-strings-uescape"/>; then the server
      will check that the character conversion is possible.
 -->
-特に8進数や16進数エスケープを用いて作成されるバイトシーケンスが、サーバ文字セット符号化方式において有効な文字で構成されていることはコードを書く人の責任です。
+特に8進数や16進数エスケープを用いて作成されるバイトシーケンスが、サーバ文字集合符号化方式において有効な文字で構成されていることはコードを書く人の責任です。
 便利な代替手段は、Unicodeエスケープか、<xref linkend="sql-syntax-strings-uescape"/>で説明するもう一つのUnicodeエスケープ構文を代わりとして使用することです。そうすればサーバが文字変換を可能か検査するでしょう。
     </para>
 


### PR DESCRIPTION
「character set」→「文字集合」
「character repertoire」→「文字レパートリ」
に変更。
 #3425 で修正してしまったのを再修正で、 #2830 の対応です。