### PR TITLE
"parallel apply workers" が「並列同期ワーカー」となっている翻訳を修正

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -7896,7 +7896,7 @@ WALレコードは、適用される準備が整うまでスタンバイに保�
         in-progress transactions with subscription parameter
         <literal>streaming = parallel</literal>.
 -->
-サブスクリプションごとの適用並列ワーカーの最大数です。
+サブスクリプションごとのパラレル適用ワーカーの最大数です。
 このパラメータは、サブスクリプションパラメータの<literal>streaming = parallel</literal>が指定されている進行中のトランザクションのストリーミングに対する並列度の数を制御します。
        </para>
        <para>
@@ -7904,7 +7904,7 @@ WALレコードは、適用される準備が整うまでスタンバイに保�
         The parallel apply workers are taken from the pool defined by
         <varname>max_logical_replication_workers</varname>.
 -->
-並列同期ワーカーは、<varname>max_logical_replication_workers</varname>で定義されたプールから取得されます。
+パラレル適用ワーカーは、<varname>max_logical_replication_workers</varname>で定義されたプールから取得されます。
        </para>
        <para>
 <!--

--- a/doc/src/sgml/config1.sgml
+++ b/doc/src/sgml/config1.sgml
@@ -3577,7 +3577,7 @@ WALレコードは、適用される準備が整うまでスタンバイに保�
         in-progress transactions with subscription parameter
         <literal>streaming = parallel</literal>.
 -->
-サブスクリプションごとの適用並列ワーカーの最大数です。
+サブスクリプションごとのパラレル適用ワーカーの最大数です。
 このパラメータは、サブスクリプションパラメータの<literal>streaming = parallel</literal>が指定されている進行中のトランザクションのストリーミングに対する並列度の数を制御します。
        </para>
        <para>
@@ -3585,7 +3585,7 @@ WALレコードは、適用される準備が整うまでスタンバイに保�
         The parallel apply workers are taken from the pool defined by
         <varname>max_logical_replication_workers</varname>.
 -->
-並列同期ワーカーは、<varname>max_logical_replication_workers</varname>で定義されたプールから取得されます。
+パラレル適用ワーカーは、<varname>max_logical_replication_workers</varname>で定義されたプールから取得されます。
        </para>
        <para>
 <!--


### PR DESCRIPTION
max_parallel_apply_workers_per_subscription の説明において、「parallel apply workers」が一部「並列同期ワーカー」と翻訳されておりました。
こちらは「同期ワーカー」ではなく「適用ワーカー」が正しいと思いますので、PR いたしました。

現状の日本語ドキュメント：
https://www.postgresql.jp/document/17/html/runtime-config-replication.html
```
max_parallel_apply_workers_per_subscription (integer)

並列同期ワーカーは、max_logical_replication_workersで定義されたプールから取得されます。
```

英語ドキュメント：
https://www.postgresql.org/docs/current/runtime-config-replication.html
```
max_parallel_apply_workers_per_subscription (integer)

The parallel apply workers are taken from the pool defined by max_logical_replication_workers.
```

また、他の箇所では、parallel apply worker は「パラレル適用ワーカー」との翻訳が多数でしたので、「適用並列ワーカー」と翻訳されている箇所も「パラレル適用ワーカー」と統一いたしました。

