### PR TITLE
pg_dump*やpg_restore関連の訳文を統一

### DIFF
--- a/doc/src/sgml/ref/clusterdb.sgml
+++ b/doc/src/sgml/ref/clusterdb.sgml
@@ -187,7 +187,7 @@ PostgreSQL documentation
 <!--
         Print detailed information during processing.
 -->
-処理の間、詳細な情報を出力します。
+処理中に詳細な情報を表示します。
        </para>
       </listitem>
      </varlistentry>
@@ -256,7 +256,7 @@ PostgreSQL documentation
         extension on which the server
         is listening for connections.
 -->
-サーバが接続を監視するTCPポートもしくはUnixドメインソケットファイルの拡張子を指定します。
+サーバが接続を監視するTCPポートもしくはローカルUnixドメインソケットファイルの拡張子を指定します。
        </para>
       </listitem>
      </varlistentry>
@@ -269,7 +269,7 @@ PostgreSQL documentation
 <!--
         User name to connect as.
 -->
-接続するためのユーザ名です。
+接続ユーザ名です。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/ref/createdb.sgml
+++ b/doc/src/sgml/ref/createdb.sgml
@@ -379,7 +379,7 @@ ICUロケールプロバイダを選択した場合に、このデータベー�
         Specifies the TCP port or the local Unix domain socket file
         extension on which the server is listening for connections.
 -->
-サーバが接続を監視するTCPポートもしくはUnixドメインソケットのファイル拡張子を指定します。
+サーバが接続を監視するTCPポートもしくはローカルUnixドメインソケットファイルの拡張子を指定します。
        </para>
       </listitem>
      </varlistentry>
@@ -392,7 +392,7 @@ ICUロケールプロバイダを選択した場合に、このデータベー�
 <!--
         User name to connect as.
 -->
-接続に使用するユーザ名を指定します。
+接続ユーザ名です。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/ref/createuser.sgml
+++ b/doc/src/sgml/ref/createuser.sgml
@@ -530,7 +530,7 @@ PostgreSQL documentation
         extension on which the server
         is listening for connections.
 -->
-サーバが接続を監視するTCPポートもしくはUnixドメインソケットファイルの拡張子を指定します。
+サーバが接続を監視するTCPポートもしくはローカルUnixドメインソケットファイルの拡張子を指定します。
        </para>
       </listitem>
      </varlistentry>
@@ -543,7 +543,7 @@ PostgreSQL documentation
 <!--
         User name to connect as (not the user name to create).
 -->
-接続に使用するユーザ名です（作成するユーザの名前ではありません）。
+接続ユーザ名です（作成するユーザの名前ではありません）。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/ref/dropdb.sgml
+++ b/doc/src/sgml/ref/dropdb.sgml
@@ -214,7 +214,7 @@ PostgreSQL documentation
         extension on which the server
         is listening for connections.
 -->
-サーバが接続を監視するTCPポートもしくはUnixドメインソケットファイルの拡張子を指定します。
+サーバが接続を監視するTCPポートもしくはローカルUnixドメインソケットファイルの拡張子を指定します。
        </para>
       </listitem>
      </varlistentry>
@@ -227,7 +227,7 @@ PostgreSQL documentation
 <!--
         User name to connect as.
 -->
-接続するユーザ名を指定します。
+接続ユーザ名です。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/ref/dropuser.sgml
+++ b/doc/src/sgml/ref/dropuser.sgml
@@ -205,7 +205,7 @@ PostgreSQL documentation
         extension on which the server
         is listening for connections.
 -->
-サーバが接続を監視するTCPポートもしくはUnixドメインソケットのファイル拡張子を指定します。
+サーバが接続を監視するTCPポートもしくはローカルUnixドメインソケットファイルの拡張子を指定します。
        </para>
       </listitem>
      </varlistentry>
@@ -218,8 +218,7 @@ PostgreSQL documentation
 <!--
         User name to connect as (not the user name to drop).
 -->
-接続に使用するユーザ名です
-（削除するユーザ名ではありません）。
+接続ユーザ名です（削除するユーザ名ではありません）。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/ref/pg_basebackup.sgml
+++ b/doc/src/sgml/ref/pg_basebackup.sgml
@@ -209,7 +209,7 @@ PostgreSQL documentation
     The following command-line options control the location and format of the
     output:
 -->
-以下のコマンドラインオプションは出力の場所と書式を制御します。
+以下のコマンドラインオプションは、出力の場所と書式を制御します。
 
     <variablelist>
      <varlistentry>
