### PR TITLE
legal.sgmlの17.6対応です

### DIFF
--- a/doc/src/sgml/legal.sgml
+++ b/doc/src/sgml/legal.sgml
@@ -15,15 +15,30 @@
  <title>法的告知</title>
 
  <para>
+  [訳注：日本語は参考程度と解釈してください。]
+ </para>
+
+ <para>
   <productname>PostgreSQL</productname> Database Management System
   (also known as Postgres, formerly known as Postgres95)
+ </para>
+
+ <para>
+<productname>PostgreSQL</productname>データベース管理システム
+（Postgresとしても知られ、以前はPostgres95として知られていました）
  </para>
 
  <para>
   Portions Copyright &copy; 1996-2025, PostgreSQL Global Development Group
  </para>
  <para>
+  一部の著作権 &copy; 1996&ndash;2025、PostgreSQL Global Development Group
+ </para>
+ <para>
   Portions Copyright &copy; 1994, The Regents of the University of California
+ </para>
+ <para>
+  一部の著作権 &copy; 1994、カリフォルニア大学理事会
  </para>
 
  <para>
@@ -35,7 +50,6 @@
  </para>
 
  <para>
-  [訳注：日本語は参考程度と解釈してください。]
   上記の著作権表示、および
   本段落と続く2つの段落を全てのコピーに含めることを条件として、無料かつ
   書面による許可なしに、このソフトウェアとドキュメントの使用、複製、改変、


### PR DESCRIPTION
形式を少し変え原文をさらに残すようにしました。
The Regents of the University of Californiaの訳は
「カリフォルニア大学評議員」から「カリフォルニア大学理事会」に変更しました。