### PR TITLE
doc_ja_18に含まれていなかった17ブランチからの修正

### DIFF
--- a/doc/src/sgml/config2.sgml
+++ b/doc/src/sgml/config2.sgml
@@ -4493,13 +4493,12 @@ SQL関数、C言語関数も追跡するためには<literal>all</literal>と指
 デフォルトは1.5億トランザクションです。
 ユーザはこの値をゼロから20億までの任意の値に設定することができますが、<command>VACUUM</command>は警告することなく、周回問題対策のautovacuumがテーブルに対して起動する前に定期的な手動<command>VACUUM</command>が実行する機会を持つように、<xref linkend="guc-autovacuum-freeze-max-age"/>の95%に実効値を制限します。
 詳細は<xref linkend="vacuum-for-wraparound"/>を参照してください。
-《機械翻訳》<command>VACUUM</command>は、テーブルの<structname>pg_frozen</structname><structfield>relfrozenxid</structfield>スキャンがこの設定で指定された経過時間に達した場合、積極的なクラスを実行します。
+《機械翻訳》<command>VACUUM</command>は、テーブルの<structname>pg_class</structname>.<structfield>relfrozenxid</structfield>スキャンがこの設定で指定された経過時間に達した場合、積極的なクラスを実行します。
 積極的なフィールドは、通常の<command>VACUUM</command>不要なタプルを含む可能性のあるページだけでなく、フリーズされていないXIDまたはMXIDを含む可能性のあるすべてのデフォルトを訪問するとは異なります。
-は150,000,000トランザクションです。
+デフォルトは150,000,000トランザクションです。
 ユーザはこの値をゼロから2,000,000,000までの任意の場所に設定できますが、<command>VACUUM</command>は暗黙的に実効値を<xref linkend="guc-autovacuum-freeze-max-age"/>の95%に制限します。
-これにより、定期的なマニュアル<command>VACUUM</command>アンチを実行する機会があります-周回オートバキュームがテーブルに対して起動されます。
+これにより、テーブルに対して反ラップアラウンドの自動バキュームが起動される前に、定期的な手動<command>VACUUM</command>が実行される可能性があります。
 詳細は<xref linkend="vacuum-for-wraparound"/>を参照してください。
-スキャン前
         </para>
        </listitem>
       </varlistentry>

--- a/doc/src/sgml/config3.sgml
+++ b/doc/src/sgml/config3.sgml
@@ -2097,7 +2097,7 @@ GINインデックススキャンにより返されるセットのソフトな�
 -->
 文字列リテラルの中で引用符が<literal>\'</literal>で表現されるかどうかを管理します。
 引用符の表現として標準SQLの方式では二重化（<literal>''</literal>）ですが、<productname>PostgreSQL</productname>は歴史的に<literal>\'</literal>も受け付けます。
-とは言っても、いくつかのクライアント文字集合符号化方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
+とは言っても、いくつかのクライアント文字集合エンコーディング方式において、最終バイトが数値的にASCIIの<literal>\</literal>に等しいマルチバイト文字があり、<literal>\'</literal>を使用するとセキュリティ上問題を引き起こす可能性があります。
 クライアント側のコードが事実上エスケープを正しく扱わない場合、SQLインジェクション攻撃が可能になります。この危険性の回避は、サーバが逆スラッシュでエスケープされた引用符を含む問い合わせを拒絶するようにします。
 許可される<varname>backslash_quote</varname>の値は、<literal>on</literal> （常に <literal>\'</literal> を許可）,<literal>off</literal> （常に拒否）、および<literal>safe_encoding</literal> （クライアント符号化方式がASCIIの<literal>\</literal>を許可しないときのみ、マルチバイト文字内で許可）。
 <literal>safe_encoding</literal> がデフォルトの設定。

--- a/doc/src/sgml/information_schema.sgml
+++ b/doc/src/sgml/information_schema.sgml
@@ -999,7 +999,7 @@ PostgreSQLはひとつのデータベース内で複数の文字集合をサポ�
 <!--
      <term>character set</term>
 -->
-     <term>文字レパートリ</term>
+     <term>文字集合</term>
      <listitem>
       <para>
 <!--

--- a/doc/src/sgml/ref/psql-ref.sgml
+++ b/doc/src/sgml/ref/psql-ref.sgml
@@ -2166,7 +2166,7 @@ SELECT $1 \parse stmt1
         If <literal>+</literal> is appended to the command name, each object
         is listed with its associated description.
 -->
-《マッチ度[71.072797]》文字セット符号化方式間の変換の一覧を表示します。
+《マッチ度[71.072797]》文字集合符号化方式間の変換の一覧を表示します。
 <replaceable class="parameter">pattern</replaceable>が指定された場合、そのパターンに名前がマッチする変換のみが表示されます。
 デフォルトではユーザが作成したオブジェクトのみが表示されます。
 システムオブジェクトを含めるためには、パターンまたは<literal>S</literal>修飾子を付与してください。
@@ -4127,7 +4127,7 @@ SELECT
         (Size information is only available for databases that the current
         user can connect to.)
 -->
-《マッチ度[73.118280]》サーバ内のデータベースについて、その名前、所有者、文字セット符号化方式、アクセス権限を一覧表示します。
+《マッチ度[73.118280]》サーバ内のデータベースについて、その名前、所有者、文字集合符号化方式、アクセス権限を一覧表示します。
 <replaceable class="parameter">pattern</replaceable>を指定すると、パターンにマッチする名前を持つデータベースのみを表示します。
 コマンド名に<literal>+</literal>を付けると、データベースのサイズ、デフォルトのテーブル空間、説明も表示します。
 （サイズ情報は現在のユーザが接続可能なデータベースでのみ表示されます。）


### PR DESCRIPTION
「character set」→「文字集合」
「character repertoire」→「文字レパートリ」
に変更。
 #3425 で修正してしまったのを再修正で、 #2830 の対応です。