### PR TITLE
translate pg_dump.sgml for PG18.2

### DIFF
--- a/doc/src/sgml/ref/pg_dump.sgml
+++ b/doc/src/sgml/ref/pg_dump.sgml
@@ -1988,8 +1988,7 @@ pg_dumpを始めた時に読み書きを行う実行中のトランザクショ�
 <!--
         Dump optimizer statistics.
 -->
-《マッチ度[50.000000]》統計情報をダンプします。
-《機械翻訳》ダンプオプティマイザ統計処理。
+オプティマイザ統計情報をダンプします。
        </para>
       </listitem>
      </varlistentry>
@@ -2003,11 +2002,8 @@ pg_dumpを始めた時に読み書きを行う実行中のトランザクショ�
         Optimizer statistics for tables, materialized views, foreign tables,
         and indexes are dumped.
 -->
-《マッチ度[83.229814]》統計情報のみをダンプし、スキーマ（データ定義）とデータはダンプしません。
-テーブル、マテリアライズドビュー、外部テーブル、およびインデックスの統計情報がダンプされます。
-《機械翻訳》ダンプ統計処理のみをダンプします。
-スキーマ（データの定義）やデータはダンプしません。
-オプティマイザ統計処理のテーブル、実体化ビュー(Materialized View)、外部テーブル、インデックスをダンプします。
+統計情報のみをダンプし、スキーマ（データ定義）とデータはダンプしません。
+テーブル、マテリアライズドビュー、外部テーブル、およびインデックスのオプティマイザ統計情報がダンプされます。
        </para>
       </listitem>
      </varlistentry>
@@ -2423,14 +2419,10 @@ CREATE DATABASE foo WITH TEMPLATE template0;
    optimal performance; see <xref linkend="vacuum-for-statistics"/> and <xref
    linkend="autovacuum"/> for more information.
 -->
-《マッチ度[77.326565]》<option>--statistics</option>が指定されている場合、<command>pg_dump</command>は出力されるダンプファイルにほとんどのオプティマイザの統計情報を含めます。
-しかし、<xref linkend="sql-createstatistics"/>で明示的に作成された統計情報や、拡張により追加された独自統計情報など、一部の統計情報は含まれない場合があります。
+<option>--statistics</option>が指定されている場合、<command>pg_dump</command>は出力されるダンプファイルにほとんどのオプティマイザの統計情報を含めます。
+これにはすべての統計情報が含まれるわけではありません。例えば、<xref linkend="sql-createstatistics"/>で明示的に作成された統計情報や、拡張により追加された独自統計情報、累積統計システムによって収集された統計情報などはダンプファイルには含まれません。
 そのため、最適な性能を発揮するためには、ダンプファイルからリストアした後で<command>ANALYZE</command>を実行すると効果的な場合があります。
 詳細は<xref linkend="vacuum-for-statistics"/>および<xref linkend="autovacuum"/>を参照してください。
-《機械翻訳》<option>--statistics</option>が指定されている場合、<command>pg_dump</command>は結果のダンプファイルのほとんどのオプティマイザ統計処理をincludeします。
-<xref linkend="sql-createstatistics"/>で明示的に作成された統計処理、extensionによって追加されたカスタム統計処理、または累積統計処理システムによって収集された統計処理など、すべてのをincludeするわけではありません。
-したがって、<command>ANALYZE</command>ダンプファイルから保証の最適パフォーマンスにリストアした後を実行すると便利な場合があります。
-詳細は、<xref linkend="vacuum-for-statistics"/>および<xref linkend="autovacuum"/>を参照してください。
   </para>
 
   <para>


### PR DESCRIPTION
pg_dumpall.sgmlの変更内容も同じようです。こちらのファイル完了後に取り組みます。

`--statistics`の翻訳については、一部文章を2つに分けています。問題があればお伝えください。