### PR TITLE
translate ecpg.sgml

### DIFF
--- a/doc/src/sgml/ecpg.sgml
+++ b/doc/src/sgml/ecpg.sgml
@@ -2556,12 +2556,9 @@ while (1)
      columns <literal>a</literal> and <literal>b</literal>, and select
      them from the table after that.
 -->
-《マッチ度[87.476636]》以下に<xref linkend="xtypes"/>に含まれる<type>complex</type>型を使った例を示します。
-この型の外部文字列表現は<literal>(%f,%f)</literal>で、<xref linkend="xtypes"/>の<function>complex_in()</function>関数および<function>complex_out()</function>関数で定義されています。
+以下に<xref linkend="xtypes"/>に含まれる<type>complex</type>型を使った例を示します。
+この型の外部文字列表現は<literal>(%f,%f)</literal>で、<xref linkend="xtypes"/>の<function>complex_in()</function>および<function>complex_out()</function>で定義されています。
 以下の例は、カラム<literal>a</literal>と<literal>b</literal>に、complex型の値<literal>(1,1)</literal>および<literal>(3,3)</literal>を挿入し、その後、それらをテーブルからSELECTします。
-《機械翻訳》これは、<xref linkend="xtypes"/>の例からデータタイプ<type>複合</type>を使用した例です。
-そのタイプの外部文字列表現形式は<literal>(%f,%f)</literal>で、関数<function>complex_in()</function>および<function>complex_out()</function><xref linkend="xtypes"/>ので定義されています。
-次の例は、複合型の値<literal>(1,1)</literal>および<literal>(3,3)</literal>を<literal>a</literal>および<literal>b</literal>列に挿入し、その後テーブルからセレクトします。
 
 <programlisting>
 EXEC SQL BEGIN DECLARE SECTION;


### PR DESCRIPTION
原文では「function」が一か所消えただけですが、整合性を保つために二か所から「関数」を消しています。