@@ -1166,8 +1166,8 @@ SHAハッシュ関数を使うと、バックアップが変更されていな�
         linkend="libpq-connstring">connection string</link>;  these
         will override any conflicting command line options.
 -->
-サーバとの接続のために使用するパラメータを、<link linkend="libpq-connstring">接続文字列</link>として指定します。
-衝突するコマンドラインオプションよりも優先します。
+サーバに接続するために使用されるパラメータを<link linkend="libpq-connstring">接続文字列</link>として指定します。
+これは衝突するコマンドラインオプションよりも優先します。
        </para>
        <para>
 <!--

--- a/doc/src/sgml/ref/pg_dump.sgml
+++ b/doc/src/sgml/ref/pg_dump.sgml
@@ -170,7 +170,7 @@ PostgreSQL documentation
     The following command-line options control the content and
     format of the output.
 -->
-以下のコマンドラインオプションは出力内容とその形式を制御します。
+以下のコマンドラインオプションは、出力の内容と形式を制御します。
 
     <variablelist>
      <varlistentry>
@@ -208,7 +208,7 @@ PostgreSQL documentation
         This option is similar to, but for historical reasons not identical
         to, specifying <option>&#45;-section=data</option>.
 -->
-このオプションは<option>--section=data</option>を指定することと似ていますが、歴史的な理由で同一ではありません。
+このオプションは<option>--section=data</option>を指定することと似ていますが、歴史的な理由により同一ではありません。
        </para>
       </listitem>
      </varlistentry>
@@ -802,9 +802,9 @@ tar形式アーカイブを展開すると、有効なディレクトリ形式�
         (Usually, it's better to leave this out, and instead start the
         resulting script as superuser.)
 -->
-トリガを無効にする場合に使用する、スーパーユーザのユーザ名を指定します。
-これは<option>--disable-triggers</option>を使う場合にのみ使用されます。
-（通常は、このオプションを使うよりも、出力されたスクリプトをスーパーユーザ権限で実行する方が良いでしょう。）
+トリガを無効にする場合に使用するスーパーユーザのユーザ名を指定します。
+これは<option>--disable-triggers</option>を使用する場合にのみ関連します。
+（通常はこのオプションを使うよりも、出力されたスクリプトをスーパーユーザ権限で実行する方が良いでしょう。）
        </para>
       </listitem>
      </varlistentry>
@@ -1098,7 +1098,7 @@ tarアーカイブ形式では現在圧縮を全くサポートしていませ�
         a superuser name with <option>-S</option>, or preferably be careful to
         start the resulting script as a superuser.
 -->
-現在のところ、<option>--disable-triggers</option>に対応するコマンドを実行するのは、スーパーユーザでなければなりません。
+現在のところ、<option>--disable-triggers</option>を指定してコマンドを実行するのは、スーパーユーザでなければなりません。
 そのため、<option>-S</option>でスーパーユーザの名前を指定するか、あるいは、可能であれば、スーパーユーザ権限でスクリプトを開始するよう注意する必要があります。
        </para>
 
@@ -1397,7 +1397,7 @@ tarアーカイブ形式では現在圧縮を全くサポートしていませ�
 <literal>#</literal>で始まる行はコメントと見なされ、無視されます。
 コメントはオブジェクトパターン行の後にも置くことができます。
 空行も無視されます。
-パターン内の引用符の実行方法については<xref linkend="app-psql-patterns"/>を参照してください。
+パターンの引用符付けの方法については、<xref linkend="app-psql-patterns"/>を参照してください。
        </para>
 
        <para>
@@ -1423,7 +1423,7 @@ tarアーカイブ形式では現在圧縮を全くサポートしていませ�
         specified.
 -->
 <literal>DROP ... IF EXISTS</literal>コマンドを使用して、<option>--clean</option>モードでオブジェクトを削除します。
-これは、そうでなければ報告される<quote>does not exist</quote>エラーを抑制します。
+これは、そうでなければ報告される可能性のある<quote>does not exist</quote>エラーを抑制します。
 このオプションは、<option>--clean</option>も指定されていない場合には無効です。
        </para>
       </listitem>
@@ -1524,10 +1524,10 @@ tarアーカイブ形式では現在圧縮を全くサポートしていませ�
         and the two systems have different definitions of the collation used
         to sort the partitioning column.
 -->
