### PR TITLE
算術関数の訳の統一

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -1228,7 +1228,7 @@ NULL引数の数を返す。
 <!--
         Addition
 -->
-和
+加算
        </para>
        <para>
         <literal>2 + 3</literal>
@@ -1245,7 +1245,7 @@ NULL引数の数を返す。
 <!--
         Unary plus (no operation)
 -->
-単項和（演算なし）
+単項プラス（演算なし）
        </para>
        <para>
         <literal>+ 3.5</literal>
@@ -1262,7 +1262,7 @@ NULL引数の数を返す。
 <!--
         Subtraction
 -->
-差
+減算
        </para>
        <para>
         <literal>2 - 3</literal>
@@ -1279,7 +1279,7 @@ NULL引数の数を返す。
 <!--
         Negation
 -->
-否定
+単項マイナス
        </para>
        <para>
         <literal>- (-4)</literal>
@@ -1296,7 +1296,7 @@ NULL引数の数を返す。
 <!--
         Multiplication
 -->
-積
+乗算
        </para>
        <para>
         <literal>2 * 3</literal>
@@ -1314,7 +1314,7 @@ NULL引数の数を返す。
         Division (for integral types, division truncates the result towards
         zero)
 -->
-商（整数型では、除算によってゼロへ余りが切り捨てられます）
+除算（整数型では、除算によってゼロへ余りが切り捨てられます）
        </para>
        <para>
         <literal>5.0 / 2</literal>
@@ -1444,7 +1444,7 @@ NULL引数の数を返す。
 <!--
         Bitwise AND
 -->
-ビットごとのAND
+ビット積
        </para>
        <para>
         <literal>91 &amp; 15</literal>
@@ -1461,7 +1461,7 @@ NULL引数の数を返す。
 <!--
         Bitwise OR
 -->
-ビットごとのOR
+ビット論理和
        </para>
        <para>
         <literal>32 | 3</literal>
@@ -1478,7 +1478,7 @@ NULL引数の数を返す。
 <!--
         Bitwise exclusive OR
 -->
-ビットごとの排他的論理和
+ビットの排他的論理和
        </para>
        <para>
         <literal>17 # 5</literal>
@@ -1495,7 +1495,7 @@ NULL引数の数を返す。
 <!--
         Bitwise NOT
 -->
-ビットごとのNOT
+ビット反転
        </para>
        <para>
         <literal>~1</literal>
@@ -1512,7 +1512,7 @@ NULL引数の数を返す。
 <!--
         Bitwise shift left
 -->
-ビットごとの左シフト
+ビット単位の左シフト
        </para>
        <para>
         <literal>1 &lt;&lt; 4</literal>
@@ -1529,7 +1529,7 @@ NULL引数の数を返す。
 <!--
         Bitwise shift right
 -->
-ビットごとの右シフト
+ビット単位の右シフト
        </para>
        <para>
         <literal>8 &gt;&gt; 2</literal>
@@ -5496,7 +5496,7 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
         Returns number of bits in the binary string (8
         times the <function>octet_length</function>).
 -->
-文字列中のビット数を返します（<function>octet_length</function>の8倍）。
+バイナリ文字列中のビット数を返します（<function>octet_length</function>の8倍）。
        </para>
        <para>
         <literal>bit_length('\x123456'::bytea)</literal>
@@ -6552,7 +6552,7 @@ cast(-1234 as bytea)           <lineannotation>\xfffffb2e</lineannotation>
 <!--
         Bitwise AND (inputs must be of equal length)
 -->
-ビット単位のAND（入力は同じ長さでなければなりません）
+ビット積（入力は同じ長さでなければなりません）
        </para>
        <para>
         <literal>B'10001' &amp; B'01101'</literal>
@@ -6569,7 +6569,7 @@ cast(-1234 as bytea)           <lineannotation>\xfffffb2e</lineannotation>
 <!--
         Bitwise OR (inputs must be of equal length)
 -->
-ビット単位のOR（入力は同じ長さでなければなりません）
+ビット論理和（入力は同じ長さでなければなりません）
        </para>
        <para>
         <literal>B'10001' | B'01101'</literal>
@@ -6586,7 +6586,7 @@ cast(-1234 as bytea)           <lineannotation>\xfffffb2e</lineannotation>
 <!--
         Bitwise exclusive OR (inputs must be of equal length)
 -->
-ビット単位の排他的論理和（入力は同じ長さでなければなりません）
+ビットの排他的論理和（入力は同じ長さでなければなりません）
        </para>
        <para>
         <literal>B'10001' # B'01101'</literal>
