### PR TITLE
s/WAL送信処理/WAL送信プロセス

### DIFF
--- a/doc/src/sgml/high-availability.sgml
+++ b/doc/src/sgml/high-availability.sgml
@@ -1533,7 +1533,7 @@ primary_conninfo = 'host=192.168.1.50 port=5432 user=foo password=foopass'
      <function>pg_last_wal_receive_lsn</function> on the standby might indicate
      network delay, or that the standby is under heavy load.
 -->
-<link linkend="monitoring-pg-stat-replication-view"><structname>pg_stat_replication</structname></link>ビューを介してWAL送信処理プロセスのリストを入手することができます。
+<link linkend="monitoring-pg-stat-replication-view"><structname>pg_stat_replication</structname></link>ビューを介してWAL送信プロセスのリストを入手することができます。
 <function>pg_current_wal_lsn</function>とビューの<literal>sent_lsn</literal>フィールドとの違いが大きい場合、プライマリサーバが高負荷状態であることを示している可能性があります。
 一方でスタンバイサーバ上の<literal>sent_lsn</literal>と<function>pg_last_wal_receive_lsn</function>の値の差異は、ネットワーク遅延、またはスタンバイが高負荷状態であることを示す可能性があります。
     </para>

--- a/doc/src/sgml/monitoring.sgml
+++ b/doc/src/sgml/monitoring.sgml
@@ -1861,7 +1861,7 @@ WAL送信プロセスにログインしたユーザの名前です。
        Name of the application that is connected
        to this WAL sender
 -->
-WAL送信処理に接続したアプリケーションの名前です。
+WAL送信プロセスに接続したアプリケーションの名前です。
       </para></entry>
      </row>
 
@@ -1875,7 +1875,7 @@ WAL送信処理に接続したアプリケーションの名前です。
        If this field is null, it indicates that the client is
        connected via a Unix socket on the server machine.
 -->
-WAL送信処理に接続したクライアントのIPアドレスです。
+WAL送信プロセスに接続したクライアントのIPアドレスです。
 このフィールドがNULLの場合、クライアントがサーバマシン上のUnixソケット経由で接続したことを示します。
       </para></entry>
      </row>
@@ -1904,7 +1904,7 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
        TCP port number that the client is using for communication
        with this WAL sender, or <literal>-1</literal> if a Unix socket is used
 -->
-クライアントがWAL送信処理との通信に使用するTCPポート番号、もしUnixソケットを使用する場合は<literal>-1</literal>です。
+クライアントがWAL送信プロセスとの通信に使用するTCPポート番号、もしUnixソケットを使用する場合は<literal>-1</literal>です。
       </para></entry>
      </row>
 
@@ -1917,7 +1917,7 @@ IP接続、かつ<xref linkend="guc-log-hostname"/>が有効である場合に�
        Time when this process was started, i.e., when the
        client connected to this WAL sender
 -->
-プロセスが開始、つまりクライアントがWAL送信処理に接続した時刻です。
+プロセスが開始、つまりクライアントがWAL送信プロセスに接続した時刻です。
       </para></entry>
      </row>
 


### PR DESCRIPTION
「WAL送信処理」という記述が何点かありますが、文脈的には「WAL送信プロセス」とするのが正しいように思われます。
ご確認いただけますでしょうか。