### PR TITLE
翻訳統一: runtime.sgmlの「影響」を「効果」に修正

### DIFF
--- a/doc/src/sgml/runtime.sgml
+++ b/doc/src/sgml/runtime.sgml
@@ -3685,7 +3685,7 @@ Unixシステムでは、<filename>server.key</filename>の権限は所有者以
 <!--
       <entry>Effect</entry>
 -->
-      <entry>影響</entry>
+      <entry>効果</entry>
      </row>
     </thead>
 


### PR DESCRIPTION
Conflict 7「<entry>Effect</entry>」の翻訳を統一。
config.sgml、config2.sgml、libpq.sgml、libpq3.sgml、postgres-fdw.sgmlに 合わせてruntime.sgmlの「<entry>影響</entry>」を「<entry>効果</entry>」に変更。