### PR TITLE
訳文でタグの単語を省略しないように修正

### DIFF
--- a/doc/src/sgml/amcheck.sgml
+++ b/doc/src/sgml/amcheck.sgml
@@ -215,10 +215,10 @@ ORDER BY c.relpages DESC LIMIT 10;
 -->
 <function>bt_index_parent_check</function>は、対象となるB-Treeインデックスが様々な不変量を保っていることを検査します。
 オプションとして、<parameter>heapallindexed</parameter>引数が<literal>true</literal>の場合、インデックスに対応して存在すべきすべてのヒープタプルの存在を検証します。
-<parameter>checkunique</parameter>が<literal>true</literal>の場合、一意インデックスの重複エントリの中で可視のものが1つだけであることを検査します。
+<parameter>checkunique</parameter>が<literal>true</literal>の場合、<function>bt_index_parent_check</function>は一意インデックス内の重複エントリの中で可視のものが1つだけであることを検査します。
 省略可能な引数<parameter>rootdescend</parameter>が<literal>true</literal>であれば、各タプルに対するルートページから新しく探索することで、検証はリーフレベルのタプルを再び見つけます。
 <function>bt_index_parent_check</function>により実施される検査は、<function>bt_index_check</function>により実施される検査のスーパーセットになっています。
-<function>bt_index_parent_check</function>は、<function>bt_index_check</function>の更なる完璧版であると考えることができます。
+<function>bt_index_parent_check</function>は、<function>bt_index_check</function>の徹底した検査版であると考えることができます。
 つまり、<function>bt_index_check</function>と違って<function>bt_index_parent_check</function>は、インデックス構造中のダウンリンクに漏れがないことを含め、親／子関係に渡る不変量も検査します。
 <function>bt_index_parent_check</function>は、論理的な非一貫性やその他の問題を発見した場合、一般的な習慣に従ってエラーを報告します。
      </para>

--- a/doc/src/sgml/ref/delete.sgml
+++ b/doc/src/sgml/ref/delete.sgml
@@ -280,7 +280,7 @@ DELETE FROM [ ONLY ] <replaceable class="parameter">table_name</replaceable> [ *
       using the target table name or alias will return old values.
 -->
 列名や<literal>*</literal>は、<literal>OLD</literal>や<literal>NEW</literal>、または<literal>OLD</literal>や<literal>NEW</literal>の対応する<replaceable class="parameter">output_alias</replaceable>を使用して修飾すると、古い値や新しい値を戻すことができます。
-非修飾の列名や<literal>*</literal>、または対象テーブル名前もしくは別名を使用して修飾された列名または<literal>*</literal>は、古い値が戻されます。
+非修飾の列名や<literal>*</literal>、または対象テーブル名もしくは別名を使用して修飾された列名または<literal>*</literal>は、古い値が戻されます。
      </para>
 
      <para>

--- a/doc/src/sgml/ref/delete.sgml
+++ b/doc/src/sgml/ref/delete.sgml
@@ -279,7 +279,7 @@ DELETE FROM [ ONLY ] <replaceable class="parameter">table_name</replaceable> [ *
       <literal>*</literal>, or a column name or <literal>*</literal> qualified
       using the target table name or alias will return old values.
 -->
-列名や<literal>*</literal> は<literal>OLD</literal>や<literal>NEW</literal>または対応する<replaceable class="parameter">output_alias</replaceable> を使用して修飾すると、古い値または新しい値が戻されます。
+列名や<literal>*</literal>は、<literal>OLD</literal>や<literal>NEW</literal>、または<literal>OLD</literal>や<literal>NEW</literal>の対応する<replaceable class="parameter">output_alias</replaceable>を使用して修飾すると、古い値や新しい値を戻すことができます。
 非修飾の列名や<literal>*</literal>、または対象テーブル名前もしくは別名を使用して修飾された列名または<literal>*</literal>は、古い値が戻されます。
      </para>
 


### PR DESCRIPTION
-  訳文でタグの単語を省略しないように修正
- 「更なる完璧版」は変に感じたので修正