-テーブルパーティションのデータをダンプするときには、<command>COPY</command>あるいは<command>INSERT</command>文の対象を、そのパーティションではなく、それを含むパーティション階層のルートにします。
-これにより、データが読み込まれるときに各行に対して適切なパーティションが再判断されます。
-これは行が元のサーバ上と同じパーティションに必ずしも落ちないようなサーバ上にデータを再読み込みするときに有用でしょう。
-例えば、パーティション列がtext型で二つのシステムがパーティション列のソートで使われる照合順序の異なる定義を持っている場合に、これはあり得ます。
+テーブルパーティションのデータをダンプする場合、<command>COPY</command>または<command>INSERT</command>文の対象をパーティション自体ではなく、それを含むパーティション階層のルートにします。
+これにより、データが読み込まれるときに、各行に対して適切なパーティションが再決定されます。
+これは、リストア先のサーバで、行が元のサーバと同じパーティションに常に収まらない場合に有用です。
+例えば、パーティション化列がtext型で、2つのシステムでパーティション化列のソートに使用される照合順序の定義が異なる場合などに発生する可能性があります。
        </para>
       </listitem>
      </varlistentry>
@@ -1678,8 +1678,8 @@ tarアーカイブ形式では現在圧縮を全くサポートしていませ�
         With this option, all objects will be created with whichever
         table access method is the default during restore.
 -->
-セレクトテーブルアクセスメソッドにコマンドを出力しません。
-このオプションを使用すると、リストア中にどのテーブルアクセスメソッドがデフォルトであっても、すべてのオブジェクトが作成されます。
+テーブルアクセスメソッドを選択するコマンドを出力しません。
+このオプションを使用すると、すべてのオブジェクトはリストア時にデフォルトとなっているテーブルアクセスメソッドで作成されます。
        </para>
 
        <para>
@@ -1704,7 +1704,7 @@ tarアーカイブ形式では現在圧縮を全くサポートしていませ�
         tablespace is the default during restore.
 -->
 テーブル空間を選択するコマンドを出力しません。
-このオプションを使用すると、すべてのオブジェクトはリストア時のデフォルトのテーブル空間の中に作成されます。
+このオプションを使用すると、すべてのオブジェクトはリストア時にデフォルトとなっているテーブル空間内に作成されます。
        </para>
 
        <para>

--- a/doc/src/sgml/ref/pg_dumpall.sgml
+++ b/doc/src/sgml/ref/pg_dumpall.sgml
@@ -125,7 +125,7 @@ SQLスクリプトは標準出力に書き込まれます。
     The following command-line options control the content and
     format of the output.
 -->
-以下のコマンドラインオプションは出力内容や形式を制御します。
+以下のコマンドラインオプションは、出力の内容と形式を制御します。
 
     <variablelist>
      <varlistentry>
@@ -270,8 +270,8 @@ SQLスクリプトは標準出力に書き込まれます。
         (Usually, it's better to leave this out, and instead start the
         resulting script as superuser.)
 -->
-トリガを無効にする際に使用するスーパーユーザのユーザ名を指定します。
-これは<option>--disable-triggers</option>を使用する場合にのみ使用されます。
+トリガを無効にする場合に使用するスーパーユーザのユーザ名を指定します。
+これは<option>--disable-triggers</option>を使用する場合にのみ関連します。
 （通常はこのオプションを使うよりも、出力されたスクリプトをスーパーユーザ権限で実行する方が良いでしょう。）
        </para>
       </listitem>
@@ -333,7 +333,7 @@ SQLスクリプトは標準出力に書き込まれます。
 <!--
         Prevent dumping of access privileges (grant/revoke commands).
 -->
-アクセス権限のダンプ（grant/revokeコマンド）を行いません。
+アクセス権限（grant/revokeコマンド）のダンプを抑制します。
        </para>
       </listitem>
      </varlistentry>
@@ -483,7 +483,7 @@ SQLスクリプトは標準出力に書き込まれます。
 <!--
         The file lists one database pattern per row, with the following format:
 -->
-ファイルには、1行に1つのデータベースパターンがリストされ、次の形式になります。
+ファイルは、1行につき1つのデータベースパターンを、以下の形式でリストします。
 <synopsis>
 exclude database <replaceable class="parameter">PATTERN</replaceable>
 </synopsis>
@@ -499,7 +499,7 @@ exclude database <replaceable class="parameter">PATTERN</replaceable>
 <literal>#</literal>で始まる行はコメントと見なされ、無視されます。
 コメントはオブジェクトパターン行の後にも置くことができます。
 空行も無視されます。