@@ -6603,7 +6603,7 @@ cast(-1234 as bytea)           <lineannotation>\xfffffb2e</lineannotation>
 <!--
         Bitwise NOT
 -->
-ビット単位の否定
+ビット反転
        </para>
        <para>
         <literal>~ B'10001'</literal>
@@ -17012,7 +17012,7 @@ IPネットワークアドレス型である<type>cidr</type>と<type>inet</type
 <!--
         Computes bitwise NOT.
 -->
-ビット否定を計算します。
+ビット反転を計算します。
        </para>
        <para>
         <literal>~ inet '192.168.1.6'</literal>
@@ -17046,7 +17046,7 @@ IPネットワークアドレス型である<type>cidr</type>と<type>inet</type
 <!--
         Computes bitwise OR.
 -->
-ビット和を計算します。
+ビット論理和を計算します。
        </para>
        <para>
         <literal>inet '192.168.1.6' | inet '0.0.0.255'</literal>
@@ -17478,7 +17478,7 @@ IPアドレスをテキストとして返します。ネットマスクは無視
    (NOT, AND and OR), just as shown above for IP addresses.
 -->
 MACアドレス型である<type>macaddr</type>と<type>macaddr8</type>は、<xref linkend="functions-comparison-op-table"/>で示す通常の比較演算子と<xref linkend="macaddr-functions-table"/>で示す特定目的のための関数をサポートします。
-加えて上記のIPアドレス用に示したのと同様に、ビットごとの論理演算子<literal>~</literal>、<literal>&amp;</literal>、<literal>|</literal>(NOT、AND、OR)をサポートします。
+加えて上記のIPアドレス用に示したのと同様に、ビット単位の論理演算子<literal>~</literal>、<literal>&amp;</literal>、<literal>|</literal>(NOT、AND、OR)をサポートします。
   </para>
 
    <table id="macaddr-functions-table">
@@ -23776,7 +23776,7 @@ ERROR:  jsonpath member accessor can only be applied to an object
         Unary plus (no operation); unlike addition, this can iterate over
         multiple values
 -->
-単項のプラス（演算なし）。加算と違って、複数の値に渡って適用できます。
+単項プラス（演算なし）。加算と違って、複数の値に渡って適用できます。
        </para>
        <para>
         <literal>jsonb_path_query_array('{"x": [2,3,4]}', '+ $.x')</literal>
@@ -23811,7 +23811,7 @@ ERROR:  jsonpath member accessor can only be applied to an object
         Negation; unlike subtraction, this can iterate over
         multiple values
 -->
-負符号。減算と違って、複数の値に渡って適用できます。
+単項マイナス。減算と違って、複数の値に渡って適用できます。
        </para>
        <para>
         <literal>jsonb_path_query_array('{"x": [2,3,4]}', '- $.x')</literal>
@@ -23862,7 +23862,7 @@ ERROR:  jsonpath member accessor can only be applied to an object
 <!--
         Modulo (remainder)
 -->
-剰余（残り）
+剰余（余り）
        </para>
        <para>
         <literal>jsonb_path_query('[32]', '$[0] % 10')</literal>
@@ -28850,7 +28850,7 @@ NULLも含めてすべての入力値を収集して配列に格納します。
 <!--
         Computes the bitwise OR of all non-null input values.
 -->
-全ての非NULLの入力値のビット和を計算します。
+全ての非NULLの入力値のビット論理和を計算します。
        </para></entry>
 <!--
        <entry>Yes</entry>
@@ -28883,7 +28883,7 @@ NULLも含めてすべての入力値を収集して配列に格納します。
         Computes the bitwise exclusive OR of all non-null input values.
         Can be useful as a checksum for an unordered set of values.
 -->
-すべての非NULL入力値のビット毎の排他的論理和を計算します。
+すべての非NULL入力値のビットの排他的論理和を計算します。
 順序付けられない値の集合のチェックサムとして有用かもしれません。
        </para></entry>
 <!--
@@ -31464,7 +31464,7 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
    See <xref linkend="row-wise-comparison"/> for details about the meaning
    of a row constructor comparison.
 -->
-行コンストラクタ比較の意味についての詳細は<xref linkend="row-wise-comparison"/>を参照して下さい。
+行コンストラクタに関する比較の意味についての詳細は<xref linkend="row-wise-comparison"/>を参照してください。
   </para>
   </sect2>
 
@@ -31544,7 +31544,7 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
    See <xref linkend="row-wise-comparison"/> for details about the meaning
    of a row constructor comparison.
 -->
