### PR TITLE
update for 18.0 - part 4

### DIFF
--- a/src/backend/catalog/sql_features.txt.ja
+++ b/src/backend/catalog/sql_features.txt.ja
@@ -281,7 +281,7 @@ F461	名前付き文字セット			NO
 F471	スカラ副問い合わせ値			YES	
 F481	拡張NULL述語			YES	
 F491	制約管理			YES	
-F492	省略可能なテーブル制約の強制			NO	
+F492	省略可能なテーブル制約の強制			YES	非NULL制約を除く
 F501	機能と準拠ビュー			YES	
 F501	機能と準拠ビュー	01	SQL_FEATURESビュー	YES	
 F501	機能と準拠ビュー	02	SQL_SIZINGビュー	YES	

--- a/src/backend/utils/errcodes.txt.ja
+++ b/src/backend/utils/errcodes.txt.ja
@@ -2,7 +2,7 @@
 # errcodes.txt
 #      PostgreSQL error codes
 #
-# Copyright (c) 2003-2024, PostgreSQL Global Development Group
+# Copyright (c) 2003-2025, PostgreSQL Global Development Group
 #
 # This list serves as the basis for generating source files containing error
 # codes. It is kept in a common format to make sure all these source files have
@@ -140,6 +140,12 @@ Section: クラス 0Z - 診断の例外
 
 0Z000    E    ERRCODE_DIAGNOSTICS_EXCEPTION                                  diagnostics_exception
 0Z002    E    ERRCODE_STACKED_DIAGNOSTICS_ACCESSED_WITHOUT_ACTIVE_HANDLER    stacked_diagnostics_accessed_without_active_handler
+
+Section: Class 10 - XQueryエラー
+
+# recent SQL versions define quite a few codes in this class, but for now
+# we are only using this generic one
+10608    E    ERRCODE_INVALID_ARGUMENT_FOR_XQUERY                            invalid_argument_for_xquery
 
 Section: クラス 20 - caseが存在しない
 
@@ -438,6 +444,7 @@ Section: クラス 58 - システムエラー(PostgreSQL自体の外部のエラ
 58030    E    ERRCODE_IO_ERROR                                               io_error
 58P01    E    ERRCODE_UNDEFINED_FILE                                         undefined_file
 58P02    E    ERRCODE_DUPLICATE_FILE                                         duplicate_file
+58P03    E    ERRCODE_FILE_NAME_TOO_LONG                                     file_name_too_long
 
 Section: クラス F0 - 設定ファイルエラー
 


### PR DESCRIPTION
doc/src/sgml/ の下にはないですが、以下のファイルも更新しないといけないと思います。

- src/backend/catalog/sql_features.txt.ja
- src/backend/utils/errcodes.txt.ja

（src/backend/catalog/sql_feature_packages.txt.ja も対象なのですが、今回は.jaなしのファイルに変更がありませんでした。）