### PR TITLE
xfunc.sgmlの18.0対応

### DIFF
--- a/doc/src/sgml/xfunc.sgml
+++ b/doc/src/sgml/xfunc.sgml
@@ -3456,7 +3456,7 @@ Version-1関数では、それぞれの実引数は、引数のデータ型に�
 これらの便利な関数および類似の関数は、<filename>fmgr.h</filename>にあります。
 <function>DirectFunctionCall<replaceable>n</replaceable></function>族はC関数の名前を最初の引数として想定しています。
 また、対象関数のOIDを受け取る<function>OidFunctionCall<replaceable>n</replaceable></function>や、その他の亜種もあります。
-これらはすべて、関数の引数が<type>Datum</type>sとして提供されることを想定しており、同様に<type>Datum</type>として返します。
+これらはすべて、関数の引数が<type>Datum</type>として提供されることを想定しており、同様に<type>Datum</type>として返します。
 これらの便利な関数を使用する場合、引数も結果もNULLではないことを想定していることに注意してください。
     </para>
 
@@ -4027,7 +4027,7 @@ C関数の作成と構築の基本規則を以下に示します。
       The <acronym>API</acronym>, or application programming interface, is the
       interface used at compile time.
 -->
-<acronym>API</acronym>またはアプリケーション・プログラミング・インタフェースは、コンパイル時に使用されるインタフェースです。
+<acronym>API</acronym>、すなわちアプリケーションプログラミングインタフェースは、コンパイル時に使用されるインタフェースです。
      </para>
 
      <sect4 id="xfunc-guidance-api-major-versions">
@@ -4091,7 +4091,7 @@ C関数の作成と構築の基本規則を以下に示します。
        The <acronym>ABI</acronym>, or application binary interface, is the
        interface used at run time.
 -->
-<acronym>ABI</acronym>、またはアプリケーション・バイナリ・インタフェースは、実行時に使用されるインタフェースです。
+<acronym>ABI</acronym>、すなわちアプリケーションバイナリインタフェースは、実行時に使用されるインタフェースです。
       </para>
 
      <sect4 id="xfunc-guidance-abi-major-versions">


### PR DESCRIPTION
## 翻訳メモ

variant 亜種
色々な意味があり難しい… 変種・亜種などがあるが、多そうなのは亜種

and/or AおよびB、またはいずれか一方
英語では明確かつ端的に示せる便利な言葉だが日本語だとややこしい

semantic セマンティック 
「意味」という意味、そのまま「セマンティック」としている箇所が多いので「セマンティック」を採用

Semantiv versioning セマンティックバージョニング
そのままでバージョン規則に関するルール名が一般的な模様

family 族
アドレスファミリー、などの使い方を除くと、何々族、という使い方が多い

collation information 照合順序情報

C Type Cの型

extension 拡張機能

guidance 手引

When a change <emphasis>is</emphasis> required 
「必要」を強調 英文ではisのみを強調する形。存在する場合を強調しているという理解なので日本語ではその後のワードを強調、「変更が必要」という全体を強調したほうが自然？

critical section クリティカルセクション

Cumulative Statistics System 累積統計システム
ドキュメントの既存翻訳のまま

Custom Cumulative Statistics カスタム累積統計
ドキュメントでは「累積統計」ですが、本体日本語エラーメッセージでは「独自集積統計情報」。ドキュメントの方が自然と考えそちらに寄せています

## セクションIDのtypo

セクションIDにtypoと思われる箇所あり mninor->minor

```
<sect4 id="xfunc-guidance-api-mninor-versions">
<sect4 id="xfunc-guidance-abi-mninor-versions">
```

現状どこからもリンクはされていないので、問題はないです。
細かすぎるのでできればなにかに合わせて本体にフィードバック？