### PR TITLE
logical-replication.sgmlの18.4対応です

### DIFF
--- a/doc/src/sgml/logical-replication.sgml
+++ b/doc/src/sgml/logical-replication.sgml
@@ -106,8 +106,7 @@ PostgreSQLは両方の仕組みを同時にサポートします。
      Replicating between PostgreSQL instances on different platforms (for
      example Linux to Windows).
 -->
-《マッチ度[88.421053]》異なるプラットフォーム上のPostgreSQLインスタンス間（たとえばLinuxからWindows）でレプリケーションする。
-《機械翻訳》異なるプラットフォーム上のPostgreSQLインスタンス間でのレプリケーション（例リナックスからWindowsへ）。
+異なるプラットフォーム上のPostgreSQLインスタンス間（たとえばLinuxからWindows）でレプリケーションする。
     </para>
    </listitem>
 
@@ -140,7 +139,7 @@ PostgreSQLは両方の仕組みを同時にサポートします。
   other hand, if there are other writes done either by an application or by other
   subscribers to the same set of tables, conflicts can arise.
 -->
-《マッチ度[96.511628]》サブスクライバーのデータベースは、他のPostgreSQLインスタンスと同様に振る舞い、自分用のパブリケーションを定義することにより、他のデータベースに対するパブリッシャーとして利用できます。
+サブスクライバーのデータベースは、他のPostgreSQLインスタンスと同様に振る舞い、自分用のパブリケーションを定義することにより、他のデータベースに対するパブリッシャーとして利用できます。
 アプリケーションがそのサブスクライバーを読み取り専用として取り扱うときには、単独のサブスクリプションからはコンフリクトは発生しません。
 一方、アプリケーションあるいは他のサブスクライバーから同じテーブルに書き込みが起こるとすると、コンフリクトが発生する可能性があります。
  </para>
@@ -320,7 +319,7 @@ PostgreSQLは両方の仕組みを同時にサポートします。
    to another database and the set of publications (one or more) to which it
    wants to subscribe.
 -->
-《マッチ度[93.312102]》<firstterm>サブスクリプション</firstterm>は論理レプリケーションの下流側です。
+<firstterm>サブスクリプション</firstterm>は論理レプリケーションの下流側です。
 サブスクリプションが定義されたノードは<firstterm>サブスクライバー</firstterm>として参照されます。
 サブスクリプションは他のデータベースへの接続と、サブスクリプション対象の一つ以上のパブリケーションの集合を定義します。
   </para>
@@ -1420,7 +1419,7 @@ HINT:  To initiate replication, you must manually create the replication slot, e
      doesn't use row filters even if they are defined in the publication.
      This is because old releases can only copy the entire table data.
 -->
-《マッチ度[91.304348]》サブスクライバーが15より前のリリースにある場合、既存のデータのコピーでは、パブリケーションで定義されていても行フィルタは使用されません。
+サブスクライバーが15より前のリリースの場合、既存のデータのコピーは、パブリケーションで定義されていても行フィルタを使用しません。
 これは、古いリリースではテーブルデータ全体しかコピーできないためです。
     </para>
    </note>
@@ -3156,12 +3155,12 @@ WAL送信プロセスはWALのロジカルデコーディング（<xref linkend=
      control of the replication of the table is given back to the main apply
      process where replication continues as normal.
 -->
-《マッチ度[91.547862]》既存のサブスクライブされたテーブル中の初期データのスナップショットが取得され、特殊な適用プロセスの並列インスタンスにコピーされます。
+既存のサブスクライブされたテーブル中の初期データのスナップショットが取得され、特殊な適用プロセスの並列インスタンスにコピーされます。
 これらの特殊な適用プロセスは、同期されるテーブルごとに生成された、専用のテーブル同期ワーカーです。
 このプロセスは自身のレプリケーションスロットを作成し、既存のデータをコピーします。
 コピーが終わるとすぐにテーブル内容が他のバックエンドから見えるようになります。
 既存のデータのコピーが終わると、ワーカーは同期モードに入ります。
-このモードでは、初期データのコピー中に起こった更新を標準の論理レプリケーションを使ってストリーミングすることにより、テーブルが主適用プロセスと同期状態になることを保証します。
+このモードでは、初期データのコピー中に起こった変更を標準の論理レプリケーションを使ってストリーミングすることにより、テーブルが主適用プロセスと同期状態になることを保証します。
 この同期フェーズの間、パブリッシャーで発生したのと同じ順序で変更が適用され、コミットされます。
 ひとたび同期が完了すれば、テーブルのレプリケーションの制御は主適用プロセスに戻され、レプリケーションは通常通り継続されます。
     </para>


### PR DESCRIPTION
翻訳に関係ある変更はあまりなく、既存訳の見直しが主です。