### PR TITLE
glossary.sgmlの18.0対応です

### DIFF
--- a/doc/src/sgml/glossary.sgml
+++ b/doc/src/sgml/glossary.sgml
@@ -126,10 +126,16 @@
   </glossentry>
 
   <glossentry id="glossary-aio">
+<!--
    <glossterm>Asynchronous <acronym>I/O</acronym></glossterm>
+-->
+   <glossterm>Asynchronous <acronym>I/O</acronym>【非同期<acronym>I/O</acronym>】</glossterm>
    <acronym>AIO</acronym>
    <indexterm>
     <primary>Asynchronous <acronym>I/O</acronym></primary>
+   </indexterm>
+   <indexterm>
+    <primary>非同期<acronym>I/O</acronym></primary>
    </indexterm>
    <glossdef>
     <para>
@@ -139,7 +145,7 @@
      in contrast to synchronous <acronym>I/O</acronym>, which blocks for the
      entire duration of the <acronym>I/O</acronym>.
 -->
-《機械翻訳》非同期<acronym>入出力</acronym><acronym>AIO</acronym>は、<acronym>入出力</acronym>の全期間にわたってブロックするブロッキング<acronym>入出力</acronym>とは対照的に、同期的以外の方法（非同期的）で<acronym>入出力</acronym>を実行することを記述している。
+非同期<acronym>I/O</acronym>（<acronym>AIO</acronym>）は、<acronym>I/O</acronym>の全期間にわたってブロックする同期<acronym>I/O</acronym>とは対照的に、ブロッキングしない方法（非同期）で<acronym>I/O</acronym>を実行することを指します。
     </para>
     <para>
 <!--
@@ -150,8 +156,8 @@
      concurrently with <acronym>I/O</acronym>. The price for that increased
      concurrency is increased complexity.
 -->
-《機械翻訳》<acronym>AIO</acronym>を使用すると、<acronym>入出力</acronym>オペレーションの開始がオペレーションの結果待ちから分離されるため、<acronym>入出力</acronym>と同時に<acronym>中央演算処理装置</acronym>の負荷の高い操作を実行するだけでなく、マルチプル<acronym>入出力</acronym>操作を同時に開始できるようになります。
-同時実行性が向上すると、複雑さが増します。
+<acronym>AIO</acronym>では、<acronym>I/O</acronym>操作の開始とその操作の結果を待つことが分離されており、複数の<acronym>I/O</acronym>操作を同時に開始したり、<acronym>I/O</acronym>と同時に<acronym>CPU</acronym>負荷の高い操作を実行したりすることができます。
+この並行性の向上の代償は、複雑さの増加です。
     </para>
     <glossseealso otherterm="glossary-io" />
    </glossdef>
@@ -1493,7 +1499,10 @@ WALファイルと組み合わせてリカバリ、ログシッピング、ま�
   </glossentry>
 
   <glossentry id="glossary-io">
+<!--
    <glossterm>Input/Output</glossterm>
+-->
+   <glossterm>Input/Output【入力/出力】</glossterm>
    <acronym>I/O</acronym>
    <glossdef>
     <para>
@@ -1503,8 +1512,8 @@ WALファイルと組み合わせてリカバリ、ログシッピング、ま�
      <acronym>I/O</acronym> commonly, but not exclusively, refers to
      interaction with storage devices or the network.
 -->
-《機械翻訳》入出力<acronym>I/O</acronym>は、プログラムと周辺装置との間の通信を記述します。
-コンテキストシステムのデータベースでは、<acronym>I/O</acronym>は通常、ストレージ装置またはネットワークとの対話を指しますが、これに限定されません。
+Input/Output（入力/出力）（<acronym>I/O</acronym>）は、プログラムと周辺装置との間の通信を記述します。
+データベースシステムの文脈では、<acronym>I/O</acronym>は一般的に、ストレージ装置またはネットワークとの対話を指しますが、これに限定されません。
     </para>
     <glossseealso otherterm="glossary-aio" />
    </glossdef>
@@ -1729,7 +1738,7 @@ WALファイルと組み合わせてリカバリ、ログシッピング、ま�
      A set of publisher and subscriber instances with the publisher instance
      replicating changes to the subscriber instance.
 -->
-《機械翻訳》パブリッシャーインスタンスの変更をサブスクライバーインスタンスに複製する、パブリッシャーとサブスクライバーの一連のインスタンス。
+パブリッシャーインスタンスがサブスクライバーインスタンスに変更をレプリケートする、パブリッシャーとサブスクライバーの一連のインスタンス。
     </para>
    </glossdef>
   </glossentry>
@@ -1852,7 +1861,10 @@ WALファイルと組み合わせてリカバリ、ログシッピング、ま�
   </glossentry>
 
   <glossentry id="glossary-merge">
+<!--
    <glossterm>Merge</glossterm>
+-->
+   <glossterm>Merge【マージ】</glossterm>
    <glossdef>
     <para>
 <!--
@@ -3005,7 +3017,10 @@ WALファイルと組み合わせてリカバリ、ログシッピング、ま�
   </glossentry>
 
   <glossentry id="glossary-tps">
+<!--
    <glossterm>Transactions per second (TPS)</glossterm>
+-->
+   <glossterm>Transactions per second (TPS)【1秒あたりのトランザクション数】</glossterm>
    <glossdef>
     <para>
 <!--


### PR DESCRIPTION
抜けがあったglosstermの訳も追加してます。