### PR TITLE
translate protocol.sgml

### DIFF
--- a/doc/src/sgml/protocol.sgml
+++ b/doc/src/sgml/protocol.sgml
@@ -4807,7 +4807,7 @@ PostgreSQLサーバの操作中に作成される種々の一時ファイルお�
        <literal>parallel</literal> value.
 -->
 進行中のトランザクションのストリーミングを有効にするオプションです。
-有効な値は<literal>off</literal>(デフォルトです)、<literal>on</literal>および<literal>parallel</literal>できます。
+有効な値は<literal>off</literal>（デフォルトです）、<literal>on</literal>および<literal>parallel</literal>です。
 <literal>parallel</literal>に設定すると、並列化に使われるいくつかの情報が追加で送られるようになります。
 本パラメータを<literal>on</literal>に設定するには、プロトコルバージョンが2以上である必要があります。
 <literal>parallel</literal>に設定するには、プロトコルバージョンが4以上である必要があります。

--- a/doc/src/sgml/protocol.sgml
+++ b/doc/src/sgml/protocol.sgml
@@ -1207,9 +1207,8 @@ SELCT 1/0;<!-- this typo is intentional -->
      except in cases where the query string ends a previously-started
      transaction and begins a new one.
 -->
-《機械翻訳》最後に、ノートは、問い合わせメッセージ内のすべてのステートメントが<function>statement_timestamp()</function>の同じ値を監視します。
-これは、そのタイムスタンプが問い合わせメッセージの受信時にのみ更新されるためです。
-これにより、問い合わせ文字列が以前に開始されたトランザクションを終了し、新しい地域を開始する場合を除き、すべてのステートメントが<function>transaction_timestamp()</function>の同じ値を監視します。
+最後に、Queryメッセージ内のすべての文は、<function>statement_timestamp()</function>の値が同じになることに注意してください。これは、タイムスタンプがQueryメッセージの受信時にのみ更新されるためです。
+これにより、問い合わせ文字列が以前に開始されたトランザクションを終了し、新しいトランザクションを開始する場合を除き、すべての文は<function>statement_timestamp()</function>の値も同じになります。
     </para>
    </sect3>
   </sect2>
@@ -4807,15 +4806,11 @@ PostgreSQLサーバの操作中に作成される種々の一時ファイルお�
        <literal>on</literal>.  Minimum protocol version 4 is required for the
        <literal>parallel</literal> value.
 -->
-《マッチ度[54.382022]》進行中のトランザクションのストリーミングを有効にするブールオプションです。
-並列処理に使用される追加情報の送信を有効にするため、追加の値「parallel」を受け付けます。
-本パラメータを有効化するには、プロトコルバージョンが2以上である必要があります。
-「parallel」に指定する場合は、プロトコルバージョンが4以上である必要があります。
-《機械翻訳》進行中のトランザクションのストリーミングを有効にするオプション。
-有効な値は、<literal>off</literal>デフォルト、<literal>on</literal>および<literal>parallel</literal>です。
-設定<literal>parallel</literal>により、並列化に使用されるいくつかのメッセージとともに追加情報を送信できます。
-<literal>on</literal>回転するには最小プロトコルバージョン2が必要です。
-<literal>parallel</literal>値には最小プロトコルバージョン4が必要です。
+進行中のトランザクションのストリーミングを有効にするオプションです。
+有効な値は<literal>off</literal>(デフォルトです)、<literal>on</literal>および<literal>parallel</literal>できます。
+<literal>parallel</literal>に設定すると、並列化に使われるいくつかの情報が追加で送られるようになります。
+本パラメータを<literal>on</literal>に設定するには、プロトコルバージョンが2以上である必要があります。
+<literal>parallel</literal>に設定するには、プロトコルバージョンが4以上である必要があります。
       </para>
      </listitem>
     </varlistentry>
@@ -9866,11 +9861,8 @@ Deleteメッセージは'K'メッセージ部分と'O'メッセージ部分の�
          The LSN of the abort operation, present only when streaming is set to parallel.
          This field is available since protocol version 4.
 -->
-《マッチ度[53.488372]》トランザクションのxid（ストリームトランザクションのためにのみ存在します）。
-このフィールドはプロトコルバージョン2以降で利用可能です。
-《機械翻訳》中断オペレーションのLSN。
-ストリーミングがパラレルに設定されている場合にのみ存在します。
-このフィールドはプロトコルバージョン4から使用可能です。
+アボート操作のLSNです。streamingオプションがparallelに設定された場合にのみ存在します。
+このフィールドはプロトコルバージョン4以降で使用可能です。
         </para>
        </listitem>
       </varlistentry>
@@ -9884,13 +9876,9 @@ Deleteメッセージは'K'メッセージ部分と'O'メッセージ部分の�
          parallel. The value is in number of microseconds since PostgreSQL epoch (2000-01-01).
          This field is available since protocol version 4.
 -->
-《マッチ度[64.593301]》トランザクションのアボート時刻です。
+トランザクションのアボート時刻です。streamingオプションがparallelに設定された場合にのみ存在します。
 その値はPostgreSQLのエポック（2000-01-01）からのマイクロ秒数です。
 このフィールドはプロトコルバージョン4以降で使用可能です。
-《機械翻訳》トランザクションの中断タイムスタンプ。
-ストリーミングがパラレルに設定されている場合にのみ存在します。
-値はPostgreSQLエポック(2000-01-01)からのマイクロ秒単位です。
-このフィールドはプロトコルバージョン4から使用可能です。
         </para>
        </listitem>
       </varlistentry>


### PR DESCRIPTION
原文で怪しそうなところを見つけました、
streamingはパラメータ名、parallelはその値なので、どちらも<literal>タグで修飾すべきかも？

```
         The LSN of the abort operation, present only when streaming is set to parallel.
         This field is available since protocol version 4.
```