-パターン内の引用方法については<xref linkend="app-psql-patterns"/>を参照してください。
+パターンの引用符付けの方法については、<xref linkend="app-psql-patterns"/>を参照してください。
        </para>
 
       </listitem>
@@ -517,7 +517,7 @@ exclude database <replaceable class="parameter">PATTERN</replaceable>
         specified.
 -->
 <literal>DROP ... IF EXISTS</literal>コマンドを使用して、<option>--clean</option>モードでオブジェクトを削除します。
-これは、<quote>does not exist</quote>エラーを抑制します。
+これは、そうでなければ報告される可能性のある<quote>does not exist</quote>エラーを抑制します。
 このオプションは、<option>--clean</option>も指定されていない場合には無効です。
        </para>
       </listitem>
@@ -561,10 +561,10 @@ exclude database <replaceable class="parameter">PATTERN</replaceable>
         and the two systems have different definitions of the collation used
         to sort the partitioning column.
 -->
-テーブルパーティションに対するデータをダンプするとき、<command>COPY</command>や<command>INSERT</command>文をパーティション自体ではなく、それを含むパーティション階層のルートに向けさせます。
-これにより、データが読み込まれるときに各行に対して適切なパーティションが再判断されるようになります。
-これは、行が必ずしも元のサーバと同じパーティションに落ちないようなサーバにデータをリストアするときに有用でしょう。
-例えば、パーティション列がtext型で二つのシステムがパーティション列をソートするのに使われる照合順序の異なった定義を持っている場合に、これは起こりえることです。
+テーブルパーティションのデータをダンプする場合、<command>COPY</command>または<command>INSERT</command>文の対象をパーティション自体ではなく、それを含むパーティション階層のルートにします。
+これにより、データが読み込まれるときに、各行に対して適切なパーティションが再決定されます。
+これは、リストア先のサーバで、行が元のサーバと同じパーティションに常に収まらない場合に有用です。
+例えば、パーティション化列がtext型で、2つのシステムでパーティション化列のソートに使用される照合順序の定義が異なる場合などに発生する可能性があります。
        </para>
       </listitem>
      </varlistentry>
@@ -734,8 +734,8 @@ exclude database <replaceable class="parameter">PATTERN</replaceable>
         With this option, all objects will be created with whichever
         table access method is the default during restore.
 -->
-セレクトテーブルアクセスメソッドにコマンドを出力しません。
-このオプションを使用すると、リストア中にどのテーブルアクセスメソッドがデフォルトであっても、すべてのオブジェクトが作成されます。
+テーブルアクセスメソッドを選択するコマンドを出力しません。
+このオプションを使用すると、すべてのオブジェクトはリストア時にデフォルトとなっているテーブルアクセスメソッドで作成されます。
        </para>
       </listitem>
      </varlistentry>
@@ -751,7 +751,7 @@ exclude database <replaceable class="parameter">PATTERN</replaceable>
         tablespace is the default during restore.
 -->
 オブジェクト用にテーブル空間を作成または選択するコマンドを出力しません。
-このオプションを付けると、すべてのオブジェクトはリストア時のデフォルトのテーブル空間内に作成されます。
+このオプションを使用すると、すべてのオブジェクトはリストア時のデフォルトのテーブル空間内に作成されます。
        </para>
       </listitem>
      </varlistentry>
@@ -972,7 +972,8 @@ exclude database <replaceable class="parameter">PATTERN</replaceable>
         linkend="libpq-connstring">connection string</link>;  these
         will override any conflicting command line options.
 -->
-サーバに接続するために使用されるパラメータを<link linkend="libpq-connstring">接続文字列</link>として指定します。これは衝突するコマンドラインオプションよりも優先します。
+サーバに接続するために使用されるパラメータを<link linkend="libpq-connstring">接続文字列</link>として指定します。
+これは衝突するコマンドラインオプションよりも優先します。
        </para>
        <para>
 <!--

--- a/doc/src/sgml/ref/pg_isready.sgml
+++ b/doc/src/sgml/ref/pg_isready.sgml
@@ -106,7 +106,7 @@ PostgreSQL documentation
        environment variable or, if not set, to the port specified at
        compile time, usually 5432.
 -->
-サーバが接続を監視しているTCPポートまたはUnixドメインソケットファイルの拡張子を指定します。
+サーバが接続を監視するTCPポートもしくはローカルUnixドメインソケットファイルの拡張子を指定します。
 デフォルトは環境変数<envar>PGPORT</envar>の値、もし設定されていなければ、コンパイル時に指定したポート、通常は5432です。
        </para>
        </listitem>