-行コンストラクタに関する比較の意味については<xref linkend="row-wise-comparison"/>を参照してください。
+行コンストラクタに関する比較の意味についての詳細は<xref linkend="row-wise-comparison"/>を参照してください。
   </para>
   </sect2>
 

--- a/doc/src/sgml/func1.sgml
+++ b/doc/src/sgml/func1.sgml
@@ -1159,7 +1159,7 @@ NULL引数の数を返す。
 <!--
         Addition
 -->
-和
+加算
        </para>
        <para>
         <literal>2 + 3</literal>
@@ -1176,7 +1176,7 @@ NULL引数の数を返す。
 <!--
         Unary plus (no operation)
 -->
-単項和（演算なし）
+単項プラス（演算なし）
        </para>
        <para>
         <literal>+ 3.5</literal>
@@ -1193,7 +1193,7 @@ NULL引数の数を返す。
 <!--
         Subtraction
 -->
-差
+減算
        </para>
        <para>
         <literal>2 - 3</literal>
@@ -1210,7 +1210,7 @@ NULL引数の数を返す。
 <!--
         Negation
 -->
-否定
+単項マイナス
        </para>
        <para>
         <literal>- (-4)</literal>
@@ -1227,7 +1227,7 @@ NULL引数の数を返す。
 <!--
         Multiplication
 -->
-積
+乗算
        </para>
        <para>
         <literal>2 * 3</literal>
@@ -1245,7 +1245,7 @@ NULL引数の数を返す。
         Division (for integral types, division truncates the result towards
         zero)
 -->
-商（整数型では、除算によってゼロへ余りが切り捨てられます）
+除算（整数型では、除算によってゼロへ余りが切り捨てられます）
        </para>
        <para>
         <literal>5.0 / 2</literal>
@@ -1375,7 +1375,7 @@ NULL引数の数を返す。
 <!--
         Bitwise AND
 -->
-ビットごとのAND
+ビット積
        </para>
        <para>
         <literal>91 &amp; 15</literal>
@@ -1392,7 +1392,7 @@ NULL引数の数を返す。
 <!--
         Bitwise OR
 -->
-ビットごとのOR
+ビット論理和
        </para>
        <para>
         <literal>32 | 3</literal>
@@ -1409,7 +1409,7 @@ NULL引数の数を返す。
 <!--
         Bitwise exclusive OR
 -->
-ビットごとの排他的論理和
+ビットの排他的論理和
        </para>
        <para>
         <literal>17 # 5</literal>
@@ -1426,7 +1426,7 @@ NULL引数の数を返す。
 <!--
         Bitwise NOT
 -->
-ビットごとのNOT
+ビット反転
        </para>
        <para>
         <literal>~1</literal>
@@ -1443,7 +1443,7 @@ NULL引数の数を返す。
 <!--
         Bitwise shift left
 -->
-ビットごとの左シフト
+ビット単位の左シフト
        </para>
        <para>
         <literal>1 &lt;&lt; 4</literal>
@@ -1460,7 +1460,7 @@ NULL引数の数を返す。
 <!--
         Bitwise shift right
 -->
-ビットごとの右シフト
+ビット単位の右シフト
        </para>
        <para>
         <literal>8 &gt;&gt; 2</literal>
@@ -5427,7 +5427,7 @@ SELECT format('Testing %3$s, %2$s, %s', 'one', 'two', 'three');
         Returns number of bits in the binary string (8
         times the <function>octet_length</function>).
 -->
-文字列中のビット数を返します（<function>octet_length</function>の8倍）。
+バイナリ文字列中のビット数を返します（<function>octet_length</function>の8倍）。
        </para>
        <para>
         <literal>bit_length('\x123456'::bytea)</literal>
@@ -6483,7 +6483,7 @@ cast(-1234 as bytea)           <lineannotation>\xfffffb2e</lineannotation>
 <!--
         Bitwise AND (inputs must be of equal length)
 -->
-ビット単位のAND（入力は同じ長さでなければなりません）
+ビット積（入力は同じ長さでなければなりません）
        </para>
        <para>
         <literal>B'10001' &amp; B'01101'</literal>
@@ -6500,7 +6500,7 @@ cast(-1234 as bytea)           <lineannotation>\xfffffb2e</lineannotation>
 <!--
         Bitwise OR (inputs must be of equal length)
 -->
-ビット単位のOR（入力は同じ長さでなければなりません）
+ビット論理和（入力は同じ長さでなければなりません）
        </para>
        <para>
         <literal>B'10001' | B'01101'</literal>
