### PR TITLE
update pg_walsummary for 18.4

### DIFF
--- a/doc/src/sgml/ref/pg_walsummary.sgml
+++ b/doc/src/sgml/ref/pg_walsummary.sgml
@@ -45,7 +45,7 @@ PostgreSQL documentation
    <link linkend="backup-incremental-backup">incremental backup</link>,
    but it may be useful for debugging purposes.
 -->
-《マッチ度[94.606742]》<application>pg_walsummary</application>は、WAL要約ファイルの内容を出力するために使用します。
+<application>pg_walsummary</application>は、WAL要約ファイルの内容を出力するために使用します。
 これらのバイナリファイルは、データディレクトリの<literal>pg_wal/summaries</literal>サブディレクトリにあり、このツールを使用してテキストに変換できます。
 これは通常は必要ありません。
 WAL要約ファイルは主に<link linkend="backup-incremental-backup">増分バックアップ</link>をサポートするために存在しますが、デバッグ目的で有用な場合があります。


### PR DESCRIPTION
ref/pg_walsummary.sgml の 18.4 対応です。
（が、原文が前置詞の誤りの修正みたいなので、訳は何もやってません。）