--- a/doc/src/sgml/ref/pg_receivewal.sgml
+++ b/doc/src/sgml/ref/pg_receivewal.sgml
@@ -430,7 +430,7 @@ WALデータを受け取ると即座にディスクにフラッシュします�
 <!--
     The following command-line options control the database connection parameters.
 -->
-以下のコマンドラインオプションはデータベース接続パラメータを制御します。
+以下のコマンドラインオプションは、データベース接続パラメータを制御します。
 
     <variablelist>
      <varlistentry>
@@ -443,7 +443,7 @@ WALデータを受け取ると即座にディスクにフラッシュします�
         linkend="libpq-connstring">connection string</link>;  these
         will override any conflicting command line options.
 -->
-サーバに接続するために使用するパラメータを、<link linkend="libpq-connstring">接続文字列</link>として指定します。
+サーバに接続するために使用されるパラメータを<link linkend="libpq-connstring">接続文字列</link>として指定します。
 これは衝突するコマンドラインオプションよりも優先します。
        </para>
        <para>
@@ -511,7 +511,7 @@ WALデータを受け取ると即座にディスクにフラッシュします�
 <!--
         User name to connect as.
 -->
-接続するユーザ名です。
+接続ユーザ名です。
        </para>
       </listitem>
      </varlistentry>
@@ -608,7 +608,7 @@ WALデータを受け取ると即座にディスクにフラッシュします�
 <!--
     Other options are also available:
 -->
-この他に以下のオプションも使用することができます。
+以下のその他のオプションも使用することができます。
 
     <variablelist>
      <varlistentry>

--- a/doc/src/sgml/ref/pg_restore.sgml
+++ b/doc/src/sgml/ref/pg_restore.sgml
@@ -561,7 +561,7 @@ PostgreSQL documentation
         This option is obsolete but still accepted for backwards
         compatibility.
 -->
-このオプションは廃止されました。後方互換性を保持するために受け入れられています。
+このオプションは廃止されましたが、後方互換性を保持するため受け入れられます。
        </para>
       </listitem>
      </varlistentry>
@@ -607,8 +607,8 @@ PostgreSQL documentation
         Specify the superuser user name to use when disabling triggers.
         This is relevant only if <option>&#45;-disable-triggers</option> is used.
 -->
-トリガを無効にする場合に使用する、スーパーユーザのユーザ名を指定します。
-これは<option>--disable-triggers</option>を使う場合にのみ使用されます。
+トリガを無効にする場合に使用するスーパーユーザのユーザ名を指定します。
+これは<option>--disable-triggers</option>を使用する場合にのみ関連します。
        </para>
       </listitem>
      </varlistentry>
@@ -858,7 +858,7 @@ PostgreSQL documentation
 <!--
         The file lists one database pattern per row, with the following format:
 -->
-ファイルには、オブジェクトパターンが1行に1つずつリストされ、次の形式になります。
+ファイルは、1行につき1つのデータベースパターンを、以下の形式でリストします。
 <synopsis>
 { include | exclude } { function | index | schema | table | trigger } <replaceable class="parameter">PATTERN</replaceable>
 </synopsis>
@@ -945,7 +945,7 @@ PostgreSQL documentation
 <literal>#</literal>で始まる行はコメントと見なされ、無視されます。
 コメントはオブジェクトパターン行の後にも置くことができます。
 空行も無視されます。
-パターン内の引用符の実行方法については<xref linkend="app-psql-patterns"/>を参照してください。
+パターンの引用符付けの方法については、<xref linkend="app-psql-patterns"/>を参照してください。
        </para>
 
       </listitem>
@@ -963,8 +963,8 @@ PostgreSQL documentation
         specified.
 -->
 <literal>DROP ... IF EXISTS</literal>コマンドを使用して、<option>--clean</option>モードでオブジェクトを削除します。
-これは、そうでなければ報告される<quote>does not exist</quote>エラーを抑制します。
-このオプションは、<option>--clean</option>も指定されていない場合は無効です。
+これは、そうでなければ報告される可能性のある<quote>does not exist</quote>エラーを抑制します。
+このオプションは、<option>--clean</option>も指定されていない場合には無効です。
        </para>
       </listitem>
      </varlistentry>
@@ -1115,7 +1115,7 @@ PostgreSQL documentation
         table access method is the default during restore.
 -->
 テーブルアクセスメソッドを選択するコマンドを出力しません。