@@ -6517,7 +6517,7 @@ cast(-1234 as bytea)           <lineannotation>\xfffffb2e</lineannotation>
 <!--
         Bitwise exclusive OR (inputs must be of equal length)
 -->
-ビット単位の排他的論理和（入力は同じ長さでなければなりません）
+ビットの排他的論理和（入力は同じ長さでなければなりません）
        </para>
        <para>
         <literal>B'10001' # B'01101'</literal>
@@ -6534,7 +6534,7 @@ cast(-1234 as bytea)           <lineannotation>\xfffffb2e</lineannotation>
 <!--
         Bitwise NOT
 -->
-ビット単位の否定
+ビット反転
        </para>
        <para>
         <literal>~ B'10001'</literal>

--- a/doc/src/sgml/func2.sgml
+++ b/doc/src/sgml/func2.sgml
@@ -6536,7 +6536,7 @@ IPネットワークアドレス型である<type>cidr</type>と<type>inet</type
 <!--
         Computes bitwise NOT.
 -->
-ビット否定を計算します。
+ビット反転を計算します。
        </para>
        <para>
         <literal>~ inet '192.168.1.6'</literal>
@@ -6570,7 +6570,7 @@ IPネットワークアドレス型である<type>cidr</type>と<type>inet</type
 <!--
         Computes bitwise OR.
 -->
-ビット和を計算します。
+ビット論理和を計算します。
        </para>
        <para>
         <literal>inet '192.168.1.6' | inet '0.0.0.255'</literal>
@@ -7002,7 +7002,7 @@ IPアドレスをテキストとして返します。ネットマスクは無視
    (NOT, AND and OR), just as shown above for IP addresses.
 -->
 MACアドレス型である<type>macaddr</type>と<type>macaddr8</type>は、<xref linkend="functions-comparison-op-table"/>で示す通常の比較演算子と<xref linkend="macaddr-functions-table"/>で示す特定目的のための関数をサポートします。
-加えて上記のIPアドレス用に示したのと同様に、ビットごとの論理演算子<literal>~</literal>、<literal>&amp;</literal>、<literal>|</literal>(NOT、AND、OR)をサポートします。
+加えて上記のIPアドレス用に示したのと同様に、ビット単位の論理演算子<literal>~</literal>、<literal>&amp;</literal>、<literal>|</literal>(NOT、AND、OR)をサポートします。
   </para>
 
    <table id="macaddr-functions-table">

--- a/doc/src/sgml/func3.sgml
+++ b/doc/src/sgml/func3.sgml
@@ -2999,7 +2999,7 @@ ERROR:  jsonpath member accessor can only be applied to an object
         Unary plus (no operation); unlike addition, this can iterate over
         multiple values
 -->
-単項のプラス（演算なし）。加算と違って、複数の値に渡って適用できます。
+単項プラス（演算なし）。加算と違って、複数の値に渡って適用できます。
        </para>
        <para>
         <literal>jsonb_path_query_array('{"x": [2,3,4]}', '+ $.x')</literal>
@@ -3034,7 +3034,7 @@ ERROR:  jsonpath member accessor can only be applied to an object
         Negation; unlike subtraction, this can iterate over
         multiple values
 -->
-負符号。減算と違って、複数の値に渡って適用できます。
+単項マイナス。減算と違って、複数の値に渡って適用できます。
        </para>
        <para>
         <literal>jsonb_path_query_array('{"x": [2,3,4]}', '- $.x')</literal>
@@ -3085,7 +3085,7 @@ ERROR:  jsonpath member accessor can only be applied to an object
 <!--
         Modulo (remainder)
 -->
-剰余（残り）
+剰余（余り）
        </para>
        <para>
         <literal>jsonb_path_query('[32]', '$[0] % 10')</literal>
@@ -8073,7 +8073,7 @@ NULLも含めてすべての入力値を収集して配列に格納します。
 <!--
         Computes the bitwise OR of all non-null input values.
 -->
-全ての非NULLの入力値のビット和を計算します。
+全ての非NULLの入力値のビット論理和を計算します。
        </para></entry>
 <!--
        <entry>Yes</entry>
@@ -8106,7 +8106,7 @@ NULLも含めてすべての入力値を収集して配列に格納します。
         Computes the bitwise exclusive OR of all non-null input values.
         Can be useful as a checksum for an unordered set of values.
 -->
-すべての非NULL入力値のビット毎の排他的論理和を計算します。
+すべての非NULL入力値のビットの排他的論理和を計算します。
 順序付けられない値の集合のチェックサムとして有用かもしれません。
        </para></entry>
 <!--

