### PR TITLE
syntax.sgmlの18.0対応です。

### DIFF
--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -3848,7 +3848,7 @@ SELECT getf1(CAST(ROW(11,'this is a test',2.5) AS myrowtype));
    use them in connection with subqueries, as discussed in <xref
    linkend="functions-subquery"/>.
 -->
-《マッチ度[94.693878]》行コンストラクタを使用すると、複合値を作成し、複合型のテーブル列に格納したり、複合パラメータを受け入れる関数に渡すことができます。
+行コンストラクタを使用すると、複合値を作成し、複合型のテーブル列に格納したり、複合パラメータを受け入れる関数に渡すことができます。
 また、<xref linkend="functions-comparison"/>で説明されているように、標準比較演算子を使用して行をテストしたり、<xref linkend="functions-comparisons"/>で説明されているように、ある行を別の行と比較したり、<xref linkend="functions-subquery"/>で説明されているように、副問い合わせと組み合わせてそれらを使用したりすることもできます。
   </para>
 


### PR DESCRIPTION
ピリオドミスの修正なので訳文変更なしです。