-このオプションを付けると、すべてのオブジェクトはリストア時にデフォルトとなっているテーブルアクセスメソッドで作成されます。
+このオプションを使用すると、すべてのオブジェクトはリストア時にデフォルトとなっているテーブルアクセスメソッドで作成されます。
        </para>
       </listitem>
      </varlistentry>
@@ -1130,7 +1130,7 @@ PostgreSQL documentation
         tablespace is the default during restore.
 -->
 テーブル空間を選択するコマンドを出力しません。
-このオプションを付けると、すべてのオブジェクトはリストア時にデフォルトとなっているテーブル空間内に作成されます。
+このオプションを使用すると、すべてのオブジェクトはリストア時にデフォルトとなっているテーブル空間内に作成されます。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/ref/psql-ref.sgml
+++ b/doc/src/sgml/ref/psql-ref.sgml
@@ -467,7 +467,7 @@ EOF
       environment variable or, if not set, to the port specified at
       compile time, usually 5432.
 -->
-サーバが接続監視を行っているTCPポートもしくはローカルUnixドメインソケットファイルの拡張子を指定します。
+サーバが接続を監視するTCPポートもしくはローカルUnixドメインソケットファイルの拡張子を指定します。
 環境変数<envar>PGPORT</envar>の値、環境変数が設定されていない場合はコンパイル時に指定した値（通常は5432）がデフォルト値となります。
       </para>
       </listitem>
@@ -3526,7 +3526,7 @@ Tue Oct 26 21:40:57 CEST 1999
 -->
 環境変数<replaceable class="parameter">env_var</replaceable>の値を取得し、<application>psql</application>変数<replaceable class="parameter">psql_var</replaceable>に割り当てます。
 <application>psql</application>のプロセスの環境で<replaceable class="parameter">env_var</replaceable>が定義されていない場合、<replaceable class="parameter">psql_var</replaceable>は変更されません。
-例:
+例：
 <programlisting>
 =&gt; <userinput>\getenv home HOME</userinput>
 =&gt; <userinput>\echo :home</userinput>

--- a/doc/src/sgml/ref/reindexdb.sgml
+++ b/doc/src/sgml/ref/reindexdb.sgml
@@ -372,7 +372,7 @@ PostgreSQL documentation
         directory for the Unix domain socket.
 -->
 サーバが稼働しているマシンのホスト名を指定します。
-ホスト名がスラッシュから始まる場合、Unixドメインソケット用のディレクトリとして使用されます。
+この値がスラッシュから始まる場合、Unixドメインソケット用のディレクトリとして使用されます。
        </para>
       </listitem>
      </varlistentry>
@@ -387,7 +387,7 @@ PostgreSQL documentation
         extension on which the server
         is listening for connections.
 -->
-サーバが接続を監視するTCPポートもしくはUnixドメインソケットファイルの拡張子を指定します。
+サーバが接続を監視するTCPポートもしくはローカルUnixドメインソケットファイルの拡張子を指定します。
        </para>
       </listitem>
      </varlistentry>
@@ -400,7 +400,7 @@ PostgreSQL documentation
 <!--
         User name to connect as.
 -->
-接続するユーザ名を指定します。
+接続ユーザ名です。
        </para>
       </listitem>
      </varlistentry>

--- a/doc/src/sgml/ref/vacuumdb.sgml
+++ b/doc/src/sgml/ref/vacuumdb.sgml
@@ -662,7 +662,7 @@ PostgreSQL documentation
         as the directory for the Unix domain socket.
 -->
 サーバが稼働しているマシンのホスト名を指定します。
-ホスト名がスラッシュから始まる場合、Unixドメインソケット用のディレクトリとして使用されます。
+この値がスラッシュから始まる場合、Unixドメインソケット用のディレクトリとして使用されます。
        </para>
       </listitem>
      </varlistentry>
@@ -677,7 +677,7 @@ PostgreSQL documentation
         extension on which the server
         is listening for connections.
 -->
-サーバが接続を監視するTCPポートもしくはUnixドメインソケットファイルの拡張子を指定します。
+サーバが接続を監視するTCPポートもしくはローカルUnixドメインソケットファイルの拡張子を指定します。
        </para>
       </listitem>
      </varlistentry>
@@ -690,7 +690,7 @@ PostgreSQL documentation
 <!--
         User name to connect as.
 -->
-接続するユーザ名を指定します。
+接続ユーザ名です。
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
pg_dump*やpg_restore関連の訳文を統一しました。
pg_dump*やpg_restoreだけ統一しても他とあわなくなるため、範囲が広がってます。