--- a/doc/src/sgml/func4.sgml
+++ b/doc/src/sgml/func4.sgml
@@ -483,7 +483,7 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
    See <xref linkend="row-wise-comparison"/> for details about the meaning
    of a row constructor comparison.
 -->
-行コンストラクタ比較の意味についての詳細は<xref linkend="row-wise-comparison"/>を参照して下さい。
+行コンストラクタに関する比較の意味についての詳細は<xref linkend="row-wise-comparison"/>を参照してください。
   </para>
   </sect2>
 
@@ -563,7 +563,7 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
    See <xref linkend="row-wise-comparison"/> for details about the meaning
    of a row constructor comparison.
 -->
-行コンストラクタに関する比較の意味については<xref linkend="row-wise-comparison"/>を参照してください。
+行コンストラクタに関する比較の意味についての詳細は<xref linkend="row-wise-comparison"/>を参照してください。
   </para>
   </sect2>
 

--- a/doc/src/sgml/ref/pgbench.sgml
+++ b/doc/src/sgml/ref/pgbench.sgml
@@ -2016,7 +2016,7 @@ SELECT 4 AS four \; SELECT 5 AS five \aset
    a double value if either input is double, otherwise they produce
    an integer result.
 -->
-<xref linkend="pgbench-operators"/>に載っている算術、ビットごと、比較、論理の演算子は<application>pgbench</application>に組み込まれていて、<link linkend="pgbench-metacommand-set"><literal>\set</literal></link>の式で使用できます。
+<xref linkend="pgbench-operators"/>に載っている算術、ビット単位、比較、論理の演算子は<application>pgbench</application>に組み込まれていて、<link linkend="pgbench-metacommand-set"><literal>\set</literal></link>の式で使用できます。
 演算子は優先度の低い順に載っています。
 注意書きがある場合を除いて、2つの数値を取る演算子は、入力の片方が倍精度実数であれば倍精度実数の値を結果とし、そうでなければ整数の結果になります。
   </para>
@@ -2264,7 +2264,7 @@ NULLであるかのテスト
 <!--
         Bitwise OR
 -->
-ビット毎のOR
+ビット論理和
        </para>
        <para>
         <literal>1 | 2</literal>
@@ -2281,7 +2281,7 @@ NULLであるかのテスト
 <!--
         Bitwise XOR
 -->
-ビット毎のXOR
+ビットの排他的論理和
        </para>
        <para>
         <literal>1 # 3</literal>
@@ -2298,7 +2298,7 @@ NULLであるかのテスト
 <!--
         Bitwise AND
 -->
-ビット毎のAND
+ビット積
        </para>
        <para>
         <literal>1 &amp; 3</literal>

--- a/doc/src/sgml/ref/pgbench.sgml
+++ b/doc/src/sgml/ref/pgbench.sgml
@@ -2315,7 +2315,7 @@ NULLであるかのテスト
 <!--
         Bitwise NOT
 -->
-ビット毎のNOT
+ビット反転
        </para>
        <para>
         <literal>~ 1</literal>
@@ -2332,7 +2332,7 @@ NULLであるかのテスト
 <!--
         Bitwise shift left
 -->
-ビット毎の左シフト
+ビット単位の左シフト
        </para>
        <para>
         <literal>1 &lt;&lt; 2</literal>
@@ -2349,7 +2349,7 @@ NULLであるかのテスト
 <!--
         Bitwise shift right
 -->
-ビット毎の右シフト
+ビット単位の右シフト
        </para>
        <para>
         <literal>8 &gt;&gt; 2</literal>
@@ -2417,7 +2417,7 @@ NULLであるかのテスト
 <!--
         Division (truncates the result towards zero if both inputs are integers)
 -->
-除算(入力が両方とも整数であれば、結果は0に向けて丸められる)
+除算（入力が両方とも整数であれば、結果は0に向けて丸められる）
        </para>
        <para>
         <literal>5 / 3</literal>
@@ -2434,7 +2434,7 @@ NULLであるかのテスト
 <!--
         Modulo (remainder)
 -->
-剰余(余り)
+剰余（余り）
        </para>
        <para>
         <literal>3 % 2</literal>
@@ -2451,7 +2451,7 @@ NULLであるかのテスト
 <!--
         Negation
 -->
-符号反転
+単項マイナス
        </para>
        <para>
         <literal>- 2.0</literal>


### PR DESCRIPTION
算術関数の説明を統一しました。
加算、減算、乗算、除算。
単独の＋ーは単項プラス、単項マイナス。

ビット論理和、ビット積、ビット反転は単語があると解釈して割当。
シフトはビット単位の左シフト、ビット単位の右シフトに統一